### PR TITLE
OLS-109: Pass conversation history to docs summarizer

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -125,7 +125,7 @@ def conversation_request(llm_request: LLMRequest) -> LLMRequest:
                     provider=llm_request.provider, model=llm_request.model
                 )
                 llm_response.response, _ = docs_summarizer.summarize(
-                    conversation_id, llm_request.query
+                    conversation_id, llm_request.query, previous_input
                 )
             except LLMConfigurationError as e:
                 raise HTTPException(

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -19,12 +19,15 @@ logger = logging.getLogger(__name__)
 class DocsSummarizer(QueryHelper):
     """A class for summarizing documentation context."""
 
-    def summarize(self, conversation: str, query: str, **kwargs) -> tuple[str, str]:
+    def summarize(
+        self, conversation: str, query: str, history: str | None = None, **kwargs
+    ) -> tuple[str, str]:
         """Summarize the given query based on the provided conversation context.
 
         Args:
             conversation: The unique identifier for the conversation.
             query: The query to be summarized.
+            history: The history of the conversation (if available).
             kwargs: Additional keyword arguments for customization (model, verbose, etc.).
 
         Returns:
@@ -49,6 +52,7 @@ class DocsSummarizer(QueryHelper):
         )
         logger.info(f"{conversation} call settings: {settings_string}")
 
+        # TODO: use history there
         summarization_template = PromptTemplate(constants.SUMMARIZATION_TEMPLATE)
 
         logger.info(f"{conversation} Getting service context")

--- a/tests/unit/docs/test_doc_summarizer.py
+++ b/tests/unit/docs/test_doc_summarizer.py
@@ -26,6 +26,7 @@ def test_summarize(storage_context, service_context):
     config.init_empty_config()
     summarizer = DocsSummarizer()
     question = "What's the ultimate question with answer 42?"
-    summary, documents = summarizer.summarize("1234", question)
+    history = None
+    summary, documents = summarizer.summarize("1234", question, history)
     assert question in summary
     assert len(documents) == 0


### PR DESCRIPTION
## Description

Pass conversation history to docs summarizer

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-109](https://issues.redhat.com//browse/OLS-109)
- Closes #[OLS-109](https://issues.redhat.com//browse/OLS-109)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Unit tests and integration tests. Also can be run via curl/from UI
