### PR TITLE
Fix enabling dev ui via env

### DIFF
--- a/default.env
+++ b/default.env
@@ -1,8 +1,8 @@
 #######################################
 ## GLOBAL SETTINGS
 #######################################
-## enabe OLS UI
-OLS_ENABLE_UI=True
+## enable OLS UI
+OLS_ENABLE_DEV_UI=True
  
 # logging config
 LOG_LEVEL=INFO

--- a/ols/app/main.py
+++ b/ols/app/main.py
@@ -14,7 +14,7 @@ if config.ols_config.enable_debug_ui:
     app = gradioUI(logger=config.default_logger).mount_ui(app)
 else:
     config.default_logger.info(
-        "Embedded Gradio UI is disabled. To enable set ENABLE_DEV_UI to True"
+        "Embedded Gradio UI is disabled. To enable set OLS_ENABLE_DEV_UI to True"
     )
 
 

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -193,7 +193,7 @@ class OLSConfig(BaseModel):
         self.yaml_provider = data.get("yaml_provider", self.default_provider)
         self.yaml_model = data.get("yaml_model", self.default_model)
 
-        self.enable_debug_ui = data.get("enable_debug_ui", False)
+        self.enable_debug_ui = data.get("ols_enable_dev_ui", False)
         self.conversation_cache = ConversationCacheConfig(
             data.get("conversation_cache", None)
         )

--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -44,7 +44,7 @@ def load_config_from_env() -> None:
     ).logger
 
     ols_config.enable_debug_ui = (
-        True if os.getenv("ENABLE_DEV_UI", "False").lower() == "true" else False
+        os.getenv("OLS_ENABLE_DEV_UI", "False").lower() == "true"
     )
 
     ols_config.default_provider = os.getenv("DEFAULT_PROVIDER", constants.PROVIDER_BAM)


### PR DESCRIPTION
## Description

Enabling `/ui` via env is broken now. There are three different envs in different parts of the code that should do the trick and enable the ui. 
```
OLS_ENABLE_UI=false
ENABLE_DEBUG_UI=false
ENABLE_DEV_UI=true
```
but just `ENABLE_DEV_UI` is actually used for configuration.

We should fix this regardless of [config refactoring PR](https://github.com/openshift/lightspeed-service/pull/166).

## Type of change

- [X] Bug fix

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] PR has passed all pre-merge test jobs.