### PR TITLE
OLS-157: Ensure endpoints have in/out models

### DIFF
--- a/ols/app/endpoints/feedback.py
+++ b/ols/app/endpoints/feedback.py
@@ -4,14 +4,14 @@ import logging
 
 from fastapi import APIRouter
 
-from ols.app.models.models import FeedbackRequest
+from ols.app.models.models import FeedbackRequest, FeedbackResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/feedback", tags=["feedback"])
 
 
 @router.post("")
-def user_feedback(feedback_request: FeedbackRequest) -> dict:
+def user_feedback(feedback_request: FeedbackRequest) -> FeedbackResponse:
     """Handle feedback requests.
 
     Args:
@@ -20,8 +20,9 @@ def user_feedback(feedback_request: FeedbackRequest) -> dict:
     Returns:
         Response indicating the status of the feedback.
     """
-    conversation = feedback_request.conversation_id
-    logger.info(f"{conversation} New feedback received")
-    logger.info(f"{conversation} Feedback blob: {feedback_request.feedback_object}")
+    logger.info(
+        f"feed back received for conversation '{feedback_request.conversation_id}', "
+        f"feedback blob: {feedback_request.feedback_object}"
+    )
 
-    return {"status": "feedback received"}
+    return FeedbackResponse(response="feedback received")

--- a/ols/app/endpoints/health.py
+++ b/ols/app/endpoints/health.py
@@ -7,21 +7,33 @@ methods. For HEAD HTTP method, just the HTTP response code is used.
 
 from fastapi import APIRouter
 
+from ols.app.models.models import HealthResponse
+
 router = APIRouter(tags=["health"])
 
-# Still to be decided on their functionality
+
+# TODO: Still to be decided on their functionality.
+# Example status response:
+# {
+#     "status": "unhealthy",
+#     "version": "1.0.0",
+#     "dependencies": {
+#         "database": "healthy",
+#         "externalApi": "unhealthy"
+#     }
+# }
 
 
 @router.get("/readiness")
-def readiness_probe_get_method() -> dict[str, str]:
+def readiness_probe_get_method() -> HealthResponse:
     """Ready status of service."""
-    return {"status": "1"}
+    return HealthResponse(status={"status": "healthy"})
 
 
 @router.get("/liveness")
-def liveness_probe_get_method() -> dict[str, str]:
+def liveness_probe_get_method() -> HealthResponse:
     """Live status of service."""
-    return {"status": "1"}
+    return HealthResponse(status={"status": "healthy"})
 
 
 @router.head("/readiness")

--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -8,7 +8,7 @@ from langchain.prompts import PromptTemplate
 
 from ols import constants
 from ols.app import metrics
-from ols.app.models.models import LLMRequest
+from ols.app.models.models import LLMRequest, LLMResponse
 from ols.src.llms.llm_loader import LLMConfigurationError, LLMLoader
 from ols.src.query_helpers.docs_summarizer import DocsSummarizer
 from ols.src.query_helpers.question_validator import QuestionValidator
@@ -20,7 +20,7 @@ router = APIRouter(tags=["query"])
 
 
 @router.post("/query")
