### PR TITLE
OLS-83: Fixed logic in invalid state checks

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -111,11 +111,10 @@ def ols_request(llm_request: LLMRequest) -> dict:
                     llm_request.query + "\n\n" + str(llm_response.response or ""),
                 )
             return llm_response
-    else:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"response": "Internal server error. Please try again."},
-        )
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail={"response": "Internal server error. Please try again."},
+    )
 
 
 @router.post("/raw_prompt")


### PR DESCRIPTION
## Description

This might seem to be tricky one, but this change helps a lot linters and other code analyzers. Those tools are unable to infer that there are only two states: valid and invalid. So they write an error that the function does not contains `return` or `raise` in all possible branches. This fix fixes it and make clear, that exception is raised in all conditions that are not strictly valid.

## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-83](https://issues.redhat.com//browse/OLS-83)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Integration tests take this into case (at least partially)
