### PR TITLE
Added proper docstrings (that can be linted) into all existing unit tests

### DIFF
--- a/tests/unit/query_helpers/test_question_validator.py
+++ b/tests/unit/query_helpers/test_question_validator.py
@@ -1,3 +1,5 @@
+"""Unit tests for QuestionValidator class."""
+
 import pytest
 
 import src.query_helpers.question_validator
@@ -9,11 +11,13 @@ from utils import config
 
 @pytest.fixture
 def question_validator():
+    """Fixture containing constructed and initialized QuestionValidator."""
     config.load_empty_config()
     return QuestionValidator()
 
 
 def test_invalid_response(question_validator, monkeypatch):
+    """Test how invalid responses are handled by QuestionValidator."""
     # response not in the following set should generate a ValueError
     # [INVALID,NOYAML]
     # [VALID,NOYAML]
@@ -32,6 +36,7 @@ def test_invalid_response(question_validator, monkeypatch):
 
 
 def test_valid_responses(question_validator, monkeypatch):
+    """Test how valid responses are handled by QuestionValidator."""
     for retval in ["INVALID,NOYAML", "VALID,NOYAML", "VALID,YAML"]:
         ml = mock_llm_chain({"text": retval})
         monkeypatch.setattr(src.query_helpers.question_validator, "LLMChain", ml)

--- a/tests/unit/query_helpers/test_yes_no_classifier.py
+++ b/tests/unit/query_helpers/test_yes_no_classifier.py
@@ -1,3 +1,5 @@
+"""Unit tests for YesNoClassifier class."""
+
 import pytest
 
 import src.query_helpers.yes_no_classifier
@@ -8,10 +10,12 @@ from tests.mock_classes.llm_loader import mock_llm_loader
 
 @pytest.fixture
 def yes_no_classifier():
+    """Fixture containing constructed and initialized YesNoClassifier."""
     return YesNoClassifier()
 
 
 def test_bad_value_response(yes_no_classifier, monkeypatch):
+    """Test how YesNoClassifier handles improper responses."""
     # response that isn't 1, 0, or 9 should generate a ValueError
     ml = mock_llm_chain({"text": "default"})
 
@@ -25,6 +29,7 @@ def test_bad_value_response(yes_no_classifier, monkeypatch):
 
 
 def test_good_value_response(yes_no_classifier, monkeypatch):
+    """Test how YesNoClassifier handles proper responses."""
     # response that is 1, 0, or 9 should return the value
     for x in ["0", "1", "9"]:
         ml = mock_llm_chain({"text": x})

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,3 +1,5 @@
+"""Unit tests for InMemoryCache class."""
+
 import pytest
 
 from src.cache.in_memory_cache import InMemoryCache
@@ -5,23 +7,28 @@ from src.cache.in_memory_cache import InMemoryCache
 
 @pytest.fixture
 def cache():
-    c = InMemoryCache(10)
-    c.initialize_cache(10)
+    """Fixture with constucted and initialized in memory cache object."""
+    cache_size = 10
+    c = InMemoryCache(cache_size)
+    c.initialize_cache(cache_size)
     return c
 
 
 def test_insert_or_append(cache):
+    """Test the behavior of insert_or_append method."""
     cache.insert_or_append("key1", "value1")
     assert cache.get("key1") == "value1"
 
 
 def test_insert_or_append_existing_key(cache):
+    """Test the behavior of insert_or_append method for existing item."""
     cache.insert_or_append("key1", "value1")
     cache.insert_or_append("key1", "value2")
     assert cache.get("key1") == "value1\nvalue2"
 
 
 def test_insert_or_append_overflow(cache):
+    """Test if items in cache with defined capacity is handled correctly."""
     capacity = 5
     cache.capacity = capacity
     for i in range(capacity + 1):
@@ -36,10 +43,12 @@ def test_insert_or_append_overflow(cache):
 
 
 def test_get_nonexistent_key(cache):
+    """Test how non-existent items are handled by the cache."""
     assert cache.get("nonexistent_key") is None
 
 
 def test_singleton_pattern():
+    """Test if in memory cache exists as one instance in memory."""
     cache1 = InMemoryCache(10)
     cache2 = InMemoryCache(10)
     assert cache1 is cache2

--- a/tests/unit/test_cache_factory.py
+++ b/tests/unit/test_cache_factory.py
@@ -1,3 +1,5 @@
+"""Unit tests for CacheFactory class."""
+
 import pytest
 
 from app.models.config import ConversationCacheConfig
@@ -7,6 +9,7 @@ from src.cache.cache_factory import CacheFactory, InMemoryCache
 
 @pytest.fixture(scope="module")
 def in_memory_cache_config():
+    """Fixture containing initialized instance of ConversationCacheConfig."""
     # os.environ["OLS_CONVERSATION_CACHE"] = constants.IN_MEMORY_CACHE
     c = ConversationCacheConfig(
         {
@@ -19,6 +22,7 @@ def in_memory_cache_config():
 
 @pytest.fixture(scope="module")
 def invalid_cache_type_config():
+    """Fixture containing instance of ConversationCacheConfig with improper settings."""
     # os.environ["OLS_CONVERSATION_CACHE"] = "foo bar baz"
     c = ConversationCacheConfig()
     c.type = "foo bar baz"


### PR DESCRIPTION
…ests

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Docstrings, tests

## Description

Added proper docstrings (that can be linted) into all existing unit tests

## Related Tickets & Documents

- Related Issue #[OLS-83](https://issues.redhat.com//browse/OLS-83)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Unit tests passed locally.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Ruff with `[D]` rules enabled can do it: `ruff tests/unit`