-def conversation_request(llm_request: LLMRequest) -> LLMRequest:
+def conversation_request(llm_request: LLMRequest) -> LLMResponse:
     """Handle conversation requests for the OLS endpoint.
 
     Args:
@@ -43,8 +43,6 @@ def conversation_request(llm_request: LLMRequest) -> LLMRequest:
     else:
         previous_input = config.conversation_cache.get(user_id, conversation_id)
         logger.info(f"{conversation_id} Previous conversation input: {previous_input}")
-
-    llm_response = LLMRequest(query=llm_request.query, conversation_id=conversation_id)
 
     # Log incoming request
     logger.info(f"{conversation_id} Incoming request: {llm_request.query}")
@@ -78,7 +76,7 @@ def conversation_request(llm_request: LLMRequest) -> LLMRequest:
             logger.info(
                 f"{conversation_id} - Query is not relevant to kubernetes or ocp, returning"
             )
-            llm_response.response = str(
+            response = str(
                 {
                     "detail": {
                         "response": "I can only answer questions about \
@@ -95,7 +93,7 @@ def conversation_request(llm_request: LLMRequest) -> LLMRequest:
                 docs_summarizer = DocsSummarizer(
                     provider=llm_request.provider, model=llm_request.model
                 )
-                llm_response.response, _ = docs_summarizer.summarize(
+                response, _ = docs_summarizer.summarize(
                     conversation_id, llm_request.query, previous_input
                 )
             except LLMConfigurationError as e:
@@ -117,13 +115,14 @@ def conversation_request(llm_request: LLMRequest) -> LLMRequest:
         config.conversation_cache.insert_or_append(
             user_id,
             conversation_id,
-            llm_request.query + "\n\n" + str(llm_response.response or ""),
+            llm_request.query + "\n\n" + str(response or ""),
         )
+    llm_response = LLMResponse(conversation_id=conversation_id, response=response)
     return llm_response
 
 
 @router.post("/debug/query")
-def conversation_request_debug_api(llm_request: LLMRequest) -> LLMRequest:
+def conversation_request_debug_api(llm_request: LLMRequest) -> LLMResponse:
     """Handle requests for the base LLM completion endpoint.
 
     Args:
@@ -133,15 +132,12 @@ def conversation_request_debug_api(llm_request: LLMRequest) -> LLMRequest:
         Response containing the processed information.
     """
     if llm_request.conversation_id is None:
-        conversation = suid.get_suid()
+        conversation_id = suid.get_suid()
     else:
-        conversation = llm_request.conversation_id
+        conversation_id = llm_request.conversation_id
 
-    llm_response = LLMRequest(query=llm_request.query)
-    llm_response.conversation_id = conversation
-
-    logger.info(f"{conversation} New conversation")
-    logger.info(f"{conversation} Incoming request: {llm_request.query}")
+    logger.info(f"{conversation_id} New conversation")
+    logger.info(f"{conversation_id} Incoming request: {llm_request.query}")
 
     bare_llm = LLMLoader(
         config.ols_config.default_provider,
@@ -152,8 +148,10 @@ def conversation_request_debug_api(llm_request: LLMRequest) -> LLMRequest:
     llm_chain = LLMChain(llm=bare_llm, prompt=prompt, verbose=True)
     response = llm_chain(inputs={"query": llm_request.query})
 
-    logger.info(f"{conversation} Model returned: {response}")
+    logger.info(f"{conversation_id} Model returned: {response}")
 
-    llm_response.response = response["text"]
+    llm_response = LLMResponse(
+        conversation_id=conversation_id, response=response["text"]
+    )
 
     return llm_response

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -10,18 +10,18 @@ class LLMRequest(BaseModel):
 
     Attributes:
         query: The query string.
-        conversation_id: The optional conversation ID.
-        response: The optional response.
+        conversation_id: The optional conversation ID (UUID).
         provider: The optional provider.
         model: The optional model.
 
     Example:
+        ```python
         llm_request = LLMRequest(query="Tell me about Kubernetes")
+        ```
     """
 
     query: str
     conversation_id: Optional[str] = None
-    response: Optional[str] = None
     provider: Optional[str] = None
     model: Optional[str] = None
 
@@ -31,8 +31,9 @@ class LLMRequest(BaseModel):
             "examples": [
                 {
                     "query": "write a deployment yaml for the mongodb image",
-                    "conversation_id": "",
-                    "response": "",
+                    "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
+                    "provider": "openai",
+                    "model": "gpt-3.5-turbo",
                 }
             ]
         }
@@ -52,32 +53,108 @@ class LLMRequest(BaseModel):
         return self
 
 
-class FeedbackRequest(BaseModel):
-    """Model representing a feedback request.
+class LLMResponse(BaseModel):
+    """Model representing a response from the LLM (Language Model).
 
     Attributes:
