### PR TITLE
Adding coverage transformer for PROW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,14 @@ test: test-unit test-integration test-e2e
 test-unit:
 	@echo "Running unit tests..."
 	@echo "Reports will be written to ${ARTIFACT_DIR}"
-	python -m pytest tests/unit --cov=app --cov=src --cov=utils --cov-report term-missing --cov-report xml:${ARTIFACT_DIR}/coverage_unit.xml --junit-xml=${ARTIFACT_DIR}/junit_unit.xml
+	python -m pytest tests/unit --cov=app --cov=src --cov=utils --cov-report term-missing --cov-report json:${ARTIFACT_DIR}/coverage_unit.json --junit-xml=${ARTIFACT_DIR}/junit_unit.xml
+	python scripts/transform_coverage_report.py ${ARTIFACT_DIR}/coverage_unit.json ${ARTIFACT_DIR}/coverage_unit.out
 
 test-integration:
 	@echo "Running unit tests..."
 	@echo "Reports will be written to ${ARTIFACT_DIR}"
-	python -m pytest tests/integration --cov=app --cov=src --cov=utils --cov-report term-missing --cov-report xml:${ARTIFACT_DIR}/coverage_integration.xml --junit-xml=${ARTIFACT_DIR}/junit_integration.xml
+	python -m pytest tests/integration --cov=app --cov=src --cov=utils --cov-report term-missing --cov-report json:${ARTIFACT_DIR}/coverage_integration.json --junit-xml=${ARTIFACT_DIR}/junit_integration.xml
+	python scripts/transform_coverage_report.py ${ARTIFACT_DIR}/coverage_integration.json ${ARTIFACT_DIR}/coverage_integration.out
 
 test-e2e:
 	# Command to run e2e tests goes here

--- a/scripts/transform_coverage_report.py
+++ b/scripts/transform_coverage_report.py
@@ -1,0 +1,81 @@
+import json
+import sys
+
+
+"""
+Utility script to convert a Python to GO coverage report.
+"""
+
+
+def write_go_coverage_format(file_path, file_data, output_file):
+    """
+    Write coverage information in a format similar to GO test report to a file.
+
+    Args:
+        file_path (str): Path of the file.
+        file_data (dict): Coverage information for the file.
+        output_file (str): Path of the output file.
+    """
+    executed_lines = file_data.get("executed_lines", [])
+    missing_lines = file_data.get("missing_lines", [])
+    with open(output_file, "a") as f:
+        for line in executed_lines:
+            f.write(f"{file_path}:{line}.0,{line + 1}.0 1 1\n")
+
+        for line in missing_lines:
+            f.write(f"{file_path}:{line}.0,{line + 1}.0 1 0\n")
+    f.close()
+
+
+def parse_coverage_json(json_content, output_file):
+    """
+    Parse the content of a Python coverage report in JSON format and write to a file.
+
+    Args:
+        json_content (str): The JSON content of the coverage report.
+        output_file (str): Path of the output file.
+
+    Returns:
+        None: Writes information to the output file.
+
+    Raises:
+        json.JSONDecodeError: If there is an error decoding the JSON content.
+    """
+    try:
+        coverage_data = json.loads(json_content)
+        files_info = coverage_data.get("files", {})
+        for file_path, file_data in files_info.items():
+            write_go_coverage_format(
+                f"github.com/openshift/lightspeed-service/{file_path}",
+                file_data,
+                output_file,
+            )
+
+    except json.JSONDecodeError as e:
+        print(f"Error decoding JSON: {e}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python script.py <json_file> <output_file>")
+        sys.exit(1)
+
+    json_file_path = sys.argv[1]
+    output_file_path = sys.argv[2]
+
+    try:
+        with open(output_file_path, "w") as output_file:
+            output_file.write("mode: set\n")
+            pass
+
+        with open(json_file_path, "r") as json_file:
+            json_content = json_file.read()
+            parse_coverage_json(json_content, output_file_path)
+
+        json_file.close()
+        output_file.close()
+
+    except FileNotFoundError:
+        print(f"File not found: {json_file_path}")
+    except Exception as e:
+        print(f"Error processing files: {e}")


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Converting python code coverage report to GO coverage.out format that is consumed by PROW. Because currently PROW only supports GO coverage report and more details on its [parsing logic](https://github.com/kubernetes/test-infra/blob/master/gopherage/cmd/html/static/parser.ts#L172)
Docs on spyglass reads coverage files: https://docs.prow.k8s.io/docs/spyglass/#example-configuration
Code pointers:
* https://github.com/openshift/release/blob/c472a857643c0f6f479bf1cecce0e9f3b9199693/core-services/prow/02_config/_config.yaml#L147-L152
* https://github.com/openshift/release/blob/c472a857643c0f6f479bf1cecce0e9f3b9199693/core-services/prow/02_config/_config.yaml#L157-L160

## Related Tickets & Documents

- Related Issue: https://issues.redhat.com/browse/OLS-48 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested and verified in local. Preview
```
mode: set
github.com/openshift/lightspeed-service/app/constants.py:2.0,3.0 1 0
github.com/openshift/lightspeed-service/app/constants.py:3.0,4.0 1 0
github.com/openshift/lightspeed-service/app/constants.py:4.0,5.0 1 0
github.com/openshift/lightspeed-service/app/constants.py:5.0,6.0 1 0
github.com/openshift/lightspeed-service/app/constants.py:6.0,7.0 1 0
```