### PR TITLE
Standard compound key separator

### DIFF
--- a/ols/src/cache/cache.py
+++ b/ols/src/cache/cache.py
@@ -16,11 +16,14 @@ class Cache(ABC):
     read or modify other users conversations.
     """
 
+    # separator between parts of compond key
+    COMPOUND_KEY_SEPARATOR = ":"
+
     @staticmethod
     def _check_user_id(user_id: str) -> None:
         """Check if given user ID is valid."""
         # TODO: needs to be updated when we know the format
-        if "/" in user_id:
+        if Cache.COMPOUND_KEY_SEPARATOR in user_id:
             raise ValueError("Incorrect user ID {user_id}")
 
     @staticmethod
@@ -34,7 +37,7 @@ class Cache(ABC):
         """Construct key to cache."""
         Cache._check_user_id(user_id)
         Cache._check_conversation_id(conversation_id)
-        return f"{user_id}/{conversation_id}"
+        return f"{user_id}{Cache.COMPOUND_KEY_SEPARATOR}{conversation_id}"
 
     @abstractmethod
     def get(self, user_id: str, conversation_id: str) -> Union[str, None]:

--- a/tests/unit/cache/test_in_memory_cache.py
+++ b/tests/unit/cache/test_in_memory_cache.py
@@ -53,14 +53,16 @@ def test_get_nonexistent_user(cache):
 
 def test_get_improper_user_id(cache):
     """Test how improper user ID is handled."""
-    with pytest.raises(ValueError):
-        assert cache.get("foo/bar", conversation_id) is None
+    with pytest.raises(ValueError, match="Incorrect user ID"):
+        cache.get(":", conversation_id)
+    with pytest.raises(ValueError, match="Incorrect user ID"):
+        cache.get("foo:bar", conversation_id)
 
 
 def test_get_improper_conversation_id(cache):
     """Test how improper conversation ID is handled."""
-    with pytest.raises(ValueError):
-        assert cache.get("user1", "this-is-not-valid-uuid") is None
+    with pytest.raises(ValueError, match="Incorrect conversation ID"):
+        cache.get("user1", "this-is-not-valid-uuid")
 
 
 def test_singleton_pattern():

--- a/tests/unit/cache/test_redis_cache.py
+++ b/tests/unit/cache/test_redis_cache.py
@@ -45,14 +45,16 @@ def test_get_nonexistent_key(cache):
 
 def test_get_improper_user_id(cache):
     """Test how improper user ID is handled."""
-    with pytest.raises(ValueError):
-        assert cache.get("foo/bar", conversation_id) is None
+    with pytest.raises(ValueError, match="Incorrect user ID"):
+        cache.get(":", conversation_id)
+    with pytest.raises(ValueError, match="Incorrect user ID"):
+        cache.get("foo:bar", conversation_id)
 
 
 def test_get_improper_conversation_id(cache):
     """Test how improper conversation ID is handled."""
-    with pytest.raises(ValueError):
-        assert cache.get("user1", "this-is-not-valid-uuid") is None
+    with pytest.raises(ValueError, match="Incorrect conversation ID"):
+        cache.get("user1", "this-is-not-valid-uuid")
 
 
 def test_singleton_pattern():


### PR DESCRIPTION
## Description

In Redis, usually `:` is used as a separator for compound key. + make the code more readable by reducing magic constants.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
