### PR TITLE
Fix Containerfile looking for legacy ./gradio folder

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -25,7 +25,6 @@ WORKDIR ${APP_ROOT}
 COPY modules ./modules
 COPY tools ./tools
 COPY logs ./logs
-COPY gradio ./gradio
 COPY src ./src
 COPY ./ols.py ./requirements.txt ./
 RUN chown -R 1001:0 ${APP_ROOT}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

With the integration of gradio into fastapi and moving into modules directory, the ./gradio dir no longer exists so it needs to be removed from the Containerfile definition.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.