### PR TITLE
OLS-157: Proper distribution of models unit tests

### DIFF
--- a/tests/unit/app/models/__init__.py
+++ b/tests/unit/app/models/__init__.py
@@ -1,0 +1,1 @@
+"""Init of tests/unit/app/models."""

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -16,42 +16,6 @@ from ols.app.models.config import (
     ProviderConfig,
     RedisConfig,
 )
-from ols.app.models.models import FeedbackRequest, LLMRequest
-from ols.app.utils import Utils
-
-
-def test_feedback_request():
-    """Test the FeedbackRequest model."""
-    conversation_id = Utils.get_suid()
-
-    feedback_request = FeedbackRequest(
-        conversation_id=conversation_id,
-        feedback_object='{"rating": 5, "comment": "Great service!"}',
-    )
-    assert feedback_request.conversation_id == conversation_id
-    assert (
-        feedback_request.feedback_object == '{"rating": 5, "comment": "Great service!"}'
-    )
-
-
-def test_llm_request():
-    """Test the LLMRequest model."""
-    llm_request = LLMRequest(query="Tell me about Kubernetes")
-    assert llm_request.query == "Tell me about Kubernetes"
-    assert llm_request.conversation_id is None
-    assert llm_request.response is None
-
-    llm_request = LLMRequest(
-        query="Tell me about Kubernetes",
-        conversation_id="abc",
-        response="Kubernetes is a portable, extensible, open source platform ...",
-    )
-    assert llm_request.query == "Tell me about Kubernetes"
-    assert llm_request.conversation_id == "abc"
-    assert (
-        llm_request.response
-        == "Kubernetes is a portable, extensible, open source platform ..."
-    )
 
 
 def test_model_config():

--- a/tests/unit/app/models/test_models.py
+++ b/tests/unit/app/models/test_models.py
@@ -1,0 +1,38 @@
+"""Unit tests for the API models."""
+
+from ols.app.models.models import FeedbackRequest, LLMRequest
+from ols.app.utils import Utils
+
+
+def test_feedback_request():
+    """Test the FeedbackRequest model."""
+    conversation_id = Utils.get_suid()
+
+    feedback_request = FeedbackRequest(
+        conversation_id=conversation_id,
+        feedback_object='{"rating": 5, "comment": "Great service!"}',
+    )
+    assert feedback_request.conversation_id == conversation_id
+    assert (
+        feedback_request.feedback_object == '{"rating": 5, "comment": "Great service!"}'
+    )
+
+
+def test_llm_request():
+    """Test the LLMRequest model."""
+    llm_request = LLMRequest(query="Tell me about Kubernetes")
+    assert llm_request.query == "Tell me about Kubernetes"
+    assert llm_request.conversation_id is None
+    assert llm_request.response is None
+
+    llm_request = LLMRequest(
+        query="Tell me about Kubernetes",
+        conversation_id="abc",
+        response="Kubernetes is a portable, extensible, open source platform ...",
+    )
+    assert llm_request.query == "Tell me about Kubernetes"
+    assert llm_request.conversation_id == "abc"
+    assert (
+        llm_request.response
+        == "Kubernetes is a portable, extensible, open source platform ..."
+    )

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -1,4 +1,4 @@
-"""Unit tests for the configuration model."""
+"""Unit tests for the configuration models."""
 
 import io
 import logging


### PR DESCRIPTION
## Description

Just moving tests around to reflect the main package (unit tests should mirror that).
As we have modules with the same name, we need to have some __init__.py in tests, to avoid tests naming collision.
No code is changed here.

## Type of change

- [x] Refactor

