### PR TITLE
OLS-254: Return response immediatelly to avoid type confusion

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -111,8 +111,7 @@ def conversation_request(llm_request: LLMRequest) -> LLMResponse:
             conversation_id,
             llm_request.query + "\n\n" + str(response or ""),  # type: ignore
         )
-    llm_response = LLMResponse(conversation_id=conversation_id, response=response)  # type: ignore
-    return llm_response
+    return LLMResponse(conversation_id=conversation_id, response=response)
 
 
 @router.post("/debug/query")


### PR DESCRIPTION
## Description

- Return response immediatelly to avoid type confusion
- Identifier `llm_response` was used in two context (totally different). That causes type checkers to identify type errors that were forcefully ignored by `#type ignore` comment. It is not needed now.

<!--- Describe your changes in detail -->

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-254](https://issues.redhat.com//browse/OLS-254)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.
