### PR TITLE
OLS-40: Add provider and model to llm request

### DIFF
--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -10,6 +10,8 @@ class LLMRequest(BaseModel):
         query: The query string.
         conversation_id: The optional conversation ID.
         response: The optional response.
+        provider: The optional provider.
+        model: The optional model.
 
     Example:
         llm_request = LLMRequest(query="Tell me about Kubernetes")
@@ -18,6 +20,8 @@ class LLMRequest(BaseModel):
     query: str
     conversation_id: str | None = None
     response: str | None = None
+    provider: str | None = None
+    model: str | None = None
 
     # provides examples for /docs endpoint
     model_config = {

--- a/ols/src/ui/gradio_ui.py
+++ b/ols/src/ui/gradio_ui.py
@@ -24,9 +24,20 @@ class GradioUI:
 
         # ui specific
         use_history = gr.Checkbox(value=True, label="Use history")
-        self.ui = gr.ChatInterface(self.chat_ui, additional_inputs=[use_history])
+        provider = gr.Textbox(value=None, label="Provider")
+        model = gr.Textbox(value=None, label="Model")
+        self.ui = gr.ChatInterface(
+            self.chat_ui, additional_inputs=[use_history, provider, model]
+        )
 
-    def chat_ui(self, prompt: str, history, use_history: bool | None = None) -> str:
+    def chat_ui(
+        self,
+        prompt: str,
+        history,
+        use_history: bool | None = None,
+        provider: str | None = None,
+        model: str | None = None,
+    ) -> str:
         """Handle requests from web-based user interface."""
         # Headers for the HTTP request
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
@@ -41,6 +52,13 @@ class GradioUI:
         elif use_history and self.conversation_id is not None:
             data["conversation_id"] = self.conversation_id
             logger.info(f"Using conversation ID: {self.conversation_id}")
+
+        if provider:
+            logger.info(f"Using provider: {provider}")
+            data["provider"] = provider
+        if model:
+            logger.info(f"Using model: {model}")
+            data["model"] = model
 
         # Convert the data dictionary to a JSON string
         json_data = json.dumps(data)

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -102,6 +102,8 @@ def test_post_question_on_invalid_question() -> None:
             "conversation_id": conversation_id,
             "query": "test query",
             "response": expected_details,
+            "provider": None,  # default value in request
+            "model": None,  # default value in request
         }
         assert response.json() == expected_json
 
@@ -131,6 +133,8 @@ def test_post_question_on_unknown_response_type() -> None:
             "conversation_id": conversation_id,
             "query": "test query",
             "response": expected_details,
+            "provider": None,  # default value in request
+            "model": None,  # default value in request
         }
         assert response.json() == expected_json
 

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -7,6 +7,7 @@ import requests
 from fastapi.testclient import TestClient
 
 from ols import constants
+from ols.app.models.config import ProviderConfig
 from ols.app.utils import Utils
 from tests.mock_classes.llm_chain import mock_llm_chain
 from tests.mock_classes.llm_loader import mock_llm_loader
@@ -54,6 +55,8 @@ def test_debug_query() -> None:
         "conversation_id": conversation_id,
         "query": "test query",
         "response": "test response",
+        "provider": None,  # default value in request
+        "model": None,  # default value in request
     }
 
 
@@ -130,3 +133,56 @@ def test_post_question_on_unknown_response_type() -> None:
             "response": expected_details,
         }
         assert response.json() == expected_json
+
+
+class TestQuery:
+    """Test the /v1/query endpoint."""
+
+    def test_unsupported_provider_in_post(self):
+        """Check the REST API /v1/query with POST method when unsupported provider is requested."""
+        # empty config - no providers
+        with patch("ols.utils.config.llm_config.providers", new={}):
+            response = client.post(
+                "/v1/query",
+                json={
+                    "query": "hello?",
+                    "provider": "some-provider",
+                    "model": "some-model",
+                },
+            )
+
+            assert response.status_code == requests.codes.unprocessable
+            assert response.json() == {
+                "detail": {
+                    "response": "Unable to process this request because "
+                    "'Unsupported LLM provider some-provider'"
+                }
+            }
+
+    def test_unsupported_model_in_post(self):
+        """Check the REST API /v1/query with POST method when unsupported model is requested."""
+        test_provider = "test-provider"
+        provider_config = ProviderConfig()
+        provider_config.models = {}  # no models configured
+
+        with patch(
+            "ols.utils.config.llm_config.providers",
+            new={test_provider: provider_config},
+        ):
+            response = client.post(
+                "/v1/query",
+                json={
+                    "query": "hello?",
+                    "provider": test_provider,
+                    "model": "some-model",
+                },
+            )
+
+            assert response.status_code == requests.codes.unprocessable
+            assert response.json() == {
+                "detail": {
+                    "response": "Unable to process this request because "
+                    "'No configuration provided for model some-model under "
+                    "LLM provider test-provider'"
+                }
+            }

--- a/tests/unit/app/endpoints/test_ols.py
+++ b/tests/unit/app/endpoints/test_ols.py
@@ -1,0 +1,53 @@
+"""Unit tests for OLS endpoint."""
+
+import logging
+
+import pytest
+from fastapi import HTTPException, status
+
+from ols.app.endpoints.ols import verify_request_provider_and_model
+from ols.app.models.models import LLMRequest
+
+
+class TestVerifyRequestProviderAndModel:
+    """Test the verify_request_provider_and_model function."""
+
+    def test_provider_set_model_not_raises(self):
+        """Test raise when the provider is set and the model is not."""
+        request = LLMRequest(query="bla", provider="provider", model=None)
+        with pytest.raises(
+            HTTPException,
+            match="LLM model must be specified when provider is specified",
+        ) as e:
+            verify_request_provider_and_model(request)
+            assert e.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_model_set_provider_not_raises(self):
+        """Test no raise when the model is set and the provider is not."""
+        request = LLMRequest(query="bla", provider=None, model="model")
+        with pytest.raises(
+            HTTPException,
+            match="LLM provider must be specified when the model is specified",
+        ) as e:
+            verify_request_provider_and_model(request)
+            assert e.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_model_and_provider_logged_when_set(self, caplog):
+        """Test that the function logs the provider and model when they are set."""
+        caplog.set_level(logging.DEBUG)
+        request = LLMRequest(query="bla", provider="provider", model="model")
+        verify_request_provider_and_model(request)
+
+        # check captured outputs
+        captured_out = caplog.text
+        assert "provider 'provider' is set in request" in captured_out
+        assert "model 'model' is set in request" in captured_out
+
+    def test_nothing_is_logged_when_provider_and_model_not_set(self, caplog):
+        """Test that the function does not log anything when the provider and model are not set."""
+        request = LLMRequest(query="bla", provider=None, model=None)
+        verify_request_provider_and_model(request)
+
+        # check captured outputs
+        captured_out = caplog.text
+        assert captured_out == ""


### PR DESCRIPTION
## Description

Adds provider and model to llm request.

Prerequisites:
- [x] [Add QueryHelper parent](https://github.com/openshift/lightspeed-service/pull/217)
- [x] [docs_summarizer to query_helpers](https://github.com/openshift/lightspeed-service/pull/230)

## Type of change

- [X] New feature

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Start app `make run`, visit the `/ui`, and provide values (or not) to provider/model fields.
  - or do posts to `/query` endpoint directly
