### PR TITLE
OLS-201: Fix: conversation ID is a string, not a number

### DIFF
--- a/ols/app/endpoints/feedback.py
+++ b/ols/app/endpoints/feedback.py
@@ -20,7 +20,7 @@ def user_feedback(feedback_request: FeedbackRequest) -> dict:
     Returns:
         Response indicating the status of the feedback.
     """
-    conversation = str(feedback_request.conversation_id)
+    conversation = feedback_request.conversation_id
     logger.info(f"{conversation} New feedback received")
     logger.info(f"{conversation} Feedback blob: {feedback_request.feedback_object}")
 

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -47,13 +47,13 @@ class FeedbackRequest(BaseModel):
     Example:
         ```python
         feedback_request = FeedbackRequest(
-            conversation_id=123,
+            conversation_id="123",
             feedback_object='{"rating": 5, "comment": "Great service!"}'
         )
         ```
     """
 
-    conversation_id: int
+    conversation_id: str
     feedback_object: str
 
     # provides examples for /docs endpoint

--- a/tests/unit/test_app_endpoints.py
+++ b/tests/unit/test_app_endpoints.py
@@ -24,7 +24,7 @@ def load_config():
 def test_user_feedback(load_config):
     """Test user feedback API endpoint."""
     feedback_request = FeedbackRequest(
-        conversation_id=123,
+        conversation_id=Utils.get_suid(),
         feedback_object='{"rating": 5, "comment": "Great service!"}',
     )
     response = feedback.user_feedback(feedback_request)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -17,15 +17,18 @@ from ols.app.models.config import (
     RedisConfig,
 )
 from ols.app.models.models import FeedbackRequest, LLMRequest
+from ols.app.utils import Utils
 
 
 def test_feedback_request():
     """Test the FeedbackRequest model."""
+    conversation_id = Utils.get_suid()
+
     feedback_request = FeedbackRequest(
-        conversation_id=123,
+        conversation_id=conversation_id,
         feedback_object='{"rating": 5, "comment": "Great service!"}',
     )
-    assert feedback_request.conversation_id == 123
+    assert feedback_request.conversation_id == conversation_id
     assert (
         feedback_request.feedback_object == '{"rating": 5, "comment": "Great service!"}'
     )


### PR DESCRIPTION
## Description

Fix: conversation ID is a string, not a number

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-201](https://issues.redhat.com//browse/OLS-201)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Both unit tests and integration tests was updated
