### PR TITLE
Invoke pdm sync to make sure packages are installed according to pmd.lock

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -26,7 +26,7 @@ COPY pyproject.toml pdm.lock runner.py ./
 
 RUN pip3.11 install --no-cache-dir --upgrade pip pdm \
     && pdm config python.use_venv false \
-    && pdm install --global --prod --frozen-lockfile -p ${APP_ROOT}
+    && pdm sync --global --prod -p ${APP_ROOT}
 
 # Run the application
 EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,17 @@ images: ## Build container images
 install-tools: ## Install required utilities/tools
 	@command -v pdm > /dev/null || { echo >&2 "pdm is not installed. Installing..."; pip install pdm; }
 
-install-deps: install-tools ## Install all required dependencies needed to run the service
-	pdm install
+pdm-lock-check: ## Check that the pdm.lock file is in a good shape
+	pdm lock --check
 
-install-deps-test: install-tools ## Install all required dependencies needed to test the service
+install-deps: install-tools pdm-lock-check ## Install all required dependencies needed to run the service, according to pdm.lock
+	pdm sync
+
+install-deps-test: install-tools pdm-lock-check ## Install all required dev dependencies needed to test the service, according to pdm.lock
+	pdm sync --dev
+
+update-deps: ## Check pyproject.toml for changes, update the lock file if needed, then sync.
+	pdm install
 	pdm install --dev
 
 run: ## Run the service locally


### PR DESCRIPTION
## Description

Invoke pdm sync to make sure packages are installed according to pmd.lock
 Added a separate target for "pdm install" for picking up pyproject.toml updates.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
