### PR TITLE
Fix: `VectorDB` parameter is not optional

### DIFF
--- a/ols/src/query_helpers/query_docs.py
+++ b/ols/src/query_helpers/query_docs.py
@@ -21,7 +21,7 @@ class QueryDocs:
     def get_relevant_docs(
         self,
         query: str,
-        vectordb: VectorStore = None,
+        vectordb: VectorStore,
         search_type: str = "similarity",
         **search_kwargs: Any,
     ) -> list[Document] | None:


### PR DESCRIPTION
## Description

Fix: `VectorDB` parameter is not optional

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.
