### PR TITLE
ols-241: - add TLS supported Example openshift manifest

### DIFF
--- a/examples/openshift-lightspeed-tls.yaml
+++ b/examples/openshift-lightspeed-tls.yaml
@@ -1,0 +1,180 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: openshift-lightspeed
+    app.kubernetes.io/component: lightspeed-w-rag
+    app.kubernetes.io/instance: lightspeed-w-rag
+    app.kubernetes.io/name: lightspeed-w-rag
+    app.kubernetes.io/part-of: lightspeed-w-rag-app
+  name: lightspeed-w-rag
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: openshift-lightspeed
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: openshift-lightspeed
+        deployment: lightspeed-w-rag
+    spec:
+      volumes:
+        - name: olsconfig
+          configMap:
+            name: olsconfig
+        - name: openai
+          secret:
+            secretName: openai
+        - name: tls-certs
+          secret:
+            secretName: lightspeed-certs
+      containers:
+      - image: quay.io/openshiftdemos/lightspeed-w-rag:latest
+        command:
+          - uvicorn
+        args:
+          - 'ols.app.main:app'
+          - '--host'
+          - 0.0.0.0
+          - '--port'
+          - '443'
+          - '--ssl-keyfile'
+          - /app-root/certs/tls.key
+          - '--ssl-certfile'
+          - /app-root/certs/tls.crt
+        imagePullPolicy: Always
+        name: lightspeed-w-rag
+        env:
+          - name: OLS_CONFIG_FILE
+            value: /app-root/config/olsconfig.yaml
+        ports:
+        - containerPort: 443
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+          - name: olsconfig
+            mountPath: /app-root/config
+          - name: openai
+            mountPath: /app-root/config/openai
+          - name: tls-certs
+            mountPath: /app-root/certs
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: openshift-lightspeed
+    app.kubernetes.io/component: lightspeed-w-rag
+    app.kubernetes.io/instance: lightspeed-w-rag
+    app.kubernetes.io/name: lightspeed-w-rag
+    app.kubernetes.io/part-of: lightspeed-w-rag-app
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: lightspeed-certs
+  name: lightspeed-w-rag
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: 443-tcp
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: openshift-lightspeed
+    deployment: lightspeed-w-rag
+  sessionAffinity: None
+  type: ClusterIP
+
+#---
+#apiVersion: route.openshift.io/v1
+#kind: Route
+#metadata:
+#  labels:
+#    app: openshift-lightspeed
+#    app.kubernetes.io/component: lightspeed-w-rag
+#    app.kubernetes.io/instance: lightspeed-w-rag
+#    app.kubernetes.io/name: lightspeed-w-rag
+#    app.kubernetes.io/part-of: lightspeed-w-rag-app
+#  name: lightspeed-w-rag
+#spec:
+#  port:
+#    targetPort: 443-tcp
+#  tls:
+#    insecureEdgeTerminationPolicy: Redirect
+#    termination: edge
+#  to:
+#    kind: Service
+#    name: lightspeed-w-rag
+#    weight: 100
+#  wildcardPolicy: None
+
+---
+apiVersion: v1
+data:
+  olsconfig.yaml: |
+    llm_providers:
+      - name: openai
+        url: "https://api.openai.com/v1"
+        credentials_path: config/openai/openai_api_key.txt
+        models:
+          - name: gpt-4-1106-preview
+          - name: gpt-3.5-turbo
+    ols_config:
+      conversation_cache:
+        type: memory
+        memory:
+          max_entries: 1000
+      logging_config:
+        app_log_level: info
+        lib_log_level: warning
+      default_provider: openai
+      default_model: gpt-4-1106-preview
+    dev_config:
+      enable_dev_ui: true
+      # llm_temperature_override: 0
+      # disable_question_validation: false
+      # disable_auth: false
+immutable: false
+kind: ConfigMap
+metadata:
+  labels:
+    app: openshift-lightspeed
+    app.kubernetes.io/component: lightspeed-w-rag
+    app.kubernetes.io/instance: lightspeed-w-rag
+    app.kubernetes.io/name: lightspeed-w-rag
+    app.kubernetes.io/part-of: lightspeed-w-rag-app
+  name: olsconfig
+
+---
+apiVersion: v1
+stringData:
+  openai_api_key.txt: <OPENAI_API_KEY>
+kind: Secret
+metadata:
+  labels:
+    app: openshift-lightspeed
+    app.kubernetes.io/component: lightspeed-w-rag
+    app.kubernetes.io/instance: lightspeed-w-rag
+    app.kubernetes.io/name: lightspeed-w-rag
+    app.kubernetes.io/part-of: lightspeed-w-rag-app
+  name: openai
+type: Opaque


### PR DESCRIPTION
## Description

Added an example manifest under examples dir, that makes use of Service Serving certs that would enable TLS certs
trusted by Openshift internal communication.
which also being used by OLS itself (provide to uvicorn)
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
