### PR TITLE
Removed redundant `else` statement

### DIFF
--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -219,5 +219,4 @@ class DocsSummarizer(QueryHelper):
             return HuggingFaceBgeEmbeddings(
                 model_name=config.ols_config.reference_content.embeddings_model_path
             )
-        else:
-            return "local:BAAI/bge-base-en"
+        return "local:BAAI/bge-base-en"


### PR DESCRIPTION
## Description

The `else` statement is not needed because the `return` statement will always
break out of the enclosing function. Removing the `else` will reduce
nesting and make the code more readable.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.
