### PR TITLE
Dependa bot Config for python Dependencies management

### DIFF
--- a/.github/dependabot copy.yml
+++ b/.github/dependabot copy.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "dependency"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,3 @@ updates:
     commit-message:
       prefix: "dependency"
       include: "scope"
-    pull-request:
-      body: |
-        This pull request updates the following dependencies:\n
-        {{this.name}} ({{this.from}} → {{this.to}})\n{{/each}}
-        \nThis is an automated update by Dependabot.
-        Please review the changes and approve if appropriate.


### PR DESCRIPTION
## Description

added the Config that required for Dependa-bot to rn for a python project mainly,
if we plan to change any of the Dependa-bot behavior this file is where we can manage that

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #[OLS-85](https://issues.redhat.com//browse/OLS-85)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

- after this changes get merged, we expect a DependaBot job  to run and analyze our project dependencies.