### PR TITLE
OLS-109: Keys to cache must contain user ID

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -34,12 +34,15 @@ def conversation_request(llm_request: LLMRequest) -> LLMRequest:
     previous_input = None
     conversation = llm_request.conversation_id
 
+    # TODO: retrieve proper user ID from request
+    user_id = "user1"
+
     # Generate a new conversation ID if not provided
     if conversation is None:
         conversation = Utils.get_suid()
         logger.info(f"{conversation} New conversation")
     else:
-        previous_input = config.conversation_cache.get(conversation)
+        previous_input = config.conversation_cache.get(user_id, conversation)
         logger.info(f"{conversation} Previous conversation input: {previous_input}")
 
     llm_response = LLMRequest(query=llm_request.query, conversation_id=conversation)
@@ -126,6 +129,7 @@ def conversation_request(llm_request: LLMRequest) -> LLMRequest:
 
     if config.conversation_cache is not None:
         config.conversation_cache.insert_or_append(
+            user_id,
             conversation,
             llm_request.query + "\n\n" + str(llm_response.response or ""),
         )

--- a/ols/src/cache/cache.py
+++ b/ols/src/cache/cache.py
@@ -1,5 +1,6 @@
 """Abstract class that is parent for all cache implementations."""
 
+import re
 from abc import ABC, abstractmethod
 from typing import Union
 
@@ -7,22 +8,44 @@ from typing import Union
 class Cache(ABC):
     """Abstract class that is parent for all cache implementations."""
 
+    @staticmethod
+    def _check_user_id(user_id: str):
+        """Check if given user ID is valid."""
+        # TODO: needs to be updated when we know the format
+        if "/" in user_id:
+            raise ValueError("Incorrect user ID {user_id}")
+
+    @staticmethod
+    def _check_conversation_id(conversation_id: str):
+        """Check if given conversation ID is a valid UUID (including optional dashes)."""
+        if re.compile("^[a-f0-9]{32}$").match(conversation_id) is None:
+            raise ValueError(f"Incorrect conversation ID {conversation_id}")
+
+    @staticmethod
+    def construct_key(user_id: str, conversation_id: str) -> str:
+        """Construct key to cache."""
+        Cache._check_user_id(user_id)
+        Cache._check_conversation_id(conversation_id)
+        return f"{user_id}/{conversation_id}"
+
     @abstractmethod
-    def get(self, key: str) -> Union[str, None]:
+    def get(self, user_id: str, conversation_id: str) -> Union[str, None]:
         """Abstract method to retrieve a value from the cache.
 
         Args:
-            key: The key associated with the value.
+            user_id: User identification.
+            conversation_id: Conversation ID unique for given user.
 
         Returns:
             The value associated with the key, or None if not found.
         """
 
     @abstractmethod
-    def insert_or_append(self, key: str, value: str) -> None:
+    def insert_or_append(self, user_id: str, conversation_id: str, value: str) -> None:
         """Abstract method to store a value in the cache.
 
         Args:
-            key: The key to associate with the value.
+            user_id: User identification.
+            conversation_id: Conversation ID unique for given user.
             value: The value to be stored in the cache.
         """

--- a/ols/src/cache/in_memory_cache.py
+++ b/ols/src/cache/in_memory_cache.py
@@ -29,15 +29,18 @@ class InMemoryCache(Cache):
         self.deque: deque[str] = deque()
         self.cache: dict[str, str] = {}
 
-    def get(self, key: str) -> Union[str, None]:
+    def get(self, user_id: str, conversation_id: str) -> Union[str, None]:
         """Get the value associated with the given key.
 
         Args:
-          key: The key to look up in the cache.
+          user_id: User identification.
+          conversation_id: Conversation ID unique for given user.
 
         Returns:
           The value associated with the key, or `None` if the key is not present.
         """
+        key = super().construct_key(user_id, conversation_id)
+
         if key not in self.cache:
             return None
 
@@ -45,13 +48,16 @@ class InMemoryCache(Cache):
         self.deque.appendleft(key)
         return self.cache[key]
 
