### PR TITLE
OLS-420: Bump-up pytest-cov version (devel library)

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:885f190cc79f01126faa3d899fe459d04a7638abe90bcf7be06b89e74eeaa7d4"
+content_hash = "sha256:b39fada539237f87e436cc2585abd7340e51f9ddd74f1c00c5c7902a27c5524a"
 
 [[package]]
 name = "aiofiles"
@@ -1725,8 +1725,8 @@ files = [
 
 [[package]]
 name = "pytest-cov"
-version = "4.1.0"
-requires_python = ">=3.7"
+version = "5.0.0"
+requires_python = ">=3.8"
 summary = "Pytest plugin for measuring coverage."
 groups = ["dev"]
 dependencies = [
@@ -1734,8 +1734,8 @@ dependencies = [
     "pytest>=4.6",
 ]
 files = [
-    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
-    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
+    {file = "pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"},
+    {file = "pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
     "httpx>=0.26.0",
     "mypy>=1.8.0",
     "pytest>=8.0.0",
-    "pytest-cov>=4.1.0",
+    "pytest-cov>=5.0.0",
     "pytest_asyncio>=0.23.5",
     "ruff>=0.3.4",
     # types-requests<2.31.0.7 to avoid upgrading urllib3>1.27 that breaks ibm-cos-sdk-core 2.13.


### PR DESCRIPTION
## Description

Bump-up `pytest-cov` version (devel library)

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-420](https://issues.redhat.com//browse/OLS-420)
