### PR TITLE
Add QueryHelper parent

### DIFF
--- a/ols/src/query_helpers/__init__.py
+++ b/ols/src/query_helpers/__init__.py
@@ -1,1 +1,28 @@
 """Question validators, statament classifiers, and response generators."""
+import re
+
+from ols.utils import config
+from ols.utils.logger import Logger
+
+
+def camel_to_snake(string: str) -> str:
+    """Convert a string from camel case to snake case.
+
+    Args:
+        string: The string to be converted.
+
+    Returns:
+        The converted string.
+    """
+    string = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", string)
+    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", string).lower()
+
+
+class QueryHelper:
+    """Base class for query helpers."""
+
+    def __init__(self, provider: str | None = None, model: str | None = None):
+        """Initialize query helper."""
+        self.provider = provider or config.ols_config.default_provider
+        self.model = model or config.ols_config.default_model
+        self.logger = Logger(camel_to_snake(self.__class__.__name__)).logger

--- a/ols/src/query_helpers/question_validator.py
+++ b/ols/src/query_helpers/question_validator.py
@@ -5,16 +5,11 @@ from langchain.prompts import PromptTemplate
 
 from ols import constants
 from ols.src.llms.llm_loader import LLMLoader
-from ols.utils import config
-from ols.utils.logger import Logger
+from ols.src.query_helpers import QueryHelper
 
 
-class QuestionValidator:
+class QuestionValidator(QueryHelper):
     """This class is responsible for validating questions and providing one-word responses."""
