### PR TITLE
OLS-311: Ability to start service from Python script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ install-deps-test: install-tools ## Install all required dependencies needed to 
 	pdm install --dev
 
 run: ## Run the service locally
-	uvicorn ols.app.main:app --reload --port 8080
+	python runner.py
 
 test: test-unit test-integration test-e2e ## Run all tests
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ OpenShift LightSpeed (OLS) is an AI powered assistant that runs on OpenShift and
 ### Run the server
 in order to run the API service
 ```sh
-uvicorn ols.app.main:app --reload --port 8080
+make run
 ```
 
 ### Optionally run with podman

--- a/runner.py
+++ b/runner.py
@@ -1,0 +1,6 @@
+"""Script that is able to start Uvicorn-based REST API service."""
+
+import uvicorn
+
+if __name__ == "__main__":
+    uvicorn.run("ols.app.main:app", host="127.0.0.1", port=8080, reload=True)


### PR DESCRIPTION
## Description

Ability to start service from Python script

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-311](https://issues.redhat.com//browse/OLS-311)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Simply start the new script: `python runner.py`
