### PR TITLE
OLS-378: User UUID checks in cache implementations

### DIFF
--- a/tests/unit/cache/test_in_memory_cache.py
+++ b/tests/unit/cache/test_in_memory_cache.py
@@ -59,12 +59,23 @@ def test_get_nonexistent_user(cache):
     assert cache.get("ffffffff-ffff-ffff-ffff-ffffffffffff", conversation_id) is None
 
 
-def test_get_improper_user_id(cache):
+improper_user_uuids = [
+    "",
+    " ",
+    "\t",
+    ":",
+    "foo:bar",
+    "ffffffff-ffff-ffff-ffff-fffffffffff",  # UUID-like string with missing chararacter
+    "ffffffff-ffff-ffff-ffff-fffffffffffZ",  # UUID-like string, but with wrong character
+    "ffffffff:ffff:ffff:ffff:ffffffffffff",
+]
+
+
+@pytest.mark.parametrize("uuid", improper_user_uuids)
+def test_get_improper_user_id(cache, uuid):
     """Test how improper user ID is handled."""
-    with pytest.raises(ValueError, match="Invalid user ID :"):
-        cache.get(":", conversation_id)
-    with pytest.raises(ValueError, match="Invalid user ID foo:bar"):
-        cache.get("foo:bar", conversation_id)
+    with pytest.raises(ValueError, match=f"Invalid user ID {uuid}"):
+        cache.get(uuid, conversation_id)
 
 
 def test_get_improper_conversation_id(cache):

--- a/tests/unit/cache/test_redis_cache.py
+++ b/tests/unit/cache/test_redis_cache.py
@@ -47,12 +47,23 @@ def test_get_nonexistent_key(cache):
     assert cache.get("ffffffff-ffff-ffff-ffff-ffffffffffff", conversation_id) is None
 
 
-def test_get_improper_user_id(cache):
+improper_user_uuids = [
+    "",
+    " ",
+    "\t",
+    ":",
+    "foo:bar",
+    "ffffffff-ffff-ffff-ffff-fffffffffff",  # UUID-like string with missing chararacter
+    "ffffffff-ffff-ffff-ffff-fffffffffffZ",  # UUID-like string, but with wrong character
+    "ffffffff:ffff:ffff:ffff:ffffffffffff",
+]
+
+
+@pytest.mark.parametrize("uuid", improper_user_uuids)
+def test_get_improper_user_id(cache, uuid):
     """Test how improper user ID is handled."""
-    with pytest.raises(ValueError, match="Invalid user ID :"):
-        cache.get(":", conversation_id)
-    with pytest.raises(ValueError, match="Invalid user ID foo:bar"):
-        cache.get("foo:bar", conversation_id)
+    with pytest.raises(ValueError, match=f"Invalid user ID {uuid}"):
+        cache.get(uuid, conversation_id)
 
 
 def test_get_improper_conversation_id(cache):


### PR DESCRIPTION
## Description

User UUID checks in cache implementations

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Unit tests

## Related Tickets & Documents

- Related Issue #[OLS-378](https://issues.redhat.com//browse/OLS-378)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

