### PR TITLE
Fix error: response is string already

### DIFF
--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -109,7 +109,7 @@ class DocsSummarizer(QueryHelper):
             response = bare_llm.invoke(query)
             summary = f""" The following response was generated without access to RAG content:
 
-                        {response.content}
+                        {response}
                       """
             referenced_documents = ""
 


### PR DESCRIPTION
## Description

Fix error: `response` is string already

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

