### PR TITLE
Unit test skeleton for our internal modules

### DIFF
--- a/src/query_helpers/yes_no_classifier.py
+++ b/src/query_helpers/yes_no_classifier.py
@@ -56,10 +56,10 @@ class YesNoClassifier:
 
         response = llm_chain(inputs={"statement": statement})
 
-        # strip  from the response
-        clean_response = response["text"].split("")[0]
+        self.logger.info(f"{conversation} bare response: {response}")
+        self.logger.info(f"{conversation} yes/no response: {response['text']}")
 
-        self.logger.info(f"{conversation} yes/no response: {clean_response}")
+        if response["text"] not in ["0", "1", "9"]:
+            raise ValueError("Returned response not 0, 1, or 9")
 
-        # TODO: handle when this doesn't end up with an integer
-        return int(clean_response)
+        return int(response["text"])

--- a/tests/mock_classes/llm_chain.py
+++ b/tests/mock_classes/llm_chain.py
@@ -1,0 +1,20 @@
+def mock_llm_chain(retval):
+    class MockLLMChain:
+        """
+        Mock LLMChain class for testing
+
+        Example usage in a test:
+
+            from tests.mock_classes.llm_chain import mock_llm_chain
+            ml = mock_llm_chain({"text": "default"})
+            monkeypatch.setattr(src.query_helpers.yes_no_classifier, "LLMChain", ml)
+
+        """
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __call__(self, *args, **kwargs):
+            return retval
+
+    return MockLLMChain

--- a/tests/unit/query_helpers/test_yes_no_classifier.py
+++ b/tests/unit/query_helpers/test_yes_no_classifier.py
@@ -1,0 +1,32 @@
+import pytest
+
+import src.query_helpers.yes_no_classifier
+from src.query_helpers.yes_no_classifier import YesNoClassifier
+from tests.mock_classes.llm_chain import mock_llm_chain
+
+
+@pytest.fixture
+def yes_no_classifier():
+    return YesNoClassifier()
+
+
+def test_bad_value_response(yes_no_classifier, monkeypatch):
+    # response that isn't 1, 0, or 9 should generate a ValueError
+    ml = mock_llm_chain({"text": "default"})
+
+    monkeypatch.setattr(src.query_helpers.yes_no_classifier, "LLMChain", ml)
+
+    with pytest.raises(ValueError):
+        yes_no_classifier.classify(conversation="1234", statement="The sky is blue.")
+
+
+def test_good_value_response(yes_no_classifier, monkeypatch):
+    # response that is 1, 0, or 9 should return the value
+    for x in ["0", "1", "9"]:
+        ml = mock_llm_chain({"text": x})
+
+        monkeypatch.setattr(src.query_helpers.yes_no_classifier, "LLMChain", ml)
+
+        assert yes_no_classifier.classify(
+            conversation="1234", statement="The sky is blue."
+        ) == int(x)

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,4 +1,4 @@
-import logging, sys, os
+import logging, logging.handlers, sys, os
 
 
 class Logger:


### PR DESCRIPTION
## Type of change

- [X] Refactor
- [X] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Creates a first example of how to test our internal modules.

* yes_no_classifier test, an extremely basic one
* mock class for LLMChain which is used by all our modules - takes an argument to simulate whatever response you want to guarantee so that you can base your tests off of it
* fixes a bug in the Logging class
* fixes a bug in the yes_no_classifier

## Related Tickets & Documents
N/A

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] If it is a core feature, I have added thorough tests.

## Testing
`make test` succeeded.