### PR TITLE
Imports statements are sorted + added new linter rule

### DIFF
--- a/app/endpoints/ols.py
+++ b/app/endpoints/ols.py
@@ -1,14 +1,14 @@
 from fastapi import APIRouter, HTTPException
 
+from app import constants
 from app.models.models import LLMRequest
 from app.utils import Utils
 from src.docs.docs_summarizer import DocsSummarizer
+from src.llms.llm_loader import LLMLoader
 from src.query_helpers.happy_response_generator import HappyResponseGenerator
 from src.query_helpers.question_validator import QuestionValidator
 from src.query_helpers.yaml_generator import YamlGenerator
 from utils import config
-from src.llms.llm_loader import LLMLoader
-from app import constants
 
 router = APIRouter(prefix="/ols", tags=["ols"])
 

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,6 @@ from app.endpoints import feedback, ols
 from src.ui.gradio_ui import gradioUI
 from utils import config
 
-
 app = FastAPI()
 
 # config = load_config(os.environ.get("OLS_CONFIG_FILE","olsconfig.yaml"))

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -1,6 +1,7 @@
 import logging
+from typing import Dict, Optional
+
 from pydantic import BaseModel
-from typing import Optional, Dict
 
 import src.constants as constants
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 
-select = ["E", "F", "W", "C", "S"]
+select = ["E", "F", "W", "C", "S", "I"]
 
 # E501 rule checks for maximum line length
 ignore = ["E501"]

--- a/src/cache/cache_factory.py
+++ b/src/cache/cache_factory.py
@@ -1,11 +1,11 @@
 # cache_factory.py
 
 
+from app.models.config import ConversationCacheConfig
 from src import constants
 from src.cache.cache import Cache
 from src.cache.in_memory_cache import InMemoryCache
 from src.cache.redis_cache import RedisCache
-from app.models.config import ConversationCacheConfig
 
 
 class CacheFactory:

--- a/src/docs/docs_summarizer.py
+++ b/src/docs/docs_summarizer.py
@@ -1,15 +1,14 @@
 import os
 
 import llama_index
-from llama_index import StorageContext, load_index_from_storage
-from llama_index.prompts import PromptTemplate
+from llama_index import ServiceContext, StorageContext, load_index_from_storage
 from llama_index.embeddings import TextEmbeddingsInference
-from llama_index import ServiceContext
+from llama_index.prompts import PromptTemplate
 
-from utils.logger import Logger
-from utils import config
-from src.llms.llm_loader import LLMLoader
 from src import constants
+from src.llms.llm_loader import LLMLoader
+from utils import config
+from utils.logger import Logger
 
 
 class DocsSummarizer:

--- a/src/llms/llm_loader.py
+++ b/src/llms/llm_loader.py
@@ -5,9 +5,9 @@ import warnings
 from langchain.callbacks.manager import CallbackManager
 from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
-from utils.logger import Logger
-from utils import config
 import src.constants as constants
+from utils import config
+from utils.logger import Logger
 
 # workaround to disable UserWarning
 warnings.simplefilter("ignore", UserWarning)
@@ -112,8 +112,8 @@ class LLMLoader:
         self.logger.debug(f"[{inspect.stack()[0][3]}] BAM LLM instance")
         try:
             # BAM Research lab
-            from genai.extensions.langchain import LangChainInterface
             from genai.credentials import Credentials
+            from genai.extensions.langchain import LangChainInterface
             from genai.schemas import GenerateParams
         except Exception:
             self.logger.error(

--- a/src/query_helpers/happy_response_generator.py
+++ b/src/query_helpers/happy_response_generator.py
@@ -1,10 +1,10 @@
 from langchain.chains import LLMChain
 from langchain.prompts import PromptTemplate
 
-from utils.logger import Logger
-from utils import config
-from src.llms.llm_loader import LLMLoader
 from src import constants
+from src.llms.llm_loader import LLMLoader
+from utils import config
+from utils.logger import Logger
 
 
 class HappyResponseGenerator:

--- a/src/query_helpers/question_validator.py
+++ b/src/query_helpers/question_validator.py
@@ -1,10 +1,10 @@
 from langchain.chains import LLMChain
 from langchain.prompts import PromptTemplate
 
-from utils.logger import Logger
-from utils import config
-from src.llms.llm_loader import LLMLoader
 from src import constants
+from src.llms.llm_loader import LLMLoader
+from utils import config
+from utils.logger import Logger
 
 
 class QuestionValidator:

--- a/src/query_helpers/yaml_generator.py
+++ b/src/query_helpers/yaml_generator.py
@@ -1,10 +1,10 @@
 from langchain.chains import LLMChain
 from langchain.prompts import PromptTemplate
 
-from utils.logger import Logger
-from utils import config
-from src.llms.llm_loader import LLMLoader
 from src import constants
+from src.llms.llm_loader import LLMLoader
+from utils import config
+from utils.logger import Logger
 
 
 class YamlGenerator:

--- a/src/query_helpers/yes_no_classifier.py
+++ b/src/query_helpers/yes_no_classifier.py
@@ -1,10 +1,10 @@
 from langchain.chains import LLMChain
 from langchain.prompts import PromptTemplate
 
-from utils.logger import Logger
-from utils import config
-from src.llms.llm_loader import LLMLoader
 from src import constants
+from src.llms.llm_loader import LLMLoader
+from utils import config
+from utils.logger import Logger
 
 
 class YesNoClassifier:

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -1,8 +1,8 @@
-from fastapi.testclient import TestClient
 import requests
+from fastapi.testclient import TestClient
 
-from app.main import app
 from app.endpoints import ols
+from app.main import app
 
 client = TestClient(app)
 
@@ -51,8 +51,8 @@ def test_raw_prompt(monkeypatch):
     # model_context is what imports LangChainInterface, so we have to mock that particular usage/"instance"
     # of it in our tests
 
-    from tests.mock_classes.llm_loader import mock_llm_loader
     from tests.mock_classes.langchain_interface import mock_langchain_interface
+    from tests.mock_classes.llm_loader import mock_llm_loader
 
     ml = mock_langchain_interface("test response")
 

--- a/tests/unit/test_cache_factory.py
+++ b/tests/unit/test_cache_factory.py
@@ -1,8 +1,8 @@
 import pytest
 
+from app.models.config import ConversationCacheConfig
 from src import constants
 from src.cache.cache_factory import CacheFactory, InMemoryCache
-from app.models.config import ConversationCacheConfig
 
 
 @pytest.fixture(scope="module")

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,12 +1,10 @@
-import os
 import logging
+import os
 
-
-import src.constants as constants
-from utils.logger import Logger
-from src.cache.cache_factory import CacheFactory
 import app.models.config as config_model
-
+import src.constants as constants
+from src.cache.cache_factory import CacheFactory
+from utils.logger import Logger
 
 ols_config = None
 llm_config = None


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Description

- Imports statements are sorted according to common Python standards (see below)
- Added new linter rule, so `make verify` will check for this problem

### Details

This rule is derived from the **isort** linter.

## What it does
De-duplicates, groups, and sorts imports based on the provided `isort` settings.

## Why is this bad?
Consistency is good. Use a common convention for imports to make your code
more readable and idiomatic.

## Example
```python
import pandas
import numpy as np
```

Use instead:
```python
import numpy as np
import pandas
```

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Unit tests passed locally.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- To be performed on CI
