### PR TITLE
Bug fix: top_p and frequency_penalty are model kwargs

### DIFF
--- a/ols/src/llms/providers/openai.py
+++ b/ols/src/llms/providers/openai.py
@@ -26,14 +26,15 @@ class OpenAI(LLMProvider):
             "base_url": self.provider_config.url or self.url,
             "openai_api_key": self.provider_config.credentials,
             "model": self.model,
-            "model_kwargs": {},
+            "model_kwargs": {
+                "top_p": 0.95,
+                "frequency_penalty": 1.03,
+            },
             "organization": None,
             "cache": None,
             "streaming": True,
             "temperature": 0.01,
             "max_tokens": 512,
-            "top_p": 0.95,
-            "frequency_penalty": 1.03,
             "verbose": False,
         }
 


### PR DESCRIPTION
## Description

Bug fix: `top_p` and `frequency_penalty` are model kwargs

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
