### PR TITLE
introduce llm loader abstraction

### DIFF
--- a/default.env
+++ b/default.env
@@ -3,8 +3,7 @@
 #######################################
 ## enabe OLS UI
 OLS_ENABLE_UI=True
-## LLMs to activate {'ollama','tgi','openai','tgi','bam','watson'}
-LLM_BACKENDS={'openai','ollama'}
+## LLMs backends {'ollama','tgi','openai','bam','watson'}
 LLM_DEFAULT=openai 
 #######################################
 ## LLM BACKENDS

--- a/default.env
+++ b/default.env
@@ -4,13 +4,26 @@
 ## enabe OLS UI
 OLS_ENABLE_UI=True
 ## LLMs backends {'ollama','tgi','openai','bam','watson'}
-LLM_DEFAULT=openai 
+LLM_DEFAULT=openai
+ 
+# logging config
+# Logs to stdout if not set 
+# LOG_FILE_NAME=/tmp/ols.log
+
+# Default is ~100 megs
+# LOG_FILE_SIZE = <size in bytes>
+
+LOG_LEVEL=INFO
+LOG_LEVEL_CONSOLE=INFO
+
 #######################################
 ## LLM BACKENDS
 #######################################
 ## BAM
 BAM_API_KEY=<api_key>
 BAM_API_URL=https://bam-api.res.ibm.com
+## Maintained for compatibility while completing migration
+BAM_URL=https://bam-api.res.ibm.com
 BAM_MODEL=<model_id>
 ## Open AI
 OPENAI_API_KEY=<api_key>
@@ -25,12 +38,7 @@ WATSON_API_KEY=<api_key>
 WATSON_API_URL=<api_url>
 WATSON_PROJECT_ID=<project_id>
 WATSON_MODEL=<model_id>
-#######################################
-## BACKWARDS COMPATIBLITY SETTINGS
-#######################################
-## Maintained for compatibility while completing migration
-BAM_API_KEY=<your key here>
-BAM_URL=https://bam-api.res.ibm.com
+
 # set these if you want to use non-default models for different functions
 # BASE_COMPLETION_MODEL=
 # HAPPY_RESPONSE_GENERATOR_MODEL=

--- a/default.env
+++ b/default.env
@@ -1,6 +1,37 @@
+#######################################
+## GLOBAL SETTINGS
+#######################################
+## enabe OLS UI
+OLS_ENABLE_UI=True
+## LLMs to activate {'ollama','tgi','openai','tgi','bam','watson'}
+LLM_BACKENDS={'openai','ollama'}
+LLM_DEFAULT=openai 
+#######################################
+## LLM BACKENDS
+#######################################
+## BAM
+BAM_API_KEY=<api_key>
+BAM_API_URL=https://bam-api.res.ibm.com
+BAM_MODEL=<model_id>
+## Open AI
+OPENAI_API_KEY=<api_key>
+OPENAI_MODEL=<model_id>
+## OLLAMA
+OLLAMA_API_URL=http://127.0.0.1:11434
+OLLAMA_MODEL=<model_id>
+## TGI
+TGI_API_URL=<api_url>
+## WATSON
+WATSON_API_KEY=<api_key>
+WATSON_API_URL=<api_url>
+WATSON_PROJECT_ID=<project_id>
+WATSON_MODEL=<model_id>
+#######################################
+## BACKWARDS COMPATIBLITY SETTINGS
+#######################################
+## Maintained for compatibility while completing migration
 BAM_API_KEY=<your key here>
 BAM_URL=https://bam-api.res.ibm.com
-OLS_ENABLE_UI=True
 # set these if you want to use non-default models for different functions
 # BASE_COMPLETION_MODEL=
 # HAPPY_RESPONSE_GENERATOR_MODEL=

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 fastapi
 gradio
-ibm-generative-ai
-ibm_watson_machine_learning
 kubernetes
 langchain
 llama_index
@@ -9,3 +7,4 @@ torch
 transformers
 uvicorn
 redis
+-r src/llms/requirements.txt

--- a/src/llms/llm_loader.py
+++ b/src/llms/llm_loader.py
@@ -1,5 +1,6 @@
 # workaround to disable UserWarning
 import warnings
+
 warnings.simplefilter("ignore", UserWarning)
 
 from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
