### PR TITLE
OLS-332: avoid on-demand downloading of the embeddings model from HuggingFace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ tmp
 data
 vector-db
 vendor
+embeddings_model
 
 # ignore credential files
 *_api_key.txt

--- a/Containerfile
+++ b/Containerfile
@@ -11,7 +11,7 @@ RUN microdnf install -y --nodocs --setopt=keepcache=0 --setopt=tsflags=nodocs \
 # PYTHONDONTWRITEBYTECODE 1 : disable the generation of .pyc
 # PYTHONUNBUFFERED 1 : force the stadout and stderr streams to be unbufferred
 # PYTHONCOERCECLOCALE 0, PYTHONUTF8 1 : skip lgeacy locales and use UTF-8 mode
-ENV PYTHONDONTWRITEBYTECODE=1 \ 
+ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYTHONCOERCECLOCALE=0 \
     PYTHONUTF8=1 \
@@ -31,7 +31,7 @@ RUN python3.11 -m venv ${APP_ROOT}/venv \
     # avoid using or leaving cache on final image
     && pip install --no-cache-dir --upgrade pip pdm \
     # Install project dependencies using PDM
-    && pdm install --no-lock \
+    && pdm install --frozen-lockfile \
     # The following echo adds the unset command for the variables set below to the
     # venv activation script. This is inspired from scl_enable script and prevents
     # the virtual environment to be activated multiple times and also every time

--- a/Containerfile.rag
+++ b/Containerfile.rag
@@ -11,11 +11,14 @@ USER 0
 RUN microdnf install -y unzip wget \
   && mkdir -p vector-db \
 	&& cd vector-db \
-  && wget $RAG_INDEX \
-	&& unzip local.zip \
+  && wget -q $RAG_INDEX \
+	&& unzip -qq local.zip \
 	&& mv local ocp-product-docs \
 	&& rm -f local.zip \
 	&& microdnf remove -y unzip wget
+
+COPY scripts/download_embeddings_model.py .
+RUN python download_embeddings_model.py embeddings_model && rm download_embeddings_model.py
 
 RUN chown -R 1001:0 ${APP_ROOT} && \
     chmod -R g+rx ${APP_ROOT}

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@
 
 ARTIFACT_DIR := $(if $(ARTIFACT_DIR),$(ARTIFACT_DIR),tests/test_results)
 
-
 images: ## Build container images
 	scripts/build-container.sh
 
@@ -46,7 +45,7 @@ test-e2e: ## Run e2e tests - requires running OLS server
 	@echo "Running e2e tests..."
 	@echo "Reports will be written to ${ARTIFACT_DIR}"
 	python -m pytest tests/e2e --junit-xml="${ARTIFACT_DIR}/junit_e2e.xml"
-		
+
 
 coverage-report:	test-unit ## Export unit test coverage report into interactive HTML
 	coverage html --data-file="${ARTIFACT_DIR}/.coverage.unit"
@@ -61,6 +60,16 @@ format: ## Format the code into unified format
 verify: ## Verify the code using various linters
 	black . --check
 	ruff . --per-file-ignores=tests/*:S101
+
+get-rag: ## Download RAG embeddings model and index
+	@echo "Downloading embeddings model from HF..."
+	python scripts/download_embeddings_model.py embeddings_model
+	@echo "Downloading embeddings..."
+	mkdir -p vector-db/ocp-product-docs && \
+	pushd vector-db/ocp-product-docs && \
+	wget -q https://github.com/ilan-pinto/lightspeed-rag-documents/releases/latest/download/local.zip && \
+	unzip -qq -o local.zip && \
+	rm local.zip && popd
 
 help: ## Show this help screen
 	@echo 'Usage: make <OPTIONS> ... <TARGETS>'

--- a/examples/olsconfig.yaml
+++ b/examples/olsconfig.yaml
@@ -23,6 +23,7 @@ ols_config:
   reference_content:
 #    product_docs_index_path: "./vector-db/ocp-product-docs"
 #    product_docs_index_id: product
+#    embeddings_model_path: "./embeddings_model"
   conversation_cache:
     type: memory
     memory:

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -1,6 +1,7 @@
 """A class for summarizing documentation context."""
 
 import logging
+import os
 from typing import Any, Optional
 
 import llama_index
@@ -92,7 +93,23 @@ class DocsSummarizer(QueryHelper):
 
         logger.info(f"{conversation_id} Getting service context")
 
-        embed_model = "local:BAAI/bge-base-en"
+        embed_model: Optional[Any]  # need this to make mypy happy
+        if (
+            config.ols_config.reference_content is not None
+            and config.ols_config.reference_content.embeddings_model_path is not None
+        ):
+            from langchain_community.embeddings import HuggingFaceBgeEmbeddings
+
+            # TODO syedriko consolidate these env vars into a central location as per OLS-345.
+            os.environ["TRANSFORMERS_CACHE"] = (
+                config.ols_config.reference_content.embeddings_model_path
+            )
+            os.environ["TRANSFORMERS_OFFLINE"] = "1"
+            embed_model = HuggingFaceBgeEmbeddings(
+                model_name=config.ols_config.reference_content.embeddings_model_path
+            )
+        else:
+            embed_model = "local:BAAI/bge-base-en"
 
         service_context = ServiceContext.from_defaults(
             chunk_size=1024, llm=bare_llm, embed_model=embed_model, **kwargs

--- a/ols/src/ui/gradio_ui.py
+++ b/ols/src/ui/gradio_ui.py
@@ -21,6 +21,7 @@ class GradioUI:
         conversation_id: Optional[str] = None,
     ) -> None:
         """Initialize UI API handlers."""
+        # TODO syedriko consolidate this env var into a central location as per OLS-345.
         # disable Gradio analytics, which calls home to https://api.gradio.app
         os.environ["GRADIO_ANALYTICS_ENABLED"] = "false"
 

--- a/scripts/download_embeddings_model.py
+++ b/scripts/download_embeddings_model.py
@@ -1,0 +1,27 @@
+"""Utility script to download a model from HuggingFace."""
+
+import os
+import sys
+
+if __name__ == "__main__":
+
+    if len(sys.argv) != 2:
+        print("Usage: python download_embeddings_model.py <local_dir>")
+        sys.exit(1)
+
+    local_dir = sys.argv[1]
+
+    os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
+
+    from huggingface_hub import snapshot_download
+
+    snapshot_download(
+        repo_id="BAAI/bge-base-en", local_dir=local_dir, local_dir_use_symlinks=False
+    )
+
+    # workaround for https://github.com/UKPLab/sentence-transformers/pull/2460
+    os.makedirs(os.path.join(local_dir, "2_Normalize"), exist_ok=True)
+
+    # pretend local_dir is HF cache
+    with open(os.path.join(local_dir, "version.txt"), "w") as f:
+        f.write("1")


### PR DESCRIPTION
## Description

- Added ols_config.reference_content.embeddings_model_path to configuration to store the path to the embeddings model. If this path is specified, the OLS expects to find the embeddings model in that directory. Otherwise, the behavior is as before, the model is downloaded from HuggingFace on-demand and is cached locally.
- For everyday development, added `get-rag` make target that downloads both the embeddings model and database to the local directories.
- Added the embeddings model to the RAG'ged image via Containerfile.rag

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [x] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/OLS-52
- Closes # https://issues.redhat.com/browse/OLS-332

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
