### PR TITLE
OLS-153: Added missing type info for all LLM constructors

### DIFF
--- a/ols/src/llms/llm_loader.py
+++ b/ols/src/llms/llm_loader.py
@@ -3,17 +3,15 @@
 import inspect
 import os
 import warnings
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from langchain.callbacks.manager import CallbackManager
 from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain.llms.base import LLM
 
 from ols import constants
 from ols.utils import config
 from ols.utils.logger import Logger
-
-if TYPE_CHECKING:
-    from langchain.llms.base import LLM
 
 # workaround to disable UserWarning
 warnings.simplefilter("ignore", UserWarning)

--- a/ols/src/llms/llm_loader.py
+++ b/ols/src/llms/llm_loader.py
@@ -83,7 +83,7 @@ class LLMLoader:
         self.llm_params = params if params else {}
         self.llm: LLM = self._llm_instance()
 
-    def _llm_instance(self):
+    def _llm_instance(self) -> LLM:
         self.logger.debug(
             f"[{inspect.stack()[0][3]}] Loading LLM {self.model} from {self.provider}"
         )
@@ -104,7 +104,7 @@ class LLMLoader:
                 self.logger.error(msg)
                 raise UnsupportedProvider(msg)
 
-    def _openai_llm_instance(self):
+    def _openai_llm_instance(self) -> LLM:
         self.logger.debug(f"[{inspect.stack()[0][3]}] Creating OpenAI LLM instance")
         try:
             from langchain.chat_models import ChatOpenAI
@@ -146,7 +146,7 @@ class LLMLoader:
         self.logger.debug(f"[{inspect.stack()[0][3]}] OpenAI LLM instance {llm}")
         return llm
 
-    def _bam_llm_instance(self):
+    def _bam_llm_instance(self) -> LLM:
         """BAM Research Lab."""
         self.logger.debug(f"[{inspect.stack()[0][3]}] BAM LLM instance")
         try:
@@ -199,7 +199,7 @@ class LLMLoader:
         return llm
 
     # TODO: update this to use config not direct env vars
-    def _ollama_llm_instance(self):
+    def _ollama_llm_instance(self) -> LLM:
         self.logger.debug(f"[{inspect.stack()[0][3]}] Creating Ollama LLM instance")
         try:
             from langchain.llms import Ollama
@@ -225,7 +225,7 @@ class LLMLoader:
         return llm
 
     # TODO: update this to use config not direct env vars
-    def _tgi_llm_instance(self):
+    def _tgi_llm_instance(self) -> LLM:
         """Note: TGI does not support specifying the model, it is an instance per model."""
         self.logger.debug(
             f"[{inspect.stack()[0][3]}] Creating Hugging Face TGI LLM instance"
@@ -259,7 +259,7 @@ class LLMLoader:
         return llm
 
     # TODO: update this to use config not direct env vars
-    def _watson_llm_instance(self):
+    def _watson_llm_instance(self) -> LLM:
         self.logger.debug(f"[{inspect.stack()[0][3]}] Watson LLM instance")
         # WatsonX (requires WansonX libraries)
         try:


### PR DESCRIPTION
## Description

Added missing type info for all LLM constructors

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-153](https://issues.redhat.com//browse/OLS-153)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Use `make check-types`
