### PR TITLE
OLS-40: Llm loader parent error

### DIFF
--- a/ols/src/llms/llm_loader.py
+++ b/ols/src/llms/llm_loader.py
@@ -17,23 +17,23 @@ from ols.utils.logger import Logger
 warnings.simplefilter("ignore", UserWarning)
 
 
-class MissingProvider(Exception):
+class MissingProviderError(Exception):
     """Provider is not specified."""
 
 
-class MissingModel(Exception):
+class MissingModelError(Exception):
     """Model is not specified."""
 
 
-class UnsupportedProvider(Exception):
+class UnsupportedProviderError(Exception):
     """Provider is not supported or is unknown."""
 
 
-class ModelConfigMissingException(Exception):
+class ModelConfigMissingError(Exception):
     """No configuration exists for the requested model name."""
 
 
-class ModelConfigInvalidException(Exception):
+class ModelConfigInvalidError(Exception):
     """Model configuration is not valid."""
 
 
@@ -68,13 +68,13 @@ class LLMLoader:
         if provider is None:
             msg = "Missing provider"
             self.logger.error(msg)
-            raise MissingProvider(msg)
+            raise MissingProviderError(msg)
         self.provider = provider
         self.url = url
         if model is None:
             msg = "Missing model"
             self.logger.error(msg)
-            raise MissingModel(msg)
+            raise MissingModelError(msg)
         self.model = model
 
         # return empty dictionary if not defined
@@ -100,7 +100,7 @@ class LLMLoader:
             case _:
                 msg = f"Unsupported LLM provider {self.provider}"
                 self.logger.error(msg)
-                raise UnsupportedProvider(msg)
+                raise UnsupportedProviderError(msg)
 
     def _openai_llm_instance(self) -> LLM:
         self.logger.debug(f"[{inspect.stack()[0][3]}] Creating OpenAI LLM instance")
@@ -119,7 +119,7 @@ class LLMLoader:
                 f"LLM provider {constants.PROVIDER_OPENAI}"
             )
             self.logger.error(msg)
-            raise ModelConfigMissingException(msg)
+            raise ModelConfigMissingError(msg)
         params: dict = {
             "base_url": provider.url
             if provider.url is not None
@@ -167,7 +167,7 @@ class LLMLoader:
                 f"LLM provider {constants.PROVIDER_BAM}"
             )
             self.logger.error(msg)
-            raise ModelConfigMissingException(msg)
+            raise ModelConfigMissingError(msg)
 
         creds = Credentials(
             api_key=provider.credentials,

--- a/ols/src/llms/llm_loader.py
+++ b/ols/src/llms/llm_loader.py
@@ -17,23 +17,27 @@ from ols.utils.logger import Logger
 warnings.simplefilter("ignore", UserWarning)
 
 
-class MissingProviderError(Exception):
+class LLMConfigurationError(Exception):
+    """LLM configuration is wrong."""
+
+
+class MissingProviderError(LLMConfigurationError):
     """Provider is not specified."""
 
 
-class MissingModelError(Exception):
+class MissingModelError(LLMConfigurationError):
     """Model is not specified."""
 
 
-class UnsupportedProviderError(Exception):
+class UnsupportedProviderError(LLMConfigurationError):
     """Provider is not supported or is unknown."""
 
 
-class ModelConfigMissingError(Exception):
+class ModelConfigMissingError(LLMConfigurationError):
     """No configuration exists for the requested model name."""
 
 
-class ModelConfigInvalidError(Exception):
+class ModelConfigInvalidError(LLMConfigurationError):
     """Model configuration is not valid."""
 
 

--- a/tests/unit/llms/test_llm_loader.py
+++ b/tests/unit/llms/test_llm_loader.py
@@ -9,9 +9,11 @@ import pytest
 from ols import constants
 from ols.app.models.config import LLMConfig, ProviderConfig
 from ols.src.llms.llm_loader import (
+    LLMConfigurationError,
     LLMLoader,
     MissingModelError,
     MissingProviderError,
+    ModelConfigInvalidError,
     ModelConfigMissingError,
     UnsupportedProviderError,
 )
@@ -39,6 +41,15 @@ def setup():
     # make Python think that the modules are loaded already
     for module in mock_modules:
         sys.modules[module] = MagicMock()
+
+
+def test_errors_relationship():
+    """Test the relationship between LLMConfigurationError and its subclasses."""
+    assert issubclass(MissingProviderError, LLMConfigurationError)
+    assert issubclass(MissingModelError, LLMConfigurationError)
+    assert issubclass(UnsupportedProviderError, LLMConfigurationError)
+    assert issubclass(ModelConfigMissingError, LLMConfigurationError)
+    assert issubclass(ModelConfigInvalidError, LLMConfigurationError)
 
 
 def test_constructor_no_provider():

--- a/tests/unit/llms/test_llm_loader.py
+++ b/tests/unit/llms/test_llm_loader.py
@@ -10,10 +10,10 @@ from ols import constants
 from ols.app.models.config import LLMConfig, ProviderConfig
 from ols.src.llms.llm_loader import (
     LLMLoader,
-    MissingModel,
-    MissingProvider,
-    ModelConfigMissingException,
-    UnsupportedProvider,
+    MissingModelError,
+    MissingProviderError,
+    ModelConfigMissingError,
+    UnsupportedProviderError,
 )
 from ols.utils import config
 
@@ -43,19 +43,19 @@ def setup():
 
 def test_constructor_no_provider():
     """Test that constructor checks for provider."""
-    with pytest.raises(MissingProvider, match="Missing provider"):
+    with pytest.raises(MissingProviderError, match="Missing provider"):
         LLMLoader(provider=None)
 
 
 def test_constructor_no_model():
     """Test that constructor checks for model."""
-    with pytest.raises(MissingModel, match="Missing model"):
+    with pytest.raises(MissingModelError, match="Missing model"):
         LLMLoader(provider=constants.PROVIDER_BAM, model=None)
 
 
 def test_constructor_wrong_provider():
     """Test how wrong provider is checked."""
-    with pytest.raises(UnsupportedProvider):
+    with pytest.raises(UnsupportedProviderError):
         LLMLoader(provider="invalid-provider", model=constants.GRANITE_13B_CHAT_V1)
 
 
@@ -79,7 +79,7 @@ def test_constructor_correct_provider_no_models(provider, model):
     message = (
         f"No configuration provided for model {model} under LLM provider {provider}"
     )
-    with pytest.raises(ModelConfigMissingException, match=message):
+    with pytest.raises(ModelConfigMissingError, match=message):
         LLMLoader(provider=provider, model=model)
 
 


### PR DESCRIPTION
## Description

Contains two commits:
- Custom errors class naming is formatted according to google's standards.
- Adds parent configuration error to make catching these errors easy on the endpoint side (except just parent instead of 5 different ones.)
  - the assumption here is that all those errors are the same from the user's perspective -> 422 unprocessable entity

## Type of change

- [X] Refactor
- [X] New feature

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] PR has passed all pre-merge test jobs.
- [X] If it is a core feature, I have added thorough tests.
