### PR TITLE
OLS-353: Use keywords for query validation

### DIFF
--- a/examples/olsconfig.yaml
+++ b/examples/olsconfig.yaml
@@ -49,6 +49,7 @@ ols_config:
   #   - name: bar_filter
   #     pattern: '\b(?:bar)\b'
   #     replace_with: "openshift"
+  query_validation_method: llm
   authentication_config:
     k8s_cluster_api: "https://api.example.com:6443"
     k8s_ca_cert_path: "/Users/home/ca.crt"
@@ -64,6 +65,5 @@ dev_config:
   enable_dev_ui: true
   # llm_params:
   #   temperature_override: 0
-  # disable_question_validation: false
   # disable_auth: false
   # k8s_auth_token: optional_token_when_no_available_kube_config

--- a/examples/openshift-lightspeed-tls.yaml
+++ b/examples/openshift-lightspeed-tls.yaml
@@ -146,7 +146,6 @@ data:
     dev_config:
       enable_dev_ui: true
       # llm_temperature_override: 0
-      # disable_question_validation: false
       disable_auth: true
 immutable: false
 kind: ConfigMap

--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -18,6 +18,7 @@ from ols.src.query_helpers.docs_summarizer import DocsSummarizer
 from ols.src.query_helpers.question_validator import QuestionValidator
 from ols.utils import config, suid
 from ols.utils.auth_dependency import auth_dependency
+from ols.utils.keywords import KEYWORDS
 
 logger = logging.getLogger(__name__)
 
@@ -206,8 +207,8 @@ def redact_query(conversation_id: str, llm_request: LLMRequest) -> LLMRequest:
         )
 
 
-def validate_question(conversation_id: str, llm_request: LLMRequest) -> str:
-    """Validate user question, raise HTTPException in case of any problem."""
+def _validate_question_llm(conversation_id: str, llm_request: LLMRequest) -> str:
+    """Validate user question using llm, raise HTTPException in case of any problem."""
     # Validate the query
     try:
         question_validator = QuestionValidator(
@@ -229,6 +230,43 @@ def validate_question(conversation_id: str, llm_request: LLMRequest) -> str:
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Error while validating question",
         )
+
+
+def _validate_question_keyword(query: str) -> str:
+    """Validate user question using keyword."""
+    # Current implementation is without any tokenizer method, lemmatization/n-grams.
+    # Add valid keywords to keywords.txt file.
+    query_temp = query.lower()
+    for kw in KEYWORDS:
+        if kw in query_temp:
+            return constants.SUBJECT_VALID
+    # query_temp = {q_word.lower().strip(".?,") for q_word in query.split()}
+    # common_words = config.keywords.intersection(query_temp)
+    # if len(common_words) > 0:
+    #     return constants.SUBJECT_VALID
+
+    logger.debug(f"No matching keyword found for query: {query}")
+    return constants.SUBJECT_INVALID
+
+
+def validate_question(conversation_id: str, llm_request: LLMRequest) -> str:
+    """Validate user question."""
+    match config.ols_config.query_validation_method:
+
+        case constants.QueryValidationMethod.DISABLED:
+            logger.debug(
+                f"{conversation_id} Question validation is disabled. "
+                f"Treating question as valid."
+            )
+            return constants.SUBJECT_VALID
+
+        case constants.QueryValidationMethod.KEYWORD:
+            logger.debug("Keyword based query validation.")
+            return _validate_question_keyword(llm_request.query)
+
+        case _:
+            logger.debug("LLM based query validation.")
+            return _validate_question_llm(conversation_id, llm_request)
 
 
 def generate_bare_response(conversation_id: str, llm_request: LLMRequest) -> str:

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -3,12 +3,25 @@
 # ruff: noqa: E501
 """Constants used in business logic."""
 
+from enum import StrEnum
+
+
+class QueryValidationMethod(StrEnum):
+    """Possible options for query validation method."""
+
+    KEYWORD = "keyword"
+    LLM = "llm"
+    DISABLED = "disabled"
+
+
 SUBJECT_VALID = "SUBJECT_VALID"
 SUBJECT_INVALID = "SUBJECT_INVALID"
 POSSIBLE_QUESTION_VALIDATOR_RESPONSES = (
     SUBJECT_VALID,
     SUBJECT_INVALID,
 )
