### PR TITLE
OLS-305: Make LLMResponse include URLs for the embedding documents used to generate the response

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -32,6 +32,7 @@ def conversation_request(llm_request: LLMRequest) -> LLMResponse:
     """
     # Initialize variables
     previous_input = None
+    referenced_documents: list[str] = []
 
     # TODO: retrieve proper user ID from request
     user_id = "user1"
@@ -69,7 +70,7 @@ def conversation_request(llm_request: LLMRequest) -> LLMResponse:
                 docs_summarizer = DocsSummarizer(
                     provider=llm_request.provider, model=llm_request.model
                 )
-                llm_response, _ = docs_summarizer.summarize(
+                llm_response, referenced_documents = docs_summarizer.summarize(
                     conversation_id, llm_request.query, previous_input
                 )
                 response = llm_response.response
@@ -82,7 +83,11 @@ def conversation_request(llm_request: LLMRequest) -> LLMResponse:
                 )
 
     store_conversation_history(user_id, conversation_id, llm_request, response)
-    return LLMResponse(conversation_id=conversation_id, response=response)
+    return LLMResponse(
+        conversation_id=conversation_id,
+        response=response,
+        referenced_documents=referenced_documents,
+    )
 
 
 def retrieve_conversation_id(llm_request: LLMRequest) -> str:
@@ -158,7 +163,9 @@ def conversation_request_debug_api(llm_request: LLMRequest) -> LLMResponse:
     logger.info(f"{conversation_id} Model returned: {response}")
 
     llm_response = LLMResponse(
-        conversation_id=conversation_id, response=response["text"]
+        conversation_id=conversation_id,
+        response=response["text"],
+        referenced_documents=[],
     )
 
     return llm_response

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -60,10 +60,12 @@ class LLMResponse(BaseModel):
     Attributes:
         conversation_id: The optional conversation ID (UUID).
         response: The optional response.
+        referenced_documents: The optional URLs for the documents used to generate the response.
     """
 
     conversation_id: str
     response: str
+    referenced_documents: list[str]
 
     # provides examples for /docs endpoint
     model_config = {
@@ -71,7 +73,11 @@ class LLMResponse(BaseModel):
             "examples": [
                 {
                     "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
-                    "response": "sure, here is deployment yaml for the mongodb image...",
+                    "response": "Operator Lifecycle Manager (OLM) helps users install...",
+                    "referenced_documents": [
+                        "https://docs.openshift.com/container-platform/4.14/operators/"
+                        "understanding/olm/olm-understanding-olm.html"
+                    ],
                 }
             ]
         }

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -53,6 +53,7 @@ def test_invalid_question():
     expected_json = {
         "conversation_id": conversation_id,
         "response": expected_details,
+        "referenced_documents": [],
     }
     assert response.json() == expected_json
 

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -40,6 +40,7 @@ def test_debug_query():
     assert response.json() == {
         "conversation_id": conversation_id,
         "response": "test response",
+        "referenced_documents": [],
     }
 
 
@@ -144,6 +145,7 @@ def test_post_question_on_invalid_question():
         expected_json = {
             "conversation_id": conversation_id,
             "response": expected_details,
+            "referenced_documents": [],
         }
         assert response.json() == expected_json
 

--- a/tests/unit/app/endpoints/test_ols.py
+++ b/tests/unit/app/endpoints/test_ols.py
@@ -137,7 +137,7 @@ def test_conversation_request(
     )
     mock_summarize.return_value = (
         mock_response,
-        "",  # referenced documents
+        [],  # referenced_documents
     )
     llm_request = LLMRequest(query="Tell me about Kubernetes")
     response = ols.conversation_request(llm_request)

--- a/tests/unit/app/models/test_models.py
+++ b/tests/unit/app/models/test_models.py
@@ -64,14 +64,17 @@ class TestLLM:
         """Test the LLMResponse model."""
         conversation_id = "id"
         response = "response"
+        referenced_documents = ["https://foo.bar.com/index.html"]
 
         llm_response = LLMResponse(
             conversation_id=conversation_id,
             response=response,
+            referenced_documents=referenced_documents,
         )
 
         assert llm_response.conversation_id == conversation_id
         assert llm_response.response == response
+        assert llm_response.referenced_documents == referenced_documents
 
 
 class TestFeedback:


### PR DESCRIPTION
## Description

LLMResponse now includes a list of URLs for the embedding documents used to generate the response

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # https://issues.redhat.com/browse/OLS-305

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
