### PR TITLE
OLS-338: Add docs_url metadata element while creating embedding index

### DIFF
--- a/Containerfile.rag
+++ b/Containerfile.rag
@@ -1,6 +1,6 @@
 # vim: set filetype=dockerfile
 ARG OLS_VERSION=latest
-ARG LIGHTSPEED_RAG_CONTENT_DIGEST=sha256:eb3472dd675cc79b02e4d15b53b12c9c365d6c2335a6026f55de443dd95c902f
+ARG LIGHTSPEED_RAG_CONTENT_DIGEST=sha256:d15bf56776c40a8709b0e648e3b0f043de63b24ad8f59eeea6f8d965dfcbe4e3
 
 FROM quay.io/openshift/lightspeed-rag-content@${LIGHTSPEED_RAG_CONTENT_DIGEST} as lightspeed-rag-content
 

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ schema:	## Generate OpenAPI schema file
 	python scripts/generate_openapi_schema.py docs/openapi.json
 
 get-rag: ## Download a copy of the RAG embedding model and vector database
-	podman create --replace --name tmp-rag-container quay.io/openshift/lightspeed-rag-content@sha256:eb3472dd675cc79b02e4d15b53b12c9c365d6c2335a6026f55de443dd95c902f true
+	podman create --replace --name tmp-rag-container quay.io/openshift/lightspeed-rag-content@sha256:d15bf56776c40a8709b0e648e3b0f043de63b24ad8f59eeea6f8d965dfcbe4e3 true
 	podman cp tmp-rag-container:/rag/vector_db vector_db
 	podman cp tmp-rag-container:/rag/embeddings_model embeddings_model
 	podman rm tmp-rag-container

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -175,11 +175,6 @@ GRANITE_20B_CODE_INSTRUCT_V1 = "ibm/granite-20b-code-instruct-v1"
 GPT35_TURBO_1106 = "gpt-3.5-turbo-1106"
 GPT35_TURBO = "gpt-3.5-turbo"
 
-# embeddings metadata
-EMBEDDINGS_ROOT_DIR = "/workdir/ocp-product-docs-plaintext"
-OCP_DOCS_ROOT_URL = "https://docs.openshift.com/container-platform"
-OCP_DOCS_VERSION = "4.15"
-
 # cache constants
 IN_MEMORY_CACHE = "memory"
 IN_MEMORY_CACHE_MAX_ENTRIES = 1000

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -22,22 +22,6 @@ logger = logging.getLogger(__name__)
 class DocsSummarizer(QueryHelper):
     """A class for summarizing documentation context."""
 
-    @staticmethod
-    def _file_path_to_doc_url(file_path: str) -> str:
-        """Convert file_path metadata to the corresponding URL on the OCP docs website.
-
-        Embedding node metadata 'file_path' in the form
-        file_path: /workspace/source/ocp-product-docs-plaintext/hardware_enablement/
-                    psap-node-feature-discovery-operator.txt
-        is mapped into a doc URL such as
-        https://docs.openshift.com/container-platform/4.14/hardware_enablement/
-        psap-node-feature-discovery-operator.html.
-        """
-        return (
-            constants.OCP_DOCS_ROOT_URL
-            + file_path.removeprefix(constants.EMBEDDINGS_ROOT_DIR)
-        ).removesuffix("txt") + "html"
-
     def _format_rag_data(self, rag_data: list[dict]) -> tuple[str, list[str]]:
         """Format rag text & metadata.
 
@@ -45,12 +29,12 @@ class DocsSummarizer(QueryHelper):
         Create list of metadata from rag data dictionary.
         """
         rag_text = []
-        file_path = []
+        docs_url = []
         for data in rag_data:
             rag_text.append(data["text"])
-            file_path.append(self._file_path_to_doc_url(data["file_path"]))
+            docs_url.append(data["docs_url"])
 
