### PR TITLE
OLS-439: Avoid multiple token calculation

### DIFF
--- a/tests/integration/test_authorized.py
+++ b/tests/integration/test_authorized.py
@@ -1,8 +1,8 @@
 """Integration tests for /livenss and /readiness REST API endpoints."""
 
-import os
 from unittest.mock import patch
 
+import pytest
 import requests
 from fastapi.testclient import TestClient
 
@@ -14,9 +14,7 @@ from tests.mock_classes.mock_k8s_api import (
 )
 
 
-# we need to patch the config file path to point to the test
-# config file before we import anything from main.py
-@patch.dict(os.environ, {"OLS_CONFIG_FILE": "tests/config/valid_config.yaml"})
+@pytest.fixture(scope="module")
 def setup():
     """Setups the test client."""
     global client
@@ -26,7 +24,7 @@ def setup():
     client = TestClient(app)
 
 
-def test_post_authorized_disabled():
+def test_post_authorized_disabled(setup):
     """Check the REST API /v1/query with POST HTTP method when no payload is posted."""
     # perform POST request with authentication disabled
     config.dev_config.disable_auth = True
@@ -40,7 +38,7 @@ def test_post_authorized_disabled():
     }
 
 
-def test_post_authorized_no_token():
+def test_post_authorized_no_token(setup):
     """Check the REST API /v1/query with POST HTTP method when no payload is posted."""
     # perform POST request without any payload
     config.dev_config.disable_auth = False
@@ -50,7 +48,7 @@ def test_post_authorized_no_token():
 
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authn_api")
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authz_api")
-def test_is_user_authorized_valid_token(mock_authz_api, mock_authn_api):
+def test_is_user_authorized_valid_token(mock_authz_api, mock_authn_api, setup):
     """Tests the is_user_authorized function with a mocked valid-token."""
     config.dev_config.disable_auth = False
     # Setup mock responses for valid token
@@ -73,7 +71,7 @@ def test_is_user_authorized_valid_token(mock_authz_api, mock_authn_api):
 
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authn_api")
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authz_api")
-def test_is_user_authorized_invalid_token(mock_authz_api, mock_authn_api):
+def test_is_user_authorized_invalid_token(mock_authz_api, mock_authn_api, setup):
     """Test the is_user_authorized function with a mocked invalid-token."""
     config.dev_config.disable_auth = False
     # Setup mock responses for invalid token

--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -1,6 +1,5 @@
 """Integration tests for REST API endpoints for providing user feedback."""
 
-import os
 from unittest.mock import patch
 
 import pytest
@@ -12,9 +11,7 @@ from ols.utils import config, suid
 from ols.utils.suid import check_suid
 
 
-# we need to patch the config file path to point to the test
-# config file before we import anything from main.py
-@patch.dict(os.environ, {"OLS_CONFIG_FILE": "tests/config/valid_config.yaml"})
+@pytest.fixture(scope="module")
 def setup():
     """Setups the test client."""
     global client
@@ -39,7 +36,7 @@ def with_enabled_feedback(tmpdir):
     )
 
 
-def test_feedback_endpoints_disabled_when_set_in_config(with_disabled_feedback):
+def test_feedback_endpoints_disabled_when_set_in_config(setup, with_disabled_feedback):
     """Check if feedback endpoints are disabled when set in config."""
     # status endpoint is always available
     response = client.get("/v1/feedback/status")

--- a/tests/unit/utils/test_auth_dependency.py
+++ b/tests/unit/utils/test_auth_dependency.py
@@ -15,6 +15,7 @@ from tests.mock_classes.mock_k8s_api import (
 )
 
 
+@pytest.fixture(scope="module")
 @patch.dict(os.environ, {"OLS_CONFIG_FILE": "tests/config/auth_config.yaml"})
 def setup():
     """Setups and load config."""
@@ -24,7 +25,7 @@ def setup():
     auth_dependency = AuthDependency(virtual_path="/ols-access")
 
 
-def test_singleton_pattern():
+def test_singleton_pattern(setup):
     """Test if K8sClientSingleton is really a singleton."""
     k1 = K8sClientSingleton()
     k2 = K8sClientSingleton()
