### PR TITLE
No need to explicitly return None value

### DIFF
--- a/ols/app/endpoints/health.py
+++ b/ols/app/endpoints/health.py
@@ -39,10 +39,10 @@ def liveness_probe_get_method() -> HealthResponse:
 @router.head("/readiness")
 def readiness_probe_head_method() -> None:
     """Ready status of service."""
-    return None
+    return
 
 
 @router.head("/liveness")
 def liveness_probe_head_method() -> None:
     """Live status of service."""
-    return None
+    return

--- a/tests/mock_classes/mock_retrievers.py
+++ b/tests/mock_classes/mock_retrievers.py
@@ -29,4 +29,4 @@ def mock_retriever(*args, **kwargs):
 
 def mock_null_value_retriever(*args, **kwargs):
     """Return no VectorStoreRetriever."""
-    return None
+    return


### PR DESCRIPTION
## Description

No need to explicitly return `None` value which is more idiomatic in this code.
Python implicitly assumes `return None` if an explicit `return` value is
omitted. Therefore, explicitly returning `None` is redundant and should be
avoided when it is the only possible `return` value across all code paths
in a given function.


## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

