### PR TITLE
OLS-365 switch metrics endpoint to FastAPI

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -211,6 +211,26 @@
                     }
                 }
             }
+        },
+        "/metrics/": {
+            "get": {
+                "tags": [
+                    "metrics"
+                ],
+                "summary": "Get Metrics",
+                "description": "Metrics Endpoint.\n\nArgs:\n    auth: The Authentication handler (FastAPI Depends) that will handle authentication Logic.\n\nReturns:\n    Response containing the latest metrics.",
+                "operationId": "get_metrics_metrics__get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {

--- a/ols/app/metrics/__init__.py
+++ b/ols/app/metrics/__init__.py
@@ -6,7 +6,6 @@ from .metrics import (
     llm_calls_validation_errors_total,
     llm_token_received_total,
     llm_token_sent_total,
-    metrics_app,
     response_duration_seconds,
     rest_api_calls_total,
     selected_model,

--- a/ols/app/metrics/metrics.py
+++ b/ols/app/metrics/metrics.py
@@ -1,6 +1,19 @@
 """Prometheus metrics that are exposed by REST API."""
 
-from prometheus_client import Counter, Histogram, Info, make_asgi_app
+from typing import Any
+
+from fastapi import APIRouter, Depends, Response
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    Counter,
+    Histogram,
+    Info,
+    generate_latest,
+)
+
+from ols.utils.auth_dependency import auth_dependency
+
+router = APIRouter(tags=["metrics"])
 
 rest_api_calls_total = Counter(
     "rest_api_calls_total", "REST API calls counter", ["path", "status_code"]
@@ -28,5 +41,15 @@ llm_token_received_total = Counter(
 selected_provider = Info("selected_provider", "Selected provider")
 selected_model = Info("selected_model", "Selected model")
 
-# register metric
-metrics_app = make_asgi_app()
+
+@router.get("/metrics/")
+def get_metrics(auth: Any = Depends(auth_dependency)) -> Response:
+    """Metrics Endpoint.
+
+    Args:
+        auth: The Authentication handler (FastAPI Depends) that will handle authentication Logic.
+
+    Returns:
+        Response containing the latest metrics.
+    """
+    return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/ols/app/routers.py
+++ b/ols/app/routers.py
@@ -2,8 +2,8 @@
 
 from fastapi import FastAPI
 
-from ols.app import metrics
 from ols.app.endpoints import feedback, health, ols
+from ols.app.metrics import metrics
 
 
 def include_routers(app: FastAPI) -> None:
@@ -15,4 +15,4 @@ def include_routers(app: FastAPI) -> None:
     app.include_router(ols.router, prefix="/v1")
     app.include_router(feedback.router, prefix="/v1")
     app.include_router(health.router)
-    app.mount("/metrics", metrics.metrics_app)
+    app.include_router(metrics.router)


### PR DESCRIPTION
## Description

Switch the handling of Metrics endpoint from ASGI to FastAPI, so we can reuse the auth_dependency in that endpoint as is.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
