### PR TITLE
Minor changes in integration tests

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests."""

--- a/tests/integration/query_helpers/test_query_docs.py
+++ b/tests/integration/query_helpers/test_query_docs.py
@@ -24,7 +24,7 @@ def setup_faiss():
     embeddings = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
 
     db = FAISS.from_documents(list_of_documents, embeddings)
-    yield db
+    return db
 
 
 def test_retrieve_top_k_similarity_search(setup_faiss):

--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -29,7 +29,6 @@ def setup():
 def with_disabled_feedback(tmpdir):
     """Fixture disables feedback."""
     config.ols_config.user_data_collection = UserDataCollection(feedback_disabled=True)
-    yield
 
 
 @pytest.fixture
@@ -38,7 +37,6 @@ def with_enabled_feedback(tmpdir):
     config.ols_config.user_data_collection = UserDataCollection(
         feedback_disabled=False, feedback_storage=tmpdir.strpath
     )
-    yield
 
 
 def test_feedback_endpoints_disabled_when_set_in_config(with_disabled_feedback):

--- a/tests/integration/test_openapi.py
+++ b/tests/integration/test_openapi.py
@@ -57,7 +57,7 @@ def test_openapi_endpoint_head_method(setup):
 def test_openapi_content(setup):
     """Check if the pre-generated OpenAPI schema is up-to date."""
     # retrieve pre-generated OpenAPI schema
-    with open("docs/openapi.json", "r") as fin:
+    with open("docs/openapi.json") as fin:
         pre_generated_schema = json.load(fin)
 
     # retrieve current OpenAPI schema

--- a/tests/integration/test_redis.py
+++ b/tests/integration/test_redis.py
@@ -10,7 +10,7 @@ user_id = "00000000-0000-0000-0000-000000000001"
 conversation_id = "00000000-0000-0000-0000-000000000002"
 
 
-@pytest.mark.redis
+@pytest.mark.redis()
 def setup():
     """Setups the Redis client."""
     global redis_cache
@@ -30,7 +30,7 @@ def setup():
     redis_cache = RedisCache(redis_config)
 
 
-@pytest.mark.redis
+@pytest.mark.redis()
 def test_conversation_in_redis():
     """Check the elementary GET operation and insert_or_append operation."""
     # make sure the cache is empty


### PR DESCRIPTION
## Description

Minor changes in integration tests:
- proper usage of `pytest.mark`
- `__init__.py` to define module
- default open mode parameter not required
- `yield` was used instead of `return`

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
