### PR TITLE
Explicit return from `try` block

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -186,7 +186,6 @@ def redact_query(conversation_id: str, llm_request: LLMRequest) -> LLMRequest:
         llm_request.query = config.query_redactor.redact_query(
             conversation_id, llm_request.query
         )
-        return llm_request
     except Exception as redactor_error:
         logger.error(
             f"Error while redacting query {redactor_error} for conversation {conversation_id}"
@@ -195,6 +194,8 @@ def redact_query(conversation_id: str, llm_request: LLMRequest) -> LLMRequest:
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={"response": f"Error while redacting query '{redactor_error}'"},
         )
+    else:
+        return llm_request
 
 
 def validate_question(conversation_id: str, llm_request: LLMRequest) -> str:

--- a/ols/utils/suid.py
+++ b/ols/utils/suid.py
@@ -16,6 +16,7 @@ def check_suid(suid: str) -> bool:
     """Check if given string is a proper session ID."""
     try:
         uuid.UUID(suid)
-        return True
     except ValueError:
         return False
+    else:
+        return True


### PR DESCRIPTION
## Description

The `try`-`except` statement has an `else` clause for code that should
run _only_ if no exceptions were raised. Using the `else` clause is more
explicit than using a `return` statement inside of a `try` block.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.
