### PR TITLE
OLS-83: Improved improper LLM model configuration checks

### DIFF
--- a/tests/unit/llms/test_llm_loader.py
+++ b/tests/unit/llms/test_llm_loader.py
@@ -3,19 +3,56 @@
 import pytest
 
 from ols import constants
-from ols.src.llms.llm_loader import LLMLoader, UnsupportedProvider
+from ols.app.models.config import LLMConfig, ProviderConfig
+from ols.src.llms.llm_loader import (
+    LLMLoader,
+    MissingModel,
+    MissingProvider,
+    ModelConfigMissingException,
+    UnsupportedProvider,
+)
+from ols.utils import config
 
 
 def test_constructor_no_provider():
     """Test that constructor checks for provider."""
-    # we use bare Exception in the code, so need to check
-    # message, at least
-    with pytest.raises(Exception, match="ERROR: Missing provider"):
+    with pytest.raises(MissingProvider, match="Missing provider"):
         LLMLoader(provider=None)
+
+
+def test_constructor_no_model():
+    """Test that constructor checks for model."""
+    with pytest.raises(MissingModel, match="Missing model"):
+        LLMLoader(provider=constants.PROVIDER_BAM, model=None)
 
 
 def test_constructor_wrong_provider():
     """Test how wrong provider is checked."""
-    # currently, it just logs error and that's it
     with pytest.raises(UnsupportedProvider):
         LLMLoader(provider="invalid-provider", model=constants.GRANITE_13B_CHAT_V1)
+
+
+llm_cfgs = [
+    [constants.PROVIDER_OPENAI, constants.GRANITE_13B_CHAT_V1],
+    # following providers has no checks for params provided
+    # TODO: update the code itself
+    # [constants.PROVIDER_OLLAMA, constants.GRANITE_13B_CHAT_V1],
+    # [constants.PROVIDER_WATSONX, constants.GRANITE_13B_CHAT_V1],
+    # [constants.PROVIDER_TGI, constants.GRANITE_13B_CHAT_V1],
+    # [constants.PROVIDER_BAM, constants.GRANITE_13B_CHAT_V1],
+]
+
+
+@pytest.mark.parametrize("provider, model", llm_cfgs)
+def test_constructor_correct_provider_no_models(provider, model):
+    """Test if model setup is check for given provider."""
+    config.load_empty_config()
+    config.llm_config = LLMConfig()
+    providerConfig = ProviderConfig()
+    providerConfig.models = {model: None}
+    config.llm_config.providers = {provider: providerConfig}
+    message = (
+        f"No configuration provided for model {model} under LLM provider {provider}"
+    )
+    with pytest.raises(ModelConfigMissingException, match=message):
+        LLMLoader(provider=provider, model=model)


### PR DESCRIPTION
## Description

- Improved improper LLM model configuration checks. Specific exceptions are much better than bare `Exception` and can be decided later. Even in unit tests it's better to check which condition occurs (because errors in unit tests itself will raise `Exception` so it's tricky to catch them).

- Added some logging too.

- And checked by new unit tests

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Unit tests

## Related Tickets & Documents

- Related Issue #[OLS-83](https://issues.redhat.com//browse/OLS-83)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- `make test-unit` will do the trick
