### PR TITLE
Docstrings in all mocks classes

### DIFF
--- a/tests/mock_classes/__init__.py
+++ b/tests/mock_classes/__init__.py
@@ -1,0 +1,1 @@
+"""Mocks that are used in unit tests."""

--- a/tests/mock_classes/langchain_interface.py
+++ b/tests/mock_classes/langchain_interface.py
@@ -1,6 +1,11 @@
+"""Mock for LangChainInterface to be used in unit tests."""
+
+
 def mock_langchain_interface(retval):
+    """Constructs mock for LangChainInterface."""
+
     class MockLangChainInterface:
-        """Mock LangChainInterface class for testing
+        """Mock LangChainInterface class for testing.
 
         Example usage in a test:
 

--- a/tests/mock_classes/llm_chain.py
+++ b/tests/mock_classes/llm_chain.py
@@ -1,6 +1,11 @@
+"""Mock for LLMChain to be used in unit tests."""
+
+
 def mock_llm_chain(retval):
+    """Constructs mock for LLMChain."""
+
     class MockLLMChain:
-        """Mock LLMChain class for testing
+        """Mock LLMChain class for testing.
 
         Example usage in a test:
 

--- a/tests/mock_classes/llm_loader.py
+++ b/tests/mock_classes/llm_loader.py
@@ -1,9 +1,17 @@
+"""Mock for LLMLoader to be used in unit tests."""
+
+
 class MockLLMLoader:
+    """Mock for LLMLoader."""
+
     def __init__(self, llm=None):
+        """Constructor that just stores the selected LLM into object's attribute."""
         self.llm = llm
 
 
 def mock_llm_loader(llm=None):
+    """Constructs mock for LLMLoader."""
+
     def loader(*args, **kwargs):
         return MockLLMLoader(llm)
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Docstrings, tests

## Description

Docstrings in all mocks classes

## Related Tickets & Documents

- Related Issue #[OLS-83](https://issues.redhat.com//browse/OLS-83)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Unit tests passed locally.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Ruff with `[D]` rules enabled can do it: `ruff tests/unit`
