### PR TITLE
Configure logging for other libraries

### DIFF
--- a/ols/utils/logging.py
+++ b/ols/utils/logging.py
@@ -15,3 +15,7 @@ def configure_logging(logging_config: LoggingConfig) -> None:
     logging.getLogger("httpcore").setLevel(logging_config.library_log_level)
     logging.getLogger("httpx").setLevel(logging_config.library_log_level)
     logging.getLogger("urllib3").setLevel(logging_config.library_log_level)
+    logging.getLogger("langchain_community").setLevel(logging_config.library_log_level)
+    logging.getLogger("openai").setLevel(logging_config.library_log_level)
+    logging.getLogger("fsspec").setLevel(logging_config.library_log_level)
+    logging.getLogger("llama_index").setLevel(logging_config.library_log_level)


### PR DESCRIPTION
## Description

Setting logging level for other libs that pops up when logging is set to debug.

For context, with the previous logging implementation, those were silenced (IRC correctly) as we were not configuring the root logger.

Some examples
`2024-01-26 15:08:09,670 [langchain_community.chat_models.openai:openai.py:255] WARNING: WARNING! frequency_penalty is not default parameter.`
`2024-01-26 15:08:13,809 [openai:util.py:60] DEBUG: message='OpenAI API response' path=https://api.openai.com/v1/chat/completions processing_ms=88 request_id=41bb9…`
`2024-01-26 15:07:05,235 [fsspec.local:local.py:294] DEBUG: open file: /home/ometelka/projects/lightspeed-service/vector-db/ocp-product-docs/docstore.json`
`2024-01-26 15:09:17,906 [llama_index.storage.kvstore.simple_kvstore:simple_kvstore.py:74] DEBUG: Loading llama_index.storage.kvstore.simple_kvstore from ./vector-db/ocp-product-docs/docstore.json.`

The list of logging libs is probably not final. I admit it is a bit unusual, but its given by the area we are working on. A lot of our dependencies are doing some other 3rd party calls so they implement root logging to have some debugging ability for the end user.

## Type of change

- [x] New feature