-        conversation_id: The required conversation ID.
-        feedback_object: The JSON blob representing feedback.
-
-    Example:
-        ```python
-        feedback_request = FeedbackRequest(
-            conversation_id="12345678-abcd-0000-0123-456789abcdef",
-            feedback_object='{"rating": 5, "comment": "Great service!"}'
-        )
-        ```
+        conversation_id: The optional conversation ID (UUID).
+        response: The optional response.
     """
 
     conversation_id: str
-    feedback_object: str
+    response: str
 
     # provides examples for /docs endpoint
     model_config = {
         "json_schema_extra": {
             "examples": [
                 {
-                    "feedback_object": '{"rating": 5, "comment": "Great service!"}',
+                    "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
+                    "response": "sure, here is deployment yaml for the mongodb image...",
+                }
+            ]
+        }
+    }
+
+
+class FeedbackRequest(BaseModel):
+    """Model representing a feedback request.
+
+    Attributes:
+        conversation_id: The required conversation ID (UUID).
+        feedback_object: The JSON blob representing feedback.
+
+    Example:
+        ```python
+        feedback_request = FeedbackRequest(
+            conversation_id="12345678-abcd-0000-0123-456789abcdef",
+            feedback_object={"rating": 5, "comment": "Great service!"}
+        )
+        ```
+    """
+
+    conversation_id: str
+    feedback_object: dict  # TODO: proper object (OLS-77)
+
+    # provides examples for /docs endpoint
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
                     "conversation_id": "12345678-abcd-0000-0123-456789abcdef",
+                    "feedback_object": {"rating": 5, "comment": "Great service!"},
+                }
+            ]
+        }
+    }
+
+
+class FeedbackResponse(BaseModel):
+    """Model representing a response to a feedback request.
+
+    Attributes:
+        response: The response of the feedback request.
+
+    Example:
+        ```python
+        feedback_response = FeedbackResponse(response="feedback received")
+        ```
+    """
+
+    response: str
+
+    # provides examples for /docs endpoint
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "response": "feedback received",
+                }
+            ]
+        }
+    }
+
+
+class HealthResponse(BaseModel):
+    """Model representing a response to a health request.
+
+    Attributes:
+        status: The status of the app.
+
+    Example:
+        ```python
+        health_response = HealthResponse(status={"status": "healthy"})
+        ```
+    """
+
+    status: dict[str, str]
+
+    # provides examples for /docs endpoint
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "status": {"status": "healthy"},
                 }
             ]
         }

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -21,7 +21,7 @@ class DocsSummarizer(QueryHelper):
 
     def summarize(
         self, conversation: str, query: str, history: Optional[str] = None, **kwargs
-    ) -> tuple[str, str]:
+    ) -> tuple[Response, str]:
         """Summarize the given query based on the provided conversation context.
 
         Args:
@@ -112,14 +112,14 @@ class DocsSummarizer(QueryHelper):
             logger.info("Using llm to answer the query without reference content")
             response = bare_llm.invoke(query)
             summary = Response(
-                f""" The following response was generated without access to reference content:
-
-                        {response}
-                    """
+                "The following response was generated without access to reference content:"
+                "\n\n"
+                # NOTE: The LLM returns AIMessage, but typing sees it as a plain str
+                f"{response.content}"  # type: ignore
             )
             referenced_documents = ""
 
         logger.info(f"{conversation} Summary response: {summary!s}")
         logger.info(f"{conversation} Referenced documents: {referenced_documents}")
 
-        return str(summary), referenced_documents
+        return summary, referenced_documents

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -12,14 +12,14 @@ def test_readiness():
     """Test handler for /readiness REST API endpoint."""
     response = client.get("/readiness")
     assert response.status_code == requests.codes.ok
-    assert response.json() == {"status": "1"}
+    assert response.json() == {"status": {"status": "healthy"}}
 
 
 def test_liveness():
     """Test handler for /liveness REST API endpoint."""
     response = client.get("/liveness")
     assert response.status_code == requests.codes.ok
-    assert response.json() == {"status": "1"}
+    assert response.json() == {"status": {"status": "healthy"}}
 
 
 def test_raw_prompt():
@@ -34,7 +34,6 @@ def test_raw_prompt():
 
     assert r.status_code == requests.codes.ok
     assert response["conversation_id"] == conversation_id
-    assert response["query"] == "say hello"
     assert "hello" in response["response"].lower()
 
 
@@ -47,19 +46,12 @@ def test_invalid_question():
     )
     print(vars(response))
     assert response.status_code == requests.codes.ok
