### PR TITLE
Use explicit encoding when working with files

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -23,7 +23,7 @@ def _get_attribute_from_file(data: dict, file_name_key: str) -> Optional[str]:
     """Retrieve value of an attribute from a file."""
     file_path = data.get(file_name_key)
     if file_path is not None:
-        with open(file_path, mode="r") as f:
+        with open(file_path, mode="r", encoding="utf-8") as f:
             return f.read().rstrip()
     return None
 

--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -44,7 +44,7 @@ def init_config(config_file: str) -> None:
     global conversation_cache
 
     try:
-        with open(config_file, "r") as f:
+        with open(config_file, "r", encoding="utf-8") as f:
             config = load_config_from_stream(f)
             ols_config = config.ols_config
             llm_config = config.llm_providers

--- a/scripts/download_embeddings_model.py
+++ b/scripts/download_embeddings_model.py
@@ -23,5 +23,5 @@ if __name__ == "__main__":
     os.makedirs(os.path.join(local_dir, "2_Normalize"), exist_ok=True)
 
     # pretend local_dir is HF cache
-    with open(os.path.join(local_dir, "version.txt"), "w") as f:
+    with open(os.path.join(local_dir, "version.txt"), "w", encoding="utf-8") as f:
         f.write("1")

--- a/scripts/transform_coverage_report.py
+++ b/scripts/transform_coverage_report.py
@@ -14,7 +14,7 @@ def write_go_coverage_format(file_path, file_data, output_file):
     """
     executed_lines = file_data.get("executed_lines", [])
     missing_lines = file_data.get("missing_lines", [])
-    with open(output_file, "a") as f:
+    with open(output_file, "a", encoding="utf-8") as f:
         for line in executed_lines:
             f.write(f"{file_path}:{line}.0,{line + 1}.0 1 1\n")
 
@@ -58,10 +58,10 @@ if __name__ == "__main__":
     output_file_path = sys.argv[2]
 
     try:
-        with open(output_file_path, "w") as output_file:
+        with open(output_file_path, "w", encoding="utf-8") as output_file:
             output_file.write("mode: set\n")
 
-        with open(json_file_path, "r") as json_file:
+        with open(json_file_path, "r", encoding="utf-8") as json_file:
             json_content = json_file.read()
             parse_coverage_json(json_content, output_file_path)
 


### PR DESCRIPTION
## Description

Using `open` in text mode without an explicit encoding can lead to
non-portable code, with differing behavior across platforms.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library


## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.
