### PR TITLE
OLS-437: Expose model and provider metrics

### DIFF
--- a/ols/app/main.py
+++ b/ols/app/main.py
@@ -29,10 +29,10 @@ else:
         "in the `dev_config` section of the configuration file."
     )
 
+
 # update provider and model as soon as possible so the metrics will be visible
 # even for first scraping
-metrics.selected_provider.info({"name": config.ols_config.default_provider})
-metrics.selected_model.info({"name": config.ols_config.default_model})
+metrics.setup_model_metrics(config)
 
 
 @app.middleware("")

--- a/ols/app/metrics/__init__.py
+++ b/ols/app/metrics/__init__.py
@@ -10,6 +10,7 @@ from .metrics import (
     rest_api_calls_total,
     selected_model,
     selected_provider,
+    setup_model_metrics,
 )
 from .token_counter import GenericTokenCounter, TokenMetricUpdater
 
@@ -26,4 +27,5 @@ __all__ = [
     "rest_api_calls_total",
     "selected_model",
     "selected_provider",
+    "setup_model_metrics",
 ]

--- a/tests/config/valid_config.yaml
+++ b/tests/config/valid_config.yaml
@@ -13,7 +13,7 @@ llm_providers:
       - name: m2
         url: "https://murl2"
   - name: p2
-    type: bam
+    type: openai
     url: "https://url2"
     models:
       - name: m1

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -590,6 +590,9 @@ def test_metrics() -> None:
         "llm_validation_errors_total",
         "llm_token_sent_total",
         "llm_token_received_total",
+        "selected_model_info",
+        "selected_provider_info",
+        "model_enabled",
     )
 
     # check if all counters are present

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -48,6 +48,7 @@ def test_metrics(setup):
         "llm_token_received_total",
         "selected_provider_info",
         "selected_model_info",
+        "model_enabled",
     )
 
     # check if all counters are present
@@ -128,3 +129,14 @@ def test_metrics_duration(setup):
         r"response_duration_seconds_bucket{le=\"\+Inf\",path=\"\/metrics\"}"
     )
     assert re.findall(pattern, response_text)
+
+
+def test_model_enabled_metrics(setup):
+    """Check if model_enabled metrics shows the expected information."""
+    response_text = retrieve_metrics(client)
+    for provider in ("bam", "openai"):
+        for model in ("m1", "m2"):
+            assert (
+                f'model_enabled{{model="{model}",provider="{provider}"}}'
+                in response_text
+            )

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -720,7 +720,7 @@ def test_valid_config_file():
                     },
                     {
                         "name": "p2",
-                        "type": "bam",
+                        "type": "openai",
                         "url": "https://url2",
                         "models": [
                             {


### PR DESCRIPTION
## Description

Expose model and provider metrics:

```
$ curl localhost:8080/metrics | grep provider

selected_provider_info{name="bam"} 1.0
selected_model_info{name="ibm/granite-13b-chat-v2"} 1.0
model_enabled{model="ibm/granite-13b-chat-v2",provider="bam"} 1.0
model_enabled{model="gpt-4-1106-preview",provider="openai"} 1.0
model_enabled{model="gpt-3.5-turbo",provider="openai"} 1.0

```

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-437](https://issues.redhat.com//browse/OLS-437)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
