### PR TITLE
OLS-420: New WatsonxLLM used instead of deprecated one

### DIFF
--- a/ols/src/llms/providers/watsonx.py
+++ b/ols/src/llms/providers/watsonx.py
@@ -3,14 +3,11 @@
 import logging
 from typing import Any
 
-from ibm_watson_machine_learning.foundation_models import Model
-from ibm_watson_machine_learning.foundation_models.extensions.langchain import (
-    WatsonxLLM,
-)
 from ibm_watson_machine_learning.metanames import (
     GenTextParamsMetaNames as GenParams,
 )
 from langchain.llms.base import LLM
+from langchain_ibm.llms import WatsonxLLM
 
 from ols import constants
 from ols.src.llms.providers.provider import LLMProvider
@@ -42,15 +39,10 @@ class WatsonX(LLMProvider):
 
     def load(self) -> LLM:
         """Load LLM."""
-        creds = {
-            "url": self.provider_config.url or self.url,
-            "apikey": self.provider_config.credentials,
-        }
-
-        llm_model = Model(
+        return WatsonxLLM(
             model_id=self.model,
-            credentials=creds,
-            params=self.params,
+            url=self.provider_config.url or self.url,
+            apikey=self.provider_config.credentials,
             project_id=self.provider_config.project_id,
+            params=self.params,
         )
-        return WatsonxLLM(model=llm_model)

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:3d040581b37837646e3e78a060892192c1bfa68c371a4d5694cade1ff2eb73dc"
+content_hash = "sha256:7598800bb580c06975d02ebe1675394e541953ff500af970a69f3ba80b4e0114"
 
 [[package]]
 name = "aiofiles"
@@ -796,6 +796,20 @@ files = [
 ]
 
 [[package]]
+name = "ibm-watsonx-ai"
+version = "0.2.3"
+requires_python = ">=3.10"
+summary = "IBM watsonx.ai API Client"
+groups = ["default"]
+dependencies = [
+    "ibm-watson-machine-learning>=1.0.349",
+]
+files = [
+    {file = "ibm_watsonx_ai-0.2.3-py3-none-any.whl", hash = "sha256:53e254876f30b4d6eb4cb12d1370360ad513958bce698002c5a61fa70b3dadcd"},
+    {file = "ibm_watsonx_ai-0.2.3.tar.gz", hash = "sha256:743b2328273d501d8ca72405b5d6336271c9627704100c91b18a5f99eae05888"},
+]
+
+[[package]]
 name = "idna"
 version = "3.6"
 requires_python = ">=3.5"
@@ -1064,6 +1078,21 @@ dependencies = [
 files = [
     {file = "langchain_core-0.1.38-py3-none-any.whl", hash = "sha256:d881b2754254cb4bdb0d5bb56e5c138d032b6e75e5cb21f151b01224b322e02b"},
     {file = "langchain_core-0.1.38.tar.gz", hash = "sha256:ee8da6d061c06cce7dc22fec224b6ecbc3a8de106d6dd9f409c7fe448ea41861"},
+]
+
+[[package]]
+name = "langchain-ibm"
+version = "0.1.3"
+requires_python = ">=3.10,<4.0"
+summary = "An integration package connecting IBM watsonx.ai and LangChain"
+groups = ["default"]
+dependencies = [
+    "ibm-watsonx-ai<0.3.0,>=0.2.0",
+    "langchain-core<0.2.0,>=0.1.29",
+]
+files = [
+    {file = "langchain_ibm-0.1.3-py3-none-any.whl", hash = "sha256:ca2fefe593742c3d96d69b8bbacdf5c90a7020d871873f9d55aaba57dd9e4418"},
+    {file = "langchain_ibm-0.1.3.tar.gz", hash = "sha256:9a12ee5991904bfee16dc677dee18c22613895ea899d4b8b77c88c42d5d242ce"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "fastapi==0.110.0",
     "gradio==4.24.0",
     "langchain==0.1.14",
+    "langchain-ibm==0.1.3",
     "llama-index==0.9.39",  # dev dep?
     "uvicorn==0.29.0",
     "redis==5.0.3",

--- a/tests/mock_classes/mock_watsonxllm.py
+++ b/tests/mock_classes/mock_watsonxllm.py
@@ -1,0 +1,21 @@
+"""Mocked WatsonxLLM class to avoid accessing real Watsonx API."""
+
+from langchain.llms.base import LLM
+
+
+class WatsonxLLM(LLM):
+    """Mocked WatsonxLLM class to avoid accessing real Watsonx API."""
+
+    def __init__(self):
+        """Initialize mocked WatsonxLLM."""
+
+    def _call(self):
+        """Override abstract method from LLM abstract class."""
+        return self
+
+    def __call__(self, **kwargs):
+        """Override abstract method from LLM abstract class."""
+        return self
+
+    def _llm_type(self):
+        """Override abstract method from LLM abstract class."""

--- a/tests/unit/llms/providers/test_watsonx.py
+++ b/tests/unit/llms/providers/test_watsonx.py
@@ -1,17 +1,14 @@
 """Unit tests for OpenAI provider."""
 
-from unittest.mock import MagicMock, patch
-
-from ibm_watson_machine_learning.foundation_models.extensions.langchain import (
-    WatsonxLLM,
-)
+from unittest.mock import patch
 
 from ols.app.models.config import ProviderConfig
 from ols.src.llms.providers.watsonx import WatsonX
 from ols.utils import config
+from tests.mock_classes.mock_watsonxllm import WatsonxLLM
 
 
-@patch("ols.src.llms.providers.watsonx.Model", new=MagicMock())
+@patch("ols.src.llms.providers.watsonx.WatsonxLLM", new=WatsonxLLM())
 def test_basic_interface():
     """Test basic interface."""
     config.init_empty_config()  # needed for checking the config.dev_config.llm_params


### PR DESCRIPTION
## Description

New WatsonxLLM used instead of deprecated one
It requires changes in code and tests too

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
