### PR TITLE
Use default logging level if nothing is specified in config file

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -281,7 +281,7 @@ class LoggingConfig(BaseModel):
         """Initialize configuration and perform basic validation."""
         super().__init__()
         if data is None:
-            return
+            data = {}
 
         self.app_log_level = self._get_log_level(data, "app_log_level", "info")
         self.library_log_level = self._get_log_level(

--- a/tests/config/config_without_logging.yaml
+++ b/tests/config/config_without_logging.yaml
@@ -1,0 +1,21 @@
+---
+LLMProviders:
+  - name: p1
+    url: "https://url1"
+    credentials_path: tests/config/secret.txt
+    models:
+      - name: m1
+        url: "https://murl1"
+OLSConfig:
+  conversation_cache:
+    type: redis
+    redis:
+      host: "foobar.com"
+      port: "1234"
+      max_memory: 100MB
+      max_memory_policy: "allkeys-lru"
+      credentials:
+        user_path: tests/config/redis_user.txt
+        password_path: tests/config/redis_password.txt
+  default_provider: p1
+  default_model: m1

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,6 +1,7 @@
 """Unit tests for the configuration model."""
 
 import io
+import logging
 import traceback
 from typing import TypeVar
 
@@ -402,3 +403,15 @@ def test_valid_config_file_with_redis() -> None:
     except Exception:
         print(traceback.format_exc())
         pytest.fail()
+
+
+def test_config_file_without_logging_config() -> None:
+    """Check how a configuration file without logging config is correctly initialized."""
+    # when logging configuration is not provided, default values will be used
+    # it means the following call should not fail
+    config.init_config("tests/config/config_without_logging.yaml")
+
+    # test if default values have been set
+    logging_config = config.ols_config.logging_config
+    assert logging_config.app_log_level == logging.INFO
+    assert logging_config.library_log_level == logging.WARNING

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -204,7 +204,7 @@ class TestLoggingConfig:
         assert logging_config.library_log_level == logging.DEBUG
 
         logging_config = LoggingConfig()
-        assert logging_config.app_log_level is None
+        assert logging_config.app_log_level == logging.INFO
 
     def test_invalid_values(self):
         """Test invalid values."""


### PR DESCRIPTION
## Description

- Previously the code "accepts" config with missing logging info, but then fail on the first call of any log method
- Now default logging level will be used

## Type of change

- [ ] Refactor
- [x] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Unit tests and integration tests should pass
