### PR TITLE
Overall code coverage computation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,15 @@ During testing, code coverage is measured. If the coverage is below defined thre
 
 Code coverage reports are generated in JSON and also in format compatible with _JUnit_. It is also possible to start `make coverage-report` to generate code coverage reports in form of interactive HTML pages. These pages are stored in `htmlcov` subdirectory. Just open index page from this subdirectory in your web browser.
 
+Overall code coverage measured for both unit tests and integration tests can be checked by following command:
+
+```
+make check-coverage
+```
+
+The threshold set for combined coverage is larger than threshold for unit tests and integration tests because it is preferred to have most statements covered by at least one type of tests.
+
+
 
 ### Type hints checks
 

--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -92,7 +92,7 @@ def conversation_request(llm_request: LLMRequest) -> LLMResponse:
                 llm_response, _ = docs_summarizer.summarize(
                     conversation_id, llm_request.query, previous_input
                 )
-                # TODO: There are some inconsitencies in the types to be solved.
+                # TODO: There are some inconsistencies in the types to be solved.
                 # See the comment in `summarize` method in `docs_summarizer.py`
                 # Because of that, we are ignoring some type checks when we
                 # are creating response model.


### PR DESCRIPTION
## Description

Overall code coverage computation.
We had a discussion with @syedriko that it would be useful to know code coverage for both unit tests and integration tests. It is logical as we don't want to cover literally everything from unit tests and in some cases it is not even possible (`ols/app/main.py` for example). On other hand we don't want to repeat the same checks in integration tests just to have nice code coverage (`config.py`). And additionally the overall code coverage might be very near 100% - and any part not covered is either dead code or our testing is not complete.

This is how the overall code coverage look like today. It is clear that some parts of `llm_loader.py` is not tested at all. And it is not a coincidence that this is most problematic part of our codebase:

```
Name                                          Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------
ols/__init__.py                                   0      0   100%
ols/app/__init__.py                               0      0   100%
ols/app/endpoints/__init__.py                     0      0   100%
ols/app/endpoints/feedback.py                     9      0   100%
ols/app/endpoints/health.py                      15      0   100%
ols/app/endpoints/ols.py                         68      0   100%
ols/app/main.py                                  18      1    94%   33
ols/app/metrics.py                                5      0   100%
ols/app/models/__init__.py                        0      0   100%
ols/app/models/config.py                        320      8    98%   315, 355, 394, 455, 489-497, 541
ols/app/models/models.py                         30      0   100%
ols/app/routers.py                                8      0   100%
ols/constants.py                                 33      0   100%
ols/src/__init__.py                               0      0   100%
ols/src/cache/__init__.py                         0      0   100%
ols/src/cache/cache.py                           22      0   100%
ols/src/cache/cache_factory.py                   15      0   100%
ols/src/cache/in_memory_cache.py                 39      1    97%   10
ols/src/cache/redis_cache.py                     34      0   100%
ols/src/llms/__init__.py                          0      0   100%
ols/src/llms/llm_loader.py                      103     36    65%   108, 119, 150, 159, 164, 174-199, 203-235, 299-335, 339-341
ols/src/query_helpers/__init__.py                 6      0   100%
ols/src/query_helpers/docs_summarizer.py         58      5    91%   27-29, 45, 77
ols/src/query_helpers/query_docs.py              19      0   100%
ols/src/query_helpers/question_validator.py      25      0   100%
ols/src/ui/__init__.py                            0      0   100%
ols/src/ui/gradio_ui.py                          48      2    96%   94, 98
ols/utils/__init__.py                             0      0   100%
ols/utils/config.py                              32      0   100%
ols/utils/logging.py                              6      0   100%
ols/utils/suid.py                                 9      0   100%
ols/utils/token_handler.py                       41      0   100%
---------------------------------------------------------------------------
TOTAL                                           963     53    94%

```


## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Run the new command `make check-coverage`
