### PR TITLE
OLS-81: Team ownership of RAG pipeline - RAG content image

### DIFF
--- a/Containerfile.rag
+++ b/Containerfile.rag
@@ -18,4 +18,4 @@ RUN microdnf install -y unzip wget \
     && microdnf remove -y unzip wget
 
 COPY scripts/download_embeddings_model.py .
-RUN python3.11 download_embeddings_model.py embeddings_model && rm download_embeddings_model.py
+RUN python3.11 download_embeddings_model.py -l embeddings_model -r BAAI/bge-base-en && rm download_embeddings_model.py

--- a/Containerfile.rag-content
+++ b/Containerfile.rag-content
@@ -1,0 +1,37 @@
+ARG OCP_VERSION=4.15
+ARG EMBEDDING_MODEL=BAAI/bge-base-en
+
+FROM registry.access.redhat.com/ubi9/python-311 as lightspeed-rag-builder
+ARG OCP_VERSION
+ARG EMBEDDING_MODEL
+
+USER 0
+RUN dnf install -y --nodocs --setopt=keepcache=0 --setopt=tsflags=nodocs git ruby gem
+RUN pip install torch --index-url https://download.pytorch.org/whl/cpu
+RUN pip install PyYAML huggingface_hub llama_index langchain_community \
+                faiss-cpu llama-index-vector-stores-faiss sentence_transformers \
+                llama-index-embeddings-huggingface
+RUN gem install asciidoctor
+
+WORKDIR /workdir
+RUN git clone --single-branch --branch enterprise-${OCP_VERSION} https://github.com/openshift/openshift-docs.git
+COPY scripts/asciidoctor-text ./asciidoctor-text
+RUN python asciidoctor-text/convert-it-all.py \
+           -i openshift-docs \
+           -t openshift-docs/_topic_maps/_topic_map.yml \
+           -o ocp-product-docs-plaintext \
+           -a asciidoctor-text/attributes.yaml
+
+COPY scripts/download_embeddings_model.py .
+RUN python download_embeddings_model.py -l ./embeddings_model -r ${EMBEDDING_MODEL}
+
+COPY scripts/generate_embeddings.py .
+RUN python generate_embeddings.py -f ocp-product-docs-plaintext -md embeddings_model \
+    -mn ${EMBEDDING_MODEL} -o vector_db/ocp_product_docs/${OCP_VERSION} \
+    -i ocp-product-docs-$(echo $OCP_VERSION | sed 's/\./_/g')
+
+FROM scratch
+ARG OCP_VERSION
+COPY --from=lightspeed-rag-builder /workdir/ocp-product-docs-plaintext /rag/ocp-product-docs-plaintext
+COPY --from=lightspeed-rag-builder /workdir/vector_db/ocp_product_docs/${OCP_VERSION} /rag/vector_db/ocp_product_docs/${OCP_VERSION}
+COPY --from=lightspeed-rag-builder /workdir/embeddings_model /rag/embeddings_model

--- a/scripts/asciidoctor-text/attributes.yaml
+++ b/scripts/asciidoctor-text/attributes.yaml
@@ -1,0 +1,1 @@
+product-title: Red Hat OpenShift Container Platform

--- a/scripts/asciidoctor-text/convert-it-all.py
+++ b/scripts/asciidoctor-text/convert-it-all.py
@@ -1,0 +1,86 @@
+"""Utility script to convert OCP docs from adoc to plain text."""
+
+import argparse
+import os
+import subprocess
+import sys
+
+import yaml
+
+
+def process_node(node, dir="", file_list=[]):
+    """Process YAML node from the topic map."""
+    currentdir = dir
+    if "Topics" in node.keys():
+        currentdir = os.path.join(currentdir, node["Dir"])
+        for subnode in node["Topics"]:
+            file_list = process_node(subnode, dir=currentdir, file_list=file_list)
+    else:
+        file_list.append(os.path.join(currentdir, node["File"]))
+    return file_list
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="This command converts the openshift-docs assemblies to plain text.",
+        usage="convert-it-all [options]",
+    )
+
+    parser.add_argument(
+        "--input-dir",
+        "-i",
+        required=True,
+        help="The input directory for the openshift-docs repo",
+    )
+    parser.add_argument("--topic-map", "-t", required=True, help="The topic map file")
+    parser.add_argument(
+        "--output-dir", "-o", required=True, help="The output directory for text"
+    )
+    parser.add_argument(
+        "--attributes", "-a", help="An optional file containing attributes"
+    )
+
+    args = parser.parse_args(sys.argv[1:])
+
+    attribute_list = []
+    if args.attributes is not None:
+        attributes = yaml.safe_load(open(args.attributes, "r"))
+        for key, value in attributes.items():
+            attribute_list = [*attribute_list, "-a", key + '="%s"' % value]
+
+    topic_map = yaml.safe_load_all(open(args.topic_map, "r"))
+    mega_file_list = []
+    for map in topic_map:
+        file_list = []
+        file_list = process_node(map, file_list=file_list)
+        mega_file_list = mega_file_list + file_list
+
+    output_dir = os.path.normpath(args.output_dir)
+    os.makedirs(output_dir, exist_ok=True)
+    input_dir = os.path.normpath(args.input_dir)
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+
+    for filename in mega_file_list:
+        output_file = os.path.join(output_dir, filename + ".txt")
+        os.makedirs(os.path.dirname(os.path.realpath(output_file)), exist_ok=True)
+        input_file = os.path.join(input_dir, filename + ".adoc")
+        converter_file = os.path.join(script_dir, "text-converter.rb")
+        print("Processing: " + input_file)
+        command = ["asciidoctor"]
+        command = command + attribute_list
+        command = [
+            *command,
+            "-r",
+            converter_file,
+            "-b",
+            "text",
+            "-o",
+            output_file,
+            "--trace",
+            "--quiet",
+            input_file,
+        ]
+        result = subprocess.run(command)  # noqa: S603
+        if result.returncode != 0:
+            print(result)
+            print(result.stdout)

