### PR TITLE
OLS-186: No `pass` for abstract methods

### DIFF
--- a/ols/src/cache/cache.py
+++ b/ols/src/cache/cache.py
@@ -17,7 +17,6 @@ class Cache(ABC):
         Returns:
             Union[str, None]: The value associated with the key, or None if not found.
         """
-        pass
 
     @abstractmethod
     def insert_or_append(self, key: str, value: str) -> None:
@@ -30,4 +29,3 @@ class Cache(ABC):
         Returns:
             None
         """
-        pass


### PR DESCRIPTION
## Description

- No `pass` for abstract methods
- Actually those methods have bodies - the docstring (it is regular expression)
- Unit test and integration test code coverage will be more precise (higher ;)

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-186](https://issues.redhat.com//browse/OLS-186)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
