### PR TITLE
OLS-302: Redis tests as part of integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test-unit: ## Run the unit tests
 test-integration: ## Run integration tests tests
 	@echo "Running integration tests..."
 	@echo "Reports will be written to ${ARTIFACT_DIR}"
-	COVERAGE_FILE="${ARTIFACT_DIR}/.coverage.integration" python -m pytest tests/integration --cov=ols --cov-report term-missing --cov-report "json:${ARTIFACT_DIR}/coverage_integration.json" --junit-xml="${ARTIFACT_DIR}/junit_integration.xml" --cov-fail-under=60
+	COVERAGE_FILE="${ARTIFACT_DIR}/.coverage.integration" python -m pytest -m 'not redis' tests/integration --cov=ols --cov-report term-missing --cov-report "json:${ARTIFACT_DIR}/coverage_integration.json" --junit-xml="${ARTIFACT_DIR}/junit_integration.xml" --cov-fail-under=60
 	python scripts/transform_coverage_report.py "${ARTIFACT_DIR}/coverage_integration.json" "${ARTIFACT_DIR}/coverage_integration.out"
 	scripts/codecov.sh "${ARTIFACT_DIR}/coverage_integration.out"
 

--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -3,3 +3,5 @@ log_cli=false
 filterwarnings = 
 	ignore::DeprecationWarning
 junit_logging=system-out
+markers =
+	redis

--- a/tests/integration/test_redis.py
+++ b/tests/integration/test_redis.py
@@ -1,0 +1,69 @@
+"""Integration tests for real Redis behaviour."""
+
+import pytest
+from langchain.schema import AIMessage, HumanMessage
+
+from ols.app.models.config import RedisConfig
+from ols.src.cache.redis_cache import RedisCache
+
+user_id = "00000000-0000-0000-0000-000000000001"
+conversation_id = "00000000-0000-0000-0000-000000000002"
+
+
+@pytest.mark.redis
+def setup():
+    """Setups the Redis client."""
+    global redis_cache
+
+    # please note that the setup expect Redis running locally on default port
+    redis_config = RedisConfig(
+        {
+            "host": "localhost",
+            "port": 6379,
+            "max_memory": "100mb",
+            "max_memory_policy": "allkeys-lru",
+            "retry_on_error": "false",
+            "retry_on_timeout": "false",
+        }
+    )
+
+    redis_cache = RedisCache(redis_config)
+
+
+@pytest.mark.redis
+def test_conversation_in_redis():
+    """Check the elementary GET operation and insert_or_append operation."""
+    # make sure the cache is empty
+    redis_cache.redis_client.delete(user_id + ":" + conversation_id)
+
+    # the initial value should be empty
+    retrieved = redis_cache.get(user_id, conversation_id)
+    assert retrieved is None
+
+    # insert some conversation
+    conversation = [
+        HumanMessage(content="First human message"),
+        AIMessage(content="First AI response"),
+    ]
+    redis_cache.insert_or_append(user_id, conversation_id, conversation)
+
+    # check what is stored in conversation cache
+    retrieved = redis_cache.get(user_id, conversation_id)
+    assert retrieved is not None
+
+    # just the initial conversation should be stored
+    assert retrieved == conversation
+
+    # append more conversation
+    conversation2 = [
+        HumanMessage(content="Second human message"),
+        AIMessage(content="Second AI response"),
+    ]
+    redis_cache.insert_or_append(user_id, conversation_id, conversation2)
+
+    # check what is stored in conversation cache
+    retrieved = redis_cache.get(user_id, conversation_id)
+    assert retrieved is not None
+
+    # now both conversations should be stored
+    assert retrieved == conversation + conversation2


### PR DESCRIPTION
## Description

Redis tests as part of integration tests
(now not enabled as it needs changes in integration tests setup)

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Integration tests

## Related Tickets & Documents

- Related Issue #[OLS-302](https://issues.redhat.com//browse/OLS-302)
