### PR TITLE
OLS-405: Refactor e2e so we can run tests against multiple providers in one shot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 .PHONY: test test-unit test-e2e images run format verify
 
 ARTIFACT_DIR := $(if $(ARTIFACT_DIR),$(ARTIFACT_DIR),tests/test_results)
+TEST_TAGS := $(if $(TEST_TAGS),$(TEST_TAGS),"")
+SUITE_ID := $(if $(SUITE_ID),$(SUITE_ID),"nosuite")
 
 images: ## Build container images
 	scripts/build-container.sh
@@ -51,8 +53,7 @@ check-coverage: test-unit test-integration  ## Unit tests and integration tests 
 test-e2e: ## Run e2e tests - requires running OLS server
 	@echo "Running e2e tests..."
 	@echo "Reports will be written to ${ARTIFACT_DIR}"
-	python -m pytest tests/e2e --junit-xml="${ARTIFACT_DIR}/junit_e2e.xml"
-
+	python -m pytest tests/e2e -o junit_suite_name="${SUITE_ID}" -m "${TEST_TAGS}" --junit-xml="${ARTIFACT_DIR}/junit_e2e_${SUITE_ID}.xml"
 
 coverage-report:	test-unit ## Export unit test coverage report into interactive HTML
 	coverage html --data-file="${ARTIFACT_DIR}/.coverage.unit"

--- a/tests/config/cluster_install/ols_configmap.yaml
+++ b/tests/config/cluster_install/ols_configmap.yaml
@@ -1,6 +1,8 @@
 # Env vars for use w/ envsubst:
 # $PROVIDER - the llm provider to use (e.g. openai)
 # $PROVIDER_PROJECT_ID - for use with watsonx, can leave empty otherwise
+# $PROVIDER_URL - set the provider api url/override the default, primarily for use with azure openai
+# $PROVIDER_DEPLOYMENT_NAME - for use with azure openai, can leave empty otherwise
 # $MODEL - the llm model to use from the provider (e.g. gpt-3.5.-turbo)
 
 ---
@@ -13,7 +15,9 @@ data:
   olsconfig.yaml: |
     llm_providers:
       - name: "$PROVIDER"
+        url: $PROVIDER_URL
         project_id: "$PROVIDER_PROJECT_ID"
+        deployment_name: "$PROVIDER_DEPLOYMENT_NAME"
         credentials_path: /app-root/config/llmcreds/llmkey
         models:
           - name: "$MODEL"

--- a/tests/e2e/pytest.ini
+++ b/tests/e2e/pytest.ini
@@ -1,5 +1,17 @@
 [pytest]
+addopts = --strict-markers
 log_cli=false
 filterwarnings = 
 	ignore::DeprecationWarning
 junit_logging=system-out
+markers =
+	any
+	cluster
+	standalone
+	rag
+	norag
+	provider_bam
+	provider_openai
+	provider_azure_openai
+	provider_watsonx
+

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -2,6 +2,7 @@
 
 import os
 
+import pytest
 import requests
 from httpx import Client
 
@@ -231,6 +232,7 @@ def test_valid_question() -> None:
         )
 
 
+@pytest.mark.rag
 def test_rag_question() -> None:
     """Ensure responses include rag references."""
     endpoint = "/v1/query"
@@ -330,14 +332,16 @@ def test_metrics() -> None:
     assert 'response_duration_seconds_sum{path="/metrics/"}' in response.text
 
 
+@pytest.mark.cluster
 def test_improper_token():
     """Test accessing /v1/query endpoint using improper auth. token."""
     # let's assume that auth. is enabled when token is specified
