### PR TITLE
OLS-230: Script to generate OpenAPI schema + Makefile target to call this script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,9 @@ get-rag: ## Download RAG embeddings model and index
 	unzip -qq -o local.zip && \
 	rm local.zip && popd
 
+schema:	## Generate OpenAPI schema file
+	python scripts/generate_openapi_schema.py docs/openapi.json
+
 help: ## Show this help screen
 	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
 	@echo ''

--- a/scripts/generate_openapi_schema.py
+++ b/scripts/generate_openapi_schema.py
@@ -1,0 +1,34 @@
+"""Utility script to generate OpenAPI schema."""
+
+import json
+import os.path
+import sys
+
+from fastapi.openapi.utils import get_openapi
+
+# we need to import OLS app from directory above, so it is needed to update
+# search path accordingly
+sys.path.append(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
+)
+from ols.app.main import app
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python generate_openapi_schema.py <filename>")
+        sys.exit(1)
+
+    filename = sys.argv[1]
+
+    # retrieve OpenAPI schema via initialized app
+    open_api = get_openapi(
+        title=app.title,
+        version=app.version,
+        openapi_version=app.openapi_version,
+        description=app.description,
+        routes=app.routes,
+    )
+
+    # dump the schema into file
+    with open(filename, "w") as fout:
+        json.dump(open_api, fout, indent=4)


### PR DESCRIPTION
## Description

Script to generate OpenAPI schema + Makefile target to call this script

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-230](https://issues.redhat.com//browse/OLS-230)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Call `make schema` from command line to generate OpenAPI schema
