### PR TITLE
OLS-214: Add transcripts capture configuration

### DIFF
--- a/examples/olsconfig.yaml
+++ b/examples/olsconfig.yaml
@@ -57,6 +57,8 @@ ols_config:
   user_data_collection:
     feedback_disabled: false
     feedback_storage: "/app-root/data/feedback"
+    transcripts_disabled: false
+    transcripts_storage: "/app-root/data/transcripts"
   tls_config:
     tls_certificate_path: /app-root/certs/certificate.crt
     tls_key_path: /app-root/certs/private.key

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -646,12 +646,18 @@ class UserDataCollection(BaseModel):
 
     feedback_disabled: bool = True
     feedback_storage: Optional[str] = None
+    transcripts_disabled: bool = True
+    transcripts_storage: Optional[str] = None
 
     @model_validator(mode="after")
     def check_storage_location_is_set_when_needed(self) -> Self:
         """Check that storage_location is set when enabled."""
         if not self.feedback_disabled and self.feedback_storage is None:
             raise ValueError("feedback_storage is required when feedback is enabled")
+        if not self.transcripts_disabled and self.transcripts_storage is None:
+            raise ValueError(
+                "transcripts_storage is required when transcripts capturing is enabled"
+            )
         return self
 
 

--- a/tests/config/cluster_install/ols_configmap.yaml
+++ b/tests/config/cluster_install/ols_configmap.yaml
@@ -48,6 +48,8 @@ data:
       user_data_collection:
         feedback_disabled: false
         feedback_storage: "/app-root/ols-user-data/feedback"
+        transcripts_disabled: false
+        transcripts_storage: "/app-root/ols-user-data/transcripts"
     dev_config:
       enable_dev_ui: true
       disable_auth: false

--- a/tests/config/singleprovider.e2e.template.config.yaml
+++ b/tests/config/singleprovider.e2e.template.config.yaml
@@ -11,6 +11,8 @@ ols_config:
   user_data_collection:
     feedback_disabled: false
     feedback_storage: $FEEDBACK_STORAGE_LOCATION
+    transcripts_disabled: false
+    transcripts_storage: $TRANSCRIPTS_STORAGE_LOCATION
   conversation_cache:
     type: memory
     memory:

--- a/tests/scripts/test-e2e-standalone.sh
+++ b/tests/scripts/test-e2e-standalone.sh
@@ -34,8 +34,10 @@ TMPDIR=$(mktemp -d)
 ARTIFACT_DIR=${ARTIFACT_DIR:-$TMPDIR}
 
 # configure feedback storage location
-export FEEDBACK_STORAGE_LOCATION="$ARTIFACT_DIR/insights/feedback"
+export FEEDBACK_STORAGE_LOCATION="$ARTIFACT_DIR/user-data/feedback"
 echo "Feedback storage location: $FEEDBACK_STORAGE_LOCATION"
+export TRANSCRIPTS_STORAGE_LOCATION="$ARTIFACT_DIR/user-data/transcripts"
+echo "Transcripts storage location: $TRANSCRIPTS_STORAGE_LOCATION"
 
 export OLS_CONFIG_FILE="$ARTIFACT_DIR/olsconfig.yaml"
 OLS_LOGS=$ARTIFACT_DIR/ols.log

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -1761,8 +1761,8 @@ def test_authentication_config_validation_invalid_cert_path():
         auth_config.validate_yaml()
 
 
-def test_user_data_config(tmpdir):
-    """Tests the UserDataCollection model."""
+def test_user_data_config__feedback(tmpdir):
+    """Tests the UserDataCollection model, feedback part."""
     # valid configuration
     user_data = UserDataCollection(
         feedback_disabled=False, feedback_storage=tmpdir.strpath
@@ -1781,3 +1781,25 @@ def test_user_data_config(tmpdir):
     user_data = UserDataCollection(feedback_disabled=True)
     assert user_data.feedback_disabled is True
     assert user_data.feedback_storage is None
+
+
+def test_user_data_config__transcripts(tmpdir):
+    """Tests the UserDataCollection model, transripts part."""
+    # valid configuration
+    user_data = UserDataCollection(
+        transcripts_disabled=False, transcripts_storage=tmpdir.strpath
+    )
+    assert user_data.transcripts_disabled is False
+    assert user_data.transcripts_storage == tmpdir.strpath
+
+    # enabled needs transcripts_storage
+    with pytest.raises(
+        ValueError,
+        match="transcripts_storage is required when transcripts capturing is enabled",
+    ):
+        UserDataCollection(transcripts_disabled=False)
+
+    # disabled doesn't need transcripts_storage
+    user_data = UserDataCollection(transcripts_disabled=True)
+    assert user_data.transcripts_disabled is True
+    assert user_data.transcripts_storage is None


### PR DESCRIPTION
## Description

Add transcripts capture configuration.

https://issues.redhat.com/browse/OLS-285 says:

> This is a post june task because we do not want to give OLS to anyone who's going to turn off data collection for now (the whole reason we are giving it to them is to get the data about how it performs)

My plan is to have it available in config, but hardcode it can't be turned off (just log a msg) later in the relevant place.

## Type of change

- [x] New feature