-
-    def __init__(self) -> None:
-        """Initialize the `QuestionValidator` instance."""
-        self.logger = Logger("question_validator").logger
 
     def validate_question(
         self, conversation: str, query: str, verbose: bool = False
@@ -29,14 +24,11 @@ class QuestionValidator:
         Returns:
             A list of one-word responses.
         """
-        model = config.ols_config.validator_model
-        provider = config.ols_config.validator_provider
-
         settings_string = (
             f"conversation: {conversation}, "
             f"query: {query}, "
-            f"provider: {provider}, "
-            f"model: {model}, "
+            f"provider: {self.provider}, "
+            f"model: {self.model}, "
             f"verbose: {verbose}"
         )
         self.logger.info(f"{conversation} call settings: {settings_string}")
@@ -46,10 +38,10 @@ class QuestionValidator:
         )
 
         self.logger.info(f"{conversation} Validating query")
-        self.logger.info(f"{conversation} using model: {model}")
+        self.logger.info(f"{conversation} using model: {self.model}")
 
         bare_llm = LLMLoader(
-            provider, model, params={"min_new_tokens": 1, "max_new_tokens": 4}
+            self.provider, self.model, params={"min_new_tokens": 1, "max_new_tokens": 4}
         ).llm
 
         llm_chain = LLMChain(llm=bare_llm, prompt=prompt_instructions, verbose=verbose)

--- a/ols/src/query_helpers/yaml_generator.py
+++ b/ols/src/query_helpers/yaml_generator.py
@@ -5,16 +5,11 @@ from langchain.prompts import PromptTemplate
 
 from ols import constants
 from ols.src.llms.llm_loader import LLMLoader
-from ols.utils import config
-from ols.utils.logger import Logger
+from ols.src.query_helpers import QueryHelper
 
 
-class YamlGenerator:
+class YamlGenerator(QueryHelper):
     """This class is responsible for generating YAML responses to user requests."""
-
-    def __init__(self) -> None:
-        """Initialize the `YamlGenerator` instance."""
-        self.logger = Logger("yaml_generator").logger
 
     def generate_yaml(
         self, conversation_id: str, query: str, history: str | None = None, **kwargs
@@ -30,21 +25,18 @@ class YamlGenerator:
         Returns:
             The generated YAML response.
         """
-        model = config.ols_config.validator_model
-        provider = config.ols_config.validator_provider
-
         verbose = kwargs.get("verbose", "").lower() == "true"
         settings_string = (
             f"conversation: {conversation_id}, "
             f"query: {query}, "
-            f"provider: {provider}, "
-            f"model: {model}, "
+            f"provider: {self.provider}, "
+            f"model: {self.model}, "
             f"verbose: {verbose}"
         )
         self.logger.info(f"{conversation_id} call settings: {settings_string}")
-        self.logger.info(f"{conversation_id} using model: {model}")
+        self.logger.info(f"{conversation_id} using model: {self.model}")
 
-        bare_llm = LLMLoader(provider, model).llm
+        bare_llm = LLMLoader(self.provider, self.model).llm
 
         if history:
             prompt_instructions = PromptTemplate.from_template(

--- a/ols/src/query_helpers/yes_no_classifier.py
+++ b/ols/src/query_helpers/yes_no_classifier.py
@@ -5,16 +5,11 @@ from langchain.prompts import PromptTemplate
 
 from ols import constants
 from ols.src.llms.llm_loader import LLMLoader
-from ols.utils import config
-from ols.utils.logger import Logger
+from ols.src.query_helpers import QueryHelper
 
 
-class YesNoClassifier:
+class YesNoClassifier(QueryHelper):
     """This class is responsible for classifying a statement as yes, no, or undetermined."""
-
-    def __init__(self) -> None:
-        """Initialize the `YesNoClassifier` instance."""
-        self.logger = Logger("yes_no_classifier").logger
 
     def classify(self, conversation: str, statement: str, **kwargs) -> int:
         """Classifies a statement as yes, no, or undetermined.
@@ -27,15 +22,13 @@ class YesNoClassifier:
         Returns:
             The classification result (1 for yes, 0 for no, 9 for undetermined).
         """
-        model = config.ols_config.validator_model
-        provider = config.ols_config.validator_provider
         verbose = kwargs.get("verbose", "").lower() == "true"
 
         settings_string = (
             f"conversation: {conversation}, "
             f"query: {statement}, "
-            f"provider: {provider}, "
-            f"model: {model}, verbose: {verbose}"
+            f"provider: {self.provider}, "
+            f"model: {self.model}, verbose: {verbose}"
         )
         self.logger.info(f"{conversation} call settings: {settings_string}")
 
@@ -43,14 +36,14 @@ class YesNoClassifier:
             constants.YES_OR_NO_CLASSIFIER_PROMPT_TEMPLATE
         )
 
-        self.logger.info(f"{conversation} using model: {model}")
+        self.logger.info(f"{conversation} using model: {self.model}")
         self.logger.info(f"{conversation} determining yes/no: {statement}")
         query = prompt_instructions.format(statement=statement)
 
         self.logger.info(f"{conversation} yes/no query: {query}")
-        self.logger.info(f"{conversation} using model: {model}")
+        self.logger.info(f"{conversation} using model: {self.model}")
 
-        bare_llm = LLMLoader(provider, model).llm
+        bare_llm = LLMLoader(self.provider, self.model).llm
         llm_chain = LLMChain(llm=bare_llm, prompt=prompt_instructions, verbose=verbose)
 
         response = llm_chain(inputs={"statement": statement})

--- a/tests/unit/query_helpers/test_query_helper.py
+++ b/tests/unit/query_helpers/test_query_helper.py
@@ -1,0 +1,39 @@
+"""Unit tests for query helper class."""
+
+from ols.src.query_helpers import QueryHelper, camel_to_snake
+from ols.utils import config
+
+
+def test_camel_to_snake():
+    """Test camel case to snake case conversion."""
+    assert camel_to_snake("") == ""
+    assert camel_to_snake("dog") == "dog"
+    assert camel_to_snake("LOUD") == "loud"
+    assert camel_to_snake("quiet") == "quiet"
+    assert camel_to_snake("OCP4") == "ocp4"
+    assert camel_to_snake("Is there a space?") == "is there a space?"
+    assert camel_to_snake("rainyDay") == "rainy_day"
+    assert camel_to_snake("NiceDay") == "nice_day"
+    assert camel_to_snake("AGoodDay") == "a_good_day"
+
+
+class TestQueryHelper:
+    """Test the query helper class."""
+
+    def test_defaults_used(self):
+        """Test that the defaults are used when no inputs are provided."""
+        config.init_config("tests/config/valid_config.yaml")
+
+        qh = QueryHelper()
+
+        assert qh.provider == config.ols_config.default_provider
+        assert qh.model == config.ols_config.default_model
+
+    def test_inputs_are_used(self):
+        """Test that the inputs are used when provided."""
+        test_provider = "test_provider"
+        test_model = "test_model"
+        qh = QueryHelper(provider=test_provider, model=test_model)
+
+        assert qh.provider == test_provider
+        assert qh.model == test_model

--- a/tests/unit/query_helpers/test_question_validator.py
+++ b/tests/unit/query_helpers/test_question_validator.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from ols.src.query_helpers.question_validator import QuestionValidator
+from ols.src.query_helpers.question_validator import QueryHelper, QuestionValidator
 from ols.utils import config
 from tests.mock_classes.llm_chain import mock_llm_chain
 from tests.mock_classes.llm_loader import mock_llm_loader
@@ -15,6 +15,11 @@ def question_validator():
     """Fixture containing constructed and initialized QuestionValidator."""
     config.init_empty_config()
     return QuestionValidator()
+
+
+def test_is_query_helper_subclass():
+    """Test that QuestionValidator is a subclass of QueryHelper."""
+    assert issubclass(QuestionValidator, QueryHelper)
 
 
 @patch(

--- a/tests/unit/query_helpers/test_yaml_generator.py
+++ b/tests/unit/query_helpers/test_yaml_generator.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from ols.src.query_helpers.yaml_generator import YamlGenerator
+from ols.src.query_helpers.yaml_generator import QueryHelper, YamlGenerator
 from ols.utils import config
 from tests.mock_classes.llm_chain import mock_llm_chain
 from tests.mock_classes.llm_loader import mock_llm_loader
@@ -15,6 +15,11 @@ def yaml_generator():
     """Fixture containing constructed and initialized YamlGenerator."""
     config.init_empty_config()
     return YamlGenerator()
+
+
+def test_is_query_helper_subclass():
+    """Test that YamlGenerator is a subclass of QueryHelper."""
+    assert issubclass(YamlGenerator, QueryHelper)
 
 
 @patch("ols.src.query_helpers.yaml_generator.LLMLoader", new=mock_llm_loader(None))

--- a/tests/unit/query_helpers/test_yes_no_classifier.py
+++ b/tests/unit/query_helpers/test_yes_no_classifier.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from ols.src.query_helpers.yes_no_classifier import YesNoClassifier
+from ols.src.query_helpers.yes_no_classifier import QueryHelper, YesNoClassifier
 from tests.mock_classes.llm_chain import mock_llm_chain
 from tests.mock_classes.llm_loader import mock_llm_loader
 
@@ -13,6 +13,11 @@ from tests.mock_classes.llm_loader import mock_llm_loader
 def yes_no_classifier():
     """Fixture containing constructed and initialized YesNoClassifier."""
     return YesNoClassifier()
+
+
+def test_is_query_helper_subclass():
+    """Test that YesNoClassifier is a subclass of QueryHelper."""
+    assert issubclass(YesNoClassifier, QueryHelper)
 
 
 @patch("ols.src.query_helpers.yes_no_classifier.LLMLoader", new=mock_llm_loader(None))


### PR DESCRIPTION
## Description

This PR unifies the query helpers interface. If there is a need to configure provider/model per helper, we can still do something like this at the place where it's initialized (in ols endpoint now). 
```python
If config.yaml_provider:
   yaml_gen = YamlGenerator(provider=config.yaml_provider, …)
# it will use default/provided one otherwise
```

Allows dependency injection in tests.

The `camel_to_snake` is there only to ensure the same logger name as before (it will be refactored eventually).


## Type of change

- [X] Refactor

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
