### PR TITLE
OLS-281: Implements azure openai support

### DIFF
--- a/examples/olsconfig.yaml
+++ b/examples/olsconfig.yaml
@@ -14,6 +14,13 @@ llm_providers:
     models:
       - name: gpt-4-1106-preview
       - name: gpt-3.5-turbo
+  - name: my_azure_openai
+    type: azure_openai
+    url: "https://myendpoint.openai.azure.com/"
+    credentials_path: azure_openai_api_key.txt
+    deployment_name: my_azure_openai_deployment_name
+    models:
+      - name: gpt-3.5-turbo
   - name: my_watsonx
     type: watsonx
     url: "https://us-south.ml.cloud.ibm.com"

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -151,6 +151,7 @@ class ProviderConfig(BaseModel):
     credentials: Optional[str] = None
     project_id: Optional[str] = None
     models: dict[str, ModelConfig] = {}
+    deployment_name: Optional[str] = None
 
     def __init__(self, data: Optional[dict] = None) -> None:
         """Initialize configuration and perform basic validation."""
@@ -183,6 +184,13 @@ class ProviderConfig(BaseModel):
                 raise InvalidConfigurationError("model name is missing")
             model = ModelConfig(m)
             self.models[m["name"]] = model
+        if self.type == constants.PROVIDER_AZURE_OPENAI:
+            # deployment_name only required when using Azure OpenAI
+            self.deployment_name = data.get("deployment_name", None)
+            if self.deployment_name is None:
+                raise InvalidConfigurationError(
+                    f"deployment_name is required for Azure OpenAI provider {self.name}"
+                )
 
     def __eq__(self, other: object) -> bool:
         """Compare two objects for equality."""

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -137,8 +137,11 @@ Response:
 # providers
 PROVIDER_BAM = "bam"
 PROVIDER_OPENAI = "openai"
+PROVIDER_AZURE_OPENAI = "azure_openai"
 PROVIDER_WATSONX = "watsonx"
-SUPPORTED_PROVIDER_TYPES = frozenset({PROVIDER_BAM, PROVIDER_OPENAI, PROVIDER_WATSONX})
+SUPPORTED_PROVIDER_TYPES = frozenset(
+    {PROVIDER_BAM, PROVIDER_OPENAI, PROVIDER_AZURE_OPENAI, PROVIDER_WATSONX}
+)
 
 # models
 # embedding
@@ -149,7 +152,7 @@ GRANITE_13B_CHAT_V1 = "ibm/granite-13b-chat-v1"
 GRANITE_13B_CHAT_V2 = "ibm/granite-13b-chat-v2"
 GRANITE_20B_CODE_INSTRUCT_V1 = "ibm/granite-20b-code-instruct-v1"
 
-# OpenAI
+# OpenAI & Azure OpenAI
 GPT35_TURBO_1106 = "gpt-3.5-turbo-1106"
 GPT35_TURBO = "gpt-3.5-turbo"
 

--- a/ols/src/llms/providers/azure_openai.py
+++ b/ols/src/llms/providers/azure_openai.py
@@ -1,0 +1,53 @@
+"""Azure OpenAI provider implementation."""
+
+import logging
+from typing import Any
+
+from langchain.llms.base import LLM
+from langchain_openai import AzureChatOpenAI
+
+from ols import constants
+from ols.src.llms.providers.provider import LLMProvider
+from ols.src.llms.providers.registry import register_llm_provider_as
+
+logger = logging.getLogger(__name__)
+
+
+@register_llm_provider_as(constants.PROVIDER_AZURE_OPENAI)
+class AzureOpenAI(LLMProvider):
+    """Azure OpenAI provider."""
+
+    url: str = "https://thiswillalwaysfail.openai.azure.com"
+
+    @property
+    def default_params(self) -> dict[str, Any]:
+        """Default LLM params."""
+        # TODO: need to be parameterize the api version probably
+        return {
+            "azure_endpoint": self.provider_config.url or self.url,
+            "api_key": self.provider_config.credentials,
+            "api_version": "2023-05-15",
+            "deployment_name": self.provider_config.deployment_name,
+            "model": self.model,
+            "model_kwargs": {},
+            "organization": None,
+            "cache": None,
+            "streaming": True,
+            "temperature": 0.01,
+            "max_tokens": 512,
+            "top_p": 0.95,
+            "frequency_penalty": 1.03,
+            "verbose": False,
+        }
+
+    def load(self) -> LLM:
+        """Load LLM."""
+        # TODO: these are not allowed for OpenAI - we need to figure
+        # out first how to handle params in general - whitelist/validation, ...
+        # https://issues.redhat.com/browse/OLS-363
+        if "min_new_tokens" in self.params:
+            self.params.pop("min_new_tokens")
+        if "max_new_tokens" in self.params:
+            self.params.pop("max_new_tokens")
+
+        return AzureChatOpenAI(**self.params)

