### PR TITLE
Really check line length on CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,10 @@
 
 select = ["E", "F", "W", "C", "S", "I", "TCH"]
 
-# E501 rule checks for maximum line length
-ignore = ["E501"]
+ignore = []
 
 target-version = "py311"
-line-length = 100
+line-length = 168
 
 [tool.coverage.report]
 # unit tests fails if the total coverage measurement is under this threshold value

--- a/src/constants.py
+++ b/src/constants.py
@@ -8,8 +8,11 @@ Summary:
 
 """
 
-SUMMARY_TASK_BREAKDOWN_TEMPLATE = """
-The following documentation contains a task list. Your job is to extract the list of tasks. If the user-supplied query seems unrelated to the list of tasks, please reply that you do not know what to do with the query and the summary documentation. Use only the supplied content and extract the task list.
+SUMMARY_TASK_BREAKDOWN_TEMPLATE = (
+    """
+The following documentation contains a task list. Your job is to extract the list of tasks. """
+    """If the user-supplied query seems unrelated to the list of tasks, please reply that you do not know what to do with the query and the summary documentation. """
+    """Use only the supplied content and extract the task list.
 
 Summary document:
 {context_str}
@@ -19,6 +22,7 @@ User query:
 
 What are the tasks?
 """
+)
 
 TASK_PERFORMER_PROMPT_TEMPLATE = """
 Instructions:


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Description

Really check line length on CI

The max.length has been set for CI not to fail for this moment.


## Related Tickets & Documents

- Related Issue #OCP-83

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Unit tests passed locally.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Done on CI or during `make verify`
