### PR TITLE
OLS-165: Response sanity check

### DIFF
--- a/scripts/validate_response.py
+++ b/scripts/validate_response.py
@@ -1,0 +1,147 @@
+"""Response validation using pre-defined question/answer pair."""
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+
+import requests
+from llama_index.embeddings.huggingface import HuggingFaceEmbedding
+from pandas import DataFrame
+from scipy.spatial.distance import cosine, euclidean
+
+from ols.constants import NO_RAG_CONTENT_RESP
+
+
+# TODO: Add more question/answer pair
+def _args_parser(args):
+    """Arguments parser."""
+    parser = argparse.ArgumentParser(description="Response validation module.")
+    parser.add_argument(
+        "-s",
+        "--scenario",
+        choices=["with_rag", "without_rag"],
+        default="with_rag",
+        help="Scenario for which responses will be evaluated.",
+    )
+    parser.add_argument(
+        "-m",
+        "--model",
+        choices=["gpt", "granite"],
+        default="gpt",
+        help="Model for which responses will be evaluated.",
+    )
+    parser.add_argument(
+        "-t",
+        "--threshold",
+        type=lambda val: float(val),
+        default=0.25,
+        help="Threshold value to be used for similarity score.",
+    )
+    parser.add_argument(
+        "-n",
+        "--num_questions",
+        type=lambda val: int(val),
+        default=2,
+        help="Number of questions to be validated.",
+    )
+    return parser.parse_args(args)
+
+
+class ResponseValidation:
+    """Validate LLM response."""
+
+    def __init__(self):
+        """Initialize."""
+        self._embedding_model = HuggingFaceEmbedding("BAAI/bge-base-en")
+
+    def get_similarity_score(self, response, answer):
+        """Calculate similarity score between two strings."""
+        response = response.replace(NO_RAG_CONTENT_RESP, "")
+        res_vec = self._embedding_model.get_text_embedding(response)
+        ans_vec = self._embedding_model.get_text_embedding(answer)
+
+        # Distance score
+        cos_score = cosine(res_vec, ans_vec)
+        euc_score = euclidean(res_vec, ans_vec)
+
+        # Naive length consideration with reduced weightage.
+        len_res, len_ans = len(response), len(answer)
+        len_score = (abs(len_res - len_ans) / (len_res + len_ans)) * 0.1
+
+        score = len_score + (cos_score + euc_score) / 2
+        # TODO: Consider both contextual/non-contextual embedding.
+
+        print(
+            f"cos_score: {cos_score}, "
+            f"euc_score: {euc_score}, "
+            f"len_score: {len_score}\n"
+            f"final_score: {score}"
+        )
+        return score
+
+    def get_response_quality(self, args, qa_pairs):
+        """Get response quality."""
+        result_dict = defaultdict(list)
+
+        for idx in range(min(len(qa_pairs), args.num_questions)):
+            question = qa_pairs[idx]["question"]
+            answer = qa_pairs[idx]["answer"]
+
+            response = requests.post(
+                # API question validator can be disabled.
+                "http://localhost:8080/v1/query",
+                json={"query": question},
+                timeout=90,
+            ).json()["response"]
+
+            print(f"Calculating score for query: {question}")
+            score = self.get_similarity_score(response, answer)
+
+            if score > args.threshold:
+                print(f"Response is not as expected for question: {question}")
+
+            result_dict["question"].append(question)
+            result_dict["answer"].append(answer)
+            result_dict["llm_response"].append(response)
+            result_dict["recent_score"].append(score)
+
+        result_df = DataFrame.from_dict(result_dict)
+        result_df["threshold"] = args.threshold
+        return result_df
+
+
+def main():
+    """Validate LLM response."""
+    args = _args_parser(sys.argv[1:])
+    print(f"Arguments passed: {args}")
+
+    parent_dir = os.path.dirname(os.path.dirname(__file__)) + "/tests"
+
+    with open(f"{parent_dir}/test_data/question_answer_pair.json") as qna_f:
+        qa_pairs = json.load(qna_f)
+        qa_pairs = qa_pairs.get(args.model, {}).get(args.scenario, [])
+
+    result_df = ResponseValidation().get_response_quality(args, qa_pairs)
+
+    if len(result_df) > 0:
+        result_dir = f"{parent_dir}/test_results"
+        os.makedirs(result_dir, exist_ok=True)
+        result_file = (
+            f"{result_dir}/question_answer_result_{args.scenario}_{args.model}.csv"
+        )
+        result_df.to_csv(result_file, index=False)
+        print(f"Result is saved to {result_file}")
+
+        if result_df.recent_score.max() > args.threshold:
+            raise Exception(
+                "Response is not matching for question(s):\n"
+                f"Please check result in {result_file}."
+            )
+    else:
+        print("No result. Nothing to process.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_data/question_answer_pair.json
+++ b/tests/test_data/question_answer_pair.json
@@ -1,0 +1,32 @@
+{
+    "gpt": {
+        "with_rag": [
+            {
+                "question": "what is openshift virtualization?",
+                "answer": "OpenShift Virtualization is an add-on to the Red Hat OpenShift Container Platform that enables the running and management of virtual machine workloads alongside container workloads. It introduces new objects into the OpenShift cluster using Kubernetes custom resources to facilitate virtualization tasks such as creating and managing Linux and Windows virtual machines, running pod and VM workloads together in a cluster, connecting to VMs through various consoles and CLI tools, importing and cloning existing VMs, managing network interface controllers and storage disks attached to VMs, as well as live migrating VMs between nodes.\n\nThe add-on also provides an enhanced web console for graphical management of these virtualized resources alongside the OpenShift Container Platform's containers and infrastructure. Additionally, it is designed to work well with Red Hat OpenShift Data Foundation features.\n\nOpenShift Virtualization supports compliance scanning using the Compliance Operator with NIST-certified tooling for security policy enforcement. It is compatible with certified network plugins like OVN-Kubernetes, OpenShift SDN, or other listed options.\n\nIt is important to note that when deploying OpenShift Virtualization with OpenShift Data Foundation for Windows VMs, a dedicated storage class needs to be created. Furthermore, specific volume and access modes are recommended for optimal performance during live migration scenarios."
+            },
+            {
+                "question": "What is the purpose of the imagePullPolicy in Red Hat OpenShift Container Platform?",
+                "answer": "The imagePullPolicy in Red Hat OpenShift Container Platform determines whether the container image should be pulled prior to starting the container. It has three possible values: Always, IfNotPresent, and Never. The default behavior is as follows:\n\n1. If the tag of the image is \"latest,\" the imagePullPolicy is set to Always.\n2. Otherwise, if no specific parameter is specified, the imagePullPolicy defaults to IfNotPresent.\n\nThis policy allows for control over when and how container images are pulled, ensuring that containers are always started with the correct and up-to-date images based on their configuration."
+            },
+            {
+                "question": "What is the purpose of customizing source-to-image builder images?",
+                "answer": "Customizing source-to-image (S2I) builder images allows users to tailor the behavior of the default scripts included in the builder images to better suit their specific needs. This customization can involve overriding standard scripts with custom ones, adding commands before or after the standard scripts, or creating wrapper scripts that delegate work to the default scripts while incorporating custom logic. By doing so, users can adapt the S2I builder images to their particular use-cases and requirements."
+            },
+            {
+                "question": "What is a bundle in the context of the Operator Framework?",
+                "answer": "In the context of the Operator Framework, a bundle is a collection of an Operator CSV (Cluster Service Version), manifests, and metadata. Together, they form a unique version of an Operator that can be installed onto the cluster. Bundles are used to package and distribute Operators and their associated resources as a single unit for installation onto Kubernetes clusters."
+            }
+        ],
+        "without_rag": [
+            {
+                "question": "what is openshift virtualization?",
+                "answer": "OpenShift Virtualization is a feature of Red Hat OpenShift that allows users to run and manage virtual machines alongside containers in the same platform. It enables organizations to consolidate their workloads by running both VMs and containers on the same infrastructure, providing a unified platform for managing and orchestrating both types of workloads. This integration allows for greater flexibility in deploying and managing applications, as well as optimizing resource utilization within the OpenShift environment."
+            },
+            {
+                "question": "What is the purpose of the imagePullPolicy in Red Hat OpenShift Container Platform?",
+                "answer": "The imagePullPolicy in Red Hat OpenShift Container Platform is used to specify when the Kubernetes system should pull a container image. This policy determines whether the system should always pull the latest version of the image, or if it should use a locally cached version if available. The purpose of this setting is to control how OpenShift manages and updates container images, ensuring that applications are using the correct and up-to-date versions of their required images."
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Validate any deviation in LLM response.
A stand alone python script to check responses for different scenario / different models. The json file must contain question/answer pair for given scenario & model.

- Load pre-defined question/answer pair from json file.
- Call API with question/query
- Check similarity between answer from file & llm response.


## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-165](https://issues.redhat.com//browse/OLS-165)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