@@ -8,6 +9,7 @@ from langchain.callbacks.manager import CallbackManager
 import os, inspect
 
 from utils.logger import Logger
+
 
 class LLMLoader:
     """
@@ -26,114 +28,122 @@ class LLMLoader:
 
     """
 
-    def __init__(self, llm_backend: str = None, params: dict = None, logger=None) -> None:
-        self.logger = logger if logger is not None else Logger(
-            "llm_loader").logger
-        self.llm_backend = llm_backend if llm_backend else os.environ.get(
-            'LLM_DEFAULT', None)
+    def __init__(
+        self, llm_backend: str = None, params: dict = None, logger=None
+    ) -> None:
+        self.logger = logger if logger is not None else Logger("llm_loader").logger
+        self.llm_backend = (
+            llm_backend if llm_backend else os.environ.get("LLM_DEFAULT", None)
+        )
         # return empty dictionary if not defined
         self.llm_params = params if params else {}
         self.llm = None
         self._set_llm_instance()
 
     def _set_llm_instance(self):
-        self.logger.debug(f"[{inspect.stack()[0][3]}] Loading LLM instances with default {str(self.llm_backend)}")
+        self.logger.debug(
+            f"[{inspect.stack()[0][3]}] Loading LLM {str(self.llm_backend)}"
+        )
         # convert to string to handle None or False definitions
         match str(self.llm_backend):
-            case 'openai':
+            case "openai":
                 self._openai_llm_instance()
-            case 'ollama':
+            case "ollama":
                 self._ollama_llm_instance()
-            case 'tgi':
+            case "tgi":
                 self._tgi_llm_instance()
-            case 'watson':
+            case "watson":
                 self._watson_llm_instance()
-            case 'bam':
+            case "bam":
                 self._bam_llm_instance()
             case _:
                 self.logger.error(f"ERROR: Unsupported LLM {str(self.llm_backend)}")
 
     def _openai_llm_instance(self):
-        self.logger.debug(
-            f"[{inspect.stack()[0][3]}] Creating OpenAI LLM instance")
+        self.logger.debug(f"[{inspect.stack()[0][3]}] Creating OpenAI LLM instance")
         try:
             import openai
-            from langchain.llms import OpenAI 
+            from langchain.llms import OpenAI
         except e:
-            self.logger.error(f"ERROR: Missing openai libraries. Skipping loading backend LLM.")
+            self.logger.error(
+                f"ERROR: Missing openai libraries. Skipping loading backend LLM."
+            )
             return
         params = {
-            'base_url': os.environ.get('OPENAI_API_URL', 'https://api.openai.com/v1'),
-            'api_key': os.environ.get('OPENAI_API_KEY', None),
-            'model': os.environ.get('OPENAI_MODEL', None),
-            'model_kwargs': {}, # TODO: add model args
-            'organization': os.environ.get('OPENAI_ORGANIZATION', None),
-            'timeout': os.environ.get('OPENAI_TIMEOUT', None),
-            'cache': None,
-            'streaming': True,            
-            'temperature': 0.01,
-            'max_tokens': 512,
-            'top_p': 0.95,
-            'frequency_penalty': 1.03,
-            'verbose': False
+            "base_url": os.environ.get("OPENAI_API_URL", "https://api.openai.com/v1"),
+            "api_key": os.environ.get("OPENAI_API_KEY", None),
+            "model": os.environ.get("OPENAI_MODEL", None),
+            "model_kwargs": {},  # TODO: add model args
+            "organization": os.environ.get("OPENAI_ORGANIZATION", None),
+            "timeout": os.environ.get("OPENAI_TIMEOUT", None),
+            "cache": None,
+            "streaming": True,
+            "temperature": 0.01,
+            "max_tokens": 512,
+            "top_p": 0.95,
+            "frequency_penalty": 1.03,
+            "verbose": False,
         }
-        params.update(self.llm_params) # override parameters
-        self.llm=OpenAI(**params)
-        self.logger.debug(
-            f"[{inspect.stack()[0][3]}] OpenAI LLM instance {self.llm}")
+        params.update(self.llm_params)  # override parameters
+        self.llm = OpenAI(**params)
+        self.logger.debug(f"[{inspect.stack()[0][3]}] OpenAI LLM instance {self.llm}")
 
     def _ollama_llm_instance(self):