+
+KEYWORDS_FILE_PATH = "ols/data_assets/keywords.txt"
 
 # Default responses
 INVALID_QUERY_RESP = (

--- a/ols/src/query_helpers/question_validator.py
+++ b/ols/src/query_helpers/question_validator.py
@@ -9,7 +9,6 @@ from langchain.prompts import PromptTemplate
 from ols import constants
 from ols.app.metrics import TokenMetricUpdater
 from ols.src.query_helpers.query_helper import QueryHelper
-from ols.utils import config
 
 logger = logging.getLogger(__name__)
 
@@ -38,13 +37,6 @@ class QuestionValidator(QueryHelper):
         Returns:
             One-word response.
         """
-        if config.dev_config.disable_question_validation:
-            logger.debug(
-                f"{conversation_id} Question validation is disabled. "
-                f"Treating question as [valid,generic]."
-            )
-            return constants.SUBJECT_VALID
-
         settings_string = (
             f"conversation_id: {conversation_id}, "
             f"query: {query}, "
@@ -82,7 +74,7 @@ class QuestionValidator(QueryHelper):
 
         logger.info(f"{conversation_id} response: {clean_response}")
 
-        # Will return list with one of the following:
+        # Will return one of the following string:
         # SUBJECT_VALID
         # SUBJECT_INVALID
         return clean_response

--- a/ols/utils/keywords.py
+++ b/ols/utils/keywords.py
@@ -1,0 +1,48 @@
+"""Constant for set of keywords."""
+
+# Add keyword string to below set, preferably in alphabetical order.
+# We are adding this manually for now. Add to a txt file, If/when we automate this.
+# Important: Please use lower case.
+
+KEYWORDS = {
+    "alert",
+    "autoscale",
+    "cluster",
+    "config",
+    "configmap",
+    "console",
+    "container",
+    "crd",
+    "deploy",
+    "deployment",
+    "image",
+    "imagepullpolicy",
+    "imagepullsecret",
+    "infra",
+    "ingress",
+    "k8s",
+    "kubernetes",
+    "log",
+    "master",
+    "namespace",
+    "network",
+    "node",
+    "oc",
+    "ocp",
+    "openshift",
+    "operator",
+    "pod",
+    "podconfig",
+    "poddisruptionbudgets",
+    "podsecurity",
+    "policy",
+    "project",
+    "quay",
+    "replica",
+    "replicaset",
+    "secret",
+    "service",
+    "virtualization",
+    "worker",
+    "yaml",
+}

--- a/tests/integration/test_liveness_readiness.py
+++ b/tests/integration/test_liveness_readiness.py
@@ -3,12 +3,14 @@
 import os
 from unittest.mock import patch
 
+import pytest
 import requests
 from fastapi.testclient import TestClient
 
 
 # we need to patch the config file path to point to the test
 # config file before we import anything from main.py
+@pytest.fixture(scope="module")
 @patch.dict(os.environ, {"OLS_CONFIG_FILE": "tests/config/valid_config.yaml"})
 def setup():
     """Setups the test client."""
@@ -18,28 +20,28 @@ def setup():
     client = TestClient(app)
 
 
-def test_liveness():
+def test_liveness(setup):
     """Test handler for /liveness REST API endpoint."""
     response = client.get("/liveness")
     assert response.status_code == requests.codes.ok
     assert response.json() == {"status": {"status": "healthy"}}
 
 
-def test_readiness():
+def test_readiness(setup):
     """Test handler for /readiness REST API endpoint."""
     response = client.get("/readiness")
     assert response.status_code == requests.codes.ok
     assert response.json() == {"status": {"status": "healthy"}}
 
 
-def test_liveness_head_http_method() -> None:
+def test_liveness_head_http_method(setup) -> None:
     """Test handler for /liveness REST API endpoint when HEAD HTTP method is used."""
     response = client.head("/liveness")
     assert response.status_code == requests.codes.ok
     assert response.text == ""
 
 
-def test_readiness_head_http_method() -> None:
+def test_readiness_head_http_method(setup) -> None:
     """Test handler for /readiness REST API endpoint when HEAD HTTP method is used."""
     response = client.head("/readiness")
     assert response.status_code == requests.codes.ok

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -4,12 +4,14 @@ import os
 import re
 from unittest.mock import patch
 
+import pytest
 import requests
 from fastapi.testclient import TestClient
 
 
 # we need to patch the config file path to point to the test
 # config file before we import anything from main.py
+@pytest.fixture(scope="module")
 @patch.dict(os.environ, {"OLS_CONFIG_FILE": "tests/config/valid_config.yaml"})
 def setup():
     """Setups the test client."""
@@ -32,7 +34,7 @@ def retrieve_metrics(client):
     return response.text
 
 
-def test_metrics():
+def test_metrics(setup):
     """Check if service provides metrics endpoint with some expected counters."""
     response_text = retrieve_metrics(client)
 
@@ -73,7 +75,7 @@ def get_counter_value(client, counter_name, path, status_code):
     raise Exception(f"Counter {counter_name} was not found in metrics")
 
 
-def test_rest_api_call_counter_ok_status():
+def test_rest_api_call_counter_ok_status(setup):
     """Check if REST API call counter works as expected, label with 200 OK status."""
     endpoint = "/readiness"
 
@@ -89,7 +91,7 @@ def test_rest_api_call_counter_ok_status():
     assert new == old + 1, "Counter has not been updated properly"
 
 
-def test_rest_api_call_counter_not_found_status():
+def test_rest_api_call_counter_not_found_status(setup):
     """Check if REST API call counter works as expected, label with 404 NotFound status."""
     endpoint = "/this-does-not-exists"
 
@@ -106,7 +108,7 @@ def test_rest_api_call_counter_not_found_status():
     assert new == old + 1, "Counter for 404 NotFound  has not been updated properly"
 
 
-def test_metrics_duration():
+def test_metrics_duration(setup):
     """Check if service provides metrics for durations."""
     response_text = retrieve_metrics(client)
 

--- a/tests/integration/test_ols_debug.py
+++ b/tests/integration/test_ols_debug.py
@@ -3,6 +3,7 @@
 import os
 from unittest.mock import patch
 
+import pytest
 import requests
 from fastapi.testclient import TestClient
 
@@ -13,6 +14,7 @@ from tests.mock_classes.llm_loader import mock_llm_loader
 
 # we need to patch the config file path to point to the test
 # config file before we import anything from main.py
+@pytest.fixture(scope="module")
 @patch.dict(os.environ, {"OLS_CONFIG_FILE": "tests/config/valid_config.yaml"})
 def setup():
     """Setups the test client."""
@@ -26,7 +28,7 @@ def setup():
 @patch("ols.app.endpoints.ols.LLMChain", new=mock_llm_chain({"text": "test response"}))
 # during LLM init, exceptions will occur on CI, so let's mock that too
 @patch("ols.app.endpoints.ols.load_llm", new=mock_llm_loader(None))
-def test_debug_query():
+def test_debug_query(setup):
     """Check the REST API /v1/debug/query with POST HTTP method when expected payload is posted."""
     conversation_id = suid.get_suid()
     response = client.post(
@@ -47,7 +49,7 @@ def test_debug_query():
 @patch("ols.app.endpoints.ols.LLMChain", new=mock_llm_chain({"text": "test response"}))
 # during LLM init, exceptions will occur on CI, so let's mock that too
 @patch("ols.app.endpoints.ols.load_llm", new=mock_llm_loader(None))
-def test_debug_query_no_conversation_id():
+def test_debug_query_no_conversation_id(setup):
     """Check the REST API /v1/debug/query with POST HTTP method conversation ID is not provided."""
     response = client.post(
         "/v1/debug/query",
@@ -69,7 +71,7 @@ def test_debug_query_no_conversation_id():
 @patch("ols.app.endpoints.ols.LLMChain", new=mock_llm_chain({"text": "test response"}))
 # during LLM init, exceptions will occur on CI, so let's mock that too
 @patch("ols.app.endpoints.ols.load_llm", new=mock_llm_loader(None))
-def test_debug_query_no_query():
+def test_debug_query_no_query(setup):
     """Check the REST API /v1/debug/query with POST HTTP method when query is not specified."""
     conversation_id = suid.get_suid()
     response = client.post(
@@ -85,7 +87,7 @@ def test_debug_query_no_query():
 @patch("ols.app.endpoints.ols.LLMChain", new=mock_llm_chain({"text": "test response"}))
 # during LLM init, exceptions will occur on CI, so let's mock that too
 @patch("ols.app.endpoints.ols.load_llm", new=mock_llm_loader(None))
-def test_debug_query_no_payload():
+def test_debug_query_no_payload(setup):
     """Check the REST API /v1/debug/query with POST HTTP method when payload is empty."""
     response = client.post("/v1/debug/query")
 

--- a/tests/integration/test_openapi.py
+++ b/tests/integration/test_openapi.py
@@ -4,12 +4,14 @@ import json
 import os
 from unittest.mock import patch
 
+import pytest
 import requests
 from fastapi.testclient import TestClient
 
 
 # we need to patch the config file path to point to the test
 # config file before we import anything from main.py
+@pytest.fixture(scope="module")
 @patch.dict(os.environ, {"OLS_CONFIG_FILE": "tests/config/valid_config.yaml"})
 def setup():
     """Setups the test client."""
@@ -19,7 +21,7 @@ def setup():
     client = TestClient(app)
 
 
-def test_openapi_endpoint():
+def test_openapi_endpoint(setup):
     """Check if REST API provides endpoint with OpenAPI specification."""
     response = client.get("/openapi.json")
     assert response.status_code == requests.codes.ok
@@ -45,14 +47,14 @@ def test_openapi_endpoint():
         assert endpoint in paths, f"Endpoint {endpoint} is not described"
 
 
-def test_openapi_endpoint_head_method():
+def test_openapi_endpoint_head_method(setup):
     """Check if REST API allows HEAD HTTP method for endpoint with OpenAPI specification."""
     response = client.head("/openapi.json")
     assert response.status_code == requests.codes.ok
     assert response.text == ""
 
 
-def test_openapi_content():
+def test_openapi_content(setup):
     """Check if the pre-generated OpenAPI schema is up-to date."""
     # retrieve pre-generated OpenAPI schema
     with open("docs/openapi.json", "r") as fin:

--- a/tests/unit/query_helpers/test_question_validator.py
+++ b/tests/unit/query_helpers/test_question_validator.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 import pytest
 
-from ols import constants
 from ols.src.query_helpers.question_validator import QueryHelper, QuestionValidator
 from ols.utils import config
 from tests.mock_classes.llm_chain import mock_llm_chain
@@ -51,22 +50,3 @@ def test_valid_responses(question_validator):
             )
 
             assert response == retval
-
-
-def test_disabled_question_validator(question_validator):
-    """Test disabled QuestionValidator behaviour."""
-    for retval in [
-        "SUBJECT_INVALID",
-        "SUBJECT_VALID",
-    ]:
-        ml = mock_llm_chain({"text": retval})
-        conversation_id = "01234567-89ab-cdef-0123-456789abcdef"
-        # disable question validator
-        config.dev_config.disable_question_validation = True
-
-        with patch("ols.src.query_helpers.question_validator.LLMChain", new=ml):
-            response = question_validator.validate_question(
-                conversation_id=conversation_id, query="What is the meaning of life?"
-            )
-
-            assert response == constants.SUBJECT_VALID

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -496,7 +496,6 @@ ols_config:
       max_entries: 1000
 dev_config:
   enable_dev_ui: true
-  disable_question_validation: false
   disable_auth: false
 
 """,
@@ -524,7 +523,6 @@ ols_config:
 dev_config:
   llm_temperature_override: 0.1
   enable_dev_ui: true
-  disable_question_validation: false
   disable_auth: false
 
 """,
@@ -552,7 +550,6 @@ ols_config:
 dev_config:
   temperature_override: 0.1
   enable_dev_ui: true
-  disable_question_validation: false
   disable_auth: false
 
 """,
@@ -579,7 +576,6 @@ ols_config:
       max_entries: 1000
 dev_config:
   enable_dev_ui: true
-  disable_question_validation: false
   disable_auth: false
 
 """,
@@ -606,7 +602,6 @@ ols_config:
       max_entries: 1000
 dev_config:
   enable_dev_ui: true
-  disable_question_validation: false
   disable_auth: false
 
 """,
@@ -638,7 +633,6 @@ ols_config:
 dev_config:
   llm_temperature_override: 0.1
   enable_dev_ui: true
-  disable_question_validation: false
   disable_auth: false
   disable_tls: true
 
@@ -685,7 +679,6 @@ ols_config:
   default_model: m1
 dev_config:
   enable_dev_ui: true
-  disable_question_validation: false
   disable_auth: false
   disable_tls: true
   llm_params:


### PR DESCRIPTION
## Description

Load keywords from a text file.
Validate query based on basic keyword matching.
Config option to use either keyword or llm based query validation.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-353](https://issues.redhat.com//browse/OLS-353)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
