### PR TITLE
OLS-58: Truncating flag to be returned in response

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -46,7 +46,7 @@ def conversation_request(llm_request: LLMRequest) -> LLMResponse:
     metrics.llm_calls_total.inc()
     validation_result = validate_question(conversation_id, llm_request)
 
-    response, referenced_documents = generate_response(
+    response, referenced_documents, truncated = generate_response(
         conversation_id, llm_request, validation_result, previous_input
     )
 
@@ -55,6 +55,7 @@ def conversation_request(llm_request: LLMRequest) -> LLMResponse:
         conversation_id=conversation_id,
         response=response,
         referenced_documents=referenced_documents,
+        truncated=truncated,
     )
 
 
@@ -96,9 +97,13 @@ def generate_response(
                 f"{conversation_id} - Query is not relevant to kubernetes or ocp, returning"
             )
             return (
-                "I can only answer questions about OpenShift and Kubernetes. "
-                "Please rephrase your question"
-            ), []
+                (
+                    "I can only answer questions about OpenShift and Kubernetes. "
+                    "Please rephrase your question"
+                ),
+                [],
+                False,
+            )
         case constants.SUBJECT_VALID:
             logger.info(
                 f"{conversation_id} - Question is relevant to kubernetes or ocp"
@@ -108,10 +113,12 @@ def generate_response(
                 docs_summarizer = DocsSummarizer(
                     provider=llm_request.provider, model=llm_request.model
                 )
-                llm_response, referenced_documents = docs_summarizer.summarize(
-                    conversation_id, llm_request.query, previous_input
+                llm_response, referenced_documents, truncated = (
+                    docs_summarizer.summarize(
+                        conversation_id, llm_request.query, previous_input
+                    )
                 )
-                return llm_response.response, referenced_documents
+                return llm_response.response, referenced_documents, truncated
             except Exception as summarizer_error:
                 logger.error("Error while obtaining answer for user question")
                 logger.error(summarizer_error)
@@ -182,6 +189,7 @@ def conversation_request_debug_api(llm_request: LLMRequest) -> LLMResponse:
         conversation_id=conversation_id,
         response=response,
         referenced_documents=[],
+        truncated=False,
     )
 
 

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -61,11 +61,13 @@ class LLMResponse(BaseModel):
         conversation_id: The optional conversation ID (UUID).
         response: The optional response.
         referenced_documents: The optional URLs for the documents used to generate the response.
+        truncated: Set to True if conversation history was truncated to be within context window.
     """
 
     conversation_id: str
     response: str
     referenced_documents: list[str]
+    truncated: bool
 
     # provides examples for /docs endpoint
     model_config = {

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -55,7 +55,7 @@ class DocsSummarizer(QueryHelper):
         query: str,
         history: Optional[str] = None,
         **kwargs: Any,
-    ) -> tuple[Response, list[str]]:
+    ) -> tuple[Response, list[str], bool]:
         """Summarize the given query based on the provided conversation context.
 
         Args:
@@ -65,8 +65,9 @@ class DocsSummarizer(QueryHelper):
             kwargs: Additional keyword arguments for customization (model, verbose, etc.).
 
         Returns:
-            A tuple containing the summary as a string and referenced documents
-            as a list of strings.
+            A tuple containing the summary as a string, referenced documents as a list
+            of strings, and flag indicating that conversation history has been truncated
+            to fit within context window.
         """
         bare_llm = LLMLoader(self.provider, self.model).llm
 
@@ -103,6 +104,10 @@ class DocsSummarizer(QueryHelper):
         )
 
         referenced_documents: list[str] = []
+
+        truncated = (
+            False  # TODO tisnik: need to be implemented based on provided inputs
+        )
 
         # TODO get this from global config
         if (
@@ -170,4 +175,4 @@ class DocsSummarizer(QueryHelper):
         logger.info(f"{conversation_id} Summary response: {summary!s}")
         logger.info(f"{conversation_id} Referenced documents: {referenced_documents}")
 
-        return summary, referenced_documents
+        return summary, referenced_documents, truncated

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -54,6 +54,7 @@ def test_invalid_question():
         "conversation_id": conversation_id,
         "response": expected_details,
         "referenced_documents": [],
+        "truncated": False,
     }
     assert response.json() == expected_json
 

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -75,6 +75,7 @@ def test_post_question_on_invalid_question():
             "conversation_id": conversation_id,
             "response": expected_details,
             "referenced_documents": [],
+            "truncated": False,
         }
         assert response.json() == expected_json
 

--- a/tests/integration/test_ols_debug.py
+++ b/tests/integration/test_ols_debug.py
@@ -39,6 +39,7 @@ def test_debug_query():
         "conversation_id": conversation_id,
         "response": "test response",
         "referenced_documents": [],
+        "truncated": False,
     }
 
 

--- a/tests/unit/app/endpoints/test_ols.py
+++ b/tests/unit/app/endpoints/test_ols.py
@@ -159,6 +159,7 @@ def test_conversation_request(
     mock_summarize.return_value = (
         mock_response,
         [],  # referenced_documents
+        False,
     )
     llm_request = LLMRequest(query="Tell me about Kubernetes")
     response = ols.conversation_request(llm_request)
@@ -250,13 +251,14 @@ def test_generate_response_invalid_subject(load_config):
     previous_input = None
 
     # try to get response
-    response, documents = ols.generate_response(
+    response, documents, truncated = ols.generate_response(
         conversation_id, llm_request, validation_result, previous_input
     )
 
     # check the response
     assert "I can only answer questions about OpenShift and Kubernetes" in response
     assert len(documents) == 0
+    assert not truncated
 
 
 @patch("ols.src.query_helpers.docs_summarizer.DocsSummarizer.summarize")
@@ -270,6 +272,7 @@ def test_generate_response_valid_subject(mock_summarize, load_config):
     mock_summarize.return_value = (
         mock_response,
         [],  # referenced_documents
+        False,
     )
 
     # prepare arguments for DocsSummarizer
@@ -279,13 +282,14 @@ def test_generate_response_valid_subject(mock_summarize, load_config):
     previous_input = None
 
     # try to get response
-    response, documents = ols.generate_response(
+    response, documents, truncated = ols.generate_response(
         conversation_id, llm_request, validation_result, previous_input
     )
 
     # check the response
     assert "Kubernetes" in response
     assert len(documents) == 0
+    assert not truncated
 
 
 @patch("ols.src.query_helpers.docs_summarizer.DocsSummarizer.summarize")

--- a/tests/unit/app/models/test_models.py
+++ b/tests/unit/app/models/test_models.py
@@ -74,11 +74,13 @@ class TestLLM:
             conversation_id=conversation_id,
             response=response,
             referenced_documents=referenced_documents,
+            truncated=False,
         )
 
         assert llm_response.conversation_id == conversation_id
         assert llm_response.response == response
         assert llm_response.referenced_documents == referenced_documents
+        assert not llm_response.truncated
 
 
 class TestFeedback:

--- a/tests/unit/docs/test_doc_summarizer.py
+++ b/tests/unit/docs/test_doc_summarizer.py
@@ -33,7 +33,9 @@ def test_summarize(storage_context, service_context):
     summarizer = DocsSummarizer()
     question = "What's the ultimate question with answer 42?"
     history = None
-    summary, documents = summarizer.summarize(conversation_id, question, history)
+    summary, documents, truncated = summarizer.summarize(
+        conversation_id, question, history
+    )
     assert question in str(summary)
     assert len(documents) > 0
     assert (
@@ -48,6 +50,7 @@ def test_summarize(storage_context, service_context):
         f"{constants.OCP_DOCS_ROOT_URL}{constants.OCP_DOCS_VERSION}/known-bugs.html"
         in documents
     )
+    assert not truncated
 
 
 @patch(
@@ -65,9 +68,10 @@ def test_summarize_no_reference_content(storage_context, service_context):
     config.ols_config.reference_content = ReferenceContent(None)
     summarizer = DocsSummarizer()
     question = "What's the ultimate question with answer 42?"
-    summary, documents = summarizer.summarize(conversation_id, question)
+    summary, documents, truncated = summarizer.summarize(conversation_id, question)
     assert "success" in str(summary)
     assert len(documents) == 0
+    assert not truncated
 
 
 @patch(
@@ -87,9 +91,10 @@ def test_summarize_incorrect_directory(service_context):
     summarizer = DocsSummarizer()
     question = "What's the ultimate question with answer 42?"
     conversation_id = "01234567-89ab-cdef-0123-456789abcdef"
-    summary, documents = summarizer.summarize(conversation_id, question)
+    summary, documents, truncated = summarizer.summarize(conversation_id, question)
     assert (
         "The following response was generated without access to reference content"
         in str(summary)
     )
     assert len(documents) == 0
+    assert not truncated


### PR DESCRIPTION
## Description

Truncating flag to be returned in response.
This need changes in model, changes in DocsSummarizer etc.
The trunsation itself is not implemented there. This is 1st step to avoid having huge PR that will need to be constantly rebased.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-58](https://issues.redhat.com//browse/OLS-58)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.
