### PR TITLE
(Trivial) else is not needed after return in condifiton

### DIFF
--- a/ols/utils/auth_dependency.py
+++ b/ols/utils/auth_dependency.py
@@ -132,8 +132,7 @@ def get_user_info(token: str) -> Optional[kubernetes.client.V1TokenReview]:
         response = auth_api.create_token_review(token_review)
         if response.status.authenticated:
             return response.status
-        else:
-            return None
+        return None
     except ApiException as e:
         logger.error(f"API exception during TokenReview: {e}")
         return None


### PR DESCRIPTION
## Description

The `else` statement is not needed as the `raise` statement will always
break out of the current scope. Removing the `else` will reduce nesting
and make the code more readable.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.