-    expected_details = str(
-        {
-            "detail": {
-                "response": "I can only answer questions about \
-            OpenShift and Kubernetes. Please rephrase your question"
-            }
-        }
+    expected_details = (
+        "I can only answer questions about OpenShift and Kubernetes. "
+        "Please rephrase your question"
     )
     expected_json = {
         "conversation_id": conversation_id,
-        "model": None,
-        "provider": None,
-        "query": "test query",
         "response": expected_details,
     }
     assert response.json() == expected_json

--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -29,10 +29,10 @@ def test_feedback():
 
     response = client.post(
         "/v1/feedback",
-        json={"conversation_id": conversation_id, "feedback_object": "blah"},
+        json={"conversation_id": conversation_id, "feedback_object": {"blah": "bloh"}},
     )
     assert response.status_code == requests.codes.ok
-    assert response.json() == {"status": "feedback received"}
+    assert response.json() == {"response": "feedback received"}
 
 
 def test_feedback_wrong_request():

--- a/tests/integration/test_liveness_readiness.py
+++ b/tests/integration/test_liveness_readiness.py
@@ -22,14 +22,14 @@ def test_liveness():
     """Test handler for /liveness REST API endpoint."""
     response = client.get("/liveness")
     assert response.status_code == requests.codes.ok
-    assert response.json() == {"status": "1"}
+    assert response.json() == {"status": {"status": "healthy"}}
 
 
 def test_readiness():
     """Test handler for /readiness REST API endpoint."""
     response = client.get("/readiness")
     assert response.status_code == requests.codes.ok
-    assert response.json() == {"status": "1"}
+    assert response.json() == {"status": {"status": "healthy"}}
 
 
 def test_liveness_head_http_method() -> None:

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -135,13 +135,9 @@ def test_post_question_on_invalid_question():
             json={"conversation_id": conversation_id, "query": "test query"},
         )
         assert response.status_code == requests.codes.ok
