### PR TITLE
e2e trivial fix: Check for conversation ID in JSON response

### DIFF
--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -397,8 +397,9 @@ def test_valid_question() -> None:
         print(vars(response))
         assert response.status_code == requests.codes.ok
         json_response = response.json()
-        json_response["conversation_id"] == conversation_id
+
         # checking a few major information from response
+        assert json_response["conversation_id"] == conversation_id
         assert "Kubernetes is" in json_response["response"]
         assert (
             "orchestration tool" in json_response["response"]
@@ -511,6 +512,7 @@ def test_rag_question() -> None:
         print(vars(response))
         assert response.status_code == requests.codes.ok
         json_response = response.json()
+        assert "conversation_id" in json_response
         assert len(json_response["referenced_documents"]) > 0
         assert "about_virt" in json_response["referenced_documents"][0]
         assert "https://" in json_response["referenced_documents"][0]
@@ -535,6 +537,7 @@ def test_query_filter() -> None:
         print(vars(response))
         assert response.status_code == requests.codes.ok
         json_response = response.json()
+        assert "conversation_id" in json_response
 
         # values to be filtered and replaced are defined in:
         # tests/config/singleprovider.e2e.template.config.yaml


### PR DESCRIPTION
## Description

e2e trivial fix: Check for conversation ID in JSON response

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
