### PR TITLE
Fix: `module` is different type (`Module`) than module name (`Path`)

### DIFF
--- a/ols/src/llms/__init__.py
+++ b/ols/src/llms/__init__.py
@@ -8,14 +8,16 @@ import pathlib
 import sys
 
 
-def import_providers():
+def import_providers() -> None:
     """Import all providers from the providers directory."""
     providers_dir = pathlib.Path(__file__).parent.resolve() / "providers"
     sys.path.append(providers_dir.as_posix())
     modules = [f for f in providers_dir.iterdir() if not f.stem.startswith("__")]
 
-    for module in modules:
-        spec = importlib.util.spec_from_file_location("module_name", module.as_posix())
+    for module_name in modules:
+        spec = importlib.util.spec_from_file_location(
+            "module_name", module_name.as_posix()
+        )
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
 


### PR DESCRIPTION
## Description

Fix: `module` is different type (`Module`) than module name (`Path`)

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
