### PR TITLE
Refactor cache and correct type hints

### DIFF
--- a/src/cache/cache.py
+++ b/src/cache/cache.py
@@ -1,0 +1,29 @@
+from typing import Union
+from abc import ABC, abstractmethod
+
+
+class Cache(ABC):
+    @abstractmethod
+    def get(self, key: str) -> Union[str, None]:
+        """Abstract method to retrieve a value from the cache.
+
+        Args:
+            key (str): The key associated with the value.
+
+        Returns:
+            Union[str, None]: The value associated with the key, or None if not found.
+        """
+        pass
+
+    @abstractmethod
+    def insert_or_append(self, key: str, value: str) -> None:
+        """Abstract method to store a value in the cache.
+
+        Args:
+            key (str): The key to associate with the value.
+            value (str): The value to be stored in the cache.
+
+        Returns:
+            None
+        """
+        pass

--- a/src/cache/cache_factory.py
+++ b/src/cache/cache_factory.py
@@ -1,38 +1,10 @@
 # cache_factory.py
 
 import os
-from abc import ABC, abstractmethod
-from typing import Union
 import src.constants as constants
+from src.cache.cache import Cache
 from src.cache.in_memory_cache import InMemoryCache
 from src.cache.redis_cache import RedisCache
-
-
-class Cache(ABC):
-    @abstractmethod
-    def get(self, key: str) -> Union[str, None]:
-        """Abstract method to retrieve a value from the cache.
-
-        Args:
-            key (str): The key associated with the value.
-
-        Returns:
-            Union[str, None]: The value associated with the key, or None if not found.
-        """
-        pass
-
-    @abstractmethod
-    def insert_or_append(self, key: str, value: str) -> None:
-        """Abstract method to store a value in the cache.
-
-        Args:
-            key (str): The key to associate with the value.
-            value (str): The value to be stored in the cache.
-
-        Returns:
-            None
-        """
-        pass
 
 
 class CacheFactory:

--- a/src/cache/in_memory_cache.py
+++ b/src/cache/in_memory_cache.py
@@ -2,9 +2,10 @@ from collections import deque
 from typing import Union
 import threading
 import src.constants as constants
+from src.cache.cache import Cache
 
 
-class InMemoryCache:
+class InMemoryCache():
     """An in-memory LRU cache implementation in O(1) time."""
 
     _instance = None

--- a/src/cache/in_memory_cache.py
+++ b/src/cache/in_memory_cache.py
@@ -5,7 +5,7 @@ import src.constants as constants
 from src.cache.cache import Cache
 
 
-class InMemoryCache():
+class InMemoryCache(Cache):
     """An in-memory LRU cache implementation in O(1) time."""
 
     _instance = None

--- a/src/cache/redis_cache.py
+++ b/src/cache/redis_cache.py
@@ -4,6 +4,7 @@ from typing import Union
 import threading
 import src.constants as constants
 from dotenv import load_dotenv
+from src.cache.cache import Cache
 
 
 load_dotenv()
@@ -12,7 +13,7 @@ load_dotenv()
 # TODO
 # Good for on-premise hosting for now
 # Extend it to distributed setting using cloud offerings
-class RedisCache:
+class RedisCache():
     _instance = None
     _lock = threading.Lock()
 

--- a/src/cache/redis_cache.py
+++ b/src/cache/redis_cache.py
@@ -13,7 +13,7 @@ load_dotenv()
 # TODO
 # Good for on-premise hosting for now
 # Extend it to distributed setting using cloud offerings
-class RedisCache():
+class RedisCache(Cache):
     _instance = None
     _lock = threading.Lock()
 

--- a/tests/unit/test_cache_factory.py
+++ b/tests/unit/test_cache_factory.py
@@ -1,0 +1,30 @@
+import os
+import pytest
+
+import src.constants as constants
+from src.cache.cache_factory import CacheFactory
+from src.cache.cache_factory import InMemoryCache
+
+
+@pytest.fixture(scope="module")
+def in_memory_cache_env_var():
+    os.environ["OLS_CONVERSATION_CACHE"] = constants.IN_MEMORY_CACHE
+
+
+@pytest.fixture(scope="module")
+def wrong_cache_env_var():
+    os.environ["OLS_CONVERSATION_CACHE"] = "foo bar baz"
+
+
+def test_conversation_cache(in_memory_cache_env_var):
+    """Check if InMemoryCache is returned by factory with proper env.var setup."""
+    cache = CacheFactory.conversation_cache()
+    assert cache is not None
+    # check if the object has the right type
+    assert isinstance(cache, InMemoryCache)
+
+
+def test_conversation_cache_wrong_cache(wrong_cache_env_var):
+    """Check if wrong cache env.variable is detected properly."""
+    with pytest.raises(ValueError):
+        cache = CacheFactory.conversation_cache()


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- `Cache` class in separate source file to avoid cycles during import
- Fixed type hints - now `RedisCache` and `InMemoryCache` are really inherited from `Cache`
- That fixed `CacheFactory.conversation_cache` type issue
- Two new unit tests for `CacheFactory` to check the behaviour

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Partially tested by unit tests (`InMemoryCache`)
- Added two new unit tests for `CacheFactory` too
