### PR TITLE
OLS-364: Fix runtime error: got multiple values for keyword argument 'llm_params'

### DIFF
--- a/ols/src/query_helpers/question_validator.py
+++ b/ols/src/query_helpers/question_validator.py
@@ -23,7 +23,7 @@ class QuestionValidator(QueryHelper):
             "min_new_tokens": 1,
             "max_new_tokens": 4,
         }
-        super().__init__(*args, **kwargs, llm_params=llm_params)
+        super().__init__(*args, **dict(kwargs, llm_params=llm_params))
 
     def validate_question(
         self, conversation_id: str, query: str, verbose: bool = False

--- a/tests/unit/query_helpers/test_question_validator.py
+++ b/tests/unit/query_helpers/test_question_validator.py
@@ -23,6 +23,20 @@ def test_is_query_helper_subclass():
     assert issubclass(QuestionValidator, QueryHelper)
 
 
+def test_passing_parameters():
+    """Test that llm_params is handled correctly and without runtime error."""
+    question_validator = QuestionValidator()
+    assert question_validator.llm_params is not None
+    assert "max_new_tokens" in question_validator.llm_params is not None
+    assert "min_new_tokens" in question_validator.llm_params is not None
+
+    question_validator = QuestionValidator(llm_params={})
+    # the llm_params should be rewritten in constructor
+    assert question_validator.llm_params is not None
+    assert "max_new_tokens" in question_validator.llm_params is not None
+    assert "min_new_tokens" in question_validator.llm_params is not None
+
+
 def test_valid_responses(question_validator):
     """Test how valid responses are handled by QuestionValidator."""
     for retval in [


### PR DESCRIPTION
## Description

```
E       TypeError: ols.src.query_helpers.query_helper.QueryHelper.__init__() got multiple values for keyword argument 'llm_params'
```

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-364](https://issues.redhat.com//browse/OLS-364)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.
