### PR TITLE
Add gpt model to example config

### DIFF
--- a/examples/olsconfig.yaml
+++ b/examples/olsconfig.yaml
@@ -10,6 +10,7 @@ LLMProviders:
     credentials_path: openai_api_key.txt
     models:
       - name: gpt-4-1106-preview
+      - name: gpt-3.5-turbo
 OLSConfig:
   enable_debug_ui: false
   conversation_cache:


### PR DESCRIPTION
## Description

Adds gpt turbo model to example config.

What would be the best approach here?
1. have all models that we allow (as we probably don't want to allow some, eg. gpt-4-vision-preview) listed in the example config
2. leave it to user - user needs to change default_model as well as make sure the model is listed under the correct provider

WDYT?