### PR TITLE
Correct content_hash in pdm.lock

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:6de26bf93b611e761b6ad9d771ed3e40836461010445d6403848e623cb71e293"
+content_hash = "sha256:6c1d9d42f377dc0855afbb3bca3c79d8ae0ff24eb45988488ca47fff6d9a9e43"
 
 [[package]]
 name = "aiofiles"


### PR DESCRIPTION
## Description

Correct content_hash in pdm.lock. Incorrect hash was merged by https://github.com/openshift/lightspeed-service/pull/485.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
