### PR TITLE
OLS-246: Use llamaindex only as retriever

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -112,7 +112,7 @@ def generate_response(
     llm_request: LLMRequest,
     validation_result: str,
     previous_input: Optional[str],
-) -> tuple[Optional[str], list[str]]:
+) -> tuple[Optional[str], list[str], bool]:
     """Generate response based on validation result, previous input, and model output."""
     match (validation_result):
         case constants.SUBJECT_INVALID:
@@ -136,12 +136,14 @@ def generate_response(
                 docs_summarizer = DocsSummarizer(
                     provider=llm_request.provider, model=llm_request.model
                 )
-                llm_response, referenced_documents, truncated = (
-                    docs_summarizer.summarize(
-                        conversation_id, llm_request.query, previous_input
-                    )
+                llm_response = docs_summarizer.summarize(
+                    conversation_id, llm_request.query, previous_input
                 )
-                return llm_response.response, referenced_documents, truncated
+                return (
+                    llm_response["response"],
+                    llm_response["referenced_documents"],
+                    llm_response["history_truncated"],
+                )
             except Exception as summarizer_error:
                 logger.error("Error while obtaining answer for user question")
                 logger.error(summarizer_error)

--- a/ols/src/prompts/__init__.py
+++ b/ols/src/prompts/__init__.py
@@ -1,0 +1,1 @@
+"""Constants/methods for prompts."""

--- a/ols/src/prompts/prompts.py
+++ b/ols/src/prompts/prompts.py
@@ -1,0 +1,22 @@
+"""prompt handler/constants."""
+
+from langchain.prompts import (
+    ChatPromptTemplate,
+    HumanMessagePromptTemplate,
+    SystemMessagePromptTemplate,
+)
+
+# TODO: Fine-tune system prompt
+QUERY_SYSTEM_PROMPT = """You are an assistant for question-answering tasks \
+related to the openshift and kubernetes container orchestration platforms. \
+Use the following pieces of retrieved context to answer the question.
+
+{context}"""
+
+# TODO: Add placeholder for history
+CHAT_PROMPT = ChatPromptTemplate(
+    messages=[
+        SystemMessagePromptTemplate.from_template(QUERY_SYSTEM_PROMPT),
+        HumanMessagePromptTemplate.from_template("{query}"),
+    ]
+)

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -75,7 +75,11 @@ def test_valid_question() -> None:
     json_response["conversation_id"] == conversation_id
     # checking a few major information from response
     assert "Kubernetes is" in json_response["response"]
-    assert "orchestration tool" in json_response["response"]
+    assert (
+        "orchestration tool" in json_response["response"]
+        or "orchestration system" in json_response["response"]
+        or "orchestration platform" in json_response["response"]
+    )
     assert (
         "The following response was generated without access to reference content:"
         not in json_response["response"]

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 from ols import constants
 from ols.app.models.config import ProviderConfig, ReferenceContent
 from ols.utils import config, suid
+from tests.mock_classes.llm_chain import mock_llm_chain
 from tests.mock_classes.llm_loader import mock_llm_loader
 
 
@@ -230,28 +231,33 @@ def test_post_question_on_noyaml_response_type() -> None:
         from tests.mock_classes.langchain_interface import mock_langchain_interface
 
         ml = mock_langchain_interface("test response")
-        with (
-            patch(
-                "ols.src.query_helpers.LLMLoader",
-                new=mock_llm_loader(ml()),
-            ),
-            patch("ols.src.query_helpers.docs_summarizer.ServiceContext.from_defaults"),
-            patch(
-                "ols.utils.config.ols_config.reference_content.product_docs_index_path",
-                "./invalid_dir",
-            ),
+        with patch(
+            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
         ):
-            conversation_id = suid.get_suid()
-            response = client.post(
-                "/v1/query",
-                json={
-                    "conversation_id": conversation_id,
-                    "query": "test query",
-                },
-            )
-            print(response)
-            assert response.status_code == requests.codes.ok
-            assert (
-                "The following response was generated without access to reference content:"
-                in response.json()["response"]
-            )
+            with (
+                patch(
+                    "ols.src.query_helpers.LLMLoader",
+                    new=mock_llm_loader(ml()),
+                ),
+                patch(
+                    "ols.src.query_helpers.docs_summarizer.ServiceContext.from_defaults"
+                ),
+                patch(
+                    "ols.utils.config.ols_config.reference_content.product_docs_index_path",
+                    "./invalid_dir",
+                ),
+            ):
+                conversation_id = suid.get_suid()
+                response = client.post(
+                    "/v1/query",
+                    json={
+                        "conversation_id": conversation_id,
+                        "query": "test query",
+                    },
+                )
+                print(response)
+                assert response.status_code == requests.codes.ok
+                assert (
+                    "The following response was generated without access to reference content:"
+                    in response.json()["response"]
+                )

--- a/tests/mock_classes/llm_chain.py
+++ b/tests/mock_classes/llm_chain.py
@@ -27,4 +27,8 @@ def mock_llm_chain(retval):
         def __call__(self, *args, **kwargs):
             return retval
 
+        def invoke(self, input):
+            input["text"] = input["query"]
+            return input
+
     return MockLLMChain

--- a/tests/mock_classes/mock_llama_index.py
+++ b/tests/mock_classes/mock_llama_index.py
@@ -1,6 +1,7 @@
 """Mocked (llama) index."""
 
 from .mock_query_engine import MockQueryEngine
+from .mock_retrievers import MockRetriever
 
 
 class MockLlamaIndex:
@@ -24,3 +25,7 @@ class MockLlamaIndex:
     def as_query_engine(self, **kwargs):
         """Return mocked query engine."""
         return MockQueryEngine(kwargs)
+
+    def as_retriever(self, **kwargs):
+        """Return mocked query engine."""
+        return MockRetriever(kwargs)

--- a/tests/mock_classes/mock_retrievers.py
+++ b/tests/mock_classes/mock_retrievers.py
@@ -2,6 +2,31 @@
 
 from langchain_core.documents import Document
 
+from tests.unit.utils.test_token_handler import MockRetrievedNode
+
+
+class MockRetriever:
+    """Mocked retriever."""
+
+    def __init__(self, *args, **kwargs):
+        """Store all provided arguments for later usage."""
+        self.args = args
+        self.kwargs = kwargs
+
+    @staticmethod
+    def retrieve(*args):
+        """Return summary for given query."""
+        # fill-in some documents for more realistic tests
+        return [
+            MockRetrievedNode(
+                {
+                    "text": "a text text text text",
+                    "score": 0.6,
+                    "metadata": {"file_path": "/docs/test.txt"},
+                }
+            )
+        ]
+
 
 class MockVectorStore:
     """Mock for VectorStore."""

--- a/tests/unit/app/endpoints/test_ols.py
+++ b/tests/unit/app/endpoints/test_ols.py
@@ -152,15 +152,14 @@ def test_conversation_request(
     """Test conversation request API endpoint."""
     # valid question
     mock_validate_question.return_value = constants.SUBJECT_VALID
-    mock_response = Mock()
-    mock_response.response = (
+    mock_response = (
         "Kubernetes is an open-source container-orchestration system..."  # summary
     )
-    mock_summarize.return_value = (
-        mock_response,
-        [],  # referenced_documents
-        False,
-    )
+    mock_summarize.return_value = {
+        "response": mock_response,
+        "referenced_documents": [],
+        "history_truncated": False,
+    }
     llm_request = LLMRequest(query="Tell me about Kubernetes")
     response = ols.conversation_request(llm_request)
     assert (
@@ -258,15 +257,14 @@ def test_generate_response_invalid_subject(load_config):
 def test_generate_response_valid_subject(mock_summarize, load_config):
     """Test how generate_response function checks validation results."""
     # mock the DocsSummarizer
-    mock_response = Mock()
-    mock_response.response = (
+    mock_response = (
         "Kubernetes is an open-source container-orchestration system..."  # summary
     )
-    mock_summarize.return_value = (
-        mock_response,
-        [],  # referenced_documents
-        False,
-    )
+    mock_summarize.return_value = {
+        "response": mock_response,
+        "referenced_documents": [],
+        "history_truncated": False,
+    }
 
     # prepare arguments for DocsSummarizer
     conversation_id = suid.get_suid()

--- a/tests/unit/utils/test_token_handler.py
+++ b/tests/unit/utils/test_token_handler.py
@@ -1,11 +1,12 @@
 """Unit test for the token handler."""
 
+from typing import Any
 from unittest import TestCase, mock
 
-from ols.utils.token_handler import RetrievedNode, TokenHandler
+from ols.utils.token_handler import TokenHandler
 
 
-class MockRetrievedNode(RetrievedNode):
+class MockRetrievedNode:
     """Class to create mock data for retrieved node."""
 
     def __init__(self, node_detail: dict):
@@ -14,17 +15,17 @@ class MockRetrievedNode(RetrievedNode):
         self._score = node_detail["score"]
         self._metadata = node_detail["metadata"]
 
-    def get_text(self):
+    def get_text(self) -> str:
         """Mock get_text."""
         return self._text
 
     @property
-    def score(self):
+    def score(self) -> float:
         """Mock score."""
         return self._score
 
     @property
-    def metadata(self):
+    def metadata(self) -> dict[str, Any]:
         """Mock metadata."""
         return self._metadata
 
@@ -38,22 +39,22 @@ class TestTokenHandler(TestCase):
             {
                 "text": "a text text text text",
                 "score": 0.6,
-                "metadata": {"file_name": "doc1.pdf", "doc_link": "link1"},
+                "metadata": {"file_path": "data/doc1.pdf"},
             },
             {
                 "text": "b text text text text",
                 "score": 0.55,
-                "metadata": {"file_name": "doc2.pdf", "doc_link": "link2"},
+                "metadata": {"file_path": "data/doc2.pdf"},
             },
             {
                 "text": "c text text text text",
                 "score": 0.55,
-                "metadata": {"file_name": "doc3.pdf", "doc_link": "link3"},
+                "metadata": {"file_path": "data/doc3.pdf"},
             },
             {
                 "text": "d text text text text",
                 "score": 0.4,
-                "metadata": {"file_name": "doc4.pdf", "doc_link": "link4"},
+                "metadata": {"file_path": "data/doc4.pdf"},
             },
         ]
         self._mock_retrieved_obj = [MockRetrievedNode(data) for data in node_data]
@@ -68,7 +69,7 @@ class TestTokenHandler(TestCase):
         for idx, data in enumerate(context):
             assert data["text"][0] == self._mock_retrieved_obj[idx].get_text()[0]
             assert (
-                data["file_name"] == self._mock_retrieved_obj[idx].metadata["file_name"]
+                data["file_path"] == self._mock_retrieved_obj[idx].metadata["file_path"]
             )
 
     def test_token_handler_token_limit(self):


### PR DESCRIPTION
## Description

- Use llamaindex only for retrieving index and matching data based on query.
- Use langchain for LLM call.
- Integrate with token truncation.
- Some refactoring.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-246](https://issues.redhat.com//browse/OLS-246)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
