### PR TITLE
Raise exception when config file is missing

### DIFF
--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -59,3 +59,4 @@ def init_config(config_file):
     except Exception as e:
         print(f"Failed to load config file {config_file}: {e!s}")
         print(traceback.format_exc())
+        raise e

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -41,6 +41,14 @@ def test_malformed_yaml() -> None:
     )
 
 
+def test_missing_config_file() -> None:
+    """Check how missing configuration file is handled."""
+    with pytest.raises(Exception, match="Not a directory"):
+        # /dev/null is special file so it can't be directory
+        # at the same moment
+        config.init_config("/dev/null/non-existent")
+
+
 def test_invalid_config() -> None:
     """Check that invalid configuration is handled gracefully."""
     check_expected_exception("""""", InvalidConfigurationError, "no LLMProviders found")


### PR DESCRIPTION
## Description

Raise exception when config file is missing - because in such situation the UI, REST API server etc. won't start properly either

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Unit tests

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- On CI or using `make test-unit`
