### PR TITLE
Use Path module

### DIFF
--- a/tests/unit/utils/test_logger.py
+++ b/tests/unit/utils/test_logger.py
@@ -1,17 +1,19 @@
+"""Unit tests for Logger class."""
+
 import logging
-import os
+from pathlib import Path
 from tempfile import gettempdir
 
 from utils.logger import Logger
 
 # log file should be stored in temporary directory
-log_file_name = os.path.join(gettempdir(), "test.log")
+log_file_name = Path(gettempdir()).joinpath("test.log")
 
 
 def remove_logfile():
     """Remove logfile, if exists."""
-    if os.path.exists(log_file_name):
-        os.remove(log_file_name)
+    if log_file_name.exists():
+        log_file_name.unlink()
 
 
 def setup_function(function):
@@ -72,6 +74,6 @@ def test_logging_to_file():
     logging.shutdown()
 
     # check if the message has been logged properly
-    with open(log_file_name, "r") as fin:
+    with log_file_name.open("r") as fin:
         content = fin.read()
         assert "Info message" in content


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Description

`pathlib` offers a high-level API for path manipulation, as compared to
the lower-level API offered by `os`. When possible, using `Path` object
methods such as `Path.joinpath()` or the `/` operator can improve
readability over the `os` module's counterparts (e.g., `os.path.join()`).

### References
- [Python documentation: `PurePath.joinpath`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.joinpath)
- [Python documentation: `os.path.join`](https://docs.python.org/3/library/os.path.html#os.path.join)
- [PEP 428](https://peps.python.org/pep-0428/)
- [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
- [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
- [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)

## Related Tickets & Documents

- Related Issue #[OLS-83](https://issues.redhat.com//browse/OLS-83)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- To be done on CI
