### PR TITLE
OLS-269: Always initialize index from test docs

### DIFF
--- a/tests/integration/query_helpers/test_query_docs.py
+++ b/tests/integration/query_helpers/test_query_docs.py
@@ -1,7 +1,5 @@
 """Integration tests using light weight FAISS index."""
 
-import os
-
 import pytest
 from langchain_community.embeddings import HuggingFaceEmbeddings
 from langchain_community.vectorstores.faiss import FAISS
@@ -25,14 +23,8 @@ def setup_faiss():
     ]
     embeddings = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
 
-    file_path = "./index/faiss_index"
-
-    if os.path.exists(file_path):
-        db = FAISS.load_local(file_path, embeddings)
-    else:
-        db = FAISS.from_documents(list_of_documents, embeddings)
+    db = FAISS.from_documents(list_of_documents, embeddings)
     yield db
-    db.save_local(file_path)
 
 
 def test_retrieve_top_k_similarity_search(setup_faiss):

--- a/tests/integration/query_helpers/test_query_docs.py
+++ b/tests/integration/query_helpers/test_query_docs.py
@@ -35,7 +35,7 @@ def setup_faiss():
     db.save_local(file_path)
 
 
-def test_retrieve_top_k_similarity_search(setup_faiss: FAISS):
+def test_retrieve_top_k_similarity_search(setup_faiss):
     """Fetch top k similarity search."""
     docs = QueryDocs().get_relevant_docs(
         vectordb=setup_faiss, query="foo", search_kwargs={"k": 1}
@@ -47,7 +47,7 @@ def test_retrieve_top_k_similarity_search(setup_faiss: FAISS):
     assert docs[0].metadata["source"] == "adhoc"
 
 
-def test_retrieve_mmr(setup_faiss: FAISS):
+def test_retrieve_mmr(setup_faiss):
     """Fetch more documents for the MMR algorithm to consider. But only return the top 1."""
     docs = QueryDocs().get_relevant_docs(
         vectordb=setup_faiss,
@@ -62,7 +62,7 @@ def test_retrieve_mmr(setup_faiss: FAISS):
     assert docs[0].metadata["source"] == "adhoc"
 
 
-def test_similarity_score(setup_faiss: FAISS):
+def test_similarity_score(setup_faiss):
     """Fetch only the docs that has scores above similarity score threshold."""
     docs = QueryDocs().get_relevant_docs(
         vectordb=setup_faiss,
@@ -83,7 +83,7 @@ def test_similarity_score(setup_faiss: FAISS):
     assert docs[0].metadata["source"] == "adhoc"
 
 
-def test_for_filtering(setup_faiss: FAISS):
+def test_for_filtering(setup_faiss):
     """Fetch only the filtered docs."""
     docs = QueryDocs().get_relevant_docs(
         vectordb=setup_faiss,
@@ -98,7 +98,7 @@ def test_for_filtering(setup_faiss: FAISS):
     assert docs[0].metadata["source"] == "adhoc"
 
 
-def test_invalid_search_type(setup_faiss: FAISS):
+def test_invalid_search_type(setup_faiss):
     """Test for invalid search type."""
     with pytest.raises(
         RetrieveDocsExceptionError, match="search type is invalid: stuff"


### PR DESCRIPTION
## Description

The fixture setup_faiss is not deterministic in tests.

It either loads documents from a local store or uses predefined "fake" docs.

The switch condition does not check if the actual .index exists, just if there is a directory where it should live. This can lead to RuntimeError when running integration tests.

I've run the tests several times either by loading local index, or initializing using docs defined in the `list_of_documents`. The execution time is the same.

This PR removes the switch to ensure the fixture returns every time the same result (docs we create in tests).


## Type of change

- [x] Bug fix
