### PR TITLE
Explicit model and provider types to avoid the need to explicitly checks for None/not None

### DIFF
--- a/ols/src/query_helpers/query_helper.py
+++ b/ols/src/query_helpers/query_helper.py
@@ -25,7 +25,7 @@ class QueryHelper:
         # NOTE: As signature of this method is evaluated before the config,
         # is loaded, we cannot use the config directly as defaults and we
         # need to use those values in the init evaluation.
-        self.provider = provider or config.ols_config.default_provider
-        self.model = model or config.ols_config.default_model
-        self.llm_params = llm_params or {}
+        self.provider: str = provider or config.ols_config.default_provider
+        self.model: str = model or config.ols_config.default_model
+        self.llm_params: dict = llm_params or {}
         self.llm_loader = llm_loader or load_llm


### PR DESCRIPTION
## Description

Explicit model and provider types to avoid the need to explicitly checks for `None`/`not None`
In the derived classes, those two attributes are used as non-None strings, but linters are not able to infer the type properly.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
