### PR TITLE
OLS-378: Check for proper user UUID

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -40,7 +40,7 @@ def conversation_request(
     referenced_documents: list[str] = []
 
     # TODO: retrieve proper user ID from request
-    user_id = "user1"
+    user_id = constants.DEFAULT_USER_UID
 
     conversation_id = retrieve_conversation_id(llm_request)
     previous_input = retrieve_previous_input(user_id, llm_request)

--- a/ols/src/cache/cache.py
+++ b/ols/src/cache/cache.py
@@ -22,8 +22,7 @@ class Cache(ABC):
     @staticmethod
     def _check_user_id(user_id: str) -> None:
         """Check if given user ID is valid."""
-        # TODO: needs to be updated when we know the format
-        if Cache.COMPOUND_KEY_SEPARATOR in user_id:
+        if not check_suid(user_id):
             raise ValueError(f"Invalid user ID {user_id}")
 
     @staticmethod

--- a/tests/unit/app/endpoints/test_ols.py
+++ b/tests/unit/app/endpoints/test_ols.py
@@ -40,35 +40,38 @@ def test_retrieve_conversation_id_existing_id(load_config):
 
 def test_retrieve_previous_input_no_previous_history(load_config):
     """Check how function to retrieve previous input handle empty history."""
-    user_id = "1234"
     llm_request = LLMRequest(query="Tell me about Kubernetes", conversation_id=None)
-    input = ols.retrieve_previous_input(user_id, llm_request)
+    input = ols.retrieve_previous_input(constants.DEFAULT_USER_UID, llm_request)
     assert input is None
 
 
 @patch("ols.utils.config.conversation_cache.get")
 def test_retrieve_previous_input_for_previous_history(get, load_config):
     """Check how function to retrieve previous input handle existing history."""
-    user_id = "1234"
     conversation_id = suid.get_suid()
     get.return_value = "input"
     llm_request = LLMRequest(
         query="Tell me about Kubernetes", conversation_id=conversation_id
     )
-    previous_input = ols.retrieve_previous_input(user_id, llm_request)
+    previous_input = ols.retrieve_previous_input(
+        constants.DEFAULT_USER_UID, llm_request
+    )
     assert previous_input == "input"
 
 
 @patch("ols.utils.config.conversation_cache.insert_or_append")
 def test_store_conversation_history(insert_or_append, load_config):
     """Test if operation to store conversation history to cache is called."""
-    user_id = "1234"
     conversation_id = suid.get_suid()
     query = "Tell me about Kubernetes"
     llm_request = LLMRequest(query=query)
     response = ""
-    ols.store_conversation_history(user_id, conversation_id, llm_request, response)
-    insert_or_append.assert_called_with(user_id, conversation_id, f"{query}\n\n")
+    ols.store_conversation_history(
+        constants.DEFAULT_USER_UID, conversation_id, llm_request, response
+    )
+    insert_or_append.assert_called_with(
+        constants.DEFAULT_USER_UID, conversation_id, f"{query}\n\n"
+    )
 
 
 @patch("ols.utils.config.conversation_cache.insert_or_append")
@@ -96,11 +99,12 @@ def test_store_conversation_history_improper_user_id(load_config):
 
 def test_store_conversation_history_improper_conversation_id(load_config):
     """Test if basic input verification is done during history store operation."""
-    user_id = "1234"
     conversation_id = "::::"
     llm_request = LLMRequest(query="Tell me about Kubernetes")
     with pytest.raises(ValueError, match="Invalid conversation ID"):
-        ols.store_conversation_history(user_id, conversation_id, llm_request, "")
+        ols.store_conversation_history(
+            constants.DEFAULT_USER_UID, conversation_id, llm_request, ""
+        )
 
 
 @patch("ols.src.query_helpers.question_validator.QuestionValidator.validate_question")

--- a/tests/unit/cache/test_in_memory_cache.py
+++ b/tests/unit/cache/test_in_memory_cache.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from ols import constants
 from ols.app.models.config import MemoryConfig
 from ols.src.cache.in_memory_cache import InMemoryCache
 from ols.utils import suid
@@ -20,35 +21,42 @@ def cache():
 
 def test_insert_or_append(cache):
     """Test the behavior of insert_or_append method."""
-    cache.insert_or_append("user1", conversation_id, "value1")
-    assert cache.get("user1", conversation_id) == "value1"
+    cache.insert_or_append(constants.DEFAULT_USER_UID, conversation_id, "value1")
+    assert cache.get(constants.DEFAULT_USER_UID, conversation_id) == "value1"
 
 
 def test_insert_or_append_existing_key(cache):
     """Test the behavior of insert_or_append method for existing item."""
-    cache.insert_or_append("user1", conversation_id, "value1")
-    cache.insert_or_append("user1", conversation_id, "value2")
-    assert cache.get("user1", conversation_id) == "value1\nvalue2"
+    cache.insert_or_append(constants.DEFAULT_USER_UID, conversation_id, "value1")
+    cache.insert_or_append(constants.DEFAULT_USER_UID, conversation_id, "value2")
+    assert cache.get(constants.DEFAULT_USER_UID, conversation_id) == "value1\nvalue2"
 
 
 def test_insert_or_append_overflow(cache):
     """Test if items in cache with defined capacity is handled correctly."""
+    # remove last hex digit from user UUID
+    user_name_prefix = constants.DEFAULT_USER_UID[:-1]
+
     capacity = 5
     cache.capacity = capacity
     for i in range(capacity + 1):
-        user = f"user{i}"
+        user = f"{user_name_prefix}{i}"
         value = f"value{i}"
         cache.insert_or_append(user, conversation_id, value)
 
     # Ensure the oldest entry is evicted
-    assert cache.get("user0", conversation_id) is None
+    assert cache.get(f"{user_name_prefix}0", conversation_id) is None
     # Ensure the newest entry is still present
-    assert cache.get(f"user{capacity}", conversation_id) == f"value{capacity}"
+    assert (
+        cache.get(f"{user_name_prefix}{capacity}", conversation_id)
+        == f"value{capacity}"
+    )
 
 
 def test_get_nonexistent_user(cache):
     """Test how non-existent items are handled by the cache."""
-    assert cache.get("nonexistent_user", conversation_id) is None
+    # this UUID is different from DEFAULT_USER_UID
+    assert cache.get("ffffffff-ffff-ffff-ffff-ffffffffffff", conversation_id) is None
 
 
 def test_get_improper_user_id(cache):
@@ -62,7 +70,7 @@ def test_get_improper_user_id(cache):
 def test_get_improper_conversation_id(cache):
     """Test how improper conversation ID is handled."""
     with pytest.raises(ValueError, match="Invalid conversation ID"):
-        cache.get("user1", "this-is-not-valid-uuid")
+        cache.get(constants.DEFAULT_USER_UID, "this-is-not-valid-uuid")
 
 
 def test_singleton_pattern():


### PR DESCRIPTION
## Description

Now we know that user ID is proper UUID. It means that compound key to Redis can be checked more thorougly.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-378](https://issues.redhat.com//browse/OLS-378)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

