### PR TITLE
OLS-83: Specify optional types where it is needed

### DIFF
--- a/ols/src/query_helpers/yaml_generator.py
+++ b/ols/src/query_helpers/yaml_generator.py
@@ -17,7 +17,7 @@ class YamlGenerator:
         self.logger = Logger("yaml_generator").logger
 
     def generate_yaml(
-        self, conversation_id: str, query: str, history: str = None, **kwargs
+        self, conversation_id: str, query: str, history: str | None = None, **kwargs
     ) -> str:
         """Generates YAML response to a user request.
 

--- a/ols/utils/logger.py
+++ b/ols/utils/logger.py
@@ -41,8 +41,8 @@ class Logger:
     def __init__(
         self,
         logger_name: str = "default",
-        log_level: int = logging.INFO,
-        logfile: str = None,
+        log_level: str = logging.getLevelName(logging.INFO),
+        logfile: str | None = None,
         show_message: bool = False,
     ):
         """Initializes the Logger instance.


### PR DESCRIPTION
## Description

It is now required (PEP-484) that all optional types need to be specified explicitly.
Additionally, log level can be specified as int or as string
This PR fixes some errors reported by mypy/Pyright

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-83](https://issues.redhat.com//browse/OLS-83)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Use mypy or Pyright
