### PR TITLE
OLS-417: add support for authorization groups and fine-grained permissions

### DIFF
--- a/examples/openshift-lightspeed-tls.yaml
+++ b/examples/openshift-lightspeed-tls.yaml
@@ -42,6 +42,18 @@ rules:
   verbs:
     - "get"
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ols-metrics-user
+  labels:
+    app: ols
+rules:
+- nonResourceURLs:
+    - "/ols-metrics-access"
+  verbs:
+    - "get"
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/ols/app/endpoints/authorized.py
+++ b/ols/app/endpoints/authorized.py
@@ -6,10 +6,11 @@ import logging
 from fastapi import APIRouter, Request
 
 from ols.app.models.models import AuthorizationResponse
-from ols.utils.auth_dependency import auth_dependency
+from ols.utils.auth_dependency import AuthDependency
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["authorized"])
+auth_dependency = AuthDependency(virtual_path="/ols-access")
 
 
 @router.post("/authorized")

--- a/ols/app/endpoints/feedback.py
+++ b/ols/app/endpoints/feedback.py
@@ -14,11 +14,12 @@ from ols.app.models.models import (
     StatusResponse,
 )
 from ols.utils import config
-from ols.utils.auth_dependency import auth_dependency
+from ols.utils.auth_dependency import AuthDependency
 from ols.utils.suid import get_suid
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/feedback", tags=["feedback"])
+auth_dependency = AuthDependency(virtual_path="/ols-access")
 
 
 async def ensure_feedback_enabled(request: Request) -> None:

--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -17,12 +17,13 @@ from ols.src.query_helpers.chat_history import ChatHistory
 from ols.src.query_helpers.docs_summarizer import DocsSummarizer
 from ols.src.query_helpers.question_validator import QuestionValidator
 from ols.utils import config, suid
-from ols.utils.auth_dependency import auth_dependency
+from ols.utils.auth_dependency import AuthDependency
 from ols.utils.keywords import KEYWORDS
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["query"])
+auth_dependency = AuthDependency(virtual_path="/ols-access")
 
 
 @router.post("/query")

--- a/ols/app/metrics/metrics.py
+++ b/ols/app/metrics/metrics.py
@@ -13,9 +13,10 @@ from prometheus_client import (
 )
 
 import ols.app.models.config as config_model
-from ols.utils.auth_dependency import auth_dependency
+from ols.utils.auth_dependency import AuthDependency
 
 router = APIRouter(tags=["metrics"])
+auth_dependency = AuthDependency(virtual_path="/ols-metrics-access")
 
 rest_api_calls_total = Counter(
     "rest_api_calls_total", "REST API calls counter", ["path", "status_code"]

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -202,3 +202,5 @@ DEFAULT_RESPONSE_TOKEN_LIMIT = 500
 # default indentity for local testing and deployment
 DEFAULT_USER_UID = "c1143120-551e-4a47-ad47-2748d6f3c81c"
 DEFAULT_USER_NAME = "OLS"
+# TO-DO: make this UUID dynamic per cluster (dynamic uuid for each cluster)
+DEFAULT_KUBEADMIN_UID = "b6553200-0f7b-4c82-b1c5-9303ff18e5f0"

--- a/tests/config/cluster_install/ols_manifests.yaml
+++ b/tests/config/cluster_install/ols_manifests.yaml
@@ -155,3 +155,15 @@ rules:
     - "/ols-access"
   verbs:
     - "get"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ols-metrics-user
+  labels:
+    app: ols
+rules:
+- nonResourceURLs:
+    - "/ols-metrics-access"
+  verbs:
+    - "get"

--- a/tests/mock_classes/mock_k8s_api.py
+++ b/tests/mock_classes/mock_k8s_api.py
@@ -7,9 +7,13 @@ class MockK8sResponse:
     This class is designed to mock Kubernetes API responses for testing purposes.
     """
 
-    def __init__(self, authenticated=None, allowed=None, username=None, uid=None):
+    def __init__(
+        self, authenticated=None, allowed=None, username=None, uid=None, groups=None
+    ):
         """Init function."""
-        self.status = MockK8sResponseStatus(authenticated, allowed, username, uid)
+        self.status = MockK8sResponseStatus(
+            authenticated, allowed, username, uid, groups
+        )
 
 
 class MockK8sUser:
@@ -18,10 +22,11 @@ class MockK8sUser:
     Represents a user in the mocked Kubernetes environment.
     """
 
-    def __init__(self, username=None, uid=None):
+    def __init__(self, username=None, uid=None, groups=None):
         """Init function."""
         self.username = username
         self.uid = uid
+        self.groups = groups
 
 
 class MockK8sResponseStatus:
@@ -32,12 +37,12 @@ class MockK8sResponseStatus:
     and user information if authenticated.
     """
 
-    def __init__(self, authenticated, allowed, username=None, uid=None):
+    def __init__(self, authenticated, allowed, username=None, uid=None, groups=None):
         """Init function."""
         self.authenticated = authenticated
         self.allowed = allowed
         if authenticated:
-            self.user = MockK8sUser(username, uid)
+            self.user = MockK8sUser(username, uid, groups)
         else:
             self.user = None
 
@@ -55,7 +60,9 @@ def mock_token_review_response(token_review):
         A MockK8sResponse object with authentication status and user details.
     """
     if token_review.spec.token == "valid-token":  # noqa: S105
-        return MockK8sResponse(True, username="valid-user", uid="valid-uid")
+        return MockK8sResponse(
+            True, username="valid-user", uid="valid-uid", groups=["ols-group"]
+        )
     else:
         return MockK8sResponse(False)
 

--- a/tests/scripts/utils.sh
+++ b/tests/scripts/utils.sh
@@ -79,6 +79,7 @@ function install_ols() {
 
     # determine the hostname for the ols route
     export OLS_URL=https://$(oc get route ols -o jsonpath='{.spec.host}')
+
 }
 
 # $1 suite id

--- a/tests/unit/utils/test_auth_dependency.py
+++ b/tests/unit/utils/test_auth_dependency.py
@@ -5,11 +5,10 @@ from unittest.mock import patch
 
 import pytest
 from fastapi import HTTPException, Request
-from fastapi.testclient import TestClient
 from kubernetes.client import AuthenticationV1Api, AuthorizationV1Api
 
 from ols.utils import config
-from ols.utils.auth_dependency import auth_dependency
+from ols.utils.auth_dependency import AuthDependency
 from tests.mock_classes.mock_k8s_api import (
     mock_subject_access_review_response,
     mock_token_review_response,
@@ -19,11 +18,10 @@ from tests.mock_classes.mock_k8s_api import (
 @patch.dict(os.environ, {"OLS_CONFIG_FILE": "tests/config/auth_config.yaml"})
 def setup():
     """Setups and load config."""
-    global client
+    global auth_dependency
     config.init_config("tests/config/auth_config.yaml")
-    from ols.app.main import app
 
-    client = TestClient(app)
+    auth_dependency = AuthDependency(virtual_path="/ols-access")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Refactor Authorization to include the following 2 features:
1) include Groups in the SAR Request:
this will allow roles assigned to groups that a user belongs to , to take effect in addition to the user directly assigned roles

2) fine-grained permissions support:
this will allow us to customize the dependency for each endpoint separately, where we now require diffrent permissions to access Metrics compared to the regular OLS endpoints

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
