### PR TITLE
OLS-211: Removed LLMLoader param override for OpenAI

### DIFF
--- a/ols/src/llms/llm_loader.py
+++ b/ols/src/llms/llm_loader.py
@@ -133,7 +133,9 @@ class LLMLoader:
             "frequency_penalty": 1.03,
             "verbose": False,
         }
-        params.update(self.llm_params)  # override parameters
+        # TODO: We need to verify if the overridden params are valid for the LLM
+        # before updating the default.
+        # params.update(self.llm_params)  # override parameters
         self.llm = ChatOpenAI(**params)
         self.logger.debug(f"[{inspect.stack()[0][3]}] OpenAI LLM instance {self.llm}")
 


### PR DESCRIPTION
## Description
We are not able to send question to OpenAI model. This is due to an invalid parameter for ChatOpenAI has been passed. We are not updating any parameters for OpenAI with this fix. We have to see if there is a need to do override and then make a better way to ensure that the passed parameters are valid for specific model.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue [OLS-211](https://issues.redhat.com/browse/OLS-211)


## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
