### PR TITLE
Catch JSON deserialization error for payload reading

### DIFF
--- a/src/ui/gradio_ui.py
+++ b/src/ui/gradio_ui.py
@@ -51,7 +51,7 @@ class gradioUI:
                 self.logger.info(f"Response text: {response.text}")
                 return "Sorry, an error occurred: " + response.text
 
-        except requests.RequestException as e:
+        except (ValueError, requests.RequestException) as e:
             # Handle any exceptions that may occur during the request
             return f"An error occurred: {e}"
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

During response payload retrieval and deserialization, any JSON deserialization exception can be thrown. We don't know/care which JSON library is used (it can be `simplejson` or `json`), but luckily for us, the ancestor of such exceptions is `ValueError`. So all we have to, is to catch this one.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Integration tests are not available right now
