### PR TITLE
Add missing commas in query helpers tests

### DIFF
--- a/tests/unit/query_helpers/test_question_validator.py
+++ b/tests/unit/query_helpers/test_question_validator.py
@@ -35,10 +35,10 @@ def test_invalid_response(question_validator):
     # [VALID,YAML]
 
     with pytest.raises(
-        ValueError, match="Returned response did not match the expected format"
+        ValueError, match="Returned response did not match the expected format",
     ):
         question_validator.validate_question(
-            conversation="1234", query="What is the meaning of life?"
+            conversation="1234", query="What is the meaning of life?",
         )
 
 
@@ -51,7 +51,7 @@ def test_valid_responses(question_validator):
         ml = mock_llm_chain({"text": retval})
         with patch("ols.src.query_helpers.question_validator.LLMChain", new=ml):
             response = question_validator.validate_question(
-                conversation="1234", query="What is the meaning of life?"
+                conversation="1234", query="What is the meaning of life?",
             )
 
             assert response == retval.split(",")

--- a/tests/unit/query_helpers/test_yaml_generator.py
+++ b/tests/unit/query_helpers/test_yaml_generator.py
@@ -53,7 +53,7 @@ def test_yaml_generator_history_enabled(yaml_generator):
 
         # response will be constant because we mocked LLMChain and LLMLoader
         response = yaml_generator.generate_yaml(
-            "1234", "the query", history="conversation history"
+            "1234", "the query", history="conversation history",
         )
         assert response == "default"
 

--- a/tests/unit/query_helpers/test_yes_no_classifier.py
+++ b/tests/unit/query_helpers/test_yes_no_classifier.py
@@ -29,7 +29,7 @@ def test_bad_value_response(yes_no_classifier):
     with patch("ols.src.query_helpers.yes_no_classifier.LLMChain", new=ml):
         with pytest.raises(ValueError, match="Returned response not 0, 1, or 9"):
             yes_no_classifier.classify(
-                conversation="1234", statement="The sky is blue."
+                conversation="1234", statement="The sky is blue.",
             )
 
 
@@ -42,5 +42,5 @@ def test_good_value_response(yes_no_classifier):
 
         with patch("ols.src.query_helpers.yes_no_classifier.LLMChain", new=ml):
             assert yes_no_classifier.classify(
-                conversation="1234", statement="The sky is blue."
+                conversation="1234", statement="The sky is blue.",
             ) == int(x)


### PR DESCRIPTION
## Description

The presence of a trailing comma can reduce diff size when parameters or
elements are added or removed from function calls, function definitions,
literals, etc.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Nothing really changed in logic
