### PR TITLE
OLS-271: Load vector db once

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -145,7 +145,7 @@ def generate_response(
                     provider=llm_request.provider, model=llm_request.model
                 )
                 llm_response = docs_summarizer.summarize(
-                    conversation_id, llm_request.query, previous_input
+                    conversation_id, llm_request.query, config.rag_index, previous_input
                 )
                 return (
                     llm_response["response"],

--- a/ols/app/main.py
+++ b/ols/app/main.py
@@ -30,6 +30,8 @@ configure_logging(config.ols_config.logging_config)
 logger = logging.getLogger(__name__)
 logger.info(f"Config loaded from {Path(cfg_file).resolve()}")
 
+config.init_vector_index()
+
 
 if config.dev_config.enable_dev_ui:
     app = GradioUI().mount_ui(app)

--- a/ols/src/rag_index/__init__.py
+++ b/ols/src/rag_index/__init__.py
@@ -1,0 +1,1 @@
+"""Modules related to index."""

--- a/ols/src/rag_index/index_loader.py
+++ b/ols/src/rag_index/index_loader.py
@@ -1,0 +1,97 @@
+"""Module for loading index."""
+
+import logging
+from os import environ
+from typing import TYPE_CHECKING, Any, Optional
+
+from llama_index import ServiceContext, StorageContext, load_index_from_storage
+from llama_index.indices.base import BaseIndex
+
+from ols.app.models.config import ReferenceContent
+
+# This is to avoid importing HuggingFaceBgeEmbeddings in all cases, because in
+# runtime it is used only under some conditions. OTOH we need to make Python
+# interpreter happy in all circumstances, hence the definiton of Any symbol.
+if TYPE_CHECKING:
+    from langchain_community.embeddings import HuggingFaceBgeEmbeddings  # TCH004
+else:
+    HuggingFaceBgeEmbeddings = Any
+
+logger = logging.getLogger(__name__)
+
+
+class IndexLoader:
+    """Load index from local file storage."""
+
+    def __init__(self, index_config: Optional[ReferenceContent]) -> None:
+        """Initialize loader."""
+        self._index: Optional[BaseIndex] = None
+
+        self._index_config = index_config
+        logger.debug(f"Config used for index load: {self._index_config}")
+
+        if self._index_config is None:
+            logger.warning("Config for reference content is not set.")
+        else:
+            self._index_path = self._index_config.product_docs_index_path
+            self._index_id = self._index_config.product_docs_index_id
+
+            self._embed_model_path = self._index_config.embeddings_model_path
+            self._embed_model = self._get_embed_model()
+            self._load_index()
+
+    def _get_embed_model(self) -> Optional[str | HuggingFaceBgeEmbeddings]:
+        """Get embed model according to configuration."""
+        if self._embed_model_path is not None:
+            from langchain_community.embeddings import HuggingFaceBgeEmbeddings
+
+            # TODO syedriko consolidate these env vars into a central location as per OLS-345.
+            environ["TRANSFORMERS_CACHE"] = self._embed_model_path
+            environ["TRANSFORMERS_OFFLINE"] = "1"
+            logger.debug(
+                f"Loading embedding model info from path {self._embed_model_path}"
+            )
+            return HuggingFaceBgeEmbeddings(model_name=self._embed_model_path)
+
+        logger.warning("Embedding model path is not set.")
+        logger.warning("Embedding model is set to default")
+        return "local:BAAI/bge-base-en"
+
+    def _set_context(self) -> None:
+        """Set storage/service context required for index load."""
+        logger.debug(f"Using {self._embed_model!s} as embedding model for index.")
+        logger.info("Setting up service context for index load...")
+        self._service_context = ServiceContext.from_defaults(
+            embed_model=self._embed_model, llm=None
+        )
+        logger.info("Setting up storage context for index load...")
+        self._storage_context = StorageContext.from_defaults(
+            persist_dir=self._index_path
+        )
+
+    def _load_index(self) -> None:
+        """Load vector index."""
+        if self._index_path is None:
+            logger.warning("Index path is not set.")
+        else:
+            try:
+                self._set_context()
+                logger.info("Loading vector index...")
+                self._index = load_index_from_storage(
+                    service_context=self._service_context,
+                    storage_context=self._storage_context,
+                    index_id=self._index_id,
+                )
+                logger.info("Vector index is loaded.")
+            except Exception as err:
+                logger.exception(f"Error loading vector index:\n{err}")
+
+    @property
+    def vector_index(self) -> Optional[BaseIndex]:
+        """Get index."""
+        if self._index is None:
+            logger.warning(
+                "Proceeding without RAG content. "
+                "Either there is an error or required parameters are not set."
+            )
+        return self._index

--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -7,6 +7,7 @@ import yaml
 
 import ols.app.models.config as config_model
 from ols.src.cache.cache_factory import CacheFactory
+from ols.src.rag_index.index_loader import IndexLoader
 from ols.utils.query_filter import QueryFilter
 
 config = None
@@ -15,6 +16,7 @@ llm_config = None
 dev_config = None
 conversation_cache = None
 query_redactor = None
+rag_index = None
 
 
 def init_empty_config() -> None:
@@ -65,3 +67,9 @@ def init_query_filter() -> None:
     """Initialize question filter."""
     global query_redactor
     query_redactor = QueryFilter()
+
+
+def init_vector_index() -> None:
+    """Initialize vector index."""
+    global rag_index
+    rag_index = IndexLoader(ols_config.reference_content).vector_index

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -239,7 +239,6 @@ def test_post_question_on_noyaml_response_type() -> None:
                 "ols.src.query_helpers.query_helper.load_llm",
                 new=mock_llm_loader(ml()),
             ),
