### PR TITLE
Updated linter rule for pytest.fixture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ ignore = []
 target-version = "py311"
 pydocstyle.convention = "google"
 line-length = 100
+flake8-pytest-style.fixture-parentheses = false
 
 [tool.coverage.report]
 # unit tests fails if the total coverage measurement is under this threshold value


### PR DESCRIPTION
## Description

Updated linter rule for `pytest.fixture`
There are two ways how to call `pytest.fixture` without arguments:

```python
@pytest.fixture
def my_fixture():
    ...
```

or:

```python
@pytest.fixture()
def my_fixture():
    ...
```

Both variants are perfectly ok, but it's better to choose one to be consistent. I choosed the 1st one that's already in our sources, so we just need to inform linters about it.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- N/A