@@ -34,7 +35,7 @@ def test_singleton_pattern():
 @pytest.mark.asyncio
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authn_api")
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authz_api")
-async def test_auth_dependency_valid_token(mock_authz_api, mock_authn_api):
+async def test_auth_dependency_valid_token(mock_authz_api, mock_authn_api, setup):
     """Tests the auth dependency with a mocked valid-token."""
     # Setup mock responses for valid token
     mock_authn_api.return_value.create_token_review.side_effect = (
@@ -59,7 +60,7 @@ async def test_auth_dependency_valid_token(mock_authz_api, mock_authn_api):
 @pytest.mark.asyncio
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authn_api")
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authz_api")
-async def test_auth_dependency_invalid_token(mock_authz_api, mock_authn_api):
+async def test_auth_dependency_invalid_token(mock_authz_api, mock_authn_api, setup):
     """Test the auth dependency with a mocked invalid-token."""
     # Setup mock responses for invalid token
     mock_authn_api.return_value.create_token_review.side_effect = (
@@ -83,7 +84,7 @@ async def test_auth_dependency_invalid_token(mock_authz_api, mock_authn_api):
 
 
 @patch.dict(os.environ, {"KUBECONFIG": "tests/config/kubeconfig"})
-def test_auth_dependency_config():
+def test_auth_dependency_config(setup):
     """Test the auth dependency can load kubeconfig file."""
     from ols.utils.auth_dependency import K8sClientSingleton
 

--- a/tests/unit/utils/test_token_handler.py
+++ b/tests/unit/utils/test_token_handler.py
@@ -65,7 +65,9 @@ class TestTokenHandler(TestCase):
     def test_token_handler(self):
         """Test token handler for context."""
         retrieved_nodes = self._mock_retrieved_obj[:3]
-        context = self._token_handler_obj.truncate_rag_context(retrieved_nodes)
+        context, available_tokens = self._token_handler_obj.truncate_rag_context(
+            retrieved_nodes
+        )
 
         assert len(context) == len(retrieved_nodes)
         for idx, data in enumerate(context):
@@ -73,10 +75,11 @@ class TestTokenHandler(TestCase):
             assert (
                 data["docs_url"] == self._mock_retrieved_obj[idx].metadata["docs_url"]
             )
+        assert available_tokens == 485
 
     def test_token_handler_token_limit(self):
         """Test token handler when token limit is reached."""
-        context = self._token_handler_obj.truncate_rag_context(
+        context, available_tokens = self._token_handler_obj.truncate_rag_context(
             self._mock_retrieved_obj, 7
         )
 
@@ -85,21 +88,24 @@ class TestTokenHandler(TestCase):
             context[1]["text"].split()
             == self._mock_retrieved_obj[1].get_text().split()[:2]
         )
+        assert available_tokens == 0
 
     @mock.patch("ols.utils.token_handler.MINIMUM_CONTEXT_LIMIT", 3)
     def test_token_handler_token_minimum(self):
         """Test token handler when token count reached minimum threshold."""
-        context = self._token_handler_obj.truncate_rag_context(
+        context, available_tokens = self._token_handler_obj.truncate_rag_context(
             self._mock_retrieved_obj, 7
         )
 
         assert len(context) == 1
+        assert available_tokens == 2
 
     def test_token_handler_empty(self):
         """Test token handler when node is empty."""
-        context = self._token_handler_obj.truncate_rag_context([], 5)
+        context, available_tokens = self._token_handler_obj.truncate_rag_context([], 5)
 
         assert len(context) == 0
+        assert available_tokens == 5
 
     def test_message_length_string_content(self):
         """Test the message_length method when message content is a string."""


### PR DESCRIPTION
## Description

- Calculate token count for prompt once
- Utilize calculated tokens during context truncation.
- Skip token calculation for history
- Refactoring
- Fix some unrelated test cases with proper fixture.

## Related Tickets & Documents

- Related Issue # 
   [OLS-439](https://issues.redhat.com//browse/OLS-439)
   [OLS-399](https://issues.redhat.com//browse/OLS-399) (related only based on refactoring)
