### PR TITLE
OLS-254: Refactor: retrieve previous input

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -38,11 +38,7 @@ def conversation_request(llm_request: LLMRequest) -> LLMResponse:
     user_id = "user1"
 
     conversation_id = retrieve_conversation_id(llm_request)
-
-    # TODO: will be refactored in following PR
-    if llm_request.conversation_id:
-        previous_input = config.conversation_cache.get(user_id, conversation_id)
-        logger.info(f"{conversation_id} Previous conversation input: {previous_input}")
+    previous_input = retrieve_previous_input(user_id, llm_request)
 
     # Log incoming request
     logger.info(f"{conversation_id} Incoming request: {llm_request.query}")
@@ -100,6 +96,19 @@ def retrieve_conversation_id(llm_request: LLMRequest) -> str:
         logger.info(f"{conversation_id} New conversation")
 
     return conversation_id
+
+
+def retrieve_previous_input(user_id: str, llm_request: LLMRequest) -> Optional[str]:
+    """Retrieve previous user input, if exists."""
+    previous_input = None
+    if llm_request.conversation_id:
+        previous_input = config.conversation_cache.get(
+            user_id, llm_request.conversation_id
+        )
+        logger.info(
+            f"{llm_request.conversation_id} Previous conversation input: {previous_input}"
+        )
+    return previous_input
 
 
 def store_conversation_history(

--- a/tests/unit/app/endpoints/test_ols.py
+++ b/tests/unit/app/endpoints/test_ols.py
@@ -36,6 +36,27 @@ def test_retrieve_conversation_id_existing_id(load_config):
     assert new_id == old_id, "Old (existing) ID should be retrieved." ""
 
 
+def test_retrieve_previous_input_no_previous_history(load_config):
+    """Check how function to retrieve previous input handle empty history."""
+    user_id = "1234"
+    llm_request = LLMRequest(query="Tell me about Kubernetes", conversation_id=None)
+    input = ols.retrieve_previous_input(user_id, llm_request)
+    assert input is None
+
+
+@patch("ols.utils.config.conversation_cache.get")
+def test_retrieve_previous_input_for_previous_history(get, load_config):
+    """Check how function to retrieve previous input handle existing history."""
+    user_id = "1234"
+    conversation_id = suid.get_suid()
+    get.return_value = "input"
+    llm_request = LLMRequest(
+        query="Tell me about Kubernetes", conversation_id=conversation_id
+    )
+    previous_input = ols.retrieve_previous_input(user_id, llm_request)
+    assert previous_input == "input"
+
+
 @patch("ols.utils.config.conversation_cache.insert_or_append")
 def test_store_conversation_history(insert_or_append, load_config):
     """Test if operation to store conversation history to cache is called."""


### PR DESCRIPTION
## Description

Refactor: retrieve previous input
+ new unit tests

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Unit tests

## Related Tickets & Documents

- Related Issue #[OLS-254](https://issues.redhat.com//browse/OLS-254)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

