### PR TITLE
Update ruff settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,17 @@
 [tool.ruff]
 
 # description of all rules are available on https://docs.astral.sh/ruff/rules/
-select = ["D", "E", "F", "W", "C", "S", "I", "TCH", "SLOT", "RUF", "C90", "N"]
+lint.select = ["D", "E", "F", "W", "C", "S", "I", "TCH", "SLOT", "RUF", "C90", "N"]
 
 # we need to check 'mood' of all docstrings, this needs to be enabled explicitly
-extend-select = ["D401"]
+lint.extend-select = ["D401"]
 
-ignore = []
+lint.ignore = []
 
 target-version = "py311"
-pydocstyle.convention = "google"
+lint.pydocstyle.convention = "google"
 line-length = 100
-flake8-pytest-style.fixture-parentheses = false
+lint.flake8-pytest-style.fixture-parentheses = false
 
 [tool.coverage.report]
 # unit tests fails if the total coverage measurement is under this threshold value


### PR DESCRIPTION
## Description

To avoid warnings about deprecated settings:

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'extend-select' -> 'lint.extend-select'
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'flake8-pytest-style' -> 'lint.flake8-pytest-style'
  - 'pydocstyle' -> 'lint.pydocstyle'
```

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
