### PR TITLE
Don't need to use aliases during import

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 
 from pydantic import BaseModel
 
-import ols.src.constants as constants
+from ols.src import constants
 
 
 class ModelConfig(BaseModel):

--- a/ols/src/indexer/indexer.py
+++ b/ols/src/indexer/indexer.py
@@ -6,7 +6,7 @@ from llama_index import ServiceContext, SimpleDirectoryReader, VectorStoreIndex
 from llama_index.embeddings import TextEmbeddingsInference
 from llama_index.storage.storage_context import StorageContext
 
-import ols.src.constants as constants
+from ols.src import constants
 
 llama_index.set_global_handler("simple")
 

--- a/ols/src/llms/llm_loader.py
+++ b/ols/src/llms/llm_loader.py
@@ -6,7 +6,7 @@ from typing import Optional
 from langchain.callbacks.manager import CallbackManager
 from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
-import ols.src.constants as constants
+from ols.src import constants
 from ols.utils import config
 from ols.utils.logger import Logger
 

--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 import ols.app.models.config as config_model
-import ols.src.constants as constants
+from ols.src import constants
 from ols.src.cache.cache_factory import CacheFactory
 from ols.utils.logger import Logger
 


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Description

- Don't need to use aliases during import

## Why:

Using the `from` keyword to import the submodule is more concise and
readable.

## Related Tickets & Documents

- Related Issue #[OLS-83](https://issues.redhat.com//browse/OLS-83)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- N/A
