### PR TITLE
Raise w/o exception name

### DIFF
--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -56,4 +56,4 @@ def init_config(config_file: str) -> None:
     except Exception as e:
         print(f"Failed to load config file {config_file}: {e!s}")
         print(traceback.format_exc())
-        raise e
+        raise


### PR DESCRIPTION
## Description

It's redundant to specify the exception name in a `raise` statement if the
exception is being re-raised.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.
