### PR TITLE
Remove trailing slash for metrics route

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ curl 'http://127.0.0.1:8080/openapi.json' | jq .
 Service exposes metrics in Prometheus format on `/metrics` endpoint. Scraping them is straightforward:
 
 ```sh
-curl 'http://127.0.0.1:8080/metrics/'
+curl 'http://127.0.0.1:8080/metrics'
 ```
 
 ### Gradio UI

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -212,14 +212,14 @@
                 }
             }
         },
-        "/metrics/": {
+        "/metrics": {
             "get": {
                 "tags": [
                     "metrics"
                 ],
                 "summary": "Get Metrics",
                 "description": "Metrics Endpoint.\n\nArgs:\n    auth: The Authentication handler (FastAPI Depends) that will handle authentication Logic.\n\nReturns:\n    Response containing the latest metrics.",
-                "operationId": "get_metrics_metrics__get",
+                "operationId": "get_metrics_metrics_get",
                 "responses": {
                     "200": {
                         "description": "Successful Response",

--- a/ols/app/main.py
+++ b/ols/app/main.py
@@ -47,7 +47,7 @@ async def rest_api_counter(
         response = await call_next(request)
 
     # ignore /metrics endpoint that will be called periodically
-    if not path.endswith("/metrics/"):
+    if not path.endswith("/metrics"):
         # just update metrics
         metrics.rest_api_calls_total.labels(path, response.status_code).inc()
     return response

--- a/ols/app/metrics/metrics.py
+++ b/ols/app/metrics/metrics.py
@@ -42,7 +42,7 @@ selected_provider = Info("selected_provider", "Selected provider")
 selected_model = Info("selected_model", "Selected model")
 
 
-@router.get("/metrics/")
+@router.get("/metrics")
 def get_metrics(auth: Any = Depends(auth_dependency)) -> Response:
     """Metrics Endpoint.
 

--- a/scripts/generate_openapi_schema.py
+++ b/scripts/generate_openapi_schema.py
@@ -11,7 +11,12 @@ from fastapi.openapi.utils import get_openapi
 sys.path.append(
     os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
 )
-from ols.app.main import app
+
+from ols.utils import config
+
+config.init_empty_config()
+
+from ols.app.main import app  # noqa: E402
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -26,9 +26,9 @@ LLM_REST_API_TIMEOUT = 90
 
 def read_metrics(client):
     """Read all metrics using REST API call."""
-    response = client.get("/metrics/", timeout=BASIC_ENDPOINTS_TIMEOUT)
+    response = client.get("/metrics", timeout=BASIC_ENDPOINTS_TIMEOUT)
 
-    # check that the /metrics/ endpoint is correct and we got
+    # check that the /metrics endpoint is correct and we got
     # some response
     assert response.status_code == requests.codes.ok
     assert response.text is not None
@@ -541,7 +541,7 @@ def test_conversation_history() -> None:
 
 def test_metrics() -> None:
     """Check if service provides metrics endpoint with expected metrics."""
-    response = client.get("/metrics/", timeout=BASIC_ENDPOINTS_TIMEOUT)
+    response = client.get("/metrics", timeout=BASIC_ENDPOINTS_TIMEOUT)
     assert response.status_code == requests.codes.ok
     assert response.text is not None
 
@@ -560,8 +560,8 @@ def test_metrics() -> None:
         assert f"{expected_counter} " in response.text
 
     # check the duration histogram presence
-    assert 'response_duration_seconds_count{path="/metrics/"}' in response.text
-    assert 'response_duration_seconds_sum{path="/metrics/"}' in response.text
+    assert 'response_duration_seconds_count{path="/metrics"}' in response.text
+    assert 'response_duration_seconds_sum{path="/metrics"}' in response.text
 
 
 @pytest.mark.cluster

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -21,9 +21,9 @@ def setup():
 
 def retrieve_metrics(client):
     """Retrieve all service metrics."""
-    response = client.get("/metrics/")
+    response = client.get("/metrics")
 
-    # check that the /metrics/ endpoint is correct and we got
+    # check that the /metrics endpoint is correct and we got
     # some response
     assert response.status_code == requests.codes.ok
     assert response.text is not None
@@ -113,16 +113,16 @@ def test_metrics_duration():
     # duration histograms are expected to be part of metrics
 
     # first: check summary and statistic
-    assert 'response_duration_seconds_count{path="/metrics/"}' in response_text
-    assert 'response_duration_seconds_sum{path="/metrics/"}' in response_text
+    assert 'response_duration_seconds_count{path="/metrics"}' in response_text
+    assert 'response_duration_seconds_sum{path="/metrics"}' in response_text
 
     # second: check the histogram itself
     pattern = re.compile(
-        r"response_duration_seconds_bucket{le=\"0\.[0-9]+\",path=\"\/metrics\/\"}"
+        r"response_duration_seconds_bucket{le=\"0\.[0-9]+\",path=\"\/metrics\"}"
     )
     # re.findall() returns empty list if not found, and this empty list is treated as False
     assert re.findall(pattern, response_text)
     pattern = re.compile(
-        r"response_duration_seconds_bucket{le=\"\+Inf\",path=\"\/metrics\/\"}"
+        r"response_duration_seconds_bucket{le=\"\+Inf\",path=\"\/metrics\"}"
     )
     assert re.findall(pattern, response_text)


### PR DESCRIPTION
## Description

Change the metrics route from `/metrics/` to `/metrics`. 
`/metrics` is the conventional path to scrape metrics, moreover, there is no child path under `/metrics`
This PR follows the PR #601 

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
