### PR TITLE
OLS-363: Now parameters don't have to be fixed in provider classes

### DIFF
--- a/ols/src/llms/providers/azure_openai.py
+++ b/ols/src/llms/providers/azure_openai.py
@@ -43,12 +43,4 @@ class AzureOpenAI(LLMProvider):
 
     def load(self) -> LLM:
         """Load LLM."""
-        # TODO: these are not allowed for OpenAI - we need to figure
-        # out first how to handle params in general - whitelist/validation, ...
-        # https://issues.redhat.com/browse/OLS-363
-        if "min_new_tokens" in self.params:
-            self.params.pop("min_new_tokens")
-        if "max_new_tokens" in self.params:
-            self.params.pop("max_new_tokens")
-
         return AzureChatOpenAI(**self.params)

--- a/ols/src/llms/providers/openai.py
+++ b/ols/src/llms/providers/openai.py
@@ -40,12 +40,4 @@ class OpenAI(LLMProvider):
 
     def load(self) -> LLM:
         """Load LLM."""
-        # TODO: these are not allowed for OpenAI - we need to figure
-        # out first how to handle params in general - whitelist/validation, ...
-        # https://issues.redhat.com/browse/OLS-363
-        if "min_new_tokens" in self.params:
-            self.params.pop("min_new_tokens")
-        if "max_new_tokens" in self.params:
-            self.params.pop("max_new_tokens")
-
         return ChatOpenAI(**self.params)  # type: ignore [return-value]


### PR DESCRIPTION
## Description

Now parameters don't have to be fixed in provider classes because the verification and filtering code is now part of provider registration logic.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-363](https://issues.redhat.com//browse/OLS-363)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.
