### PR TITLE
Removed return statement for calls that returns nothing

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -442,9 +442,9 @@ class ConversationCacheConfig(BaseModel):
         else:
             match self.type:
                 case constants.REDIS_CACHE:
-                    return self.redis.validate_yaml()
+                    self.redis.validate_yaml()
                 case constants.IN_MEMORY_CACHE:
-                    return self.memory.validate_yaml()
+                    self.memory.validate_yaml()
                 case _:
                     raise InvalidConfigurationError(
                         f"unknown conversation cache type: {self.type}"


### PR DESCRIPTION
## Description

Removed `return` statement for calls that returns nothing

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
