### PR TITLE
Initial skeleton for e2e testing with live OLS instance + real llm backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,10 @@ test-integration: ## Run integration tests tests
 	python scripts/transform_coverage_report.py ${ARTIFACT_DIR}/coverage_integration.json ${ARTIFACT_DIR}/coverage_integration.out
 
 test-e2e: ## Run e2e tests
-	# Command to run e2e tests goes here
+	@echo "Running e2e tests..."
+	@echo "Reports will be written to ${ARTIFACT_DIR}"
+	python -m pytest tests/e2e --junit-xml=${ARTIFACT_DIR}/junit_e2e.xml
+		
 
 coverage-report:	test-unit ## Export unit test coverage report into interactive HTML
 	coverage html

--- a/tests/e2e/pytest.ini
+++ b/tests/e2e/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+log_cli=false
+filterwarnings = 
+	ignore::DeprecationWarning
+junit_logging=system-out

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -1,0 +1,52 @@
+"""Integration tests for basic OLS REST API endpoints."""
+
+import requests
+from httpx import Client
+
+client = Client(base_url="http://localhost:8080")
+
+
+def test_readiness() -> None:
+    """Test handler for /readiness REST API endpoint."""
+    response = client.get("/readiness")
+    assert response.status_code == requests.codes.ok
+    assert response.json() == {"status": "1"}
+
+
+def test_liveness() -> None:
+    """Test handler for /liveness REST API endpoint."""
+    response = client.get("/liveness")
+    assert response.status_code == requests.codes.ok
+    assert response.json() == {"status": "1"}
+
+
+def test_raw_prompt() -> None:
+    """Check the REST API /v1/debug/query with POST HTTP method when expected payload is posted."""
+    r = client.post(
+        "/v1/debug/query",
+        json={"conversation_id": "1234", "query": "say hello"},
+        timeout=20,
+    )
+    print(vars(r))
+    response = r.json()
+
+    assert r.status_code == requests.codes.ok
+    assert response["conversation_id"] == "1234"
+    assert response["query"] == "say hello"
+    assert "hello" in response["response"]["text"].lower()
+
+
+def test_invalid_question() -> None:
+    """Check the REST API /v1/query with POST HTTP method for invalid question."""
+    response = client.post(
+        "/v1/query", json={"conversation_id": "1234", "query": "test query"}, timeout=20
+    )
+    print(vars(response))
+    assert response.status_code == requests.codes.unprocessable
+    assert response.json() == {
+        "detail": {
+            "response": "Sorry, I can only answer questions about OpenShift "
+            "and Kubernetes. This does not look like something I "
+            "know how to handle."
+        }
+    }


### PR DESCRIPTION
## Description

Experiment with testing the api server end to end (i.e. with backend llm invocation).

Note: refactors the generic `/raw_prompt` endpoint slightly because the existing code was insufficiently agnostic about the LLM instance (llmloader returns a `ChatOpenAI` instance for openai and a `LangChainInterface` for BAM, these two types have different invocation parameter expectations.  The Langchain wrapper seems to resolve this but it's an area to keep an eye on as langchain has fundamentally distinct concepts of "chat" vs "generation" invocations, even if the backend LLMs don't have distinct api endpoints)

Currently this PR only passes e2e testing for openai because when used with the BAM models, the models are returning a truncated response for question validation.  This isn't a failure of the e2e tests, it's a failure of the question_validator and/or the BAM models.  i.e. they return:
```
INVALID,NOY
```

despite being told explicitly to return "INVALID,NOYAML"

and then the question validator chokes on the unexpected response.


## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.