### PR TITLE
Use proper HTTP protocol-related constants instead of magic constants

### DIFF
--- a/src/ui/gradio_ui.py
+++ b/src/ui/gradio_ui.py
@@ -42,7 +42,7 @@ class gradioUI:
             )
 
             # Check if the request was successful (status code 200)
-            if response.status_code == 200:
+            if response.status_code == requests.codes.ok:
                 self.logger.info("Response JSON:", response.json())
                 self.conversation_id = response.json().get("conversation_id")
                 return response.json().get("response")

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -1,4 +1,5 @@
 from fastapi.testclient import TestClient
+import requests
 
 
 from app.main import app
@@ -8,19 +9,19 @@ client = TestClient(app)
 
 def test_healthz():
     response = client.get("/healthz")
-    assert response.status_code == 200
+    assert response.status_code == requests.codes.ok
     assert response.json() == {"status": "1"}
 
 
 def test_readyz():
     response = client.get("/healthz")
-    assert response.status_code == 200
+    assert response.status_code == requests.codes.ok
     assert response.json() == {"status": "1"}
 
 
 def test_root():
     response = client.get("/")
-    assert response.status_code == 200
+    assert response.status_code == requests.codes.ok
     assert response.json() == {
         "message": "This is the default endpoint for OLS",
         "status": "running",
@@ -29,7 +30,7 @@ def test_root():
 
 def test_status():
     response = client.get("/")
-    assert response.status_code == 200
+    assert response.status_code == requests.codes.ok
     assert response.json() == {
         "message": "This is the default endpoint for OLS",
         "status": "running",
@@ -41,7 +42,7 @@ def test_feedback():
     response = client.post(
         "/feedback", json={"conversation_id": 1234, "feedback_object": "blah"}
     )
-    assert response.status_code == 200
+    assert response.status_code == requests.codes.ok
     assert response.json() == {"status": "feedback received"}
 
 
@@ -61,7 +62,7 @@ def test_raw_prompt(monkeypatch):
         "/ols/raw_prompt", json={"conversation_id": "1234", "query": "test query"}
     )
     print(response)
-    assert response.status_code == 200
+    assert response.status_code == requests.codes.ok
     assert response.json() == {
         "conversation_id": "1234",
         "query": "test query",


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Use proper HTTP protocol-related constants instead of magic constants
It will be checked by linters soon

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- The change is also part of integration tests, so will be tested itself ;)