### PR TITLE
OLS-83: Use `@patch` it test-yaml-generator

### DIFF
--- a/tests/unit/query_helpers/test_yaml_generator.py
+++ b/tests/unit/query_helpers/test_yaml_generator.py
@@ -1,8 +1,9 @@
 """Unit tests for YamlGenerator class."""
 
+from unittest.mock import patch
+
 import pytest
 
-import ols.src.query_helpers.yaml_generator
 from ols.src.query_helpers.yaml_generator import YamlGenerator
 from ols.utils import config
 from tests.mock_classes.llm_chain import mock_llm_chain
@@ -16,20 +17,18 @@ def yaml_generator():
     return YamlGenerator()
 
 
-def test_yaml_generator(yaml_generator, monkeypatch):
+@patch("ols.src.query_helpers.yaml_generator.LLMLoader", new=mock_llm_loader(None))
+def test_yaml_generator(yaml_generator):
     """Test the basic functionality of YAML generator."""
     ml = mock_llm_chain({"text": "default"})
-    monkeypatch.setattr(ols.src.query_helpers.yaml_generator, "LLMChain", ml)
-    monkeypatch.setattr(
-        ols.src.query_helpers.yaml_generator, "LLMLoader", mock_llm_loader()
-    )
-
-    # response will be constant because we mocked LLMChain and LLMLoader
-    response = yaml_generator.generate_yaml("1234", "the query")
-    assert response == "default"
+    with patch("ols.src.query_helpers.yaml_generator.LLMChain", new=ml):
+        # response will be constant because we mocked LLMChain and LLMLoader
+        response = yaml_generator.generate_yaml("1234", "the query")
+        assert response == "default"
 
 
-def test_yaml_generator_history_enabled(yaml_generator, monkeypatch):
+@patch("ols.src.query_helpers.yaml_generator.LLMLoader", new=mock_llm_loader(None))
+def test_yaml_generator_history_enabled(yaml_generator):
     """Test the basic functionality of YAML generator when history is enabled."""
     history_value = "conversation history"
 
@@ -43,22 +42,19 @@ def test_yaml_generator_history_enabled(yaml_generator, monkeypatch):
 
     # use mocked LLMChain
     ml = mock_llm_chain(None)
-    monkeypatch.setattr(ols.src.query_helpers.yaml_generator, "LLMChain", ml)
-    # modify __call__ special method with more checks
-    ml.__call__ = llmchain_param_check
+    with patch("ols.src.query_helpers.yaml_generator.LLMChain", new=ml):
+        # modify __call__ special method with more checks
+        ml.__call__ = llmchain_param_check
 
-    monkeypatch.setattr(
-        ols.src.query_helpers.yaml_generator, "LLMLoader", mock_llm_loader()
-    )
-
-    # response will be constant because we mocked LLMChain and LLMLoader
-    response = yaml_generator.generate_yaml(
-        "1234", "the query", history="conversation history"
-    )
-    assert response == "default"
+        # response will be constant because we mocked LLMChain and LLMLoader
+        response = yaml_generator.generate_yaml(
+            "1234", "the query", history="conversation history"
+        )
+        assert response == "default"
 
 
-def test_yaml_generator_verbose_enabled(yaml_generator, monkeypatch):
+@patch("ols.src.query_helpers.yaml_generator.LLMLoader", new=mock_llm_loader(None))
+def test_yaml_generator_verbose_enabled(yaml_generator):
     """Test the basic functionality of YAML generator when verbosity is enabled."""
 
     def llmchain_param_check(self, *args, **kwargs):
@@ -67,14 +63,10 @@ def test_yaml_generator_verbose_enabled(yaml_generator, monkeypatch):
 
     # use mocked LLMChain
     ml = mock_llm_chain({"text": "default"})
-    monkeypatch.setattr(ols.src.query_helpers.yaml_generator, "LLMChain", ml)
-    # modify __init__ special method with more checks
-    ml.__init__ = llmchain_param_check
+    with patch("ols.src.query_helpers.yaml_generator.LLMChain", new=ml):
+        # modify __init__ special method with more checks
+        ml.__init__ = llmchain_param_check
 
-    monkeypatch.setattr(
-        ols.src.query_helpers.yaml_generator, "LLMLoader", mock_llm_loader()
-    )
-
-    # response will be constant because we mocked LLMChain and LLMLoader
-    response = yaml_generator.generate_yaml("1234", "the query", verbose="true")
-    assert response == "default"
+        # response will be constant because we mocked LLMChain and LLMLoader
+        response = yaml_generator.generate_yaml("1234", "the query", verbose="true")
+        assert response == "default"


### PR DESCRIPTION
## Description

[OLS-83](https://issues.redhat.com//browse/OLS-83): Use `@patch` it test-yaml-generator

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Unit tests

## Related Tickets & Documents

- Related Issue #[OLS-83](https://issues.redhat.com//browse/OLS-83)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Look at CI
- Use `make test-unit`
