### PR TITLE
OSL-83: No need for optional config values - just use default values

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -82,8 +82,8 @@ class RedisConfig(BaseModel):
 
     host: Optional[str] = None
     port: Optional[int] = None
-    max_memory: Optional[str] = None
-    max_memory_policy: Optional[str] = None
+    max_memory: str = constants.REDIS_CACHE_MAX_MEMORY
+    max_memory_policy: str = constants.REDIS_CACHE_MAX_MEMORY_POLICY
 
     def __init__(self, data: Optional[dict] = None):
         """Initialize configuration and perform basic validation."""
@@ -101,7 +101,7 @@ class RedisConfig(BaseModel):
 class MemoryConfig(BaseModel):
     """In-memory cache configuration."""
 
-    max_entries: Optional[int] = None
+    max_entries: int = constants.IN_MEMORY_CACHE_MAX_ENTRIES
 
     def __init__(self, data: Optional[dict] = None):
         """Initialize configuration and perform basic validation."""


### PR DESCRIPTION
## Description

There's no need for optional config values - just use default values. It seems like o "local" change, but strong type checkers would require explicit tests for `is not None` everywhere the values are used. Which is innapropriate as we know, that these values will be set to default ones later.

<!--- Describe your changes in detail -->

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #OLS-83

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