-        return "\n\n".join(rag_text), file_path
+        return "\n\n".join(rag_text), docs_url
 
     def _get_rag_data(
         self,

--- a/ols/utils/token_handler.py
+++ b/ols/utils/token_handler.py
@@ -105,7 +105,7 @@ class TokenHandler:
 
             context_dict["text"] = self.tokens_to_text(tokens[:available_tokens])
             # Add Metadata
-            context_dict["file_path"] = node.metadata.get("file_path", None)
+            context_dict["docs_url"] = node.metadata.get("docs_url", None)
 
             context.append(context_dict)
             max_tokens -= available_tokens

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,0 +1,5 @@
+"""Constants used only in tests."""
+
+# embeddings metadata
+OCP_DOCS_ROOT_URL = "https://docs.openshift.com/container-platform"
+OCP_DOCS_VERSION = "4.15"

--- a/tests/mock_classes/mock_query_engine.py
+++ b/tests/mock_classes/mock_query_engine.py
@@ -6,17 +6,17 @@ from .mock_summary import MockSummary
 class Node:
     """Node containing source node metadata."""
 
-    def __init__(self, file_path):
-        """Initialize file_path metadata."""
-        self.metadata = {"file_path": file_path}
+    def __init__(self, docs_url):
+        """Initialize docs_url metadata."""
+        self.metadata = {"docs_url": docs_url}
 
 
 class SourceNode:
     """Node containing one reference to document."""
 
-    def __init__(self, file_path):
+    def __init__(self, docs_url):
         """Initialize sub-node with metadata."""
-        self.node = Node(file_path)
+        self.node = Node(docs_url)
 
 
 class MockQueryEngine:

--- a/tests/mock_classes/mock_retrievers.py
+++ b/tests/mock_classes/mock_retrievers.py
@@ -2,6 +2,7 @@
 
 from langchain_core.documents import Document
 
+from tests import constants
 from tests.unit.utils.test_token_handler import MockRetrievedNode
 
 
@@ -22,7 +23,10 @@ class MockRetriever:
                 {
                     "text": "a text text text text",
                     "score": 0.6,
-                    "metadata": {"file_path": "/docs/test.txt"},
+                    "metadata": {
+                        "docs_url": f"{constants.OCP_DOCS_ROOT_URL}/"
+                        f"{constants.OCP_DOCS_VERSION}/docs/test.html"
+                    },
                 }
             )
         ]

--- a/tests/unit/docs/test_doc_summarizer.py
+++ b/tests/unit/docs/test_doc_summarizer.py
@@ -2,9 +2,9 @@
 
 from unittest.mock import patch
 
-from ols import constants
 from ols.src.query_helpers.docs_summarizer import DocsSummarizer, QueryHelper
 from ols.utils import config, suid
+from tests import constants
 from tests.mock_classes.langchain_interface import mock_langchain_interface
 from tests.mock_classes.llm_chain import mock_llm_chain
 from tests.mock_classes.llm_loader import mock_llm_loader
@@ -30,7 +30,10 @@ def test_summarize():
     assert question in summary["response"]
     documents = summary["referenced_documents"]
     assert len(documents) > 0
-    assert f"{constants.OCP_DOCS_ROOT_URL}/docs/test.html" in documents
+    assert (
+        f"{constants.OCP_DOCS_ROOT_URL}/{constants.OCP_DOCS_VERSION}/docs/test.html"
+        in documents
+    )
     assert not summary["history_truncated"]
 
 

--- a/tests/unit/utils/test_token_handler.py
+++ b/tests/unit/utils/test_token_handler.py
@@ -41,22 +41,22 @@ class TestTokenHandler(TestCase):
             {
                 "text": "a text text text text",
                 "score": 0.6,
-                "metadata": {"file_path": "data/doc1.pdf"},
+                "metadata": {"docs_url": "data/doc1.pdf"},
             },
             {
                 "text": "b text text text text",
                 "score": 0.55,
-                "metadata": {"file_path": "data/doc2.pdf"},
+                "metadata": {"docs_url": "data/doc2.pdf"},
             },
             {
                 "text": "c text text text text",
                 "score": 0.55,
-                "metadata": {"file_path": "data/doc3.pdf"},
+                "metadata": {"docs_url": "data/doc3.pdf"},
             },
             {
                 "text": "d text text text text",
                 "score": 0.4,
-                "metadata": {"file_path": "data/doc4.pdf"},
+                "metadata": {"docs_url": "data/doc4.pdf"},
             },
         ]
         self._mock_retrieved_obj = [MockRetrievedNode(data) for data in node_data]
@@ -71,7 +71,7 @@ class TestTokenHandler(TestCase):
         for idx, data in enumerate(context):
             assert data["text"][0] == self._mock_retrieved_obj[idx].get_text()[0]
             assert (
-                data["file_path"] == self._mock_retrieved_obj[idx].metadata["file_path"]
+                data["docs_url"] == self._mock_retrieved_obj[idx].metadata["docs_url"]
             )
 
     def test_token_handler_token_limit(self):


### PR DESCRIPTION
## Description

OLS now expects to find the complete URL to the page of OCP documentation in the docs_url metadata element attached to RAG embeddings. This is an optimization compared to how the docs url is currently assembled every time a RAG embedding is retrieved.

Needs https://github.com/openshift/lightspeed-rag-content/pull/3 to merge first and RAG content to get regenerated.

## Type of change

- [] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # 
- Closes # https://issues.redhat.com/browse/OLS-338

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
