### PR TITLE
OLS-332: remove pytorch_model.bin, load the embeddings model from model.safetensors

### DIFF
--- a/scripts/download_embeddings_model.py
+++ b/scripts/download_embeddings_model.py
@@ -25,3 +25,6 @@ if __name__ == "__main__":
     # pretend local_dir is HF cache
     with open(os.path.join(local_dir, "version.txt"), "w", encoding="utf-8") as f:
         f.write("1")
+
+    # remove pytorch_model.bin, load the model from model.safetensors
+    os.remove(os.path.join(local_dir, "pytorch_model.bin"))


### PR DESCRIPTION
## Description

On HF, the BAAI/bge-base-en embeddings model is stored in two formats: [pickle'd](https://docs.python.org/3/library/pickle.html) pytorch_model.bin and [model.safetensors](https://huggingface.co/docs/safetensors/en/index). model.safetensors is preferable as more secure, so delete pytorch_model.bin after download and make RAG data smaller by 418MB.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/OLS-332
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
