### PR TITLE
(Trivial) Use lowercase local vars

### DIFF
--- a/tests/unit/ui/test_gradio_ui.py
+++ b/tests/unit/ui/test_gradio_ui.py
@@ -9,23 +9,23 @@ from ols.src.ui.gradio_ui import gradioUI
 
 def test_gradio_ui_constructor():
     """Test if all attributes are setup correctly by constructor."""
-    URL = "locahost:8080"
+    url = "locahost:8080"
     conversation_id = 1234
 
-    ui = gradioUI(ols_url=URL, conversation_id=conversation_id, logger=None)
+    ui = gradioUI(ols_url=url, conversation_id=conversation_id, logger=None)
     assert ui is not None
-    assert ui.ols_url == URL
+    assert ui.ols_url == url
     assert ui.conversation_id == conversation_id
     assert ui.logger is not None
 
 
 def test_chat_ui_handler_ok_response():
     """Test the UI handler for proper REST API response."""
-    okResponse = requests.Response()
-    okResponse.status_code = requests.codes.ok
-    okResponse.json = lambda: {"response": "this is response"}
+    ok_response = requests.Response()
+    ok_response.status_code = requests.codes.ok
+    ok_response.json = lambda: {"response": "this is response"}
 
-    with patch("ols.src.ui.gradio_ui.requests.post", return_value=okResponse):
+    with patch("ols.src.ui.gradio_ui.requests.post", return_value=ok_response):
         ui = gradioUI()
         ret = ui.chat_ui("prompt", None, False)
         assert ret == "this is response"
@@ -33,10 +33,10 @@ def test_chat_ui_handler_ok_response():
 
 def test_chat_ui_handler_bad_http_code():
     """Test the UI handler for REST API response that is not OK."""
-    badResponse = requests.Response()
-    badResponse.status_code = requests.codes.internal_server_error
+    bad_response = requests.Response()
+    bad_response.status_code = requests.codes.internal_server_error
 
-    with patch("ols.src.ui.gradio_ui.requests.post", return_value=badResponse):
+    with patch("ols.src.ui.gradio_ui.requests.post", return_value=bad_response):
         ui = gradioUI()
         ret = ui.chat_ui("prompt", None, False)
         assert "Sorry, an error occurred" in ret


### PR DESCRIPTION
## Description

(Trivial) Use lowercase local vars

### Why is this bad?
[PEP 8] recommends that all function variables use lowercase names:

> Function names should be lowercase, with words separated by underscores as necessary to
> improve readability. Variable names follow the same convention as function names. mixedCase
> is allowed only in contexts where that's already the prevailing style (e.g. threading.py),
> to retain backwards compatibility.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- N/A
