### PR TITLE
Fix: cannot raise literal

### DIFF
--- a/scripts/questions_gen.py
+++ b/scripts/questions_gen.py
@@ -347,7 +347,7 @@ async def main():
     dir_list = dirs_all_files(question_folder)
 
     if len(dir_list) == 0:
-        raise "couldn't find dirs in questions folder"
+        raise Exception("couldn't find dirs in questions folder")
 
     print("*** starting question iteration ")
 


### PR DESCRIPTION
## Description

TL;DR; `raise` must be followed by an exception instance or an exception class,
and exceptions must be instances of `BaseException` or a subclass thereof.
Raising a literal will raise a `TypeError` at runtime.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
