### PR TITLE
Refactor question validation logic

### DIFF
--- a/ols/constants.py
+++ b/ols/constants.py
@@ -13,18 +13,18 @@ class QueryValidationMethod(StrEnum):
 
 
 # Query validation responses
-SUBJECT_VALID = "SUBJECT_VALID"
-SUBJECT_INVALID = "SUBJECT_INVALID"
+SUBJECT_REJECTED = "REJECTED"
+SUBJECT_ALLOWED = "ALLOWED"
 POSSIBLE_QUESTION_VALIDATOR_RESPONSES = (
-    SUBJECT_VALID,
-    SUBJECT_INVALID,
+    SUBJECT_REJECTED,
+    SUBJECT_ALLOWED,
 )
 
 
 # Default responses
 INVALID_QUERY_RESP = (
-    "I can only answer questions about OpenShift and Kubernetes. "
-    "Please rephrase your question"
+    "I'm sorry, this question does not appear to be about OpenShift or Kubernetes.  "
+    "I can only answer questions related to those topics, please rephrase or ask another question."
 )
 NO_RAG_CONTENT_RESP = (
     "The following response was generated without access to reference content:\n\n"

--- a/ols/src/prompts/prompts.py
+++ b/ols/src/prompts/prompts.py
@@ -3,7 +3,7 @@
 # ruff: noqa: E501
 """Prompt templates/constants."""
 
-from ols.constants import SUBJECT_INVALID, SUBJECT_VALID
+from ols.constants import SUBJECT_ALLOWED, SUBJECT_REJECTED
 
 # TODO: Fine-tune system prompt
 QUERY_SYSTEM_PROMPT = """You are an assistant for question-answering tasks \
@@ -25,31 +25,25 @@ QUESTION_VALIDATOR_PROMPT_TEMPLATE = f"""
 Instructions:
 - You are a question classifying tool
 - You are an expert in kubernetes and openshift
-- Your job is to determine if a question is about kubernetes or openshift and to provide a one-word response
-- If a question is not about kubernetes or openshift, answer with only the word {SUBJECT_INVALID}
-- If a question is about kubernetes or openshift, answer with the word {SUBJECT_VALID}
-- Use a comma to separate the words
-- Do not provide explanation, only respond with the chosen words
+- Your job is to determine where or a user's question is related to kubernetes and/or openshift technologies and to provide a one-word response
+- If a question appears to be related to kubernetes or openshift technologies, answer with the word {SUBJECT_ALLOWED}, otherwise answer with the word {SUBJECT_REJECTED}
+- Do not explain your answer, just provide the one-word response
 
-Example Question:
-Can you make me lunch with ham and cheese?
-Example Response:
-{SUBJECT_INVALID}
 
 Example Question:
 Why is the sky blue?
 Example Response:
-{SUBJECT_INVALID}
+{SUBJECT_REJECTED}
 
 Example Question:
 Can you help configure my cluster to automatically scale?
 Example Response:
-{SUBJECT_VALID}
+{SUBJECT_ALLOWED}
 
 Example Question:
-please give me a vertical pod autoscaler configuration to manage my frontend deployment automatically.  Don't update the workload if there are less than 2 pods running.
+How do I accomplish $task in openshift?
 Example Response:
-{SUBJECT_VALID}
+{SUBJECT_ALLOWED}
 
 Question:
 {{query}}

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -61,9 +61,8 @@ def test_post_question_without_payload(setup):
 def test_post_question_on_invalid_question(setup):
     """Check the REST API /v1/query with POST HTTP method for invalid question."""
     # let's pretend the question is invalid without even asking LLM
-    answer = constants.SUBJECT_INVALID
     with patch(
-        "ols.app.endpoints.ols.QuestionValidator.validate_question", return_value=answer
+        "ols.app.endpoints.ols.QuestionValidator.validate_question", return_value=False
     ):
         conversation_id = suid.get_suid()
         response = client.post(
@@ -84,7 +83,7 @@ def test_post_question_on_invalid_question(setup):
 def test_post_question_on_generic_response_type_summarize_error(setup):
     """Check the REST API /v1/query with POST HTTP method when generic response type is returned."""
     # let's pretend the question is valid and generic one
-    answer = constants.SUBJECT_VALID
+    answer = constants.SUBJECT_ALLOWED
     with (
         patch(
             "ols.app.endpoints.ols.QuestionValidator.validate_question",
@@ -223,7 +222,7 @@ def test_post_question_on_noyaml_response_type(setup) -> None:
     config.ols_config.reference_content.product_docs_index_path = "./invalid_dir"
     config.ols_config.reference_content.product_docs_index_id = "product"
     config.dev_config.disable_auth = True
-    answer = constants.SUBJECT_VALID
+    answer = constants.SUBJECT_ALLOWED
     with patch(
         "ols.app.endpoints.ols.QuestionValidator.validate_question", return_value=answer
     ):
@@ -293,7 +292,7 @@ def test_post_query_with_query_filters_response_type(setup) -> None:
     """Check the REST API /v1/query with POST HTTP method with query filters."""
     config.init_empty_config()
     config.dev_config.disable_auth = True
-    answer = constants.SUBJECT_VALID
+    answer = constants.SUBJECT_ALLOWED
 
     query_filters = [
         QueryFilter(
@@ -343,7 +342,7 @@ def test_post_query_for_conversation_history(setup) -> None:
     """Check the REST API /v1/query with same conversation_id for conversation history."""
     config.init_empty_config()
     config.dev_config.disable_auth = True
-    answer = constants.SUBJECT_VALID
+    answer = constants.SUBJECT_ALLOWED
     with patch(
         "ols.app.endpoints.ols.QuestionValidator.validate_question", return_value=answer
     ):

--- a/tests/unit/query_helpers/test_question_validator.py
+++ b/tests/unit/query_helpers/test_question_validator.py
@@ -1,12 +1,9 @@
 """Unit tests for QuestionValidator class."""
 
-from unittest.mock import patch
-
 import pytest
 
 from ols.src.query_helpers.question_validator import QueryHelper, QuestionValidator
 from ols.utils import config
-from tests.mock_classes.llm_chain import mock_llm_chain
 from tests.mock_classes.llm_loader import mock_llm_loader
 
 
@@ -34,19 +31,3 @@ def test_passing_parameters():
     assert question_validator.llm_params is not None
     assert "max_new_tokens" in question_validator.llm_params is not None
     assert "min_new_tokens" in question_validator.llm_params is not None
-
-
-def test_valid_responses(question_validator):
-    """Test how valid responses are handled by QuestionValidator."""
-    for retval in [
-        "SUBJECT_INVALID",
-        "SUBJECT_VALID",
-    ]:
-        ml = mock_llm_chain({"text": retval})
-        conversation_id = "01234567-89ab-cdef-0123-456789abcdef"
-        with patch("ols.src.query_helpers.question_validator.LLMChain", new=ml):
-            response = question_validator.validate_question(
-                conversation_id=conversation_id, query="What is the meaning of life?"
-            )
-
-            assert response == retval


### PR DESCRIPTION
Make the question validation logic more tolerant (only reject questions when the llm definitively responds with a rejection)

Make the keywords more distinct (REJECT/ALLOW instead of VALID/INVALID) to hopefully help the LLM do a better job of picking the right keyword.

Rephrase the question validation prompt template

Make the question validation helper return true/false, not the keyword from the llm, so we can isolate the decision making process of interpretting the llm evaluation, from other OLS logic.

Make generate_response only responsible for asking for an inference from the llm, not doing question validation or interpretting a question validation result argument.


## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.