### PR TITLE
Make Mypy happy + inform when provider/model are not set up

### DIFF
--- a/ols/app/metrics/metrics.py
+++ b/ols/app/metrics/metrics.py
@@ -65,8 +65,8 @@ def setup_model_metrics(config: config_model.Config) -> None:
     """Perform setup of all metrics related to LLM model and provider."""
     selected_model.info(
         {
-            "model": config.ols_config.default_model,
-            "provider": config.ols_config.default_provider,
+            "model": str(config.ols_config.default_model),
+            "provider": str(config.ols_config.default_provider),
         }
     )
 


### PR DESCRIPTION
## Description

Make Mypy happy + inform when provider/model are not set up
(currently provider+model have to be set, but the typing system does not have this knowledge)

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