-    def insert_or_append(self, key: str, value: str) -> None:
+    def insert_or_append(self, user_id: str, conversation_id: str, value: str) -> None:
         """Set the value if a key is not present or else simply appends.
 
         Args:
-          key: The key to set in the cache.
+          user_id: User identification.
+          conversation_id: Conversation ID unique for given user.
           value: The value to associate with the key.
         """
+        key = super().construct_key(user_id, conversation_id)
+
         with self._lock:
             if key not in self.cache:
                 if len(self.deque) == self.capacity:

--- a/ols/src/cache/redis_cache.py
+++ b/ols/src/cache/redis_cache.py
@@ -46,29 +46,35 @@ class RedisCache(Cache):
             "maxmemory-policy", constants.REDIS_CACHE_MAX_MEMORY_POLICY
         )
 
-    def get(self, key: str) -> Union[str, None]:
+    def get(self, user_id: str, conversation_id: str) -> Union[str, None]:
         """Get the value associated with the given key.
 
         Args:
-            key: The key for the desired value.
+            user_id: User identification.
+            conversation_id: Conversation ID unique for given user.
 
         Returns:
             The value associated with the key, or None if not found.
         """
+        key = super().construct_key(user_id, conversation_id)
+
         return self.redis_client.get(key)
 
-    def insert_or_append(self, key: str, value: str) -> None:
+    def insert_or_append(self, user_id: str, conversation_id: str, value: str) -> None:
         """Set the value associated with the given key.
 
         Args:
-            key: The key for the value.
+            user_id: User identification.
+            conversation_id: Conversation ID unique for given user.
             value: The value to set.
 
         Raises:
             OutOfMemoryError: If item is evicted when Redis allocated
                 memory is higher than maxmemory.
         """
-        old_value = self.get(key)
+        key = super().construct_key(user_id, conversation_id)
+
+        old_value = self.get(user_id, conversation_id)
         with self._lock:
             if old_value:
                 self.redis_client.set(key, old_value + "\n" + value)

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -5,6 +5,8 @@ from httpx import Client
 
 client = Client(base_url="http://localhost:8080")
 
+conversation_id = "0123456789abcdef0123456789abcdef"
+
 
 def test_readiness() -> None:
     """Test handler for /readiness REST API endpoint."""
@@ -24,14 +26,14 @@ def test_raw_prompt() -> None:
     """Check the REST API /v1/debug/query with POST HTTP method when expected payload is posted."""
     r = client.post(
         "/v1/debug/query",
-        json={"conversation_id": "1234", "query": "say hello"},
+        json={"conversation_id": conversation_id, "query": "say hello"},
         timeout=20,
     )
     print(vars(r))
     response = r.json()
 
     assert r.status_code == requests.codes.ok
-    assert response["conversation_id"] == "1234"
+    assert response["conversation_id"] == conversation_id
     assert response["query"] == "say hello"
     assert "hello" in response["response"].lower()
 
@@ -39,7 +41,9 @@ def test_raw_prompt() -> None:
 def test_invalid_question() -> None:
     """Check the REST API /v1/query with POST HTTP method for invalid question."""
     response = client.post(
-        "/v1/query", json={"conversation_id": "1234", "query": "test query"}, timeout=20
+        "/v1/query",
+        json={"conversation_id": conversation_id, "query": "test query"},
+        timeout=20,
     )
     print(vars(response))
     assert response.status_code == requests.codes.ok
@@ -52,7 +56,7 @@ def test_invalid_question() -> None:
         }
     )
     expected_json = {
-        "conversation_id": "1234",
+        "conversation_id": conversation_id,
         "query": "test query",
         "response": expected_details,
     }

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -7,6 +7,7 @@ import requests
 from fastapi.testclient import TestClient
 
 from ols import constants
+from ols.app.utils import Utils
 from tests.mock_classes.llm_chain import mock_llm_chain
 from tests.mock_classes.llm_loader import mock_llm_loader
 
@@ -42,13 +43,15 @@ def test_readiness() -> None:
 @patch("ols.app.endpoints.ols.LLMLoader", new=mock_llm_loader(None))
 def test_debug_query() -> None:
     """Check the REST API /v1/debug/query with POST HTTP method when expected payload is posted."""
