### PR TITLE
OLS-201: Fix: No linefeed in OpenAPI JSON

### DIFF
--- a/ols/app/main.py
+++ b/ols/app/main.py
@@ -12,9 +12,7 @@ from ols.utils.logging import configure_logging
 
 app = FastAPI(
     title="Swagger OpenShift LightSpeed Service - OpenAPI",
-    description="""
-              OpenShift LightSpeed Service API specification.
-                  """,
+    description="""OpenShift LightSpeed Service API specification.""",
 )
 
 


### PR DESCRIPTION
## Description

Fix: No linefeed in OpenAPI JSON. That string is passed directly into OpenAPI endpoint, including all linefeeds etc. It makes it unreadable.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-201](https://issues.redhat.com//browse/OLS-201)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.

## Testing
- Run the service and access `/openapi.json`
