### PR TITLE
fix empty conversation_id

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -35,7 +35,7 @@ def conversation_request(llm_request: LLMRequest) -> LLMRequest:
     conversation = llm_request.conversation_id
 
     # Generate a new conversation ID if not provided
-    if conversation is None:
+    if not conversation:
         conversation = Utils.get_suid()
         logger.info(f"{conversation} New conversation")
     else:

--- a/tests/unit/test_app_endpoints.py
+++ b/tests/unit/test_app_endpoints.py
@@ -57,6 +57,7 @@ def test_conversation_request(
         response.response
         == "Kubernetes is an open-source container-orchestration system..."
     )
+    assert len(response.conversation_id) > 0
 
     # valid question, yaml
     mock_validate_question.return_value = [
@@ -67,6 +68,7 @@ def test_conversation_request(
     llm_request = LLMRequest(query="Generate a yaml")
     response = ols.conversation_request(llm_request)
     assert response.response == "content: generated yaml"
+    assert len(response.conversation_id) > 0
 
     # valid question, yaml, generator failure
     mock_validate_question.return_value = [
@@ -78,6 +80,7 @@ def test_conversation_request(
         llm_request = LLMRequest(query="Generate a yaml")
         response = ols.conversation_request(llm_request)
         assert excinfo.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert len(response.conversation_id) == 0
 
     # question of unknown type
     mock_validate_question.return_value = [
@@ -94,6 +97,7 @@ def test_conversation_request(
             }
         }
     )
+    assert len(response.conversation_id) > 0
 
     # invalid question
     mock_validate_question.return_value = [
@@ -110,6 +114,7 @@ def test_conversation_request(
             }
         }
     )
+    assert len(response.conversation_id) > 0
 
     # conversation is cached
     mock_validate_question.return_value = [
@@ -129,6 +134,7 @@ def test_conversation_request(
         llm_request = LLMRequest(query="Generate a yaml")
         response = ols.conversation_request(llm_request)
         assert excinfo.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert len(response.conversation_id) == 0
 
 
 def fake_llm_chain_call(self, **kwargs):


### PR DESCRIPTION
## Description
conversation id when given empty string , it goes to the preexisting conversation id flow.
Fixed by checking for empty string . 

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