+    conversation_id = Utils.get_suid()
     response = client.post(
-        "/v1/debug/query", json={"conversation_id": "1234", "query": "test query"}
+        "/v1/debug/query",
+        json={"conversation_id": conversation_id, "query": "test query"},
     )
     print(response)
     assert response.status_code == requests.codes.ok
     assert response.json() == {
-        "conversation_id": "1234",
+        "conversation_id": conversation_id,
         "query": "test query",
         "response": "test response",
     }
@@ -78,8 +81,10 @@ def test_post_question_on_invalid_question() -> None:
     with patch(
         "ols.app.endpoints.ols.QuestionValidator.validate_question", return_value=answer
     ):
+        conversation_id = Utils.get_suid()
         response = client.post(
-            "/v1/query", json={"conversation_id": "1234", "query": "test query"}
+            "/v1/query",
+            json={"conversation_id": conversation_id, "query": "test query"},
         )
         assert response.status_code == requests.codes.ok
         expected_details = str(
@@ -91,7 +96,7 @@ def test_post_question_on_invalid_question() -> None:
             }
         )
         expected_json = {
-            "conversation_id": "1234",
+            "conversation_id": conversation_id,
             "query": "test query",
             "response": expected_details,
         }
@@ -105,8 +110,10 @@ def test_post_question_on_unknown_response_type() -> None:
     with patch(
         "ols.app.endpoints.ols.QuestionValidator.validate_question", return_value=answer
     ):
+        conversation_id = Utils.get_suid()
         response = client.post(
-            "/v1/query", json={"conversation_id": "1234", "query": "test query"}
+            "/v1/query",
+            json={"conversation_id": conversation_id, "query": "test query"},
         )
         assert response.status_code == requests.codes.ok
         expected_details = str(
@@ -118,7 +125,7 @@ def test_post_question_on_unknown_response_type() -> None:
             }
         )
         expected_json = {
-            "conversation_id": "1234",
+            "conversation_id": conversation_id,
             "query": "test query",
             "response": expected_details,
         }

--- a/tests/unit/test_app_endpoints.py
+++ b/tests/unit/test_app_endpoints.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException
 from ols import constants
 from ols.app.endpoints import feedback, ols
 from ols.app.models.models import FeedbackRequest, LLMRequest
+from ols.app.utils import Utils
 from ols.utils import config
 from tests.mock_classes.llm_chain import mock_llm_chain
 from tests.mock_classes.llm_loader import mock_llm_loader
