### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,11 +13,6 @@
 - [ ] Configuration Update
 - [ ] Bump-up dependent library
 
-## Related Tickets & Documents
-
-- Related Issue #
-- Closes #
-
 ## Checklist before requesting a review
 
 - [ ] I have performed a self-review of my code.


### PR DESCRIPTION
## Description

Up for consideration.

We are using Jira issues in the PR name. With that, "Related Tickets & Documents" seems unnecessary. When you need to add more links, you still can put those in the description, but given the atomic nature of PR's, it shouldn't happen that often.

## Type of change

- [X] Documentation Update

