### PR TITLE
OLS-233: Make provider/model required inputs for LLMLoader

### DIFF
--- a/ols/src/query_helpers/__init__.py
+++ b/ols/src/query_helpers/__init__.py
@@ -1,16 +1,29 @@
 """Question validators, statament classifiers, and response generators."""
 
+import logging
 from typing import Optional
 
+from ols.src.llms.llm_loader import LLMLoader
 from ols.utils import config
+
+logger = logging.getLogger(__name__)
 
 
 class QueryHelper:
     """Base class for query helpers."""
 
     def __init__(
-        self, provider: Optional[str] = None, model: Optional[str] = None
+        self,
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+        llm_params: Optional[dict] = None,
+        llm_loader: Optional[LLMLoader] = None,
     ) -> None:
         """Initialize query helper."""
+        # NOTE: As signature of this method is evaluated before the config,
+        # is loaded, we cannot use the config directly as defaults and we
+        # need to use those values in the init evaluation.
         self.provider = provider or config.ols_config.default_provider
         self.model = model or config.ols_config.default_model
+        self.llm_params = llm_params or {}
+        self.llm_loader = llm_loader or LLMLoader

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -12,7 +12,6 @@ from llama_index.response.schema import Response
 from llama_index.schema import NodeWithScore, QueryBundle
 
 from ols import constants
-from ols.src.llms.llm_loader import LLMLoader
 from ols.src.query_helpers import QueryHelper
 from ols.utils import config
 
@@ -70,8 +69,6 @@ class DocsSummarizer(QueryHelper):
             of strings, and flag indicating that conversation history has been truncated
             to fit within context window.
         """
-        bare_llm = LLMLoader(self.provider, self.model).llm
-
         verbose = kwargs.get("verbose", "").lower() == "true"
 
         # Set up llama index to show prompting if verbose is True
@@ -112,6 +109,9 @@ class DocsSummarizer(QueryHelper):
         else:
             embed_model = "local:BAAI/bge-base-en"
 
+        bare_llm = self.llm_loader(
+            self.provider, self.model, llm_params=self.llm_params
+        ).llm  # type: ignore
         service_context = ServiceContext.from_defaults(
             chunk_size=1024, llm=bare_llm, embed_model=embed_model, **kwargs
         )

--- a/ols/src/query_helpers/question_validator.py
+++ b/ols/src/query_helpers/question_validator.py
@@ -6,7 +6,6 @@ from langchain.chains import LLMChain
 from langchain.prompts import PromptTemplate
 
 from ols import constants
-from ols.src.llms.llm_loader import LLMLoader
 from ols.src.query_helpers import QueryHelper
 from ols.utils import config
 
@@ -15,6 +14,14 @@ logger = logging.getLogger(__name__)
 
 class QuestionValidator(QueryHelper):
     """This class is responsible for validating questions and providing one-word responses."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize the QuestionValidator."""
