### PR TITLE
Disable internal checking of subprocess exit code, it's done explicitly

### DIFF
--- a/scripts/asciidoctor-text/convert-it-all.py
+++ b/scripts/asciidoctor-text/convert-it-all.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
             "--quiet",
             input_file,
         ]
-        result = subprocess.run(command)  # noqa: S603
+        result = subprocess.run(command, check=False)  # noqa: S603
         if result.returncode != 0:
             print(result)
             print(result.stdout)


### PR DESCRIPTION
## Description

Disable internal checking of subprocess exit code, it's done explicitly
It is not super needed as currently internal checking is disabled, but it will tell devels that we really don't want this behaviour.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Trivial