-        self.logger.debug(
-            f"[{inspect.stack()[0][3]}] Creating Ollama LLM instance")
+        self.logger.debug(f"[{inspect.stack()[0][3]}] Creating Ollama LLM instance")
         try:
-            from langchain.llms import Ollama 
+            from langchain.llms import Ollama
         except e:
-            self.logger.error(f"ERROR: Missing ollama libraries. Skipping loading backend LLM.")
+            self.logger.error(
+                f"ERROR: Missing ollama libraries. Skipping loading backend LLM."
+            )
             return
         params = {
-            'base_url': os.environ.get('OLLAMA_API_URL', "http://127.0.0.1:11434"),
-            'model': os.environ.get('OLLAMA_MODEL', 'Mistral'),
-            'cache': None,
-            'temperature': 0.01,
-            'top_k': 10,
-            'top_p': 0.95,
-            'repeat_penalty': 1.03,
-            'verbose': False,
-            'callback_manager': CallbackManager([StreamingStdOutCallbackHandler()])
+            "base_url": os.environ.get("OLLAMA_API_URL", "http://127.0.0.1:11434"),
+            "model": os.environ.get("OLLAMA_MODEL", "Mistral"),
+            "cache": None,
+            "temperature": 0.01,
+            "top_k": 10,
+            "top_p": 0.95,
+            "repeat_penalty": 1.03,
+            "verbose": False,
+            "callback_manager": CallbackManager([StreamingStdOutCallbackHandler()]),
         }
         params.update(self.llm_params)  # override parameters
         self.llm = Ollama(**params)
-        self.logger.debug(
-            f"[{inspect.stack()[0][3]}] Ollama LLM instance {self.llm}")
+        self.logger.debug(f"[{inspect.stack()[0][3]}] Ollama LLM instance {self.llm}")
 
     def _tgi_llm_instance(self):
         """
         Note: TGI does not support specifying the model, it is an instance per model.
         """
         self.logger.debug(
-            f"[{inspect.stack()[0][3]}] Creating Hugging Face TGI LLM instance")
+            f"[{inspect.stack()[0][3]}] Creating Hugging Face TGI LLM instance"
+        )
         try:
             from langchain.llms import HuggingFaceTextGenInference
         except e:
-            self.logger.error(f"ERROR: Missing HuggingFaceTextGenInference libraries. Skipping loading backend LLM.")
+            self.logger.error(
+                f"ERROR: Missing HuggingFaceTextGenInference libraries. Skipping loading backend LLM."
+            )
             return
         params = {
-            'inference_server_url': os.environ.get('TGI_API_URL', None),
-            'model_kwargs': {}, # TODO: add model args
-            'max_new_tokens': 512,
-            'cache': None,
-            'temperature': 0.01,
-            'top_k': 10,
-            'top_p': 0.95,
-            'repetition_penalty': 1.03,
-            'streaming': True,
-            'verbose': False,
-            'callback_manager': CallbackManager([StreamingStdOutCallbackHandler()])
-        }        
+            "inference_server_url": os.environ.get("TGI_API_URL", None),
+            "model_kwargs": {},  # TODO: add model args
+            "max_new_tokens": 512,
+            "cache": None,
+            "temperature": 0.01,
+            "top_k": 10,
+            "top_p": 0.95,
+            "repetition_penalty": 1.03,
+            "streaming": True,
+            "verbose": False,
+            "callback_manager": CallbackManager([StreamingStdOutCallbackHandler()]),
+        }
         params.update(self.llm_params)  # override parameters
         self.llm = HuggingFaceTextGenInference(**params)
         self.logger.debug(
-            f"[{inspect.stack()[0][3]}] Hugging Face TGI LLM instance {self.llm}")
+            f"[{inspect.stack()[0][3]}] Hugging Face TGI LLM instance {self.llm}"
+        )
 
     def _bam_llm_instance(self):
         """BAM Research Lab"""
@@ -145,82 +155,98 @@ class LLMLoader:
             from genai.model import Model
             from genai.schemas import GenerateParams
         except e:
-            self.logger.error(f"ERROR: Missing ibm-generative-ai libraries. Skipping loading backend LLM.")
+            self.logger.error(
+                f"ERROR: Missing ibm-generative-ai libraries. Skipping loading backend LLM."
+            )
             return
         # BAM Research lab
         creds = Credentials(
-            api_key=self.llm_params.get('api_key') if self.llm_params.get(
-                'api_key') is not None else os.environ.get('BAM_API_KEY', None),
-            api_endpoint=self.llm_params.get('api_endpoint') if self.llm_params.get(
-                'api_endpoint') is not None else os.environ.get('BAM_API_URL', 'https://bam-api.res.ibm.com')
+            api_key=self.llm_params.get("api_key")
+            if self.llm_params.get("api_key") is not None
+            else os.environ.get("BAM_API_KEY", None),
+            api_endpoint=self.llm_params.get("api_endpoint")
+            if self.llm_params.get("api_endpoint") is not None
+            else os.environ.get("BAM_API_URL", "https://bam-api.res.ibm.com"),
         )
-        model_id = self.llm_params.get('model') if self.llm_params.get(
-            'model') is not None else os.environ.get('BAM_MODEL', None)
-        bam_params = {'decoding_method': "sample",
-                      'max_new_tokens': 512,
-                      'min_new_tokens': 1,
-                      'random_seed': 42,
-                      'top_k': 10,
-                      'top_p': 0.95,
-                      'repetition_penalty': 1.03,
-                      'temperature': 0.05
-                      }
+        model_id = (
+            self.llm_params.get("model")
+            if self.llm_params.get("model") is not None
+            else os.environ.get("BAM_MODEL", None)
+        )
+        bam_params = {
+            "decoding_method": "sample",
+            "max_new_tokens": 512,
+            "min_new_tokens": 1,
+            "random_seed": 42,
+            "top_k": 10,
+            "top_p": 0.95,
+            "repetition_penalty": 1.03,
+            "temperature": 0.05,
+        }
         bam_params.update(self.llm_params)  # override parameters
         # remove none BAM params from dictionary
-        for k in ['model','api_key','api_endpoint']:
+        for k in ["model", "api_key", "api_endpoint"]:
             _ = bam_params.pop(k, None)
         params = GenerateParams(**bam_params)
 
-        self.llm = LangChainInterface(
-            model=model_id,
-            params=params,
-            credentials=creds
-        )
-        self.logger.debug(
-            f"[{inspect.stack()[0][3]}] BAM LLM instance {self.llm}")
+        self.llm = LangChainInterface(model=model_id, params=params, credentials=creds)
+        self.logger.debug(f"[{inspect.stack()[0][3]}] BAM LLM instance {self.llm}")
 
     def _watson_llm_instance(self):
         self.logger.debug(f"[{inspect.stack()[0][3]}] Watson LLM instance")
         # WatsonX (requires WansonX libraries)
         try:
             from ibm_watson_machine_learning.foundation_models import Model
-            from ibm_watson_machine_learning.metanames import GenTextParamsMetaNames as GenParams
-            from ibm_watson_machine_learning.foundation_models.extensions.langchain import WatsonxLLM
+            from ibm_watson_machine_learning.metanames import (
+                GenTextParamsMetaNames as GenParams,
+            )
+            from ibm_watson_machine_learning.foundation_models.extensions.langchain import (
+                WatsonxLLM,
+            )
         except e:
-            self.logger.error(f"ERROR: Missing ibm_watson_machine_learning libraries. Skipping loading backend LLM.")
+            self.logger.error(
+                f"ERROR: Missing ibm_watson_machine_learning libraries. Skipping loading backend LLM."
+            )
             return
         # WatsonX uses different keys
         creds = {
             # example from https://heidloff.net/article/watsonx-langchain/
-            "url": self.llm_params.get('url') if self.llm_params.get(
-                'url') is not None else os.environ.get('WATSON_API_URL', None),
-            "apikey": self.llm_params.get('apikey') if self.llm_params.get(
-                'apikey') is not None else os.environ.get('WATSON_API_KEY', None)
+            "url": self.llm_params.get("url")
+            if self.llm_params.get("url") is not None
+            else os.environ.get("WATSON_API_URL", None),
+            "apikey": self.llm_params.get("apikey")
+            if self.llm_params.get("apikey") is not None
+            else os.environ.get("WATSON_API_KEY", None),
         }
         # WatsonX uses different mechanism for defining parameters
         params = {
-            GenParams.DECODING_METHOD: self.llm_params.get('decoding_method', 'sample'),
-            GenParams.MIN_NEW_TOKENS: self.llm_params.get('min_new_tokens', 1),
-            GenParams.MAX_NEW_TOKENS: self.llm_params.get('max_new_tokens',512),
-            GenParams.RANDOM_SEED: self.llm_params.get('random_seed', 42),
-            GenParams.TEMPERATURE: self.llm_params.get('temperature', 0.05),
-            GenParams.TOP_K: self.llm_params.get('top_k',10),
-            GenParams.TOP_P: self.llm_params.get('top_p',0.95),
+            GenParams.DECODING_METHOD: self.llm_params.get("decoding_method", "sample"),
+            GenParams.MIN_NEW_TOKENS: self.llm_params.get("min_new_tokens", 1),
+            GenParams.MAX_NEW_TOKENS: self.llm_params.get("max_new_tokens", 512),
+            GenParams.RANDOM_SEED: self.llm_params.get("random_seed", 42),
+            GenParams.TEMPERATURE: self.llm_params.get("temperature", 0.05),
+            GenParams.TOP_K: self.llm_params.get("top_k", 10),
+            GenParams.TOP_P: self.llm_params.get("top_p", 0.95),
             # https://www.ibm.com/docs/en/watsonx-as-a-service?topic=models-parameters
-            GenParams.REPETITION_PENALTY: self.llm_params.get('repeatition_penallty', 1.03)
+            GenParams.REPETITION_PENALTY: self.llm_params.get(
+                "repeatition_penallty", 1.03
+            ),
         }
         # WatsonX uses different parameter names
-        llm_model = Model(model_id=self.llm_params.get('model_id', os.environ.get('WATSON_MODEL', None)),
-                          credentials=creds,
-                          params=params,
-                          project_id=self.llm_params.get(
-                              'project_id', os.environ.get('WATSON_PROJECT_ID', None))
-                          )
+        llm_model = Model(
+            model_id=self.llm_params.get(
+                "model_id", os.environ.get("WATSON_MODEL", None)
+            ),
+            credentials=creds,
+            params=params,
+            project_id=self.llm_params.get(
+                "project_id", os.environ.get("WATSON_PROJECT_ID", None)
+            ),
+        )
         self.llm = WatsonxLLM(model=llm_model)
-        self.logger.debug(
-            f"[{inspect.stack()[0][3]}] Watson LLM instance {self.llm}")
+        self.logger.debug(f"[{inspect.stack()[0][3]}] Watson LLM instance {self.llm}")
 
     def status(self):
         import json
-        return json.dumps(self.llm.schema_json, indent=4)
 
+        return json.dumps(self.llm.schema_json, indent=4)

--- a/src/llms/llm_loader.py
+++ b/src/llms/llm_loader.py
@@ -1,14 +1,14 @@
-# workaround to disable UserWarning
 import warnings
-
-warnings.simplefilter("ignore", UserWarning)
+import os
+import inspect
 
 from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from langchain.callbacks.manager import CallbackManager
 
-import os, inspect
-
 from utils.logger import Logger
+
+# workaround to disable UserWarning
+warnings.simplefilter("ignore", UserWarning)
 
 
 class LLMLoader:
@@ -62,11 +62,10 @@ class LLMLoader:
     def _openai_llm_instance(self):
         self.logger.debug(f"[{inspect.stack()[0][3]}] Creating OpenAI LLM instance")
         try:
-            import openai
             from langchain.llms import OpenAI
