### PR TITLE
OLS-83: Enable D401 check on CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 
 select = ["D", "E", "F", "W", "C", "S", "I", "TCH"]
 
+# we need to check 'mood' of all docstrings, this needs to be enabled explicitly
+extend-select = ["D401"]
+
 ignore = []
 
 target-version = "py311"


### PR DESCRIPTION
## Description

Finally we have 'clean' docstrings everywhere! So it's possible to enable the last docstrings-related check D401. That one needs to be enabled explicitly in Ruff.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-83](https://issues.redhat.com//browse/OLS-83)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- See CI
- Use `make verify` - everything should be fine
