### PR TITLE
Log where we loaded the config file from

### DIFF
--- a/ols/app/main.py
+++ b/ols/app/main.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from pathlib import Path
 
 from fastapi import FastAPI
 
@@ -16,11 +17,12 @@ app = FastAPI(
 )
 
 
-config.init_config(os.environ.get("OLS_CONFIG_FILE", "olsconfig.yaml"))
-
+cfg_file = os.environ.get("OLS_CONFIG_FILE", "olsconfig.yaml")
+config.init_config(cfg_file)
 
 configure_logging(config.ols_config.logging_config)
 logger = logging.getLogger(__name__)
+logger.info(f"Config loaded from {Path(cfg_file).resolve()}")
 
 
 if config.dev_config.enable_dev_ui:


### PR DESCRIPTION
## Description

$ make run
uvicorn ols.app.main:app --reload --port 8080
INFO:     Will watch for changes in these directories: ['/home/bparees/git/gocode/src/github.com/openshift/lightspeed-service']
INFO:     Uvicorn running on http://127.0.0.1:8080 (Press CTRL+C to quit)
INFO:     Started reloader process [1009276] using StatReload
2024-01-31 14:48:40,144 [ols.app.main:main.py:24] INFO: Config loaded from olsconfig.yaml
2024-01-31 14:48:40,144 [ols.app.main:main.py:30] INFO: Embedded Gradio UI is disabled. To enable set enable_dev_ui: true in the dev section of the configuration file
INFO:     Started server process [1009278]
INFO:     Waiting for application startup.
INFO:     Application startup complete.



## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.