### PR TITLE
clean env vars before logging unit test

### DIFF
--- a/tests/unit/utils/test_logger.py
+++ b/tests/unit/utils/test_logger.py
@@ -1,11 +1,15 @@
 """Unit tests for Logger class."""
 
 import logging
+import os
+from unittest.mock import patch
 
 from ols.utils.logger import Logger
 
 
-def test_logger_debug_level(capsys):
+@patch("dotenv.load_dotenv")
+@patch.dict(os.environ, {"LOG_LEVEL": "DEBUG"})
+def test_logger_debug_level(mock_load_dotenv, capsys):
     """Test logger set with log level to DEBUG."""
     logger = Logger(logger_name="foo", log_level=logging.DEBUG)
     logger.logger.debug("Debug message")
@@ -17,7 +21,9 @@ def test_logger_debug_level(capsys):
     assert captured_err == ""
 
 
-def test_logger_info_level(capsys):
+@patch("dotenv.load_dotenv")
+@patch.dict(os.environ, {"LOG_LEVEL": "INFO"})
+def test_logger_info_level(mock_load_dotenv, capsys):
     """Test logger set with log level to INFO."""
     logger = Logger(logger_name="foo", log_level=logging.INFO)
     logger.logger.debug("Debug message")
@@ -30,7 +36,9 @@ def test_logger_info_level(capsys):
     assert captured_err == ""
 
 
-def test_logger_show_message_flag(capsys):
+@patch("dotenv.load_dotenv")
+@patch.dict(os.environ, {"LOG_LEVEL": "INFO"})
+def test_logger_show_message_flag(mock_load_dotenv, capsys):
     """Test logger set with show_message flag."""
     logger = Logger(logger_name="foo", log_level=logging.INFO, show_message=True)
     logger.logger.debug("Debug message")


### PR DESCRIPTION
## Description

Logging unit tests are affected by environment variables such as `LOG_LEVEL`. 
These env vars can come from the `.env` file for local testing. Renaming the `.env` file everytime we run the unit test is not convenient. 
This patch on the logger unit test will set `LOG_LEVEL` per test case. 
So we can run the unit tests without restoring the env vars and `.env` file. 

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
None

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.(not a core feature)

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
