### PR TITLE
OLS-302: Atomic insert-or-append for one process

### DIFF
--- a/ols/src/cache/redis_cache.py
+++ b/ols/src/cache/redis_cache.py
@@ -104,8 +104,8 @@ class RedisCache(Cache):
         """
         key = super().construct_key(user_id, conversation_id)
 
-        old_value = self.get(user_id, conversation_id)
         with self._lock:
+            old_value = self.get(user_id, conversation_id)
             if old_value:
                 old_value.extend(value)
                 self.redis_client.set(


### PR DESCRIPTION
## Description

- Atomic insert-or-append for one process
- Don't compute key two times
- (for multiprocess atomicity we'll implement optimistic locking in separate PR)

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-302](https://issues.redhat.com//browse/OLS-302)
