### PR TITLE
pin package types-requests<2.31.0.7

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,5 +4,7 @@ mypy
 pytest
 pytest-cov
 ruff
-types-requests
+# types-requests<2.31.0.7 to avoid upgrading urllib3>1.27 that breaks ibm-cos-sdk-core 2.13.
+# todo: remove when ibm-cos-sdk-core does not depend on urllib3<1.27.
+types-requests<2.31.0.7
 


### PR DESCRIPTION
## Description

This fix a dependency conflict caused by `urllib3` : 
* latest version of  `types-requests` requires `urllib3 2.10` 
* ibm-cos-sdk-core 2.13.3 requires urllib3<1.27,>=1.26.18

Lowering the version of `type-requests` makes both packages accept the same version of `urllib3`. 

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
