### PR TITLE
Unit tests improvements: exception checks should not be too broad

### DIFF
--- a/tests/unit/query_helpers/test_question_validator.py
+++ b/tests/unit/query_helpers/test_question_validator.py
@@ -29,7 +29,9 @@ def test_invalid_response(question_validator):
     # [VALID,NOYAML]
     # [VALID,YAML]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="Returned response did not match the expected format"
+    ):
         question_validator.validate_question(
             conversation="1234", query="What is the meaning of life?"
         )

--- a/tests/unit/query_helpers/test_yes_no_classifier.py
+++ b/tests/unit/query_helpers/test_yes_no_classifier.py
@@ -22,7 +22,7 @@ def test_bad_value_response(yes_no_classifier):
     ml = mock_llm_chain({"text": "default"})
 
     with patch("ols.src.query_helpers.yes_no_classifier.LLMChain", new=ml):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Returned response not 0, 1, or 9"):
             yes_no_classifier.classify(
                 conversation="1234", statement="The sky is blue."
             )

--- a/tests/unit/test_cache_factory.py
+++ b/tests/unit/test_cache_factory.py
@@ -59,5 +59,5 @@ def test_conversation_cache_in_redis(redis_cache_config):
 
 def test_conversation_cache_wrong_cache(invalid_cache_type_config):
     """Check if wrong cache env.variable is detected properly."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Invalid cache type"):
         CacheFactory.conversation_cache(invalid_cache_type_config)


### PR DESCRIPTION
## Description

Unit tests improvements: exception checks should not be too broad.

`pytest.raises(Exception)` etc. will catch any `Exception` and may catch errors that are
unrelated to the code under test. To avoid this, `pytest.raises` should be called with a `match` parameter.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Unit tests

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- `make test-unit`
