### PR TITLE
OLS-295: Disable Gradio analytics

### DIFF
--- a/ols/src/ui/gradio_ui.py
+++ b/ols/src/ui/gradio_ui.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 from typing import Optional
 
 import gradio as gr
@@ -20,6 +21,9 @@ class GradioUI:
         conversation_id: Optional[str] = None,
     ) -> None:
         """Initialize UI API handlers."""
+        # disable Gradio analytics, which calls home to https://api.gradio.app
+        os.environ["GRADIO_ANALYTICS_ENABLED"] = "false"
+
         # class variable
         self.ols_url = ols_url
         self.conversation_id = conversation_id


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # https://issues.redhat.com/browse/OLS-295

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

Before this fix, with logging_config.lib_log_level = debug, the following was logged:

$ uvicorn ols.app.main:app --reload --port 8080
INFO:     Will watch for changes in these directories: ['/home/syedriko/lightspeed-service']
INFO:     Uvicorn running on http://127.0.0.1:8080 (Press CTRL+C to quit)
INFO:     Started reloader process [40964] using StatReload
2024-02-07 23:25:51,539 [ols.app.main:main.py:29] INFO: Config loaded from /home/syedriko/lightspeed-service/olsconfig.yaml
2024-02-07 23:25:51,541 [httpx:_config.py:78] DEBUG: load_ssl_context verify=True cert=None trust_env=True http2=False
2024-02-07 23:25:51,541 [httpx:_config.py:78] DEBUG: load_ssl_context verify=True cert=None trust_env=True http2=False
2024-02-07 23:25:51,698 [httpx:_config.py:144] DEBUG: load_verify_locations cafile='/home/syedriko/lightspeed-service/.venv/lib64/python3.11/site-packages/certifi/cacert.pem'
2024-02-07 23:25:51,713 [httpx:_config.py:144] DEBUG: load_verify_locations cafile='/home/syedriko/lightspeed-service/.venv/lib64/python3.11/site-packages/certifi/cacert.pem'
2024-02-07 23:25:51,714 [httpcore.connection:_trace.py:45] DEBUG: connect_tcp.started host='api.gradio.app' port=443 local_address=None timeout=3 socket_options=None

After the fix:
$ uvicorn ols.app.main:app --reload --port 8080
INFO:     Will watch for changes in these directories: ['/home/syedriko/lightspeed-service']
INFO:     Uvicorn running on http://127.0.0.1:8080 (Press CTRL+C to quit)
INFO:     Started reloader process [42139] using StatReload
2024-02-07 23:51:46,980 [ols.app.main:main.py:29] INFO: Config loaded from /home/syedriko/lightspeed-service/olsconfig.yaml
INFO:     Started server process [42141]
INFO:     Waiting for application startup.
INFO:     Application startup complete.

i.e. no attempt on behalf of Gradio to send analytics to its server.