### PR TITLE
Pin Pydantic to version 2.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ uvicorn
 redis
 faiss-cpu
 sentence-transformers
+pydantic==2.6.0
 -r ols/src/llms/requirements.txt


### PR DESCRIPTION
## Description

Pin Pydantic to version 2.6.0

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
