### PR TITLE
Pytest-asyncio is needed by unit tests

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:6024e78ddb8ae259bb44397d44e4f5f91342310db5c81c3b604ee08d0d1ade7c"
+content_hash = "sha256:92e6bbdcde20559b9a43c3a8f35eae05a56c82c714924addca4e036478049882"
 
 [[package]]
 name = "aiofiles"
@@ -1736,7 +1736,7 @@ name = "pytest-asyncio"
 version = "0.23.5"
 requires_python = ">=3.8"
 summary = "Pytest support for asyncio"
-groups = ["default"]
+groups = ["default", "dev"]
 dependencies = [
     "pytest<9,>=7.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "mypy>=1.8.0",
     "pytest>=8.0.0",
     "pytest-cov>=4.1.0",
+    "pytest_asyncio>=0.23.5",
     "ruff>=0.1.14",
     # types-requests<2.31.0.7 to avoid upgrading urllib3>1.27 that breaks ibm-cos-sdk-core 2.13.
     # todo: remove when ibm-cos-sdk-core does not depend on urllib3<1.27.


### PR DESCRIPTION
## Description

Pytest-asyncio is needed by unit tests

Without it, some tests will be skipped

Before this fix:

```
tests/unit/utils/test_auth_dependency.py:27
  /home/ptisnovs/lightspeed-service/tests/unit/utils/test_auth_dependency.py:27: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/unit/utils/test_auth_dependency.py:52
  /home/ptisnovs/lightspeed-service/tests/unit/utils/test_auth_dependency.py:52: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio
```

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
