### PR TITLE
Verify project sources with Python 3.11 expected idioms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,6 @@ select = ["E", "F", "W", "C", "S"]
 # E501 rule checks for maximum line length
 ignore = ["E501"]
 
+target-version = "py311"
 line-length = 100
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update

## Description

Linters are able to detect some old and now non-standard patterns in the code. In order to do this its need to know the target Python version. So let's start with Python 3.11 as documented.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Will be done on CI
- You can use `make verify` as usual