### PR TITLE
[Bug fix] Add command to keep redis container awake

### DIFF
--- a/Containerfile.redis
+++ b/Containerfile.redis
@@ -19,3 +19,6 @@ RUN make BUILD_TLS=yes && \
 
 # Expose the default Redis port
 EXPOSE 6379
+
+# Start redis server
+ENTRYPOINT [ "redis-server", "/etc/redis/redis.conf" ]


### PR DESCRIPTION
## Description

[Bug fix] Adding a  command to keep redis container awake. Currently when a redis pod start it immediately get terminated as we do have a entrypoint command that keeps it awake. So fixing it with a sleep command and the actual redis server will be spun up with required SSL/TLS and auth args from operator's code.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested integrating with https://github.com/openshift/lightspeed-operator/pull/25 