### PR TITLE
OLS-369: fix for Containerfile.rag to work with the updated Containerfile

### DIFF
--- a/Containerfile.rag
+++ b/Containerfile.rag
@@ -9,19 +9,13 @@ ARG APP_ROOT=/app-root
 USER 0
 
 RUN microdnf install -y unzip wget \
-  && mkdir -p vector-db \
-	&& cd vector-db \
-  && wget -q $RAG_INDEX \
-	&& unzip -qq local.zip \
-	&& mv local ocp-product-docs \
-	&& rm -f local.zip \
-	&& microdnf remove -y unzip wget
+    && mkdir -p vector-db \
+    && cd vector-db \
+    && wget -q $RAG_INDEX \
+    && unzip -qq local.zip \
+    && mv local ocp-product-docs \
+    && rm -f local.zip \
+    && microdnf remove -y unzip wget
 
 COPY scripts/download_embeddings_model.py .
-RUN python download_embeddings_model.py embeddings_model && rm download_embeddings_model.py
-
-RUN chown -R 1001:0 ${APP_ROOT} && \
-    chmod -R g+rx ${APP_ROOT}
-
-# default user for Python app
-USER 1001
+RUN python3.11 download_embeddings_model.py embeddings_model && rm download_embeddings_model.py


### PR DESCRIPTION
## Description

This is a fix for Containerfile.rag so it can consume the Containerfile as updated in https://github.com/openshift/lightspeed-service/pull/485

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/OLS-369
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
