### PR TITLE
OLS-83: Use @patch in unit tests for yes-no classifier

### DIFF
--- a/tests/unit/query_helpers/test_yes_no_classifier.py
+++ b/tests/unit/query_helpers/test_yes_no_classifier.py
@@ -1,8 +1,9 @@
 """Unit tests for YesNoClassifier class."""
 
+from unittest.mock import patch
+
 import pytest
 
-import ols.src.query_helpers.yes_no_classifier
 from ols.src.query_helpers.yes_no_classifier import YesNoClassifier
 from tests.mock_classes.llm_chain import mock_llm_chain
 from tests.mock_classes.llm_loader import mock_llm_loader
@@ -14,31 +15,27 @@ def yes_no_classifier():
     return YesNoClassifier()
 
 
-def test_bad_value_response(yes_no_classifier, monkeypatch):
+@patch("ols.src.query_helpers.yes_no_classifier.LLMLoader", new=mock_llm_loader(None))
+def test_bad_value_response(yes_no_classifier):
     """Test how YesNoClassifier handles improper responses."""
     # response that isn't 1, 0, or 9 should generate a ValueError
     ml = mock_llm_chain({"text": "default"})
 
-    monkeypatch.setattr(ols.src.query_helpers.yes_no_classifier, "LLMChain", ml)
-    monkeypatch.setattr(
-        ols.src.query_helpers.yes_no_classifier, "LLMLoader", mock_llm_loader()
-    )
-
-    with pytest.raises(ValueError):
-        yes_no_classifier.classify(conversation="1234", statement="The sky is blue.")
+    with patch("ols.src.query_helpers.yes_no_classifier.LLMChain", new=ml):
+        with pytest.raises(ValueError):
+            yes_no_classifier.classify(
+                conversation="1234", statement="The sky is blue."
+            )
 
 
-def test_good_value_response(yes_no_classifier, monkeypatch):
+@patch("ols.src.query_helpers.yes_no_classifier.LLMLoader", new=mock_llm_loader(None))
+def test_good_value_response(yes_no_classifier):
     """Test how YesNoClassifier handles proper responses."""
     # response that is 1, 0, or 9 should return the value
     for x in ["0", "1", "9"]:
         ml = mock_llm_chain({"text": x})
 
-        monkeypatch.setattr(ols.src.query_helpers.yes_no_classifier, "LLMChain", ml)
-        monkeypatch.setattr(
-            ols.src.query_helpers.yes_no_classifier, "LLMLoader", mock_llm_loader()
-        )
-
-        assert yes_no_classifier.classify(
-            conversation="1234", statement="The sky is blue."
-        ) == int(x)
+        with patch("ols.src.query_helpers.yes_no_classifier.LLMChain", new=ml):
+            assert yes_no_classifier.classify(
+                conversation="1234", statement="The sky is blue."
+            ) == int(x)


### PR DESCRIPTION
## Description

Use `@patch` in unit tests for yes-no classifier

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Unit tests

## Related Tickets & Documents

- Related Issue #[OLS-83](https://issues.redhat.com//browse/OLS-83)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Look at CI
- Use `make test-unit`