-    if token:
-        response = client.post(
-            "/v1/query",
-            json={"query": "what is foo in bar?"},
-            timeout=NON_LLM_REST_API_TIMEOUT,
-            headers={"Authorization": "Bearer wrong-token"},
-        )
-        assert response.status_code == requests.codes.forbidden
+    if not token:
+        pytest.skip("skipping authentication tests because OLS_TOKEN is not set")
+    response = client.post(
+        "/v1/query",
+        json={"query": "what is foo in bar?"},
+        timeout=NON_LLM_REST_API_TIMEOUT,
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+    assert response.status_code == requests.codes.forbidden

--- a/tests/scripts/utils.sh
+++ b/tests/scripts/utils.sh
@@ -1,34 +1,120 @@
 # Wait for the ols api server to respond 200 on the readiness endpoint
 # $1 - url of the ols server to poll
 function wait_for_ols() {
-    # Don't exit on error while polling the OLS server
-    # Curl will return error exit codes until OLS is available
-    set +e
-    STARTED=0
-    for i in {1..20}; do
-        echo Checking OLS readiness, attempt "$i" of 20
-        curl -sk --fail "$1/readiness"
-        if [ $? -eq 0 ]; then
-            STARTED=1
-            break
-        fi  
-        sleep 6
-    done
-    set -e
-
-    if [ $STARTED -ne 1 ]; then
-        echo "Timed out waiting for OLS to start"
-        exit 1
-    fi
+  for i in {1..30}; do
+    echo Checking OLS readiness, attempt "$i" of 30
+    curl -sk --fail "$1/readiness"
+    if [ $? -eq 0 ]; then
+      return 0
+    fi  
+    sleep 6
+  done
+  return 1
 }
 
 # collect logs + state from openshift-lightspeed namespace
 function must_gather() {
-  mkdir $ARTIFACT_DIR/cluster
-  oc get all -n openshift-lightspeed -o yaml > $ARTIFACT_DIR/cluster/resources.yaml
-  mkdir $ARTIFACT_DIR/cluster/podlogs
+  mkdir -p $ARTIFACT_DIR/$1/cluster
+  oc get all -n openshift-lightspeed -o yaml > $ARTIFACT_DIR/$1/cluster/resources.yaml
+  mkdir -p $ARTIFACT_DIR/$1/cluster/podlogs
   for podname in `oc get pods -o jsonpath="{.items[].metadata.name}"`; do
     echo "dumping pod $podname"
-    oc logs pod/${podname} > $ARTIFACT_DIR/cluster/podlogs/${podname}.log
+    oc logs pod/${podname} > $ARTIFACT_DIR/$1/cluster/podlogs/${podname}.log
   done
+}
+
+# no arguments
+function cleanup_ols() {
+    # Deletes may fail if this is the first time running against
+    # the cluster, so ignore failures
+    oc delete --wait --ignore-not-found ns openshift-lightspeed
+    oc delete --wait --ignore-not-found clusterrole ols-sar-check
+    oc delete --wait --ignore-not-found clusterrolebinding ols-sar-check
+    oc delete --wait --ignore-not-found clusterrole ols-user
+}
+
+# Arguments
+# SuiteID
+# Provider
+# Provider key path
+# Provider url (if needed, azure openai only normally)
+# Provider project id (if needed, watsonx only)
+# Deployment name (if needed, azure openai only)
+# Model
+# OLS image
+function install_ols() {
+
+    SUITE_ID=$1
+    # exports needed for values used by envsubst
+    export PROVIDER=$2
+    export PROVIDER_KEY_PATH=$3
+    export PROVIDER_URL=$4
+    export PROVIDER_PROJECT_ID=$5
+    export PROVIDER_DEPLOYMENT_NAME=$6
+    export MODEL=$7
+    export OLS_IMAGE=$8
+
+    oc create ns openshift-lightspeed
+    oc project openshift-lightspeed
+
+    # create the llm api key secret ols will mount
+    oc create secret generic llmcreds --from-file=llmkey="$PROVIDER_KEY_PATH"
+
+    # create the configmap containing the ols config yaml
+    mkdir -p "$ARTIFACT_DIR/$SUITE_ID"
+    envsubst < tests/config/cluster_install/ols_configmap.yaml > "$ARTIFACT_DIR/$SUITE_ID/ols_configmap.yaml.tmp"
+    # If no provider url is being specified, remove the url field from the config yaml
+    # so we use the default provider url values.
+    if [ -z ${PROVIDER_URL:-} ]; then
+        grep -v url: "${ARTIFACT_DIR}/$SUITE_ID/ols_configmap.yaml.tmp" > "${ARTIFACT_DIR}/$SUITE_ID/ols_configmap.yaml"
+        rm "${ARTIFACT_DIR}/$SUITE_ID/ols_configmap.yaml.tmp"
+    else
+        mv "${ARTIFACT_DIR}/$SUITE_ID/ols_configmap.yaml.tmp" "${ARTIFACT_DIR}/$SUITE_ID/ols_configmap.yaml"
+    fi
+
+    oc create -f "$ARTIFACT_DIR/$SUITE_ID/ols_configmap.yaml"
+
+    # create the ols deployment and related resources (service, route, rbac roles)
+    envsubst < tests/config/cluster_install/ols_manifests.yaml > "$ARTIFACT_DIR/$SUITE_ID/ols_manifests.yaml"
+    oc create -f "$ARTIFACT_DIR/$SUITE_ID/ols_manifests.yaml"
+
+    # create a new service account with no special permissions and get an auth token for it
+    oc create sa olsuser
+    export OLS_TOKEN=$(oc create token olsuser)
+
+    # grant the service account permission to query ols
+    oc adm policy add-cluster-role-to-user ols-user -z olsuser
+
+    # determine the hostname for the ols route
+    export OLS_URL=https://$(oc get route ols -o jsonpath='{.spec.host}')
+}
+
+# $1 suite id
+# $2 which test tags to include
+# $3 PROVIDER
+# $4 PROVIDER_KEY_PATH
+# $5 PROVIDER_URL
+# $6 PROVIDER_PROJECT_ID
+# $7 PROVIDER_DEPLOYMENT_NAME
+# $8 MODEL
+# $9 OLS_IMAGE
+function run_suite() {
+  echo "Preparing to run suite $1"
+
+  cleanup_ols
+  
+  install_ols "$1" "$3" "$4" "$5" "$6" "$7" "$8" "$9"
+
+  # wait for the ols api server to come up
+  wait_for_ols "$OLS_URL"
+  if [ $? -ne 0 ]; then
+    echo "Timed out waiting for OLS to become available"
+    must_gather $1
+    return 1
+  fi
+  
+  SUITE_ID=$1 TEST_TAGS=$2 make test-e2e
+  rc=$?
+  must_gather $1
+  return $rc
 }


### PR DESCRIPTION
This PR does a few things:

1) introduces the concept of marking our e2e tests with keywords that indicate what configuration/environment they require, if any

2) moves the test-e2e-standalone.sh script into our common test scripts directory (i already updated the e2e job to tolerate the script being in either location: https://github.com/openshift/release/pull/49695) (could have been its own PR but it's a small change)

3) refactors the test-e2e-cluster.sh script to be a bit more modular so we can rerun the steps easily (install ols, uninstall ols, execute a set of e2e tests against ols)

4) updates the test script to run against all 4 of our supported providers while providing a pattern to introduce new "test suite configurations" (such as a no-rag vs rag-enabled configuration)