### PR TITLE
OLS-268: RAG: in OLS responses, support deep links into the OCP docs

### DIFF
--- a/ols/constants.py
+++ b/ols/constants.py
@@ -17,6 +17,9 @@ The following context contains several pieces of documentation. Please answer th
 Documentation context:
 {context_str}
 
+User query:
+{query_str}
+
 Summary:
 
 """
@@ -167,3 +170,7 @@ REDIS_CACHE_MAX_MEMORY_POLICIES = frozenset({"allkeys-lru", "volatile-lru"})
 
 # provider and model roles
 PROVIDER_MODEL_ROLES = frozenset({"default"})
+
+EMBEDDINGS_ROOT_DIR = "/workspace/source/ocp-product-docs-plaintext"
+OCP_DOCS_ROOT_URL = "https://docs.openshift.com/container-platform/"
+OCP_DOCS_VERSION = "4.14"


### PR DESCRIPTION
## Description

- Added user query to the summarizer's prompt
- Removed embeddings' metadata from the summarizer's prompt
- "Referenced documents" in the summarizer's response are now OCP doc URLs

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue 
- Closes # https://issues.redhat.com/browse/OLS-268

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

For the following query:

$ curl -X 'POST' 'http://127.0.0.1:8080/v1/query' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{"query": "What is the NFD operator?"}'


the following request is sent to the LLM (note no file_path metadata):

2024-02-07 14:35:40,113 [openai._base_client:_base_client.py:439] DEBUG: Request options: {'method': 'post', 'url': '/chat/completions', 'files': None, 'json_data': {'messages': [{'role': 'user', 'content': '\nThe following context contains several pieces of documentation. Please answer the user\'s question based on this context.\nDocumentation context:\nNode Feature Discovery Operator\n\nLearn about the Node Feature Discovery (NFD) Operator and how you can use it to expose node-level information by orchestrating Node Feature Discovery, a Kubernetes add-on for detecting hardware features and system configuration.\nAbout the Node Feature Discovery Operator\nThe Node Feature Discovery Operator (NFD) manages the detection of hardware features and configuration in an "Red Hat OpenShift Container Platform" cluster by labeling the nodes with hardware-specific information. NFD labels the host with node-specific attributes, such as PCI cards, kernel, operating system version, and so on.\n\nThe NFD Operator can be found on the Operator Hub by searching for “Node Feature Discovery”.\nInstalling the Node Feature Discovery Operator\nThe Node Feature Discovery (NFD) Operator orchestrates all resources needed to run the NFD daemon set. As a cluster administrator, you can install the NFD Operator by using the "Red Hat OpenShift Container Platform" CLI or the web console.\n\nInstalling the NFD Operator using the CLI\nAs a cluster administrator, you can install the NFD Operator using the CLI.\n\nUser query:\nWhat is the NFD operator?\n\nSummary:\n\n'}], 'model': 'gpt-4-1106-preview', 'frequency_penalty': 1.03, 'max_tokens': 512, 'n': 1, 'stream': True, 'temperature': 0.01, 'top_p': 0.95}}

and the following referenced documents are logged (note the live doc link):

2024-02-07 14:35:45,335 [ols.src.query_helpers.docs_summarizer:docs_summarizer.py:155] INFO: e76f0d3b-40a0-44d1-8933-b100c7353c9e Referenced documents: https://docs.openshift.com/container-platform/4.14/hardware_enablement/psap-node-feature-discovery-operator.html
