### PR TITLE
OLS-364: Enable call-arg type checks on CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ lint.flake8-pytest-style.fixture-parentheses = false
 fail_under = 90
 
 [tool.mypy]
-disable_error_code = ["union-attr", "return-value", "arg-type", "call-arg", "import-untyped"]
+disable_error_code = ["union-attr", "return-value", "arg-type", "import-untyped"]
 ignore_missing_imports = true
 
 [tool.pdm]


### PR DESCRIPTION
## Description

Enable call-arg type checks on CI

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-364](https://issues.redhat.com//browse/OLS-364)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- `make check-types` will do the trick
