### PR TITLE
OLS-153: Ability to perform type checks from CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,17 @@ During testing, code coverage is measured. If the coverage is below defined thre
 Code coverage reports are generated in JSON and also in format compatible with _JUnit_. It is also possible to start `make coverage-report` to generate code coverage reports in form of interactive HTML pages. These pages are stored in `htmlcov` subdirectory. Just open index page from this subdirectory in your web browser.
 
 
+### Type hints checks
+
+It is possible to check if type hints added into the code are correct and whether assignments, function calls etc. use values of the right type. This check is invoked by following command:
+
+```
+make check-types
+```
+
+Please note that type hints check might be very slow.
+
+
 
 ## Testing
 

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ test-e2e: ## Run e2e tests
 coverage-report:	test-unit ## Export unit test coverage report into interactive HTML
 	coverage html
 
+check-types: ## Checks type hints in sources
+	mypy ols/
+
 format: ## Format the code into unified format
 	black .
 	ruff . --fix --per-file-ignores=tests/*:S101

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,7 @@ line-length = 100
 [tool.coverage.report]
 # unit tests fails if the total coverage measurement is under this threshold value
 fail_under = 50
+
+[tool.mypy]
+disable_error_code = ["union-attr", "return-value", "arg-type"]
+ignore_missing_imports = true

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ httpx
 pytest-cov
 ruff
 black
+mypy


### PR DESCRIPTION
## Description

[OLS-153](https://issues.redhat.com//browse/OLS-153): Ability to perform type checks from CLI
Note: it is not part of `make verify` on purpose because type checks are very slow + the code has just few type hints (need be updated step-by-step later)


## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-153](https://issues.redhat.com//browse/OLS-153)


## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Install Mypy + run `make check-types`
