### PR TITLE
OLS-113: REST API durations in metrics

### DIFF
--- a/ols/app/main.py
+++ b/ols/app/main.py
@@ -41,9 +41,13 @@ else:
 @app.middleware("")
 async def rest_api_counter(request: Request, call_next):
     """Middleware with REST API counter update logic."""
-    response = await call_next(request)
-    # ignore /metrics endpoint that will be called periodically
     path = request.url.path
+
+    # measure time to handle duration + update histogram
+    with metrics.response_duration_seconds.labels(path).time():
+        response = await call_next(request)
+
+    # ignore /metrics endpoint that will be called periodically
     if not path.endswith("/metrics/"):
         # just update metrics
         metrics.rest_api_calls_total.labels(path, response.status_code).inc()

--- a/ols/app/metrics.py
+++ b/ols/app/metrics.py
@@ -1,9 +1,13 @@
 """Prometheus metrics that are exposed by REST API."""
 
-from prometheus_client import Counter, make_asgi_app
+from prometheus_client import Counter, Histogram, make_asgi_app
 
 rest_api_calls_total = Counter(
     "rest_api_calls_total", "REST API calls counter", ["path", "status_code"]
+)
+
+response_duration_seconds = Histogram(
+    "response_duration_seconds", "Response durations", ["path"]
 )
 
 llm_calls_total = Counter("llm_calls_total", "LLM calls counter")


### PR DESCRIPTION
## Description

[OLS-113](https://issues.redhat.com//browse/OLS-113): REST API durations in metrics

Histogram values looks like

```
response_duration_seconds_bucket{le="0.005",path="/openapi.json"} 6.0
response_duration_seconds_bucket{le="0.01",path="/openapi.json"} 6.0
response_duration_seconds_bucket{le="0.025",path="/openapi.json"} 6.0
response_duration_seconds_bucket{le="0.05",path="/openapi.json"} 6.0
response_duration_seconds_bucket{le="0.075",path="/openapi.json"} 6.0
response_duration_seconds_bucket{le="0.1",path="/openapi.json"} 6.0
response_duration_seconds_bucket{le="0.25",path="/openapi.json"} 6.0
response_duration_seconds_bucket{le="0.5",path="/openapi.json"} 6.0
response_duration_seconds_bucket{le="0.75",path="/openapi.json"} 6.0
response_duration_seconds_bucket{le="1.0",path="/openapi.json"} 6.0
response_duration_seconds_bucket{le="2.5",path="/openapi.json"} 6.0
response_duration_seconds_bucket{le="5.0",path="/openapi.json"} 6.0
response_duration_seconds_bucket{le="7.5",path="/openapi.json"} 6.0
response_duration_seconds_bucket{le="10.0",path="/openapi.json"} 6.0
response_duration_seconds_bucket{le="+Inf",path="/openapi.json"} 6.0
response_duration_seconds_count{path="/openapi.json"} 6.0
```

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-113](https://issues.redhat.com//browse/OLS-113)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Run the service
- Access some REST API endpoints
- Access `/metrics/` endpoint