-        except e:
+        except Exception:
             self.logger.error(
-                f"ERROR: Missing openai libraries. Skipping loading backend LLM."
+                "ERROR: Missing openai libraries. Skipping loading backend LLM."
             )
             return
         params = {
@@ -92,9 +91,9 @@ class LLMLoader:
         self.logger.debug(f"[{inspect.stack()[0][3]}] Creating Ollama LLM instance")
         try:
             from langchain.llms import Ollama
-        except e:
+        except Exception:
             self.logger.error(
-                f"ERROR: Missing ollama libraries. Skipping loading backend LLM."
+                "ERROR: Missing ollama libraries. Skipping loading backend LLM."
             )
             return
         params = {
@@ -121,9 +120,9 @@ class LLMLoader:
         )
         try:
             from langchain.llms import HuggingFaceTextGenInference
-        except e:
+        except Exception:
             self.logger.error(
-                f"ERROR: Missing HuggingFaceTextGenInference libraries. Skipping loading backend LLM."
+                "ERROR: Missing HuggingFaceTextGenInference libraries. Skipping loading backend LLM."
             )
             return
         params = {
@@ -152,11 +151,10 @@ class LLMLoader:
             # BAM Research lab
             from genai.extensions.langchain import LangChainInterface
             from genai.credentials import Credentials
-            from genai.model import Model
             from genai.schemas import GenerateParams
-        except e:
+        except Exception:
             self.logger.error(
-                f"ERROR: Missing ibm-generative-ai libraries. Skipping loading backend LLM."
+                "ERROR: Missing ibm-generative-ai libraries. Skipping loading backend LLM."
             )
             return
         # BAM Research lab
@@ -203,9 +201,9 @@ class LLMLoader:
             from ibm_watson_machine_learning.foundation_models.extensions.langchain import (
                 WatsonxLLM,
             )
-        except e:
+        except Exception:
             self.logger.error(
-                f"ERROR: Missing ibm_watson_machine_learning libraries. Skipping loading backend LLM."
+                "ERROR: Missing ibm_watson_machine_learning libraries. Skipping loading backend LLM."
             )
             return
         # WatsonX uses different keys

--- a/src/llms/llm_loader.py
+++ b/src/llms/llm_loader.py
@@ -1,0 +1,252 @@
+# workaround to disable UserWarning
+import warnings
+warnings.simplefilter("ignore", UserWarning)
+
+from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain.callbacks.manager import CallbackManager
+
+import os, inspect
+
+## append path of current caller when __main__
+if __name__ == '__main__':
+    import sys 
+    sys.path.insert(0,'')
+
+from utils.logger import Logger
+
+class LLMLoader:
+    """
+    Note: This class loads the LLM backend librearies if the specific LLM is loaded.
+    Known caveats: Currently supports a single instance/model per backend
+    """
+    def __init__(self, llm_backends=set(),
+                 inference_url=None,
+                 prompt_type=None,
+                 api_key=None,
+                 model=None, logger=None) -> None:
+        self.logger = logger if logger is not None else Logger("llm_loader").logger
+        # a set of backend LLMs to activate
+        self.llm_backends = set(os.environ.get('LLM_BACKENDS', {'ollama'})) if len(llm_backends) == 0 else llm_backends
+        # defalt LLM backend to use or use the first index from loaded ones
+        self.llm_default = os.environ.get('LLM_DEFAULT', list(self.llm_backends)[0])
+        self.llm = {}
+        self._set_llm_instance()
+
+    def _set_llm_instance(self, inference_url=None, api_key=None, model=None):
+        self.logger.debug(f"[{inspect.stack()[0][3]}] Loading LLM instances with default {self.llm_default}")
+
+        for backend in self.llm_backends:
+            self.logger.debug(f"Loading backend LLM {backend}")
+            match backend:
+                case 'openai':
+                    self._openai_llm_instance()
+                case 'ollama':
+                    self._ollama_llm_instance()
+                case 'tgi':
+                    self._tgi_llm_instance()
+                case 'watson':
+                    self._watson_llm_instance()
+                case 'bam':
+                    self._bam_llm_instance()
+                case _:
+                    self.logger.warning(f"WARNING: Unsupported LLM {backend}")
+
+    def _openai_llm_instance(self):
+        self.logger.debug(
+            f"[{inspect.stack()[0][3]}] Creating OpenAI LLM instance")
+        try:
+            import openai
+            from langchain.llms import OpenAI 
+        except e:
+            self.logger.error(f"ERROR: Missing openai libraries. Skipping loading backend LLM.")
+            return
+        params = {
+            'base_url': os.environ.get('OPENAI_API_URL', 'https://api.openai.com/v1'),
+            'api_key': os.environ.get('OPENAI_API_KEY', None),
+            'model': os.environ.get('OPENAI_MODEL', None),
+            'model_kwargs': {}, # TODO: add model args
+            'organization': os.environ.get('OPENAI_ORGANIZATION', None),
+            'timeout': os.environ.get('OPENAI_TIMEOUT', None),
+            'cache': None,
+            'streaming': True,            
+            'temperature': 0.01,
+            'max_tokens': 512,
+            'top_p': 0.95,
+            'frequency_penalty': 1.03,
+            'verbose': False
+        }
+        self.llm['openai']=OpenAI(**params)
+        self.logger.debug(
+            f"[{inspect.stack()[0][3]}] OpenAI LLM instance {self.llm['openai']}")
+
+    def _ollama_llm_instance(self):
+        self.logger.debug(
+            f"[{inspect.stack()[0][3]}] Creating Ollama LLM instance")
+        try:
+            from langchain.llms import Ollama 
+        except e:
+            self.logger.error(f"ERROR: Missing ollama libraries. Skipping loading backend LLM.")
+            return
+        params = {
+            'base_url': os.environ.get('OLLAMA_API_URL', "http://127.0.0.1:11434"),
+            'model': os.environ.get('OLLAMA_MODEL', 'Mistral'),
+            'cache': None,
+            'temperature': 0.01,
+            'top_k': 10,
+            'top_p': 0.95,
+            'repeat_penalty': 1.03,
+            'verbose': False,
+            'callback_manager': CallbackManager([StreamingStdOutCallbackHandler()])
+        }
+        self.llm['ollama'] = Ollama(**params)
+        self.logger.debug(
+            f"[{inspect.stack()[0][3]}] Ollama LLM instance {self.llm}")
+
+    def _tgi_llm_instance(self):
+        """
+        Note: TGI does not support specifying the model, it is an instance per model.
+        """
+        self.logger.debug(
+            f"[{inspect.stack()[0][3]}] Creating Hugging Face TGI LLM instance")
+        try:
+            from langchain.llms import HuggingFaceTextGenInference
+        except e:
+            self.logger.error(f"ERROR: Missing HuggingFaceTextGenInference libraries. Skipping loading backend LLM.")
+            return
+        params = {
+            'inference_server_url': os.environ.get('TGI_API_URL', None),
+            'model_kwargs': {}, # TODO: add model args
+            'max_new_tokens': 512,
+            'cache': None,
+            'temperature': 0.01,
+            'top_k': 10,
+            'top_p': 0.95,
+            'repetition_penalty': 1.03,
+            'streaming': True,
+            'verbose': False,
+            'callback_manager': CallbackManager([StreamingStdOutCallbackHandler()])
+        }        
+        self.llm['tgi'] = HuggingFaceTextGenInference(**params)
+        self.logger.debug(
+            f"[{inspect.stack()[0][3]}] Hugging Face TGI LLM instance {self.llm}")
+
+    def _bam_llm_instance(self):
+        """BAM Research Lab"""
+        self.logger.debug(f"[{inspect.stack()[0][3]}] BAM LLM instance")
+        try:
+            # BAM Research lab
+            from genai.extensions.langchain import LangChainInterface
+            from genai.credentials import Credentials
+            from genai.model import Model
+            from genai.schemas import GenerateParams
+        except e:
+            self.logger.error(f"ERROR: Missing ibm-generative-ai libraries. Skipping loading backend LLM.")
+            return
+        # BAM Research lab
+        creds = Credentials(
+                        api_key=os.environ.get('BAM_API_KEY', None),
+                        api_endpoint=os.environ.get('BAM_API_URL', 'https://bam-api.res.ibm.com')
+                        )
+        params = GenerateParams(decoding_method="sample",
+                                max_new_tokens=512,
+                                min_new_tokens=1,
+                                random_seed=42,
+                                top_k=10,
+                                top_p=0.95,
+                                repetition_penalty=1.03,
+                                temperature=0.05)
+        self.llm['bam'] = LangChainInterface(
+                                        model=os.environ.get('BAM_MODEL', None),
+                                        params=params,
+                                        credentials=creds
+                                        )
+        self.logger.debug(
+            f"[{inspect.stack()[0][3]}] BAM LLM instance {self.llm}")
+
+    def _watson_llm_instance(self):
+        self.logger.debug(f"[{inspect.stack()[0][3]}] Watson LLM instance")
+        # watsonX (requires WansonX libraries)
+        try:
+            from ibm_watson_machine_learning.foundation_models import Model
+            from ibm_watson_machine_learning.metanames import GenTextParamsMetaNames as GenParams
+            from ibm_watson_machine_learning.foundation_models.extensions.langchain import WatsonxLLM
+        except e:
+            self.logger.error(f"ERROR: Missing ibm_watson_machine_learning libraries. Skipping loading backend LLM.")
+            return
+        #
+        creds = {
+            # example from https://heidloff.net/article/watsonx-langchain/
+            "url": os.environ.get('WATSON_API_URL', None),
+            "apikey": os.environ.get('WATSON_API_KEY', None)
+        }
+        params = {
+            GenParams.DECODING_METHOD: "sample",
+            GenParams.MIN_NEW_TOKENS: 1,
+            GenParams.MAX_NEW_TOKENS: 512,
+            GenParams.RANDOM_SEED: 42,
+            GenParams.TEMPERATURE: 0.05,
+            GenParams.TOP_K: 10,
+            GenParams.TOP_P: 0.95,
+            # https://www.ibm.com/docs/en/watsonx-as-a-service?topic=models-parameters
+            GenParams.REPETITION_PENALTY: 1.03
+        }
+        llm_model = Model(model_id=os.environ.get('WATSON_MODEL', None),
+                          credentials=creds,
+                          params=params,
+                          project_id=os.environ.get('WATSON_PROJECT_ID', None)
+                          )
+        self.llm['watson'] = WatsonxLLM(model=llm_model)
+        self.logger.debug(
+            f"[{inspect.stack()[0][3]}] Watson LLM instance {self.llm}")
+
+    def status(self):
+        import json
+        return json.dumps(self.llm, indent=4)
+
+###
+# FOR LOCAL DEVELOPMENT
+###
+if __name__ == '__main__':
+    # only load for local development
+    from langchain.prompts import PromptTemplate
+    from langchain.chains import LLMChain
+    from utils.config import Config
+
+    config = Config()
+    #logger = config.logger
+
+    # prompt="What is Kubernetes?"
+    prompt = PromptTemplate(
+        input_variables=["question"],
+        template="""\
+            {question}
+            Instruction:
+            - You are a helpful assistant with expertise in OpenShift and Kubernetes.
+            - Do not address questions unrelated to Kubernetes or OpenShift.
+            - Refuse to participate in anything that could harm a human.
+            - Provide the answer for the question based on the given context.
+            - Refuse to answer questions unrelated to topics in Kubernetes or OpenShift.
+            - Prefer succinct answers with YAML examples.
+            Answer:
+            """,
+    )
+
+    llm_backends = {'ollama','tgi','openai','bam','watson'}
+    print(f"Loading LLM backends {llm_backends}")
+    llm_config = LLMLoader(llm_backends=llm_backends)
+
+    for backend in llm_backends:
+        print(f"{'#'*40}\n#### Testing LLM backend {backend}")
+
+        llm_chain = LLMChain(llm=llm_config.llm[backend], prompt=prompt)
+
+        q1 = "How to build an application in OpenShift"
+        print(f"# Test Prompt 1: {q1}")
+        print(llm_chain.run(q1))
+
+        # system should reject this request
+        q2 = "Tell me a joke"
+        print(f"# Test Prompt 2: {q2}")
+        print(llm_chain.run(q2))
+
+        print(f"#### Completed LLM backend {backend} ###")

--- a/src/llms/requirements.txt
+++ b/src/llms/requirements.txt
@@ -1,0 +1,4 @@
+openai
+ibm_watson_machine_learning
+ibm-generative-ai
+text_generation

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -74,10 +74,6 @@ class Logger:
         self.log_level = os.getenv("LOG_LEVEL", log_level)
         self.log_level_console = os.getenv("LOG_LEVEL_CONSOLE", self.log_level)
         _logfile = os.getenv("LOG_FILE_NAME")
-        if _logfile is not None and len(str(_logfile)) >= 1:
-            # enforce the use of logs/ directory
-            # use last token if user attemps to provide full paths
-            _logfile = "logs/" + str(_logfile).split("/")[-1]
         self.logfile = _logfile if _logfile else logfile
         self.logfile_maxSize = os.getenv("LOG_FILE_SIZE", (1048576 * 100))
         self.logfile_backupCount = 3


### PR DESCRIPTION
Abstracts the way we instantiate llms to a single module.

This needs a lot of followup work.

1) nothing is leveraging this to instantiate the LLMs at runtime
2) the configuration of the loader is lacking (e.g. you can't load multiple models per provider)

but this needs to get landed so I can include it when i land my config work.

Replaces https://github.com/openshift/lightspeed-service/pull/36 because William is on PTO and i don't want to sit on his PR over the break.


## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.