### PR TITLE
Trivial: Logger.warn() call is deprecated

### DIFF
--- a/ols/utils/auth_dependency.py
+++ b/ols/utils/auth_dependency.py
@@ -180,7 +180,7 @@ class AuthDependency:
             HTTPException: If authentication fails or the user does not have access.
         """
         if config.dev_config.disable_auth:
-            logger.warn("Auth checks disabled, skipping")
+            logger.warning("Auth checks disabled, skipping")
             # TODO: replace with constants for default identity
             return DEFAULT_USER_UID, DEFAULT_USER_NAME
         authorization_header = request.headers.get("Authorization")


### PR DESCRIPTION
## Description

Trivial: `logger.warn()` call is deprecated

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
