### PR TITLE
OLS-364: `llm-loader` is not keyword argument

### DIFF
--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -120,9 +120,7 @@ class DocsSummarizer(QueryHelper):
         )
         logger.info(f"{conversation_id} call settings: {settings_string}")
 
-        bare_llm = self.llm_loader(
-            self.provider, self.model, llm_params=self.llm_params
-        )
+        bare_llm = self.llm_loader(self.provider, self.model, self.llm_params)
 
         rag_context_data: list[dict] = []
         referenced_documents: list[str] = []

--- a/ols/src/query_helpers/question_validator.py
+++ b/ols/src/query_helpers/question_validator.py
@@ -60,9 +60,7 @@ class QuestionValidator(QueryHelper):
 
         logger.info(f"{conversation_id} Validating query")
 
-        bare_llm = self.llm_loader(
-            self.provider, self.model, llm_params=self.llm_params
-        )
+        bare_llm = self.llm_loader(self.provider, self.model, self.llm_params)
         llm_chain = LLMChain(
             llm=bare_llm,
             prompt=prompt_instructions,


### PR DESCRIPTION
## Description

[OLS-364](https://issues.redhat.com//browse/OLS-364): `llm-loader` is not keyword argument

## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-364](https://issues.redhat.com//browse/OLS-364)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