-        expected_details = str(
-            {
-                "detail": {
-                    "response": "I can only answer questions about \
-            OpenShift and Kubernetes. Please rephrase your question"
-                }
-            }
+        expected_details = (
+            "I can only answer questions about OpenShift and Kubernetes. "
+            "Please rephrase your question"
         )
         expected_json = {
             "conversation_id": conversation_id,

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -40,10 +40,7 @@ def test_debug_query():
     assert response.status_code == requests.codes.ok
     assert response.json() == {
         "conversation_id": conversation_id,
-        "query": "test query",
         "response": "test response",
-        "provider": None,  # default value in request
-        "model": None,  # default value in request
     }
 
 
@@ -63,10 +60,7 @@ def test_debug_query_no_conversation_id():
 
     # check that conversation ID is being created
     assert len(json["conversation_id"]) > 0
-    assert json["query"] == "test query"
     assert json["response"] == "test response"
-    assert json["provider"] is None  # default value in request
-    assert json["model"] is None  # default value in request
 
 
 # the raw prompt should just return stuff from LLMChain, so mock that base method in ols.py
@@ -151,10 +145,7 @@ def test_post_question_on_invalid_question():
         )
         expected_json = {
             "conversation_id": conversation_id,
-            "query": "test query",
             "response": expected_details,
-            "provider": None,  # default value in request
-            "model": None,  # default value in request
         }
         assert response.json() == expected_json
 

--- a/tests/unit/app/__init__.py
+++ b/tests/unit/app/__init__.py
@@ -1,0 +1,1 @@
+"""Init of tests/unit/app."""

--- a/tests/unit/app/endpoints/__init__.py
+++ b/tests/unit/app/endpoints/__init__.py
@@ -1,0 +1,1 @@
+"""Init of tests/unit/app/endpoints."""

--- a/tests/unit/app/endpoints/test_feedback.py
+++ b/tests/unit/app/endpoints/test_feedback.py
@@ -1,23 +1,17 @@
 """Unit tests for feedback endpoint handlers."""
 
-import pytest
-
 from ols.app.endpoints import feedback
-from ols.app.models.models import FeedbackRequest
-from ols.utils import config, suid
+from ols.app.models.models import FeedbackRequest, FeedbackResponse
+from ols.utils import suid
 
 
-@pytest.fixture(scope="module")
-def load_config():
-    """Load config before unit tests."""
-    config.init_config("tests/config/test_app_endpoints.yaml")
-
-
-def test_user_feedback(load_config):
+def test_user_feedback():
     """Test user feedback API endpoint."""
     feedback_request = FeedbackRequest(
         conversation_id=suid.get_suid(),
-        feedback_object='{"rating": 5, "comment": "Great service!"}',
+        feedback_object={"rating": 5, "comment": "Great service!"},
     )
+
     response = feedback.user_feedback(feedback_request)
-    assert response == {"status": "feedback received"}
+
+    assert response == FeedbackResponse(response="feedback received")

--- a/tests/unit/app/endpoints/test_health.py
+++ b/tests/unit/app/endpoints/test_health.py
@@ -6,6 +6,7 @@ from ols.app.endpoints.health import (
     readiness_probe_get_method,
     readiness_probe_head_method,
 )
+from ols.app.models.models import HealthResponse
 
 
 def test_readiness_probe_get_method():
@@ -13,7 +14,7 @@ def test_readiness_probe_get_method():
     # the tested function returns constant right now
     # i.e. it does not depend on application state
     response = readiness_probe_get_method()
-    assert response == {"status": "1"}
+    assert response == HealthResponse(status={"status": "healthy"})
 
 
 def test_liveness_probe_get_method():
@@ -21,7 +22,7 @@ def test_liveness_probe_get_method():
     # the tested function returns constant right now
     # i.e. it does not depend on application state
     response = liveness_probe_get_method()
-    assert response == {"status": "1"}
+    assert response == HealthResponse(status={"status": "healthy"})
 
 
 def test_readiness_probe_head_method():

--- a/tests/unit/app/endpoints/test_ols.py
+++ b/tests/unit/app/endpoints/test_ols.py
@@ -58,15 +58,6 @@ def test_conversation_request(
     )
     assert len(response.conversation_id) > 0
 
-    # conversation is cached
-    mock_validate_question.return_value = constants.SUBJECT_VALID
-    mock_summarize.return_value = ("content: generated yaml", "")
-    mock_summarize.side_effect = None
-    mock_conversation_cache_get.return_value = "previous conversation input"
-    llm_request = LLMRequest(query="Generate a yaml", conversation_id=suid.get_suid())
-    response = ols.conversation_request(llm_request)
-    assert response.response == "content: generated yaml"
-
     # validation failure
     mock_validate_question.side_effect = HTTPException
     with pytest.raises(HTTPException) as excinfo:

--- a/tests/unit/app/endpoints/test_ols.py
+++ b/tests/unit/app/endpoints/test_ols.py
@@ -44,23 +44,6 @@ def test_conversation_request(
     )
     assert len(response.conversation_id) > 0
 
-    # valid question, yaml
-    mock_validate_question.return_value = constants.SUBJECT_VALID
-    mock_summarize.return_value = ("content: generated yaml", "")
-    llm_request = LLMRequest(query="Generate a yaml")
-    response = ols.conversation_request(llm_request)
-    assert response.response == "content: generated yaml"
-    assert len(response.conversation_id) > 0
-
-    # valid question, yaml, generator failure
-    mock_validate_question.return_value = constants.SUBJECT_VALID
-    mock_summarize.side_effect = Exception
-    with pytest.raises(HTTPException) as excinfo:
-        llm_request = LLMRequest(query="Generate a yaml")
-        response = ols.conversation_request(llm_request)
-        assert excinfo.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
-        assert len(response.conversation_id) == 0
-
     # invalid question
     mock_validate_question.return_value = constants.SUBJECT_INVALID
     llm_request = LLMRequest(query="Generate a yaml")

--- a/tests/unit/app/endpoints/test_ols.py
+++ b/tests/unit/app/endpoints/test_ols.py
@@ -1,7 +1,7 @@
 """Unit tests for OLS endpoint."""
 
 from http import HTTPStatus
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -9,7 +9,7 @@ from fastapi import HTTPException
 from ols import constants
 from ols.app.endpoints import ols
 from ols.app.models.models import LLMRequest
-from ols.utils import config, suid
+from ols.utils import config
 from tests.mock_classes.llm_chain import mock_llm_chain
 from tests.mock_classes.llm_loader import mock_llm_loader
 
@@ -20,6 +20,7 @@ def load_config():
     config.init_config("tests/config/test_app_endpoints.yaml")
 
 
+# TODO: distribute individual test cases to separate test functions
 @patch("ols.src.query_helpers.question_validator.QuestionValidator.validate_question")
 @patch("ols.src.query_helpers.docs_summarizer.DocsSummarizer.summarize")
 @patch("ols.utils.config.conversation_cache.get")
@@ -30,10 +31,14 @@ def test_conversation_request(
     load_config,
 ):
     """Test conversation request API endpoint."""
-    # valid question, no yaml
+    # valid question
     mock_validate_question.return_value = constants.SUBJECT_VALID
+    mock_response = Mock()
+    mock_response.response = (
+        "Kubernetes is an open-source container-orchestration system..."  # summary
+    )
     mock_summarize.return_value = (
-        "Kubernetes is an open-source container-orchestration system...",  # summary
+        mock_response,
         "",  # referenced documents
     )
     llm_request = LLMRequest(query="Tell me about Kubernetes")
@@ -48,13 +53,9 @@ def test_conversation_request(
     mock_validate_question.return_value = constants.SUBJECT_INVALID
     llm_request = LLMRequest(query="Generate a yaml")
     response = ols.conversation_request(llm_request)
-    assert response.response == str(
-        {
-            "detail": {
-                "response": "I can only answer questions about \
-            OpenShift and Kubernetes. Please rephrase your question"
-            }
-        }
+    assert response.response == (
+        "I can only answer questions about OpenShift and Kubernetes. "
+        "Please rephrase your question"
     )
     assert len(response.conversation_id) > 0
 

--- a/tests/unit/app/models/test_models.py
+++ b/tests/unit/app/models/test_models.py
@@ -3,56 +3,109 @@
 import pytest
 from pydantic import ValidationError
 
-from ols.app.models.models import FeedbackRequest, LLMRequest
-from ols.utils import suid
+from ols.app.models.models import (
+    FeedbackRequest,
+    FeedbackResponse,
+    HealthResponse,
+    LLMRequest,
+    LLMResponse,
+)
 
 
-def test_feedback_request():
-    """Test the FeedbackRequest model."""
-    conversation_id = suid.get_suid()
+class TestLLM:
+    """Unit tests for the LLMRequest/LLMResponse models."""
 
-    feedback_request = FeedbackRequest(
-        conversation_id=conversation_id,
-        feedback_object='{"rating": 5, "comment": "Great service!"}',
-    )
-    assert feedback_request.conversation_id == conversation_id
-    assert (
-        feedback_request.feedback_object == '{"rating": 5, "comment": "Great service!"}'
-    )
+    def test_llm_request_required_inputs(self):
+        """Test required inputs of the LLMRequest model."""
+        query = "Tell me about Kubernetes"
+
+        llm_request = LLMRequest(query=query)
+
+        assert llm_request.query == query
+        assert llm_request.conversation_id is None
+        assert llm_request.provider is None
+        assert llm_request.model is None
+
+    def test_llm_request_optional_inputs(self):
+        """Test optional inputs of the LLMRequest model."""
+        query = "Tell me about Kubernetes"
+        conversation_id = "id"
+        provider = "openai"
+        model = "gpt-3.5-turbo"
+        llm_request = LLMRequest(
+            query=query,
+            conversation_id=conversation_id,
+            provider=provider,
+            model=model,
+        )
+
+        assert llm_request.query == query
+        assert llm_request.conversation_id == conversation_id
+        assert llm_request.provider == provider
+        assert llm_request.model == model
+
+    def test_llm_request_provider_and_model(self):
+        """Test the LLMRequest model with provider and model."""
+        # model set and provider not
+        with pytest.raises(
+            ValidationError,
+            match="LLM provider must be specified when the model is specified!",
+        ):
+            LLMRequest(query="bla", provider=None, model="davinci")
+
+        # provider set and model not
+        with pytest.raises(
+            ValidationError,
+            match="LLM model must be specified when the provider is specified!",
+        ):
+            LLMRequest(query="bla", provider="openai", model=None)
+
+    def test_llm_response(self):
+        """Test the LLMResponse model."""
+        conversation_id = "id"
+        response = "response"
+
+        llm_response = LLMResponse(
+            conversation_id=conversation_id,
+            response=response,
+        )
+
+        assert llm_response.conversation_id == conversation_id
+        assert llm_response.response == response
 
 
-def test_llm_request():
-    """Test the LLMRequest model."""
-    llm_request = LLMRequest(query="Tell me about Kubernetes")
-    assert llm_request.query == "Tell me about Kubernetes"
-    assert llm_request.conversation_id is None
-    assert llm_request.response is None
+class TestFeedback:
+    """Unit tests for the FeedbackRequest/FeedbackResponse models."""
 
-    llm_request = LLMRequest(
-        query="Tell me about Kubernetes",
-        conversation_id="abc",
-        response="Kubernetes is a portable, extensible, open source platform ...",
-    )
-    assert llm_request.query == "Tell me about Kubernetes"
-    assert llm_request.conversation_id == "abc"
-    assert (
-        llm_request.response
-        == "Kubernetes is a portable, extensible, open source platform ..."
-    )
+    def test_feedback_request(self):
+        """Test the FeedbackRequest model."""
+        conversation_id = "id"
+        feedback_obj = {"rating": 5, "comment": "Great service!"}
+
+        feedback_request = FeedbackRequest(
+            conversation_id=conversation_id,
+            feedback_object=feedback_obj,
+        )
+
+        assert feedback_request.conversation_id == conversation_id
+        assert feedback_request.feedback_object == feedback_obj
+
+    def test_feedback_response(self):
+        """Test the FeedbackResponse model."""
+        feedback_response = "feedback received"
+
+        feedback_request = FeedbackResponse(response=feedback_response)
+
+        assert feedback_request.response == feedback_response
 
 
-def test_llm_request_provider_and_model():
-    """Test the LLMRequest model with provider and model."""
-    # model set and provider not
-    with pytest.raises(
-        ValidationError,
-        match="LLM provider must be specified when the model is specified!",
-    ):
-        LLMRequest(query="bla", provider=None, model="davinci")
+class TestHealth:
+    """Unit test for the HealthResponse model."""
 
-    # provider set and model not
-    with pytest.raises(
-        ValidationError,
-        match="LLM model must be specified when the provider is specified!",
-    ):
-        LLMRequest(query="bla", provider="openai", model=None)
+    def test_health_response(self):
+        """Test the HealthResponse model."""
+        health_response = {"status": "healthy"}
+
+        health_request = HealthResponse(status=health_response)
+
+        assert health_request.status == health_response

--- a/tests/unit/docs/test_doc_summarizer.py
+++ b/tests/unit/docs/test_doc_summarizer.py
@@ -31,7 +31,7 @@ def test_summarize(storage_context, service_context):
     question = "What's the ultimate question with answer 42?"
     history = None
     summary, documents = summarizer.summarize("1234", question, history)
-    assert question in summary
+    assert question in str(summary)
     assert len(documents) == 0
 
 
@@ -51,7 +51,7 @@ def test_summarize_no_reference_content(storage_context, service_context):
     summarizer = DocsSummarizer()
     question = "What's the ultimate question with answer 42?"
     summary, documents = summarizer.summarize("1234", question)
-    assert "success" in summary
+    assert "success" in str(summary)
     assert len(documents) == 0
 
 
@@ -74,6 +74,6 @@ def test_summarize_incorrect_directory(service_context):
     summary, documents = summarizer.summarize("1234", question)
     assert (
         "The following response was generated without access to reference content"
-        in summary
+        in str(summary)
     )
     assert len(documents) == 0


### PR DESCRIPTION
## Description

Adds request/response models for all endpoints.

I've removed the query from the response. It should be possible to track it via conversation_id. In theory, it might be a bit difficult to put those together in asynchronous scenarios, but hard to tell if it can happen.

I would like to hold it until https://github.com/openshift/lightspeed-service/pull/281 (don't want to fix tests that will be removed right after).

## Type of change

- [x] Refactor
- [x] New feature

## TODO

- [ ] refactor/update tests after PR-281
