### PR TITLE
Doc update: An example how 'raises:' should be written in docstrings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -272,6 +272,9 @@ def function_with_pep484_type_annotations(param1: int, param2: str) -> bool:
     
     Returns:
         The return value. True for success, False otherwise.
+    
+    Raises:
+        ValueError: If the first parameter does not contain proper model name
     """
 ```
 


### PR DESCRIPTION
## Description

Doc update: An example how 'raises:' should be written in docstrings

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- N/A
