### PR TITLE
Help in Makefile shown using `make help` phony target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,39 +6,39 @@
 ARTIFACT_DIR := $(if $(ARTIFACT_DIR),$(ARTIFACT_DIR),tests/test_results)
 
 
-images:
+images: ## Build container images
 	scripts/build-container.sh
 
-install-deps: 
+install-deps: ## Install all required dependencies needed to run the service
 	pip install -r requirements.txt
 
-install-deps-test:
+install-deps-test: ## Install all required dependencies needed to test the service
 	pip install -r requirements-test.txt
 
-run:
+run: ## Run the service locally
 	uvicorn app.main:app --reload --port 8080
 
-test: test-unit test-integration test-e2e
+test: test-unit test-integration test-e2e ## Run all tests
 
-test-unit:
+test-unit: ## Run the unit tests
 	@echo "Running unit tests..."
 	@echo "Reports will be written to ${ARTIFACT_DIR}"
 	python -m pytest tests/unit --cov=app --cov=src --cov=utils --cov-report term-missing --cov-report json:${ARTIFACT_DIR}/coverage_unit.json --junit-xml=${ARTIFACT_DIR}/junit_unit.xml
 	python scripts/transform_coverage_report.py ${ARTIFACT_DIR}/coverage_unit.json ${ARTIFACT_DIR}/coverage_unit.out
 
-test-integration:
+test-integration: ## Run integration tests tests
 	@echo "Running integration tests..."
 	@echo "Reports will be written to ${ARTIFACT_DIR}"
 	python -m pytest tests/integration --cov=app --cov=src --cov=utils --cov-report term-missing --cov-report json:${ARTIFACT_DIR}/coverage_integration.json --junit-xml=${ARTIFACT_DIR}/junit_integration.xml
 	python scripts/transform_coverage_report.py ${ARTIFACT_DIR}/coverage_integration.json ${ARTIFACT_DIR}/coverage_integration.out
 
-test-e2e:
+test-e2e: ## Run e2e tests
 	# Command to run e2e tests goes here
 
-format:
+format: ## Format the code into unified format
 	black .
 
-verify:
+verify: ## Verify the code using various linters
 	black . --check
 	ruff . --per-file-ignores=tests/*:S101
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Put targets here if there is a risk that a target name might conflict with a filename.
 # this list is probably overkill right now.
 # See: https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html
-.PHONY: test test-unit test-e2e images run format verify
+.PHONY: test test-unit test-e2e images run format verify help
 
 ARTIFACT_DIR := $(if $(ARTIFACT_DIR),$(ARTIFACT_DIR),tests/test_results)
 
@@ -41,4 +41,13 @@ format: ## Format the code into unified format
 verify: ## Verify the code using various linters
 	black . --check
 	ruff . --per-file-ignores=tests/*:S101
+
+help: ## Show this help screen
+	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
+	@echo ''
+	@echo 'Available targets are:'
+	@echo ''
+	@grep -E '^[ a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
+	@echo ''
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Put targets here if there is a risk that a target name might conflict with a filename.
 # this list is probably overkill right now.
 # See: https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html
-.PHONY: test test-unit test-e2e images run format verify help
+.PHONY: test test-unit test-e2e images run format verify
 
 ARTIFACT_DIR := $(if $(ARTIFACT_DIR),$(ARTIFACT_DIR),tests/test_results)
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [x] Documentation Update

## Description

Help in Makefile shown using `make help` phony target:

```$ make help
Usage: make <OPTIONS> ... <TARGETS>

Available targets are:

images                    Build container images
install-deps              Install all required dependencies needed to run the service
install-deps-test         Install all required dependencies needed to test the service
run                       Run the service locally
test                      Run all tests
test-unit                 Run the unit tests
test-integration          Run integration tests tests
format                    Format the code into unified format
verify                    Verify the code using various linters
help                      Show this help screen
```

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Just use `make help` from CLI
