### PR TITLE
Add an e2e for rag content

### DIFF
--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -78,3 +78,23 @@ def test_valid_question() -> None:
         "The following response was generated without access to reference content:"
         not in json_response["response"]
     )
+
+
+def test_rag_question() -> None:
+    """Ensure responses include rag references."""
+    response = client.post(
+        "/v1/query",
+        json={"query": "what is the first step to install an openshift cluster?"},
+        timeout=90,
+    )
+    print(vars(response))
+    assert response.status_code == requests.codes.ok
+    json_response = response.json()
+    assert len(json_response["referenced_documents"]) > 0
+    assert "install" in json_response["referenced_documents"][0]
+    assert "https://" in json_response["referenced_documents"][0]
+
+    assert (
+        "The following response was generated without access to reference content:"
+        not in json_response["response"]
+    )


### PR DESCRIPTION
## Description

checks to see that the response references some RAG content.  This confirms:
1) we are looking up related context information from the RAG db
2) we are returning the refs as part of the api response

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.