### PR TITLE
Fix: log file size must be number, not a string

### DIFF
--- a/utils/logger.py
+++ b/utils/logger.py
@@ -75,7 +75,7 @@ class Logger:
         self.log_level_console = os.getenv("LOG_LEVEL_CONSOLE", self.log_level)
         _logfile = os.getenv("LOG_FILE_NAME")
         self.logfile = _logfile if _logfile else logfile
-        self.logfile_maxSize = os.getenv("LOG_FILE_SIZE", (1048576 * 100))
+        self.logfile_maxSize = int(os.getenv("LOG_FILE_SIZE", (1048576 * 100)))
         self.logfile_backupCount = 3
 
         self.set_handlers()


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fix: log file size must be number, not a string

How to check (using the same class `RotatingFileHandler` as in sources):

```bash
export LOG_FILE_SIZE=1234
```

```python
import os
from logging.handlers import RotatingFileHandler
logfile_maxSize = os.getenv("LOG_FILE_SIZE", (1048576 * 100))
print(logfile_maxSize, type(logfile_maxSize))
1234 <class 'str'>
RotatingFileHandler("some file", maxBytes=logfile_maxSize)
```

Throws/raises:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.8/logging/handlers.py", line 146, in __init__
    if maxBytes > 0:
TypeError: '>' not supported between instances of 'str' and 'int'
```

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Set the enviromnent variable `LOG_FILE_SIZE` and run the code
