### PR TITLE
Member testing using sets

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -13,10 +13,10 @@ from ols import constants
 def _is_valid_http_url(url: str) -> bool:
     """Check is a string is a well-formed http or https URL."""
     result = urlparse(url)
-    return all([result.scheme, result.netloc]) and result.scheme in [
+    return all([result.scheme, result.netloc]) and result.scheme in {
         "http",
         "https",
-    ]
+    }
 
 
 def _get_attribute_from_file(data: dict, file_name_key: str) -> Optional[str]:

--- a/ols/src/query_helpers/query_docs.py
+++ b/ols/src/query_helpers/query_docs.py
@@ -89,7 +89,7 @@ class QueryDocs:
         """
         )
 
-        if search_type not in ("mmr", "similarity", "similarity_score_threshold"):
+        if search_type not in {"mmr", "similarity", "similarity_score_threshold"}:
             logger.error(f"incorrect search type {search_type}")
             raise RetrieveDocsExceptionError(f"search type is invalid: {search_type}")
 


### PR DESCRIPTION
## Description

When testing for membership in a static sequence, it is better to use a `set` literal over a `list` or `tuple`, as Python optimizes `set` membership tests.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.
