### PR TITLE
Fix comment: we don't use env.vars anymore

### DIFF
--- a/ols/src/cache/cache_factory.py
+++ b/ols/src/cache/cache_factory.py
@@ -12,7 +12,7 @@ class CacheFactory:
 
     @staticmethod
     def conversation_cache(config: ConversationCacheConfig) -> Cache:
-        """Create an instance of Cache based on environment variable.
+        """Create an instance of Cache based on loaded configuration.
 
         Returns:
             An instance of `Cache` (either `RedisCache` or `InMemoryCache`).


### PR DESCRIPTION
## Description

Fix comment: we don't use env.vars anymore

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
