### PR TITLE
Switch to langchain-openai dep instead of langchain-community

### DIFF
--- a/ols/src/llms/llm_loader.py
+++ b/ols/src/llms/llm_loader.py
@@ -16,7 +16,7 @@ from ibm_watson_machine_learning.metanames import (
     GenTextParamsMetaNames as GenParams,
 )
 from langchain.llms.base import LLM
-from langchain_community.chat_models import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 from ols import constants
 from ols.app.models.config import ProviderConfig

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:43cda5eeeda80225e74f8daa63d62b4e8c19470c502eeecbb3b38c83dd63e86f"
+content_hash = "sha256:4622aa027ba7597d393389825e6f56bf4e493a30fc6904efddf1c13ba2789ebc"
 
 [[package]]
 name = "aiofiles"
@@ -942,6 +942,23 @@ dependencies = [
 files = [
     {file = "langchain_core-0.1.17-py3-none-any.whl", hash = "sha256:026155cf97867bde410ab1834799ab4c5ba64c39380f2a4328bcf9c78623ca64"},
     {file = "langchain_core-0.1.17.tar.gz", hash = "sha256:59016e457cd6a1708d83a3a454acc97cf02c2a2c3af95626d13f83894fd4e777"},
+]
+
+[[package]]
+name = "langchain-openai"
+version = "0.0.5"
+requires_python = ">=3.8.1,<4.0"
+summary = "An integration package connecting OpenAI and LangChain"
+groups = ["default"]
+dependencies = [
+    "langchain-core<0.2,>=0.1.16",
+    "numpy<2,>=1",
+    "openai<2.0.0,>=1.10.0",
+    "tiktoken<0.6.0,>=0.5.2",
+]
+files = [
+    {file = "langchain_openai-0.0.5-py3-none-any.whl", hash = "sha256:93b37dfac274adad65e46d5d6e71411e00c6984bcc5e10f1d6bb58e7944dc01b"},
+    {file = "langchain_openai-0.0.5.tar.gz", hash = "sha256:f317fee5b652949ad96ad7edf8ef7a044a6a3f0cc71d1e12f9d5261789fd68c4"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "openai==1.10.0",
     "ibm-watson-machine-learning==1.0.344",
     "ibm-generative-ai==2.0.0",
+    "langchain-openai==0.0.5",
     "pydantic==2.6.0",
     "setuptools>=69.0.3",
     "prometheus-client>=0.19.0",


### PR DESCRIPTION
## Description

langchain-community is deprecated for use with ChatOpenAI

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.