### PR TITLE
OLS-40: Use pydantic ability to provide default uuid

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -27,16 +27,15 @@ def ols_request(llm_request: LLMRequest) -> LLMRequest:
     logger = config.default_logger
 
     # Initialize variables
-    previous_input = None
-    conversation = llm_request.conversation_id
+    conversation = str(llm_request.conversation_id)
+    previous_input = config.conversation_cache.get(conversation)
 
-    # Generate a new conversation ID if not provided
-    if conversation is None:
-        conversation = Utils.get_suid()
-        logger.info(f"{conversation} New conversation")
+    if previous_input:
+        logger.info(
+            f"conversation {conversation} with previous conversation input {previous_input}"
+        )
     else:
-        previous_input = config.conversation_cache.get(conversation)
-        logger.info(f"{conversation} Previous conversation input: {previous_input}")
+        logger.info(f"new conversation {conversation}")
 
     llm_response = LLMRequest(query=llm_request.query, conversation_id=conversation)
 

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -1,8 +1,9 @@
 """Data models representing payloads for REST API calls."""
 
 from typing import Union
+from uuid import UUID, uuid4
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class LLMRequest(BaseModel):
@@ -10,7 +11,7 @@ class LLMRequest(BaseModel):
 
     Attributes:
         query: The query string.
-        conversation_id: The optional conversation ID.
+        conversation_id: The optional conversation id in valid UUID format.
         response: The optional response.
 
     Example:
@@ -18,7 +19,7 @@ class LLMRequest(BaseModel):
     """
 
     query: str
-    conversation_id: Union[str, None] = None
+    conversation_id: UUID = Field(default_factory=uuid4)
     response: Union[str, None] = None
 
 


### PR DESCRIPTION
## Description

Changes:
- UUID is generated for request when not provided (at the model init)
- using full uuid instead of just hex
  - 81fde9cae75143238f71949faf40a23b -> 81fde9ca-e751-4323-8f71-949faf40a23b
- conversation cache is asked every time
  - As the retrieval is very fast (compared to other processing logic), would it be a problem? Maybe if there are 100/1000 paralell queries?

Also, it seems we are adding conversation to the cache only for yaml questions. Is that correct behavior?

If you agree with the changes, I'll proceed with the tests.

## Type of change

- [X] Refactor

## TODO
- [ ] tests
