### PR TITLE
Use constants for default responses

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -136,14 +136,7 @@ def generate_response(
             logger.info(
                 f"{conversation_id} - Query is not relevant to kubernetes or ocp, returning"
             )
-            return (
-                (
-                    "I can only answer questions about OpenShift and Kubernetes. "
-                    "Please rephrase your question"
-                ),
-                [],
-                False,
-            )
+            return constants.INVALID_QUERY_RESP, [], False
         case constants.SUBJECT_VALID:
             logger.info(
                 f"{conversation_id} - Question is relevant to kubernetes or ocp"

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -10,6 +10,14 @@ POSSIBLE_QUESTION_VALIDATOR_RESPONSES = (
     SUBJECT_INVALID,
 )
 
+# Default responses
+INVALID_QUERY_RESP = (
+    "I can only answer questions about OpenShift and Kubernetes. "
+    "Please rephrase your question"
+)
+NO_RAG_CONTENT_RESP = (
+    "The following response was generated without access to reference content:\n\n"
+)
 
 # templates
 SUMMARIZATION_TEMPLATE = """

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -173,11 +173,7 @@ class DocsSummarizer(QueryHelper):
 
         if len(rag_context) == 0:
             logger.info("Using llm to answer the query without reference content")
-            response = (
-                "The following response was generated without access to reference content:"
-                "\n\n"
-                f"{response}"
-            )
+            response = constants.NO_RAG_CONTENT_RESP + str(response)
 
         logger.info(f"{conversation_id} Summary response: {response}")
         logger.info(f"{conversation_id} Referenced documents: {referenced_documents}")

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -6,6 +6,8 @@ import pytest
 import requests
 from httpx import Client
 
+from ols.constants import INVALID_QUERY_RESP, NO_RAG_CONTENT_RESP
+
 url = os.getenv("OLS_URL", "http://localhost:8080")
 token = os.getenv("OLS_TOKEN")
 client = Client(base_url=url, verify=False)  # noqa: S501
@@ -288,13 +290,10 @@ def test_invalid_question():
         )
         print(vars(response))
         assert response.status_code == requests.codes.ok
-        expected_details = (
-            "I can only answer questions about OpenShift and Kubernetes. "
-            "Please rephrase your question"
-        )
+
         expected_json = {
             "conversation_id": conversation_id,
-            "response": expected_details,
+            "response": INVALID_QUERY_RESP,
             "referenced_documents": [],
             "truncated": False,
         }
@@ -356,10 +355,7 @@ def test_valid_question() -> None:
             or "orchestration system" in json_response["response"]
             or "orchestration platform" in json_response["response"]
         )
-        assert (
-            "The following response was generated without access to reference content:"
-            not in json_response["response"]
-        )
+        assert NO_RAG_CONTENT_RESP not in json_response["response"]
 
 
 @pytest.mark.standalone
@@ -415,10 +411,7 @@ def test_rag_question() -> None:
         assert "install" in json_response["referenced_documents"][0]
         assert "https://" in json_response["referenced_documents"][0]
 
-        assert (
-            "The following response was generated without access to reference content:"
-            not in json_response["response"]
-        )
+        assert NO_RAG_CONTENT_RESP not in json_response["response"]
 
 
 def test_query_filter() -> None:

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -69,13 +69,10 @@ def test_post_question_on_invalid_question():
             json={"conversation_id": conversation_id, "query": "test query"},
         )
         assert response.status_code == requests.codes.ok
-        expected_details = (
-            "I can only answer questions about OpenShift and Kubernetes. "
-            "Please rephrase your question"
-        )
+
         expected_json = {
             "conversation_id": conversation_id,
-            "response": expected_details,
+            "response": constants.INVALID_QUERY_RESP,
             "referenced_documents": [],
             "truncated": False,
         }
@@ -255,10 +252,7 @@ def test_post_question_on_noyaml_response_type() -> None:
             )
             print(response)
             assert response.status_code == requests.codes.ok
-            assert (
-                "The following response was generated without access to reference content:"
-                in response.json()["response"]
-            )
+            assert constants.NO_RAG_CONTENT_RESP in response.json()["response"]
 
 
 def test_post_query_with_query_filters_response_type() -> None:
@@ -304,10 +298,7 @@ def test_post_query_with_query_filters_response_type() -> None:
             )
             print(response.json())
             assert response.status_code == requests.codes.ok
-            assert (
-                "The following response was generated without access to reference content:"
-                in response.json()["response"]
-            )
+            assert constants.NO_RAG_CONTENT_RESP in response.json()["response"]
             assert (
                 "test query with redacted_ip will be replaced with redacted_ip"
                 in response.json()["response"]

--- a/tests/unit/app/endpoints/test_ols.py
+++ b/tests/unit/app/endpoints/test_ols.py
@@ -300,10 +300,7 @@ def test_conversation_request(
     mock_validate_question.return_value = constants.SUBJECT_INVALID
     llm_request = LLMRequest(query="Generate a yaml")
     response = ols.conversation_request(llm_request, auth)
-    assert response.response == (
-        "I can only answer questions about OpenShift and Kubernetes. "
-        "Please rephrase your question"
-    )
+    assert response.response == constants.INVALID_QUERY_RESP
     assert suid.check_suid(
         response.conversation_id
     ), "Improper conversation ID returned"


### PR DESCRIPTION
## Description

Use constants for default messages, so that we don't have to change in different places if there is a change in text.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
