### PR TITLE
Don't need to call `str` inside f-strings

### DIFF
--- a/ols/src/docs/docs_summarizer.py
+++ b/ols/src/docs/docs_summarizer.py
@@ -66,7 +66,7 @@ class DocsSummarizer:
         )
 
         self.logger.info(
-            f"{conversation} using embed model: {str(service_context.embed_model)}"
+            f"{conversation} using embed model: {service_context.embed_model!s}"
         )
 
         # TODO get this from global config
@@ -99,7 +99,7 @@ class DocsSummarizer:
             ]
         )
 
-        self.logger.info(f"{conversation} Summary response: {str(summary)}")
+        self.logger.info(f"{conversation} Summary response: {summary!s}")
         self.logger.info(f"{conversation} Referenced documents: {referenced_documents}")
 
         return str(summary), referenced_documents

--- a/ols/src/llms/llm_loader.py
+++ b/ols/src/llms/llm_loader.py
@@ -69,7 +69,7 @@ class LLMLoader:
             case constants.PROVIDER_BAM:
                 self._bam_llm_instance()
             case _:
-                self.logger.error(f"ERROR: Unsupported LLM {str(self.llm_backend)}")
+                self.logger.error(f"ERROR: Unsupported LLM {self.llm_backend!s}")
 
     def _openai_llm_instance(self):
         self.logger.debug(f"[{inspect.stack()[0][3]}] Creating OpenAI LLM instance")

--- a/ols/src/query_helpers/happy_response_generator.py
+++ b/ols/src/query_helpers/happy_response_generator.py
@@ -49,6 +49,6 @@ class HappyResponseGenerator:
 
         response = llm_chain(inputs={"question": user_question})
 
-        self.logger.info(f"{conversation} happy response: {str(response['text'])}")
+        self.logger.info(f"{conversation} happy response: {response['text']!s}")
 
         return str(response["text"])

--- a/ols/src/ui/gradio_ui.py
+++ b/ols/src/ui/gradio_ui.py
@@ -23,7 +23,7 @@ class gradioUI:
         # Headers for the HTTP request
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
 
-        self.logger.info(f"Using history: {str(use_history)}")
+        self.logger.info(f"Using history: {use_history!s}")
         # Body of the request (a JSON object with a "query" field)
 
         data = {"query": prompt}


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Description

Don't need to call `str` inside f-strings

f-strings support dedicated conversion flags for these types, which are
more succinct and idiomatic. In many cases, calling `str()` within an f-string is
unnecessary and can be removed entirely, as the value will be converted
to a string automatically,

## Related Tickets & Documents

- Related Issue #[OLS-83](https://issues.redhat.com//browse/OLS-83)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ x PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- To be done on CI