+        llm_params = {
+            "min_new_tokens": 1,
+            "max_new_tokens": 4,
+        }
+        super().__init__(*args, **kwargs, llm_params=llm_params)
 
     def validate_question(
         self, conversation_id: str, query: str, verbose: bool = False
@@ -51,10 +58,9 @@ class QuestionValidator(QueryHelper):
 
         logger.info(f"{conversation_id} Validating query")
 
-        bare_llm = LLMLoader(
-            self.provider, self.model, params={"min_new_tokens": 1, "max_new_tokens": 4}
-        ).llm
-
+        bare_llm = self.llm_loader(
+            self.provider, self.model, llm_params=self.llm_params
+        ).llm  # type: ignore
         llm_chain = LLMChain(llm=bare_llm, prompt=prompt_instructions, verbose=verbose)
 
         task_query = prompt_instructions.format(query=query)

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -183,7 +183,8 @@ class TestQuery:
             assert response.json() == {
                 "detail": {
                     "response": "Unable to process this request because "
-                    "'No configuration for LLM provider some-provider'"
+                    "'Provider 'some-provider' is not a valid provider. "
+                    "Valid providers are: []'"
                 }
             }
 
@@ -210,8 +211,8 @@ class TestQuery:
             assert response.json() == {
                 "detail": {
                     "response": "Unable to process this request because "
-                    "'No configuration provided for model some-model under "
-                    "LLM provider test-provider'"
+                    "'Model 'some-model' is not a valid model for provider "
+                    "'test-provider'. Valid models are: []'"
                 }
             }
 
@@ -231,7 +232,7 @@ def test_post_question_on_noyaml_response_type() -> None:
         ml = mock_langchain_interface("test response")
         with (
             patch(
-                "ols.src.query_helpers.docs_summarizer.LLMLoader",
+                "ols.src.query_helpers.LLMLoader",
                 new=mock_llm_loader(ml()),
             ),
             patch("ols.src.query_helpers.docs_summarizer.ServiceContext.from_defaults"),

--- a/tests/unit/docs/test_doc_summarizer.py
+++ b/tests/unit/docs/test_doc_summarizer.py
@@ -18,7 +18,6 @@ def test_is_query_helper_subclass():
     assert issubclass(DocsSummarizer, QueryHelper)
 
 
-@patch("ols.src.query_helpers.docs_summarizer.LLMLoader", new=mock_llm_loader(None))
 @patch("ols.src.query_helpers.docs_summarizer.ServiceContext.from_defaults")
 @patch("ols.src.query_helpers.docs_summarizer.StorageContext.from_defaults")
 @patch(
@@ -30,7 +29,7 @@ def test_summarize(storage_context, service_context):
     config.ols_config.reference_content = ReferenceContent(None)
     config.ols_config.reference_content.product_docs_index_path = "./invalid_dir"
     config.ols_config.reference_content.product_docs_index_id = "product"
-    summarizer = DocsSummarizer()
+    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
     question = "What's the ultimate question with answer 42?"
     history = None
     summary, documents, truncated = summarizer.summarize(
@@ -53,10 +52,6 @@ def test_summarize(storage_context, service_context):
     assert not truncated
 
 
-@patch(
-    "ols.src.query_helpers.docs_summarizer.LLMLoader",
-    new=mock_llm_loader(mock_langchain_interface("test response")()),
-)
 @patch("ols.src.query_helpers.docs_summarizer.ServiceContext.from_defaults")
 @patch("ols.src.query_helpers.docs_summarizer.StorageContext.from_defaults")
 @patch(
@@ -66,7 +61,9 @@ def test_summarize_no_reference_content(storage_context, service_context):
     """Basic test for DocsSummarizer using mocked index and query engine."""
     config.init_empty_config()
     config.ols_config.reference_content = ReferenceContent(None)
-    summarizer = DocsSummarizer()
+    summarizer = DocsSummarizer(
+        llm_loader=mock_llm_loader(mock_langchain_interface("test response")())
+    )
     question = "What's the ultimate question with answer 42?"
     summary, documents, truncated = summarizer.summarize(conversation_id, question)
     assert "success" in str(summary)
@@ -74,10 +71,6 @@ def test_summarize_no_reference_content(storage_context, service_context):
     assert not truncated
 
 
-@patch(
-    "ols.src.query_helpers.docs_summarizer.LLMLoader",
-    new=mock_llm_loader(mock_langchain_interface("test response")()),
-)
 @patch("ols.src.query_helpers.docs_summarizer.ServiceContext.from_defaults")
 @patch(
     "ols.src.query_helpers.docs_summarizer.load_index_from_storage", new=MockLlamaIndex
@@ -88,7 +81,9 @@ def test_summarize_incorrect_directory(service_context):
     config.ols_config.reference_content = ReferenceContent(None)
     config.ols_config.reference_content.product_docs_index_path = "./invalid_dir"
     config.ols_config.reference_content.product_docs_index_id = "product"
-    summarizer = DocsSummarizer()
+    summarizer = DocsSummarizer(
+        llm_loader=mock_llm_loader(mock_langchain_interface("test response")())
+    )
     question = "What's the ultimate question with answer 42?"
     conversation_id = "01234567-89ab-cdef-0123-456789abcdef"
     summary, documents, truncated = summarizer.summarize(conversation_id, question)

--- a/tests/unit/llms/test_llm_loader.py
+++ b/tests/unit/llms/test_llm_loader.py
@@ -1,17 +1,12 @@
 """Unit tests for LLMLoader class."""
 
-import sys
-from unittest.mock import MagicMock
-
 import pytest
 
 from ols import constants
-from ols.app.models.config import Config
+from ols.app.models.config import Config, LLMProviders
 from ols.src.llms.llm_loader import (
     LLMConfigurationError,
     LLMLoader,
-    MissingModelError,
-    MissingProviderError,
     ModelConfigInvalidError,
     ModelConfigMissingError,
     UnknownProviderError,
@@ -20,54 +15,23 @@ from ols.src.llms.llm_loader import (
 from ols.utils import config
 
 
-def setup():
-    """Provide environment for tests."""
-    # this function is called automatically by Pytest tool
-    # before unit tests are started
-    config.init_empty_config()
-
-    # the following modules should not be loaded during unit testing
-    # (these are not available on CI anyway)
-    mock_modules = [
-        "genai",
-        "genai.extensions.langchain",
-        "genai.text.generation",
-        "langchain.llms",
-        "ibm_watson_machine_learning.foundation_models",
-        "ibm_watson_machine_learning.foundation_models.extensions.langchain",
-        "ibm_watson_machine_learning.metanames",
-    ]
-    # make Python think that the modules are loaded already
-    for module in mock_modules:
-        sys.modules[module] = MagicMock()
-
-
 def test_errors_relationship():
     """Test the relationship between LLMConfigurationError and its subclasses."""
-    assert issubclass(MissingProviderError, LLMConfigurationError)
-    assert issubclass(MissingModelError, LLMConfigurationError)
     assert issubclass(UnknownProviderError, LLMConfigurationError)
     assert issubclass(UnsupportedProviderError, LLMConfigurationError)
     assert issubclass(ModelConfigMissingError, LLMConfigurationError)
     assert issubclass(ModelConfigInvalidError, LLMConfigurationError)
 
 
-def test_constructor_no_provider():
-    """Test that constructor checks for provider."""
-    with pytest.raises(MissingProviderError, match="Missing provider"):
-        LLMLoader(provider=None)
-
-
-def test_constructor_no_model():
-    """Test that constructor checks for model."""
-    with pytest.raises(MissingModelError, match="Missing model"):
-        LLMLoader(provider=constants.PROVIDER_BAM, model=None)
-
-
 def test_constructor_unknown_provider():
-    """Test how a provider missing from configuration is checked for."""
-    with pytest.raises(UnknownProviderError):
-        LLMLoader(provider="unknown-provider", model=constants.GRANITE_13B_CHAT_V1)
+    """Test raises when provider is unknown."""
+    providers = LLMProviders()  # no providers
+    config.init_empty_config()
+    config.config.llm_providers = providers
+
+    msg = "Provider 'unknown-provider' is not a valid provider"
+    with pytest.raises(UnknownProviderError, match=msg):
+        LLMLoader(provider="unknown-provider", model="some model")
 
 
 def test_constructor_unsupported_provider():
@@ -96,38 +60,33 @@ def test_constructor_unsupported_provider():
         LLMLoader(provider=test_provider, model=constants.GRANITE_13B_CHAT_V1)
 
 
-def test_constructor_when_missing_model_config():
+def test_constructor_unknown_model():
     """Test raise when model configuration is missing."""
-    test_provider = "test-provider"
-    test_model = "test-model"
-    config.config = Config(
-        {
-            "llm_providers": [
-                {"name": test_provider, "type": "bam", "models": [{"name": "foobar"}]}
-            ]
-        }
-    )
-    config.llm_config = config.config.llm_providers
+    providers = LLMProviders([{"name": "bam", "models": [{"name": "model"}]}])
+    config.init_empty_config()
+    config.config.llm_providers = providers
 
-    message = f"No configuration provided for model {test_model} under LLM provider {test_provider}"
+    message = "Model 'bla' is not a valid model for provider"
     with pytest.raises(ModelConfigMissingError, match=message):
-        LLMLoader(provider=test_provider, model=test_model)
+        LLMLoader(provider="bam", model="bla")
 
 
-providers = [
-    constants.PROVIDER_OPENAI,
-    constants.PROVIDER_BAM,
-]
+# TODO: As the LLMLoader is a subject of changes via OLS-233. Tests will
+# be delivered with the task.
+# Once changes are done, refactor also test bellow.
+#
+# providers = [
+#     constants.PROVIDER_OPENAI,
+#     constants.PROVIDER_BAM,
+# ]
+# @pytest.mark.parametrize("provider", providers)
+# def test_constructor_no_keys(provider):
+#     """Test raise when keys are missing."""
+#     test_model = constants.TEI_EMBEDDING_MODEL
+#     config.config = Config(
+#         {"llm_providers": [{"name": provider, "models": [{"name": test_model}]}]}
+#     )
+#     config.llm_config = config.config.llm_providers
 
-
-@pytest.mark.parametrize("provider", providers)
-def test_constructor_no_keys(provider):
-    """Test raise when keys are missing."""
-    test_model = constants.TEI_EMBEDDING_MODEL
-    config.config = Config(
-        {"llm_providers": [{"name": provider, "models": [{"name": test_model}]}]}
-    )
-    config.llm_config = config.config.llm_providers
-
-    with pytest.raises(ValueError, match="api_key"):
-        LLMLoader(provider=provider, model=test_model)
+#     with pytest.raises(ValueError, match="api_key"):
+#         LLMLoader(provider=provider, model=test_model)

--- a/tests/unit/query_helpers/test_query_helper.py
+++ b/tests/unit/query_helpers/test_query_helper.py
@@ -1,26 +1,27 @@
 """Unit tests for query helper class."""
 
+from ols.src.llms.llm_loader import LLMLoader
 from ols.src.query_helpers import QueryHelper
 from ols.utils import config
 
 
-class TestQueryHelper:
-    """Test the query helper class."""
+def test_defaults_used():
+    """Test that the defaults are used when no inputs are provided."""
+    config.init_config("tests/config/valid_config.yaml")
 
-    def test_defaults_used(self):
-        """Test that the defaults are used when no inputs are provided."""
-        config.init_config("tests/config/valid_config.yaml")
+    qh = QueryHelper()
 
-        qh = QueryHelper()
+    assert qh.provider == config.ols_config.default_provider
+    assert qh.model == config.ols_config.default_model
+    assert qh.llm_loader == LLMLoader
+    assert qh.llm_params == {}
 
-        assert qh.provider == config.ols_config.default_provider
-        assert qh.model == config.ols_config.default_model
 
-    def test_inputs_are_used(self):
-        """Test that the inputs are used when provided."""
-        test_provider = "test_provider"
-        test_model = "test_model"
-        qh = QueryHelper(provider=test_provider, model=test_model)
+def test_inputs_are_used():
+    """Test that the inputs are used when provided."""
+    test_provider = "test_provider"
+    test_model = "test_model"
+    qh = QueryHelper(provider=test_provider, model=test_model)
 
-        assert qh.provider == test_provider
-        assert qh.model == test_model
+    assert qh.provider == test_provider
+    assert qh.model == test_model

--- a/tests/unit/query_helpers/test_question_validator.py
+++ b/tests/unit/query_helpers/test_question_validator.py
@@ -15,7 +15,7 @@ from tests.mock_classes.llm_loader import mock_llm_loader
 def question_validator():
     """Fixture containing constructed and initialized QuestionValidator."""
     config.init_empty_config()
-    return QuestionValidator()
+    return QuestionValidator(llm_loader=mock_llm_loader(None))
 
 
 def test_is_query_helper_subclass():
@@ -23,7 +23,6 @@ def test_is_query_helper_subclass():
     assert issubclass(QuestionValidator, QueryHelper)
 
 
-@patch("ols.src.query_helpers.question_validator.LLMLoader", new=mock_llm_loader(None))
 def test_valid_responses(question_validator):
     """Test how valid responses are handled by QuestionValidator."""
     for retval in [
@@ -40,7 +39,6 @@ def test_valid_responses(question_validator):
             assert response == retval
 
 
-@patch("ols.src.query_helpers.question_validator.LLMLoader", new=mock_llm_loader(None))
 def test_disabled_question_validator(question_validator):
     """Test disabled QuestionValidator behaviour."""
     for retval in [


### PR DESCRIPTION
## Description

This PR contains a responsibility shift.

The `QueryHelper` knows which provider/model (and parameters) wants to use. It is its responsibility to set the correct inputs for `LLMLoader`. 

Resolving if the combo is actually valid input is responsibility the `LLMLoader`. It gets what provider, model, and additional parameters for llm along with the config against which the values will be validated.

## Type of change

- [x] Refactor