-            patch("ols.src.query_helpers.docs_summarizer.ServiceContext.from_defaults"),
             patch(
                 "ols.utils.config.ols_config.reference_content.product_docs_index_path",
                 "./invalid_dir",
@@ -293,7 +292,6 @@ def test_post_query_with_query_filters_response_type() -> None:
                 "ols.src.query_helpers.query_helper.load_llm",
                 new=mock_llm_loader(ml()),
             ),
-            patch("ols.src.query_helpers.docs_summarizer.ServiceContext.from_defaults"),
         ):
             conversation_id = suid.get_suid()
             response = client.post(

--- a/tests/unit/rag_index/__init__.py
+++ b/tests/unit/rag_index/__init__.py
@@ -1,0 +1,1 @@
+"""Test cases for rag index related modules."""

--- a/tests/unit/rag_index/test_index_loader.py
+++ b/tests/unit/rag_index/test_index_loader.py
@@ -1,0 +1,48 @@
+"""Unit test for the index loader module."""
+
+from unittest.mock import patch
+
+from ols.app.models.config import ReferenceContent
+from ols.src.rag_index.index_loader import IndexLoader
+from ols.utils import config
+from tests.mock_classes.mock_llama_index import MockLlamaIndex
+
+
+def test_index_loader_empty_config(caplog):
+    """Test index loader with empty/None config."""
+    index_loader_obj = IndexLoader(None)
+    index = index_loader_obj.vector_index
+
+    assert "required parameters are not set" in caplog.text
+    assert not hasattr(index_loader_obj, "_embed_model")
+    assert index is None
+
+
+@patch("ols.src.rag_index.index_loader.ServiceContext.from_defaults")
+@patch("ols.src.rag_index.index_loader.StorageContext.from_defaults")
+def test_index_loader_no_id(storage_context, service_context):
+    """Test index loader without index id."""
+    config.init_empty_config()
+    config.ols_config.reference_content = ReferenceContent(None)
+    config.ols_config.reference_content.product_docs_index_path = "./some_dir"
+
+    index_loader_obj = IndexLoader(config.ols_config.reference_content)
+    index = index_loader_obj.vector_index
+
+    assert index_loader_obj._embed_model == "local:BAAI/bge-base-en"
+    assert index is None
+
+
+@patch("ols.src.rag_index.index_loader.ServiceContext.from_defaults")
+@patch("ols.src.rag_index.index_loader.StorageContext.from_defaults")
+@patch("ols.src.rag_index.index_loader.load_index_from_storage", new=MockLlamaIndex)
+def test_index_loader(storage_context, service_context):
+    """Test index loader."""
+    config.ols_config.reference_content = ReferenceContent(None)
+    config.ols_config.reference_content.product_docs_index_path = "./some_dir"
+    config.ols_config.reference_content.product_docs_index_id = "./some_id"
+
+    index_loader_obj = IndexLoader(config.ols_config.reference_content)
+    index = index_loader_obj.vector_index
+
+    assert isinstance(index, MockLlamaIndex)


### PR DESCRIPTION
## Description

As loading vector index takes time, load this once instead of with every query.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-271](https://issues.redhat.com//browse/OLS-271)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
