### PR TITLE
Remove rag testing from standalone.sh execution

### DIFF
--- a/scripts/download_embeddings_model.py
+++ b/scripts/download_embeddings_model.py
@@ -20,6 +20,8 @@ if __name__ == "__main__":
 
     from huggingface_hub import snapshot_download
 
+    # override default download timeout of 10s
+    os.environ["HF_HUB_DOWNLOAD_TIMEOUT"] = "90"
     snapshot_download(
         repo_id=args.hf_repo_id, local_dir=args.local_dir, local_dir_use_symlinks=False
     )

--- a/tests/config/singleprovider.e2e.template.config.yaml
+++ b/tests/config/singleprovider.e2e.template.config.yaml
@@ -11,9 +11,6 @@ ols_config:
   user_data_collection:
     feedback_disabled: false
     feedback_storage: $FEEDBACK_STORAGE_LOCATION
-  reference_content:
-    product_docs_index_path: $RAG_INDEX_DIR
-    product_docs_index_id: ocp-product-docs-4_15
   conversation_cache:
     type: memory
     memory:

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -384,6 +384,7 @@ def test_query_call_with_improper_payload():
         assert "missing" in response.text
 
 
+@pytest.mark.rag
 def test_valid_question() -> None:
     """Check the REST API /v1/query with POST HTTP method for valid question and no yaml."""
     endpoint = "/v1/query"
@@ -448,7 +449,6 @@ def test_invalid_question_tokens_counter() -> None:
         assert response.status_code == requests.codes.ok
 
 
-@pytest.mark.standalone
 def test_token_counters_for_query_call_without_payload() -> None:
     """Check how the tokens counter are updated accordingly."""
     model, provider = get_model_and_provider(client)
@@ -473,7 +473,6 @@ def test_token_counters_for_query_call_without_payload() -> None:
         assert response.status_code == requests.codes.unprocessable_entity
 
 
-@pytest.mark.standalone
 def test_token_counters_for_query_call_with_improper_payload() -> None:
     """Check how the tokens counter are updated accordingly."""
     model, provider = get_model_and_provider(client)
@@ -536,9 +535,6 @@ def test_query_filter() -> None:
         print(vars(response))
         assert response.status_code == requests.codes.ok
         json_response = response.json()
-        assert len(json_response["referenced_documents"]) > 0
-        assert "openshift" in json_response["referenced_documents"][0]
-        assert "https://" in json_response["referenced_documents"][0]
 
         # values to be filtered and replaced are defined in:
         # tests/config/singleprovider.e2e.template.config.yaml

--- a/tests/scripts/test-e2e-standalone.sh
+++ b/tests/scripts/test-e2e-standalone.sh
@@ -33,16 +33,6 @@ TMPDIR=$(mktemp -d)
 # ARTIFACT_DIR is defined when running in a prow job
 ARTIFACT_DIR=${ARTIFACT_DIR:-$TMPDIR}
 
-# temp directory for index store
-RAG_TMP_DIR=$(mktemp -d)
-# Download index store
-RAG_INDEX="https://github.com/ilan-pinto/lightspeed-rag-documents/releases/latest/download/local.zip"
-export RAG_INDEX_DIR="$RAG_TMP_DIR/vector-db/ocp-product-docs"
-# Configure index store
-mkdir -p $RAG_INDEX_DIR
-wget $RAG_INDEX
-unzip -j local.zip -d $RAG_INDEX_DIR
-rm -f local.zip
 # configure feedback storage location
 export FEEDBACK_STORAGE_LOCATION="$ARTIFACT_DIR/insights/feedback"
 echo "Feedback storage location: $FEEDBACK_STORAGE_LOCATION"
@@ -79,7 +69,6 @@ function finish() {
     echo Exit trap: killing OLS server
     kill %1
     rm -rf "$TMPDIR"
-    rm -rf "$RAG_TMP_DIR"
 }
 trap finish EXIT
 
@@ -95,4 +84,4 @@ fi
 set -e
 
 echo Done waiting for OLS server start, running e2e
-SUITE_ID=standalone TEST_TAGS="not cluster" make test-e2e
+SUITE_ID=standalone TEST_TAGS="not cluster and not rag" make test-e2e


### PR DESCRIPTION
## Description

As we pivot to doing more testing on cluster installs, we will do less legwork to setup the standalone run.  In this case that means not worrying about providing RAG reference content to standalone testing.


## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.