### PR TITLE
OLS-363: Fix: don't pass wrong parameters to OpenAI and AzureOpenAI providers

### DIFF
--- a/ols/src/query_helpers/question_validator.py
+++ b/ols/src/query_helpers/question_validator.py
@@ -8,6 +8,7 @@ from langchain.prompts import PromptTemplate
 
 from ols import constants
 from ols.app.metrics import TokenMetricUpdater
+from ols.constants import PROVIDER_BAM, PROVIDER_WATSONX
 from ols.src.query_helpers.query_helper import QueryHelper
 
 logger = logging.getLogger(__name__)
@@ -18,10 +19,17 @@ class QuestionValidator(QueryHelper):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the QuestionValidator."""
-        llm_params = {
-            "min_new_tokens": 1,
-            "max_new_tokens": 4,
-        }
+        llm_params = {}
+        provider = kwargs.get("provider", "")
+
+        # min_new_tokens and max_new_tokens are valid just for BAM and Watsonx
+        # for OpenAI and AzureOpenAI it is not possible to set these values
+        # because validation will fail
+        if provider in (PROVIDER_BAM, PROVIDER_WATSONX):
+            llm_params = {
+                "min_new_tokens": 1,
+                "max_new_tokens": 4,
+            }
         super().__init__(*args, **dict(kwargs, llm_params=llm_params))
 
     def validate_question(

--- a/tests/unit/query_helpers/test_question_validator.py
+++ b/tests/unit/query_helpers/test_question_validator.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
+from ols.constants import PROVIDER_BAM, PROVIDER_OPENAI
 from ols.src.query_helpers.question_validator import QueryHelper, QuestionValidator
 from ols.utils import config
 from tests.mock_classes.llm_chain import mock_llm_chain
@@ -24,16 +25,23 @@ def test_is_query_helper_subclass():
 
 def test_passing_parameters():
     """Test that llm_params is handled correctly and without runtime error."""
-    question_validator = QuestionValidator()
+    question_validator = QuestionValidator(provider=PROVIDER_BAM)
     assert question_validator.llm_params is not None
-    assert "max_new_tokens" in question_validator.llm_params is not None
-    assert "min_new_tokens" in question_validator.llm_params is not None
+    # these params are valid for BAM
+    assert "max_new_tokens" in question_validator.llm_params
+    assert "min_new_tokens" in question_validator.llm_params
 
-    question_validator = QuestionValidator(llm_params={})
+    question_validator = QuestionValidator(llm_params={}, provider=PROVIDER_BAM)
     # the llm_params should be rewritten in constructor
     assert question_validator.llm_params is not None
-    assert "max_new_tokens" in question_validator.llm_params is not None
-    assert "min_new_tokens" in question_validator.llm_params is not None
+    assert "max_new_tokens" in question_validator.llm_params
+    assert "min_new_tokens" in question_validator.llm_params
+
+    question_validator = QuestionValidator(provider=PROVIDER_OPENAI)
+    assert question_validator.llm_params is not None
+    # these params are not valid for OpenAI
+    assert "max_new_tokens" not in question_validator.llm_params
+    assert "min_new_tokens" not in question_validator.llm_params
 
 
 def test_valid_responses(question_validator):


### PR DESCRIPTION
## Description

Fix: now pass wrong parameters to OpenAI and AzureOpenAI providers

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-363](https://issues.redhat.com//browse/OLS-363)
- Closes #
