### PR TITLE
OLS-186: Docs summarizer unit tests

### DIFF
--- a/tests/mock_classes/mock_llama_index.py
+++ b/tests/mock_classes/mock_llama_index.py
@@ -1,0 +1,16 @@
+"""Mocked (llama) index."""
+
+from .mock_query_engine import MockQueryEngine
+
+
+class MockLlamaIndex:
+    """Mocked (llama) index."""
+
+    def __init__(self, *args, **kwargs):
+        """Constructor accepting all parameters."""
+        self.args = args
+        self.kwargs = kwargs
+
+    def as_query_engine(self, **kwargs):
+        """Returns mocked query engine."""
+        return MockQueryEngine(kwargs)

--- a/tests/mock_classes/mock_query_engine.py
+++ b/tests/mock_classes/mock_query_engine.py
@@ -1,0 +1,16 @@
+"""Mocked query engine."""
+
+from .mock_summary import MockSummary
+
+
+class MockQueryEngine:
+    """Mocked query engine."""
+
+    def __init__(self, *args, **kwargs):
+        """Constructor accepting all parameters."""
+        self.args = args
+        self.kwargs = kwargs
+
+    def query(self, query):
+        """Returns summary for given query."""
+        return MockSummary(query)

--- a/tests/mock_classes/mock_summary.py
+++ b/tests/mock_classes/mock_summary.py
@@ -1,0 +1,14 @@
+"""Mocked summary returned from query engine."""
+
+
+class MockSummary:
+    """Mocked summary returned from query engine."""
+
+    def __init__(self, query, nodes=[]):
+        """Constructor that initializes all required object attributes."""
+        self.query = query
+        self.source_nodes = nodes
+
+    def __str__(self):
+        """String representation that is used by DocsSummarizer."""
+        return f"Summary for query '{self.query}'"

--- a/tests/unit/docs/test_doc_summarizer.py
+++ b/tests/unit/docs/test_doc_summarizer.py
@@ -1,0 +1,24 @@
+"""Unit tests for DocsSummarizer class."""
+
+import os
+from unittest.mock import patch
+
+from ols.src.docs.docs_summarizer import DocsSummarizer
+from ols.utils import config
+from tests.mock_classes.llm_loader import mock_llm_loader
+from tests.mock_classes.mock_llama_index import MockLlamaIndex
+
+
+@patch("ols.src.docs.docs_summarizer.LLMLoader", new=mock_llm_loader(None))
+@patch("ols.src.docs.docs_summarizer.ServiceContext.from_defaults")
+@patch("ols.src.docs.docs_summarizer.StorageContext.from_defaults")
+@patch("ols.src.docs.docs_summarizer.load_index_from_storage", new=MockLlamaIndex)
+@patch.dict(os.environ, {"TEI_SERVER_URL": "localhost"}, clear=True)
+def test_summarize(storage_context, service_context):
+    """Basic test for DocsSummarizer using mocked index and query engine."""
+    config.load_empty_config()
+    summarizer = DocsSummarizer()
+    question = "What's the ultimate question with answer 42?"
+    summary, documents = summarizer.summarize("1234", question)
+    assert question in summary
+    assert len(documents) == 0


### PR DESCRIPTION
## Description

- Docs sumarizer unit tests + required mock objects
- Actually the DocsSummarizer just call several constructors and methods in top-down approach w/o any control flow. So it is hard to actually test it's correct behavior (probably with better mocks later?). I'd suggest to have better integration tests instead.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Unit tests

## Related Tickets & Documents

- Related Issue #[OLS-186](https://issues.redhat.com//browse/OLS-186)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Unit tests on CI
