### PR TITLE
Fix ols endpoint return type

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -15,7 +15,7 @@ router = APIRouter(prefix="/ols", tags=["ols"])
 
 
 @router.post("")
-def ols_request(llm_request: LLMRequest) -> dict:
+def ols_request(llm_request: LLMRequest) -> LLMRequest:
     """Handle requests for the OLS endpoint.
 
     Args:


### PR DESCRIPTION
## Description

When I'm asking "write a deployment yaml for the mongodb image" with OpenAI. The server failed on validation as the type was dict but actually `LLMRequest` was returned.

## Type of change

- [X] Bug fix

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] PR has passed all pre-merge test jobs.

