### PR TITLE
OLS-83: Use imperative mood in mock classes: according PEP 257

### DIFF
--- a/tests/mock_classes/langchain_interface.py
+++ b/tests/mock_classes/langchain_interface.py
@@ -2,7 +2,7 @@
 
 
 def mock_langchain_interface(retval):
-    """Constructs mock for LangChainInterface."""
+    """Construct mock for LangChainInterface."""
 
     class MockLangChainInterface:
         """Mock LangChainInterface class for testing.

--- a/tests/mock_classes/llm_chain.py
+++ b/tests/mock_classes/llm_chain.py
@@ -2,7 +2,7 @@
 
 
 def mock_llm_chain(retval):
-    """Constructs mock for LLMChain."""
+    """Construct mock for LLMChain."""
 
     class MockLLMChain:
         """Mock LLMChain class for testing.

--- a/tests/mock_classes/llm_loader.py
+++ b/tests/mock_classes/llm_loader.py
@@ -5,12 +5,12 @@ class MockLLMLoader:
     """Mock for LLMLoader."""
 
     def __init__(self, llm=None):
-        """Constructor that just stores the selected LLM into object's attribute."""
+        """Store the selected LLM into object's attribute."""
         self.llm = llm
 
 
 def mock_llm_loader(llm=None):
-    """Constructs mock for LLMLoader."""
+    """Construct mock for LLMLoader."""
 
     def loader(*args, **kwargs):
         return MockLLMLoader(llm)

--- a/tests/mock_classes/mock_llama_index.py
+++ b/tests/mock_classes/mock_llama_index.py
@@ -7,10 +7,10 @@ class MockLlamaIndex:
     """Mocked (llama) index."""
 
     def __init__(self, *args, **kwargs):
-        """Constructor accepting all parameters."""
+        """Store all provided arguments for later usage."""
         self.args = args
         self.kwargs = kwargs
 
     def as_query_engine(self, **kwargs):
-        """Returns mocked query engine."""
+        """Return mocked query engine."""
         return MockQueryEngine(kwargs)

--- a/tests/mock_classes/mock_query_engine.py
+++ b/tests/mock_classes/mock_query_engine.py
@@ -7,10 +7,10 @@ class MockQueryEngine:
     """Mocked query engine."""
 
     def __init__(self, *args, **kwargs):
-        """Constructor accepting all parameters."""
+        """Store all provided arguments for later usage."""
         self.args = args
         self.kwargs = kwargs
 
     def query(self, query):
-        """Returns summary for given query."""
+        """Return summary for given query."""
         return MockSummary(query)

--- a/tests/mock_classes/mock_summary.py
+++ b/tests/mock_classes/mock_summary.py
@@ -5,10 +5,10 @@ class MockSummary:
     """Mocked summary returned from query engine."""
 
     def __init__(self, query, nodes=[]):
-        """Constructor that initializes all required object attributes."""
+        """Initialize all required object attributes."""
         self.query = query
         self.source_nodes = nodes
 
     def __str__(self):
-        """String representation that is used by DocsSummarizer."""
+        """Return string representation that is used by DocsSummarizer."""
         return f"Summary for query '{self.query}'"

--- a/tests/mock_classes/redis.py
+++ b/tests/mock_classes/redis.py
@@ -13,11 +13,11 @@ class MockRedis:
         pass
 
     def get(self, key):
-        """Implementation of GET command."""
+        """Return item from cache (implementation of GET command)."""
         if key in self.cache:
             return self.cache[key]
         return None
 
     def set(self, key, value, *args, **kwargs):
-        """Implementation of SET command."""
+        """Set item into the cache (implementation of SET command)."""
         self.cache[key] = value


### PR DESCRIPTION
## Description

[OLS-83](https://issues.redhat.com//browse/OLS-83): Use imperative mood in mock classes: according PEP 257
This will allow us to enable the last missing docstyle check: D401

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- N/A
