### PR TITLE
Missing return type in health endpoints handlers

### DIFF
--- a/ols/app/endpoints/health.py
+++ b/ols/app/endpoints/health.py
@@ -8,12 +8,12 @@ router = APIRouter(tags=["health"])
 
 
 @router.get("/readiness")
-def readiness_probe():
+def readiness_probe() -> dict[str, str]:
     """Ready status of service."""
     return {"status": "1"}
 
 
 @router.get("/liveness")
-def liveness_probe():
+def liveness_probe() -> dict[str, str]:
     """Live status of service."""
     return {"status": "1"}


### PR DESCRIPTION
## Description

Missing return type in health endpoints handlers

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
