### PR TITLE
[WIP] implements SSAR-based authentication check

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,7 @@
-from fastapi import FastAPI, Request
+import json
+import requests
+
+from fastapi import FastAPI, Request, JSONResponse
 
 from app.endpoints import feedback, ols
 from src.ui.gradio_ui import gradioUI
@@ -13,6 +16,103 @@ if config.enable_ui:
     app = gradioUI(logger=logger).mount_ui(app)
 else:
     logger.info("Embedded Gradio UI is disabled. To enable set OLS_ENABLE_UI=True")
+
+
+import os
+
+import kubernetes.client
+import kubernetes.utils
+
+
+@app.middleware("auth")
+async def auth_middleware(request: Request, call_next):
+    logger.info(f"performing auth check")
+    logger.info(f"request.url: {request.url}")
+
+    # TODO: this should not be done in the future! probably not even in debug mode.
+    logger.info(f"request.headers: {request.headers}")
+
+    # check env to see if auth checking should be performed
+    # TODO: move to config, properly boolean-ize
+    if os.getenv("OLS_AUTH_CHECK") == "False":
+        logger.info(f"auth checks disabled, skipping")
+        return await call_next(request)
+
+    # ignore auth for default routes and docs
+    # TODO: is there a way to programmatically determine which paths/routes we want to skip auth on?
+    if request.url.path in [
+        "/",
+        "/readyz",
+        "/healthz",
+        "/status",
+        "/docs",
+        "/openapi.json",
+    ]:
+        logger.info(f"ignoring default route for auth check")
+        return await call_next(request)
+
+    # not a default, so check if the user is authorized to use ols via the k8s auth
+
+    # if there's no authorization header, fail with noauth http error
+    if "authorization" not in request.headers:
+        logger.info(f"no auth header found")
+        return JSONResponse(
+            status_code=requests.codes.unauthorized,
+            content={"message": "no auth header found"},
+        )
+
+    logger.info(f"auth header found, checking k8s auth")
+
+    if not k8s_auth(request.headers["authorization"]):
+        return JSONResponse(
+            status_code=requests.codes.unauthorized,
+            content={"message": "not authorized to use ols service"},
+        )
+
+    # if we made it this far, they are authorized, so continue
+    logger.info(f"passed authorization check")
+    return await call_next(request)
+
+
+def k8s_auth(authorization) -> bool:
+    configuration = kubernetes.client.Configuration()
+
+    # strip the token from the header
+    # Configure API key authorization: BearerToken
+    configuration.api_key["authorization"] = authorization.split("Bearer ")[1]
+
+    # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+    configuration.api_key_prefix["authorization"] = "Bearer"
+
+    # Defining host is optional and default to http://localhost
+    configuration.host = os.getenv("K8S_CLUSTER_API")
+
+    # TODO: make configurable
+    # cluster is using a self-signed cert -- would need to inject CA information
+    configuration.verify_ssl = False
+
+    # create a k8s client using the supplied authentication information
+    k8s_client = kubernetes.client.ApiClient(configuration)
+
+    # create a self subject access review to determine if the user can access the lightspeed service
+    # TODO: this is currently checking a non-resource attribute path of `/ols` which is totally generic.
+    #       in the future we might want to restrict users to specific ols endpoints even and make this much
+    #       fancier
+    jsonstr = '{"apiVersion":"authorization.k8s.io/v1","kind":"SelfSubjectAccessReview","spec":{"nonResourceAttributes":{"path":"/ols","verb":"get"}}}'
+
+    # make a request to create the SSAR, whose return immediately contains the status of the check
+    jd = json.loads(jsonstr)
+
+    # TODO: if the client itself is unauthorized, this explodes. we probably want to separate creating and checking
+    #       the k8s client into its own method which can itself cause an unauthorized error
+    response = kubernetes.utils.create_from_dict(k8s_client, jd)
+
+    if response[0].status.allowed:
+        logger.info(f"passed authorization check")
+        return True
+    else:
+        logger.info(f"failed authorization check")
+        return False
 
 
 def include_routers(app: FastAPI):


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR is currently a science experiment that implements an in-cluster authentication check using SelfSubjectAccessReview and FastAPI middleware.

* It assumes that a `nonResourceURL` `clusterRole` has been created outside of OLS, a'la:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: ols-clusterrole
rules:
- nonResourceURLs: ["/ols"]
  verbs: ["get"]
  ```
* it assumes that a user or group has been given this cluster role
* it adds a requirement that a request hitting FastAPI/OLS must include an authorization header that is their Kubernetes API token
* it whitelists any of our default routes, like status checks, and only performs auth checks for everything else
* it supports globally disabling auth checks

This probably needs a lot of work before it could be merged, but it potentially replaces what we wanted to do with kube-rbac-proxy.

## Related Tickets & Documents
N/A

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
No tests, yet.