### PR TITLE
Ability to export coverage report into interactive HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ logs/*
 
 # ignore test results
 tests/test_results/*
+htmlcov/
 .coverage
 
 # ignore cache directories

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ test-integration: ## Run integration tests tests
 test-e2e: ## Run e2e tests
 	# Command to run e2e tests goes here
 
+coverage-report:	test-unit ## Export unit test coverage report into interactive HTML
+	coverage html
+
 format: ## Format the code into unified format
 	black .
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Description

- New Makefile target to export code coverage report into interactive HTML
- It can then be viewed locally
- No need to export the resulting HTML

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Unit tests passed locally.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Run `make coverage-report` on CLI
