### PR TITLE
Use more idiomatic `pytest.fail()` instead of `assert False`

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -276,7 +276,7 @@ OLSConfig:
         )
     except Exception:
         print(traceback.format_exc())
-        assert False
+        pytest.fail()
 
 
 def test_valid_config_file() -> None:
@@ -345,7 +345,7 @@ def test_valid_config_file() -> None:
         assert config.config == expected_config
     except Exception:
         print(traceback.format_exc())
-        assert False
+        pytest.fail()
 
 
 def test_valid_config_file_with_redis() -> None:
@@ -393,4 +393,4 @@ def test_valid_config_file_with_redis() -> None:
         assert config.config == expected_config
     except Exception:
         print(traceback.format_exc())
-        assert False
+        pytest.fail()


### PR DESCRIPTION
## Description

Use more idiomatic `pytest.fail()` instead of `assert False`

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- CI should still pass
