### PR TITLE
Don't need to import from typing extensions

### DIFF
--- a/ols/app/main.py
+++ b/ols/app/main.py
@@ -2,8 +2,8 @@
 
 import logging
 import os
+from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import Awaitable, Callable
 
 from fastapi import FastAPI, Request, Response
 

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -3,11 +3,10 @@
 import logging
 import os
 import re
-from typing import Optional
+from typing import Optional, Self
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, DirectoryPath, model_validator
-from typing_extensions import Self
 
 from ols import constants
 

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -1,9 +1,8 @@
 """Data models representing payloads for REST API calls."""
 
-from typing import Optional
+from typing import Optional, Self
 
 from pydantic import BaseModel, model_validator
-from typing_extensions import Self
 
 
 class LLMRequest(BaseModel):

--- a/ols/src/llms/providers/registry.py
+++ b/ols/src/llms/providers/registry.py
@@ -1,7 +1,8 @@
 """LLM providers registry."""
 
 import logging
-from typing import Callable, ClassVar
+from collections.abc import Callable
+from typing import ClassVar
 
 from ols.src.llms.providers.provider import LLMProvider
 

--- a/ols/src/query_helpers/query_helper.py
+++ b/ols/src/query_helpers/query_helper.py
@@ -1,7 +1,8 @@
 """Base class for query helpers."""
 
 import logging
-from typing import Callable, Optional
+from collections.abc import Callable
+from typing import Optional
 
 from langchain.llms.base import LLM
 


### PR DESCRIPTION
## Description

Don't need to import from typing extensions
Now types are part of `typing` and some also `collections.abc`

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library