@@ -119,7 +120,7 @@ def test_conversation_request(
     mock_generate_yaml.return_value = "content: generated yaml"
     mock_generate_yaml.side_effect = None
     mock_conversation_cache_get.return_value = "previous conversation input"
-    llm_request = LLMRequest(query="Generate a yaml", conversation_id="123")
+    llm_request = LLMRequest(query="Generate a yaml", conversation_id=Utils.get_suid())
     response = ols.conversation_request(llm_request)
     assert response.response == "content: generated yaml"
 

--- a/tests/unit/test_in_memory_cache.py
+++ b/tests/unit/test_in_memory_cache.py
@@ -2,7 +2,10 @@
 
 import pytest
 
+from ols.app.utils import Utils
 from ols.src.cache.in_memory_cache import InMemoryCache
+
+conversation_id = Utils.get_suid()
 
 
 @pytest.fixture
@@ -16,15 +19,15 @@ def cache():
 
 def test_insert_or_append(cache):
     """Test the behavior of insert_or_append method."""
-    cache.insert_or_append("key1", "value1")
-    assert cache.get("key1") == "value1"
+    cache.insert_or_append("user1", conversation_id, "value1")
+    assert cache.get("user1", conversation_id) == "value1"
 
 
 def test_insert_or_append_existing_key(cache):
     """Test the behavior of insert_or_append method for existing item."""
-    cache.insert_or_append("key1", "value1")
-    cache.insert_or_append("key1", "value2")
-    assert cache.get("key1") == "value1\nvalue2"
+    cache.insert_or_append("user1", conversation_id, "value1")
+    cache.insert_or_append("user1", conversation_id, "value2")
+    assert cache.get("user1", conversation_id) == "value1\nvalue2"
 
 
 def test_insert_or_append_overflow(cache):
@@ -32,19 +35,31 @@ def test_insert_or_append_overflow(cache):
     capacity = 5
     cache.capacity = capacity
     for i in range(capacity + 1):
-        key = f"key{i}"
+        user = f"user{i}"
         value = f"value{i}"
-        cache.insert_or_append(key, value)
+        cache.insert_or_append(user, conversation_id, value)
 
     # Ensure the oldest entry is evicted
-    assert cache.get("key0") is None
+    assert cache.get("user0", conversation_id) is None
     # Ensure the newest entry is still present
-    assert cache.get(f"key{capacity}") == f"value{capacity}"
+    assert cache.get(f"user{capacity}", conversation_id) == f"value{capacity}"
 
 
-def test_get_nonexistent_key(cache):
+def test_get_nonexistent_user(cache):
     """Test how non-existent items are handled by the cache."""
-    assert cache.get("nonexistent_key") is None
+    assert cache.get("nonexistent_user", conversation_id) is None
+
+
+def test_get_improper_user_id(cache):
+    """Test how improper user ID is handled."""
+    with pytest.raises(ValueError):
+        assert cache.get("foo/bar", conversation_id) is None
+
+
+def test_get_improper_conversation_id(cache):
+    """Test how improper conversation ID is handled."""
+    with pytest.raises(ValueError):
+        assert cache.get("user1", "this-is-not-valid-uuid") is None
 
 
 def test_singleton_pattern():

--- a/tests/unit/test_redis_cache.py
+++ b/tests/unit/test_redis_cache.py
@@ -4,8 +4,11 @@ from unittest.mock import patch
 
 import pytest
 
+from ols.app.utils import Utils
 from ols.src.cache.redis_cache import RedisCache
 from tests.mock_classes.redis import MockRedis
+
+conversation_id = Utils.get_suid()
 
 
 @pytest.fixture
@@ -19,23 +22,36 @@ def cache():
 
 def test_insert_or_append(cache):
     """Test the behavior of insert_or_append method."""
-    assert cache.get("key1") is None
-    cache.insert_or_append("key1", "value1")
-    assert cache.get("key1") == "value1"
+    assert cache.get("user1", conversation_id) is None
+    cache.insert_or_append("user1", conversation_id, "value1")
+    assert cache.get("user1", conversation_id) == "value1"
 
 
 def test_insert_or_append_existing_key(cache):
     """Test the behavior of insert_or_append method for existing item."""
-    assert cache.get("key2") is None
+    # conversation IDs are separated by users
+    assert cache.get("user2", conversation_id) is None
 
-    cache.insert_or_append("key2", "value1")
-    cache.insert_or_append("key2", "value2")
-    assert cache.get("key2") == "value1\nvalue2"
+    cache.insert_or_append("user2", conversation_id, "value1")
+    cache.insert_or_append("user2", conversation_id, "value2")
+    assert cache.get("user2", conversation_id) == "value1\nvalue2"
 
 
 def test_get_nonexistent_key(cache):
     """Test how non-existent items are handled by the cache."""
-    assert cache.get("nonexistent_key") is None
+    assert cache.get("nonexistent_key", conversation_id) is None
+
+
+def test_get_improper_user_id(cache):
+    """Test how improper user ID is handled."""
+    with pytest.raises(ValueError):
+        assert cache.get("foo/bar", conversation_id) is None
+
+
+def test_get_improper_conversation_id(cache):
+    """Test how improper conversation ID is handled."""
+    with pytest.raises(ValueError):
+        assert cache.get("user1", "this-is-not-valid-uuid") is None
 
 
 def test_singleton_pattern():


### PR DESCRIPTION
## Description

- Keys to cache must contain user ID
- Requirements: Access to the conversation history must be based on user identity plus conversation uid so that users can’t guess someone else’s conversation uid and retrieve their conversation history.
- Now we don't (yet) have the user identity code built-in (see #267), but we can update existing code in advance. Later just one line would need to be changed (marked as `TODO` in this PR)

<!--- Describe your changes in detail -->

## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-109](https://issues.redhat.com//browse/OLS-109)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Both unit tests and integration tests checks the behaviour
