### PR TITLE
Deletes the old/badly named ols service definition.

### DIFF
--- a/examples/openshift-lightspeed-tls.yaml
+++ b/examples/openshift-lightspeed-tls.yaml
@@ -103,34 +103,6 @@ spec:
     deployment: lightspeed-w-rag
   sessionAffinity: None
   type: ClusterIP
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: openshift-lightspeed
-    app.kubernetes.io/component: lightspeed-w-rag
-    app.kubernetes.io/instance: lightspeed-w-rag
-    app.kubernetes.io/name: lightspeed-w-rag
-    app.kubernetes.io/part-of: lightspeed-w-rag-app
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: lightspeed-certs-old
-  name: lightspeed-w-rag
-spec:
-  internalTrafficPolicy: Cluster
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
-  ports:
-  - name: 8443-tcp
-    port: 8443
-    protocol: TCP
-    targetPort: 8443
-  selector:
-    app: openshift-lightspeed
-    deployment: lightspeed-w-rag
-  sessionAffinity: None
-  type: ClusterIP
 
 #---
 #apiVersion: route.openshift.io/v1
@@ -151,7 +123,7 @@ spec:
 #    termination: edge
 #  to:
 #    kind: Service
-#    name: lightspeed-w-rag
+#    name: lightspeed-app-server
 #    weight: 100
 #  wildcardPolicy: None
 


### PR DESCRIPTION
Note: https://github.com/openshift/lightspeed-console/pull/51 must merge first.



## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.