### PR TITLE
Use explicit verbose kwarg in question validator

### DIFF
--- a/src/query_helpers/question_validator.py
+++ b/src/query_helpers/question_validator.py
@@ -18,14 +18,14 @@ class QuestionValidator:
         """
         self.logger = Logger("question_validator").logger
 
-    def validate_question(self, conversation, query, **kwargs):
+    def validate_question(self, conversation: str, query: str, verbose: bool = False):
         """
         Validates a question and provides a one-word response.
 
         Args:
         - conversation (str): The identifier for the conversation or task context.
         - query (str): The question to be validated.
-        - **kwargs: Additional keyword arguments for customization.
+        - verbose (bool): If `LLMChain` should be verbose. Defaults to `False`.
 
         Returns:
         - list: A list of one-word responses.
@@ -33,7 +33,6 @@ class QuestionValidator:
 
         model = config.ols_config.validator_model
         provider = config.ols_config.validator_provider
-        verbose = kwargs.get("verbose", "").lower() == "true"
 
         settings_string = f"conversation: {conversation}, query: {query}, provider: {provider}, model: {model}, verbose: {verbose}"
         self.logger.info(f"{conversation} call settings: {settings_string}")


### PR DESCRIPTION
## Type of change

- [X] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Description

Use explicit kwarg (with default) instead of plain **kwargs. Once there is a need to make the `LLMChain` indirectly configurable via **kwargs, those should be passed directly to it (and documented in docstring) to avoid unnecessary complexity.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] Unit tests passed locally.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
