### PR TITLE
OLS-378: Use user ID retrieved from auth middleware

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -39,8 +39,9 @@ def conversation_request(
     previous_input = None
     referenced_documents: list[str] = []
 
-    # TODO: retrieve proper user ID from request
-    user_id = constants.DEFAULT_USER_UID
+    # auth contains tuple with user ID (in UUID format) and user name
+    user_id = auth[0]
+    logger.info(f"User ID {user_id}")
 
     conversation_id = retrieve_conversation_id(llm_request)
     previous_input = retrieve_previous_input(user_id, llm_request)


### PR DESCRIPTION
## Description

Use user ID retrieved from auth middleware

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-378](https://issues.redhat.com//browse/OLS-378)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

