### PR TITLE
Ensure script returns error code from test execution

### DIFF
--- a/ols/src/llms/llm_loader.py
+++ b/ols/src/llms/llm_loader.py
@@ -6,8 +6,6 @@ import os
 import warnings
 from typing import Optional
 
-# from langchain.callbacks.manager import CallbackManager
-# from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from langchain.llms.base import LLM
 
 from ols import constants
@@ -134,7 +132,7 @@ class LLMLoader:
     def _openai_llm_instance(self) -> LLM:
         logger.debug(f"[{inspect.stack()[0][3]}] Creating OpenAI LLM instance")
         try:
-            from langchain.chat_models import ChatOpenAI
+            from langchain_community.chat_models import ChatOpenAI
         except Exception as e:
             logger.error(
                 "Missing openai libraries. Openai provider will be unavailable."
@@ -146,7 +144,7 @@ class LLMLoader:
                 if self.provider_config.url is not None
                 else "https://api.openai.com/v1"
             ),
-            "api_key": self.provider_config.credentials,
+            "openai_api_key": self.provider_config.credentials,
             "model": self.model,
             "model_kwargs": {},  # TODO: add model args
             "organization": os.environ.get("OPENAI_ORGANIZATION", None),
@@ -159,6 +157,8 @@ class LLMLoader:
             "frequency_penalty": 1.03,
             "verbose": False,
         }
+        keylen=len(params["openai_api_key"])
+        logger.info(f"initializing openai with openai_api_key length {keylen}")
         # TODO: We need to verify if the overridden params are valid for the LLM
         # before updating the default.
         # params.update(self.llm_params)  # override parameters

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastapi
 gradio
 kubernetes
 langchain
+langchain-community
 llama_index
 torch
 transformers

--- a/scripts/test-e2e-standalone.sh
+++ b/scripts/test-e2e-standalone.sh
@@ -21,7 +21,12 @@ OLS_LOGS=$ARTIFACT_DIR/ols.log
 
 # Generate ols config.yaml
 export PROVIDER="${PROVIDER:-openai}"
-export PROVIDER_KEY_PATH="${PROVIDER_KEY_PATH:-/home/bparees/creds/llms/openai.key}"
+export PROVIDER_KEY_PATH="${PROVIDER_KEY_PATH:-openai_api_key.txt}"
+if [ ! -e "$PROVIDER_KEY_PATH" ]; then
+  echo "No key found at $PROVIDER_KEY_PATH"
+  exit 1
+fi
+
 export MODEL="${MODEL:-gpt-3.5-turbo-1106}"
 envsubst < $(pwd)/tests/config/singleprovider.e2e.template.config.yaml > $OLS_CONFIG_FILE
 
@@ -58,4 +63,3 @@ fi
 
 echo Done waiting for OLS server start, running e2e
 make test-e2e
-echo Done running e2e


### PR DESCRIPTION
## Description
the trailing echo command in the script lead to it exiting with code 0 instead
of the error code from the make test-e2e invocation, which in turn lead to
prow always considering the job to have succeeded.


<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.