### PR TITLE
OLS-364: Chat prompt constructor based on messages only

### DIFF
--- a/ols/src/prompts/prompts.py
+++ b/ols/src/prompts/prompts.py
@@ -14,8 +14,8 @@ Use the following pieces of retrieved context to answer the question.
 {context}"""
 
 # TODO: Add placeholder for history
-CHAT_PROMPT = ChatPromptTemplate(
-    messages=[
+CHAT_PROMPT = ChatPromptTemplate.from_messages(
+    [
         SystemMessagePromptTemplate.from_template(QUERY_SYSTEM_PROMPT),
         HumanMessagePromptTemplate.from_template("{query}"),
     ]


### PR DESCRIPTION
## Description

Chat prompt constructor based on messages only

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-364](https://issues.redhat.com//browse/OLS-364):
