### PR TITLE
Prevent double call of `file.close()`

### DIFF
--- a/scripts/transform_coverage_report.py
+++ b/scripts/transform_coverage_report.py
@@ -64,7 +64,6 @@ if __name__ == "__main__":
     try:
         with open(output_file_path, "w") as output_file:
             output_file.write("mode: set\n")
-            pass
 
         with open(json_file_path, "r") as json_file:
             json_content = json_file.read()

--- a/scripts/transform_coverage_report.py
+++ b/scripts/transform_coverage_report.py
@@ -23,7 +23,6 @@ def write_go_coverage_format(file_path, file_data, output_file):
 
         for line in missing_lines:
             f.write(f"{file_path}:{line}.0,{line + 1}.0 1 0\n")
-    f.close()
 
 
 def parse_coverage_json(json_content, output_file):
@@ -70,9 +69,6 @@ if __name__ == "__main__":
         with open(json_file_path, "r") as json_file:
             json_content = json_file.read()
             parse_coverage_json(json_content, output_file_path)
-
-        json_file.close()
-        output_file.close()
 
     except FileNotFoundError:
         print(f"File not found: {json_file_path}")


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Description

Prevent double call of `file.close()`
Actually Python ignores this call for already closed file, i.e. exception is not raised. But it is not correct to call close two times.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Unit tests passed locally.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- N/A, not covered by tests
