### PR TITLE
OLS-201: Refactoring: separate elementary REST API endpoints from OLS-related endpoints

### DIFF
--- a/tests/integration/test_liveness_readiness.py
+++ b/tests/integration/test_liveness_readiness.py
@@ -1,0 +1,32 @@
+"""Integration tests for /livenss and /readiness REST API endpoints."""
+
+import os
+from unittest.mock import patch
+
+import requests
+from fastapi.testclient import TestClient
+
+
+# we need to patch the config file path to point to the test
+# config file before we import anything from main.py
+@patch.dict(os.environ, {"OLS_CONFIG_FILE": "tests/config/valid_config.yaml"})
+def setup():
+    """Setups the test client."""
+    global client
+    from ols.app.main import app
+
+    client = TestClient(app)
+
+
+def test_liveness() -> None:
+    """Test handler for /liveness REST API endpoint."""
+    response = client.get("/liveness")
+    assert response.status_code == requests.codes.ok
+    assert response.json() == {"status": "1"}
+
+
+def test_readiness() -> None:
+    """Test handler for /readiness REST API endpoint."""
+    response = client.get("/readiness")
+    assert response.status_code == requests.codes.ok
+    assert response.json() == {"status": "1"}

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -23,20 +23,6 @@ def setup():
     client = TestClient(app)
 
 
-def test_liveness() -> None:
-    """Test handler for /liveness REST API endpoint."""
-    response = client.get("/liveness")
-    assert response.status_code == requests.codes.ok
-    assert response.json() == {"status": "1"}
-
-
-def test_readiness() -> None:
-    """Test handler for /readiness REST API endpoint."""
-    response = client.get("/readiness")
-    assert response.status_code == requests.codes.ok
-    assert response.json() == {"status": "1"}
-
-
 # the raw prompt should just return stuff from LLMChain, so mock that base method in ols.py
 @patch("ols.app.endpoints.ols.LLMChain", new=mock_llm_chain({"text": "test response"}))
 # during LLM init, exceptins will occur on CI, so let's mock that too


### PR DESCRIPTION
## Description

Refactoring: separate elementary REST API endpoints from OLS-related endpoints

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-201](https://issues.redhat.com//browse/OLS-201)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- On CI, integration tests
- `make test-integration`
