### PR TITLE
OLS-254: Proper test for conversation ID from response

### DIFF
--- a/tests/unit/app/endpoints/test_ols.py
+++ b/tests/unit/app/endpoints/test_ols.py
@@ -63,7 +63,9 @@ def test_conversation_request(
         response.response
         == "Kubernetes is an open-source container-orchestration system..."
     )
-    assert len(response.conversation_id) > 0
+    assert suid.check_suid(
+        response.conversation_id
+    ), "Improper conversation ID returned"
 
     # invalid question
     mock_validate_question.return_value = constants.SUBJECT_INVALID
@@ -73,7 +75,9 @@ def test_conversation_request(
         "I can only answer questions about OpenShift and Kubernetes. "
         "Please rephrase your question"
     )
-    assert len(response.conversation_id) > 0
+    assert suid.check_suid(
+        response.conversation_id
+    ), "Improper conversation ID returned"
 
     # validation failure
     mock_validate_question.side_effect = HTTPException


### PR DESCRIPTION
## Description

Proper test for conversation ID from response

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-254](https://issues.redhat.com//browse/OLS-254)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

