### PR TITLE
OLS-186: Use `@patch` instead of monkeypatch

### DIFF
--- a/tests/unit/query_helpers/test_question_validator.py
+++ b/tests/unit/query_helpers/test_question_validator.py
@@ -1,8 +1,9 @@
 """Unit tests for QuestionValidator class."""
 
+from unittest.mock import patch
+
 import pytest
 
-import ols.src.query_helpers.question_validator
 from ols.src.query_helpers.question_validator import QuestionValidator
 from ols.utils import config
 from tests.mock_classes.llm_chain import mock_llm_chain
@@ -16,18 +17,17 @@ def question_validator():
     return QuestionValidator()
 
 
-def test_invalid_response(question_validator, monkeypatch):
+@patch(
+    "ols.src.query_helpers.question_validator.LLMChain",
+    new=mock_llm_chain({"text": "default"}),
+)
+@patch("ols.src.query_helpers.question_validator.LLMLoader", new=mock_llm_loader(None))
+def test_invalid_response(question_validator):
     """Test how invalid responses are handled by QuestionValidator."""
     # response not in the following set should generate a ValueError
     # [INVALID,NOYAML]
     # [VALID,NOYAML]
     # [VALID,YAML]
-
-    ml = mock_llm_chain({"text": "default"})
-    monkeypatch.setattr(ols.src.query_helpers.question_validator, "LLMChain", ml)
-    monkeypatch.setattr(
-        ols.src.query_helpers.question_validator, "LLMLoader", mock_llm_loader()
-    )
 
     with pytest.raises(ValueError):
         question_validator.validate_question(
@@ -35,17 +35,16 @@ def test_invalid_response(question_validator, monkeypatch):
         )
 
 
-def test_valid_responses(question_validator, monkeypatch):
+@patch("ols.src.query_helpers.question_validator.LLMLoader", new=mock_llm_loader(None))
+def test_valid_responses(question_validator):
     """Test how valid responses are handled by QuestionValidator."""
     for retval in ["INVALID,NOYAML", "VALID,NOYAML", "VALID,YAML"]:
+        # basically `@patch` and `with patch():` do the same thing, but the latter
+        # allow us to change the class/method/function behaviour in runtime
         ml = mock_llm_chain({"text": retval})
-        monkeypatch.setattr(ols.src.query_helpers.question_validator, "LLMChain", ml)
-        monkeypatch.setattr(
-            ols.src.query_helpers.question_validator, "LLMLoader", mock_llm_loader()
-        )
+        with patch("ols.src.query_helpers.question_validator.LLMChain", new=ml):
+            response = question_validator.validate_question(
+                conversation="1234", query="What is the meaning of life?"
+            )
 
-        response = question_validator.validate_question(
-            conversation="1234", query="What is the meaning of life?"
-        )
-
-        assert response == retval.split(",")
+            assert response == retval.split(",")


### PR DESCRIPTION
## Type of change

- [x] PoC
- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Description

PoC: use patch instead of monkeypatch