--- a/scripts/asciidoctor-text/text-converter.rb
+++ b/scripts/asciidoctor-text/text-converter.rb
@@ -1,0 +1,80 @@
+module Asciidoctor
+
+(QUOTE_TAGS = {
+  monospaced:  ['<code>', '</code>', true],
+  emphasis:    ['<em>', '</em>', true],
+  strong:      ['<strong>', '</strong>', true],
+  double:      ['&#8220;', '&#8221;'],
+  single:      ['&#8216;', '&#8217;'],
+  mark:        ['<mark>', '</mark>', true],
+  superscript: ['<sup>', '</sup>', true],
+  subscript:   ['<sub>', '</sub>', true],
+  asciimath:   ['\$', '\$'],
+  latexmath:   ['\(', '\)'],
+  # Opal can't resolve these constants when referenced here
+  #asciimath:  INLINE_MATH_DELIMITERS[:asciimath] + [false],
+  #latexmath:  INLINE_MATH_DELIMITERS[:latexmath] + [false],
+}).default = ['', '']
+
+class Converter::TextConverter < Converter::Base
+  register_for 'text'
+
+  def initialize *args
+    super
+    outfilesuffix '.txt'
+  end
+  def convert node, transform = node.node_name, opts = nil
+    case transform
+    when 'document', 'section'
+      [(decode node.title) + %(\n), (decode node.content)].join
+    when 'paragraph'
+      (decode node.content.tr ?\n, ' ') << ?\n
+    when 'olist', 'ulist', 'colist'
+      result = []
+      node.items.each do |item|
+        result << %(#{(decode item.text)}) << %(\n\n)
+      end
+      result.join
+    when 'dlist'
+      result = [%(\n)]
+      node.items.each do |terms, dd|
+        terms.each do |dt|
+          result << %(#{(decode dt.text)}) << ?\n
+        end
+        if defined?(dd.text)
+          result << %(#{(decode dd.text)}) << ?\n
+        end
+      end
+      result.join << ?\n
+    else
+      (transform.start_with? 'inline_') ? (decode node.text) : (decode node.content)
+    end
+  end
+
+  def decode str
+    unless str.nil?
+      str = str.
+        gsub('&lt;', '<').
+        gsub('&gt;', '>').
+        gsub('&#43;', '+').      # plus sign; alternately could use \c(pl
+        gsub('&#160;', ' ').    # non-breaking space
+        gsub('&#8201;', ' ').    # thin space
+        gsub('&#8211;', '-'). # en dash
+        gsub('&#8212;', '-'). # em dash
+        gsub('&#8216;', %(')). # left single quotation mark
+        gsub('&#8217;', %(')). # right single quotation mark
+        gsub('&#8220;', %(")). # left double quotation mark
+        gsub('&#8221;', %("")). # right double quotation mark
+        gsub('&#8592;', '<-'). # leftwards arrow
+        gsub('&#8594;', '->'). # rightwards arrow
+        gsub('&#8656;', '->'). # leftwards double arrow
+        gsub('&#8658;', '<-'). # rightwards double arrow
+        gsub('&amp;', '&').      # literal ampersand (NOTE must take place after any other replacement that includes &)
+        gsub('\'', %(')).     # apostrophe / neutral single quote
+        rstrip                   # strip trailing space
+      end
+    str
+  end
+
+end
+end

--- a/scripts/download_embeddings_model.py
+++ b/scripts/download_embeddings_model.py
@@ -1,30 +1,35 @@
-"""Utility script to download a model from HuggingFace."""
+"""Utility script to download models from HuggingFace."""
 
+import argparse
 import os
-import sys
 
 if __name__ == "__main__":
 
-    if len(sys.argv) != 2:
-        print("Usage: python download_embeddings_model.py <local_dir>")
-        sys.exit(1)
-
-    local_dir = sys.argv[1]
+    parser = argparse.ArgumentParser(
+        description="Script to download models from HuggingFace"
+    )
+    parser.add_argument(
+        "-l", "--local-dir", required=True, help="Directory to download model to"
+    )
+    parser.add_argument(
+        "-r", "--hf-repo-id", required=True, help="Model repo id, ex. BAAI/bge-base-en"
+    )
+    args = parser.parse_args()
 
     os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
 
     from huggingface_hub import snapshot_download
 
     snapshot_download(
-        repo_id="BAAI/bge-base-en", local_dir=local_dir, local_dir_use_symlinks=False
+        repo_id=args.hf_repo_id, local_dir=args.local_dir, local_dir_use_symlinks=False
     )
 
     # workaround for https://github.com/UKPLab/sentence-transformers/pull/2460
-    os.makedirs(os.path.join(local_dir, "2_Normalize"), exist_ok=True)
+    os.makedirs(os.path.join(args.local_dir, "2_Normalize"), exist_ok=True)
 
     # pretend local_dir is HF cache
-    with open(os.path.join(local_dir, "version.txt"), "w", encoding="utf-8") as f:
+    with open(os.path.join(args.local_dir, "version.txt"), "w", encoding="utf-8") as f:
         f.write("1")
 
     # remove pytorch_model.bin, load the model from model.safetensors
-    os.remove(os.path.join(local_dir, "pytorch_model.bin"))
+    os.remove(os.path.join(args.local_dir, "pytorch_model.bin"))

--- a/scripts/generate_embeddings.py
+++ b/scripts/generate_embeddings.py
@@ -1,0 +1,77 @@
+"""Utility script to generate embeddings."""
+
+import argparse
+import json
+import os
+import time
+
+import faiss
+from llama_index.core import Settings, SimpleDirectoryReader, VectorStoreIndex
+from llama_index.core.storage.storage_context import StorageContext
+from llama_index.embeddings.huggingface import HuggingFaceEmbedding
+from llama_index.vector_stores.faiss import FaissVectorStore
+
+if __name__ == "__main__":
+
+    start_time = time.time()
+
+    parser = argparse.ArgumentParser(description="embedding cli for task execution")
+    parser.add_argument("-f", "--folder", help="Plain text folder path")
+    parser.add_argument(
+        "-md",
+        "--model-dir",
+        default="embeddings_model",
+        help="Directory containing the embedding model",
+    )
+    parser.add_argument(
+        "-mn",
+        "--model-name",
+        default="BAAI/bge-base-en",
+        help="HF repo id of the embedding model",
+    )
+    parser.add_argument(
+        "-c", "--chunk", type=int, default="1500", help="Chunk size for embedding"
+    )
+    parser.add_argument(
+        "-l", "--overlap", type=int, default="10", help="Chunk overlap for embedding"
+    )
+    parser.add_argument("-o", "--output", help="Vector DB output folder")
+    parser.add_argument("-i", "--index", help="Product index")
+    args = parser.parse_args()
+
+    PERSIST_FOLDER = args.output
+
+    os.environ["HF_HOME"] = args.model_dir
+    os.environ["TRANSFORMERS_OFFLINE"] = "1"
+    Settings.chunk_size = args.chunk
+    Settings.chunk_overlap = args.overlap
+    Settings.embed_model = HuggingFaceEmbedding(model_name=args.model_dir)
+    Settings.llm = None
+
+    embedding_dimension = len(Settings.embed_model.get_text_embedding("random text"))
+    faiss_index = faiss.IndexFlatL2(embedding_dimension)
+    vector_store = FaissVectorStore(faiss_index=faiss_index)
+    storage_context = StorageContext.from_defaults(vector_store=vector_store)
+
+    documents = SimpleDirectoryReader(args.folder, recursive=True).load_data()
+
+    index = VectorStoreIndex.from_documents(
+        documents,
+        storage_context=storage_context,
+    )
+    index.set_index_id(args.index)
+    index.storage_context.persist(persist_dir=PERSIST_FOLDER)
+
+    metadata = {}
+    metadata["execution-time"] = time.time() - start_time
+    metadata["llm"] = "None"
+    metadata["embedding-model"] = args.model_name
+    metadata["index-id"] = args.index
+    metadata["vector-db"] = "faiss"
+    metadata["embedding-dimension"] = embedding_dimension
+    metadata["chunk"] = args.chunk
+    metadata["overlap"] = args.overlap
+    metadata["total-embedded-files"] = len(documents)
+
+    with open(os.path.join(PERSIST_FOLDER, "metadata.json"), "w") as file:
+        file.write(json.dumps(metadata))


### PR DESCRIPTION
## Description

This is a part of https://github.com/openshift/lightspeed-service/pull/518 that introduces quay.io/openshift/lightspeed-rag-content:${OLS_VERSION} image.

A Containerfile and supporting scripts for multi-stage build of RAG content, to be run from OLS CI. Inputs into the process are OCP 4.15 docs from https://github.com/openshift/openshift-docs and an embedding model from HuggingFace. Produced image contains
- OCP docs plaintext, not intended for inclusion into OLS RAG but can be useful to look at
- embedding model
- Faiss vector database with embeddings generated from the OCP docs plaintext

The resulting image is intended for consumption during the OLS build process.

The other half of this work is in https://github.com/openshift/release/pull/49510.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/OLS-81, https://issues.redhat.com/browse/OLS-355
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
