### PR TITLE
Docstrings in all integration tests

### DIFF
--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -1,3 +1,5 @@
+"""Integration tests for REST API endpoints for providing user feedback."""
+
 import requests
 from fastapi.testclient import TestClient
 
@@ -7,6 +9,7 @@ client = TestClient(app)
 
 
 def test_feedback() -> None:
+    """Check if feedback with correct format is accepted by the service."""
     # TODO: should we validate that the correct log messages are written?
     response = client.post(
         "/feedback", json={"conversation_id": 1234, "feedback_object": "blah"}
@@ -16,6 +19,7 @@ def test_feedback() -> None:
 
 
 def test_feedback_wrong_request() -> None:
+    """Check if feedback with wrong payload (empty one) is not accepted by the service."""
     response = client.post("/feedback", json={})
     # for the request send w/o proper payload, the server
     # should respond with proper error code
@@ -23,6 +27,7 @@ def test_feedback_wrong_request() -> None:
 
 
 def test_feedback_wrong_not_filled_in_request() -> None:
+    """Check if feedback without feedback object is not accepted by the service."""
     response = client.post(
         "/feedback", json={"conversation_id": 0, "feedback_object": None}
     )

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -1,3 +1,5 @@
+"""Integration tests for basic OLS REST API endpoints."""
+
 import requests
 from fastapi.testclient import TestClient
 
@@ -10,18 +12,21 @@ client = TestClient(app)
 
 
 def test_healthz() -> None:
+    """Test handler for /healthz REST API endpoint."""
     response = client.get("/healthz")
     assert response.status_code == requests.codes.ok
     assert response.json() == {"status": "1"}
 
 
 def test_readyz() -> None:
+    """Test handler for /readyz REST API endpoint."""
     response = client.get("/readyz")
     assert response.status_code == requests.codes.ok
     assert response.json() == {"status": "1"}
 
 
 def test_root() -> None:
+    """Test handler for / REST API endpoint."""
     response = client.get("/")
     assert response.status_code == requests.codes.ok
     assert response.json() == {
@@ -31,6 +36,7 @@ def test_root() -> None:
 
 
 def test_status() -> None:
+    """Test handler for /status REST API endpoint."""
     response = client.get("/status")
     assert response.status_code == requests.codes.ok
     assert response.json() == {
@@ -40,6 +46,7 @@ def test_status() -> None:
 
 
 def test_raw_prompt(monkeypatch) -> None:
+    """Check the REST API /ols/raw_prompt with POST HTTP method when expected payload is posted."""
     # the raw prompt should just return stuff from LangChainInterface, so mock that base method
     # model_context is what imports LangChainInterface, so we have to mock that particular usage/"instance"
     # of it in our tests
@@ -65,7 +72,6 @@ def test_raw_prompt(monkeypatch) -> None:
 
 def test_post_question_on_unexpected_payload() -> None:
     """Check the REST API /ols/ with POST HTTP method when unexpected payload is posted."""
-
     response = client.post("/ols/", json="this is really not proper payload")
     print(response)
     assert response.status_code == requests.codes.unprocessable


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Docstrings, tests 

## Description

Docstrings in all integration tests

## Related Tickets & Documents

- Related Issue #[OLS-83](https://issues.redhat.com//browse/OLS-83)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Unit tests passed locally.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Ruff with `[D]` rules enabled can do it: `ruff tests/unit`
