### PR TITLE
added config for weekly dependency checks for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "dependency"
+      include: "scope"


### PR DESCRIPTION
## Description

DependaBot is a tool provided by Github that can check for dependencies needed updates and upgrade and automate the management of it, for that i have added the config of Dependabot to the project so it can get enabled.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #[OLS-85](https://issues.redhat.com//browse/OLS-85)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
to test the changes without merging them, you will need them to persist in a fork, so you can see a Dependabot job has been started successfully.

- How were the fix/results from this change verified? Please provide relevant screenshots or results.

i have tested the config on my own fork, and it did scheduled a Dependabot job that analyzed the entire project dependencies
