### PR TITLE
OLS-83: Docstyle checks on CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 
-select = ["E", "F", "W", "C", "S", "I", "TCH"]
+select = ["D", "E", "F", "W", "C", "S", "I", "TCH"]
 
 ignore = []
 


### PR DESCRIPTION
## Description

No all docstrings are present in the code, so it is the right time to enable docstyle checks on CI and also during `make verify`. All what is needed is to enable all `D` rules in Ruff.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-83](https://issues.redhat.com//browse/OLS-83)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Done on CI
- Use `make verify`