--- a/tests/config/singleprovider.e2e.template.config.yaml
+++ b/tests/config/singleprovider.e2e.template.config.yaml
@@ -3,6 +3,7 @@ llm_providers:
   - name: $PROVIDER
     project_id: $PROVIDER_PROJECT_ID
     credentials_path: $PROVIDER_KEY_PATH
+    deployment_name: $PROVIDER_DEPLOYMENT_NAME
     models:
       - name: $MODEL
 ols_config:

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -219,6 +219,22 @@ def test_provider_config():
         )
     assert "model name is missing" in str(excinfo.value)
 
+    with pytest.raises(InvalidConfigurationError) as excinfo:
+        ProviderConfig(
+            {
+                "name": "azure_openai",
+                "type": "azure_openai",
+                "url": "test_url",
+                "credentials_path": "tests/config/secret.txt",
+                "models": [
+                    {
+                        "name": "test_model",
+                    }
+                ],
+            }
+        )
+    assert "deployment_name is required" in str(excinfo.value)
+
 
 def test_provider_config_explicit_tokens():
     """Test the ProviderConfig model when explicit tokens are specified."""

--- a/tests/unit/llms/providers/test_azure_openai.py
+++ b/tests/unit/llms/providers/test_azure_openai.py
@@ -1,0 +1,63 @@
+"""Unit tests for Azure OpenAI provider."""
+
+import pytest
+from langchain_openai import AzureChatOpenAI
+
+from ols.app.models.config import ProviderConfig
+from ols.src.llms.providers.azure_openai import AzureOpenAI
+from ols.utils import config
+
+
+@pytest.fixture
+def provider_config():
+    """Fixture with provider configuration for OpenAI."""
+    return ProviderConfig(
+        {
+            "name": "some_provider",
+            "type": "azure_openai",
+            "url": "test_url",
+            "credentials_path": "tests/config/secret.txt",
+            "deployment_name": "test_deployment_name",
+            "models": [
+                {
+                    "name": "test_model_name",
+                }
+            ],
+        }
+    )
+
+
+def test_basic_interface(provider_config):
+    """Test basic interface."""
+    config.init_empty_config()  # needed for checking the config.dev_config.llm_params
+
+    azure_openai = AzureOpenAI(
+        model="uber-model", params={}, provider_config=provider_config
+    )
+    llm = azure_openai.load()
+    assert isinstance(llm, AzureChatOpenAI)
+    assert azure_openai.default_params
+    assert "model" in azure_openai.default_params
+    assert "deployment_name" in azure_openai.default_params
+    assert "azure_endpoint" in azure_openai.default_params
+    assert "max_tokens" in azure_openai.default_params
+
+
+def test_params_handling(provider_config):
+    """Test that not allowed parameters are removed before model init."""
+    config.init_empty_config()  # needed for checking the config.dev_config.llm_params
+
+    # these two parameters should be removed before model init
+    params = {
+        "min_new_tokens": 1,
+        "max_new_tokens": 10,
+    }
+
+    azure_openai = AzureOpenAI(
+        model="uber-model", params=params, provider_config=provider_config
+    )
+    llm = azure_openai.load()
+    assert isinstance(llm, AzureChatOpenAI)
+    assert azure_openai.default_params
+    assert "min_new_tokens" not in azure_openai.default_params
+    assert "max_new_tokens" not in azure_openai.default_params


### PR DESCRIPTION
## Description
This PR implements Azure OpenAI support using Langchain's `AzureChatOpenAI`

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [X] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents
[OLS-53](https://issues.redhat.com//browse/OLS-53)
[OLS-281](https://issues.redhat.com//browse/OLS-281)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [X] If it is a core feature, I have added thorough tests.

## Testing
Added tests for:
```
tests/config/singleprovider.e2e.template.config.yaml
tests/unit/app/models/test_config.py
tests/unit/llms/providers/test_azure_openai.py
```

Although it seems like the e2e needs to be changed because of the requirements on a URL that Azure OpenAI brings.
