### PR TITLE
OLS-399: Use score to filter rag content

### DIFF
--- a/ols/constants.py
+++ b/ols/constants.py
@@ -51,9 +51,40 @@ GRANITE_20B_CODE_INSTRUCT_V1 = "ibm/granite-20b-code-instruct-v1"
 GPT35_TURBO_1106 = "gpt-3.5-turbo-1106"
 GPT35_TURBO = "gpt-3.5-turbo"
 
-# Model configs
+
+# Token related constants
 DEFAULT_CONTEXT_WINDOW_SIZE = 8000
 DEFAULT_RESPONSE_TOKEN_LIMIT = 500
+MINIMUM_CONTEXT_TOKEN_LIMIT = 1
+
+DEFAULT_TOKENIZER_MODEL = "cl100k_base"
+
+
+# RAG related constants
+
+# This is used to decide how many matching chunks we want to retrieve as context.
+# (in descending order of similarity between query & chunk)
+# Currently we want to fetch best matching chunk, hence the value is set to 1.
+# If we want to fetch multiple chunks, then this value will increase accordingly.
+
+# This also depends on chunk_size used during index creation,
+# if chunk_size is small, we need to set a higher value, so that we will get
+# more context. If chunk_size is more, then we need to set a low value as we may
+# end up using too much context. Precise context will get us better response.
+RAG_CONTENT_LIMIT = 1
+
+# Once the chunk is retrived we need to check similarity score, so that we won't
+# pick any random matching chunk.
+# Currently we use L2/KNN based FAISS index. And this cutoff signifies distance
+# between chunk and query in vector space. Lower distance means query & chunk are
+# more similar. So lower cutoff value is better.
+
+# If we set a very high cutoff, then we may end up picking irrelevant chunks.
+# And if we set a very low value, then there is risk of discarding all the chunks,
+# as there won't be perfect matching chunk. This also depends on embedding model
+# used during index creation/retrieval.
+# Range: 0 to 1
+RAG_SIMILARITY_CUTOFF_L2 = 0.5
 
 
 # cache constants

--- a/tests/unit/docs/test_doc_summarizer.py
+++ b/tests/unit/docs/test_doc_summarizer.py
@@ -18,6 +18,7 @@ def test_is_query_helper_subclass():
     assert issubclass(DocsSummarizer, QueryHelper)
 
 
+@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF_L2", 0.7)
 @patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize():
     """Basic test for DocsSummarizer using mocked index and query engine."""

--- a/tests/unit/utils/test_token_handler.py
+++ b/tests/unit/utils/test_token_handler.py
@@ -40,7 +40,7 @@ class TestTokenHandler(TestCase):
         node_data = [
             {
                 "text": "a text text text text",
-                "score": 0.6,
+                "score": 0.4,
                 "metadata": {"docs_url": "data/doc1.pdf"},
             },
             {
@@ -55,13 +55,14 @@ class TestTokenHandler(TestCase):
             },
             {
                 "text": "d text text text text",
-                "score": 0.4,
+                "score": 0.6,
                 "metadata": {"docs_url": "data/doc4.pdf"},
             },
         ]
         self._mock_retrieved_obj = [MockRetrievedNode(data) for data in node_data]
         self._token_handler_obj = TokenHandler()
 
+    @mock.patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF_L2", 0.9)
     def test_token_handler(self):
         """Test token handler for context."""
         retrieved_nodes = self._mock_retrieved_obj[:3]
@@ -69,14 +70,30 @@ class TestTokenHandler(TestCase):
             retrieved_nodes
         )
 
-        assert len(context) == len(retrieved_nodes)
-        for idx, data in enumerate(context):
-            assert data["text"][0] == self._mock_retrieved_obj[idx].get_text()[0]
+        assert len(context) == len(("text", "docs_url"))
+        assert len(context["text"]) == 3
+        for idx in range(3):
+            assert context["text"][idx] == self._mock_retrieved_obj[idx].get_text()
             assert (
-                data["docs_url"] == self._mock_retrieved_obj[idx].metadata["docs_url"]
+                context["docs_url"][idx]
+                == self._mock_retrieved_obj[idx].metadata["docs_url"]
             )
         assert available_tokens == 485
 
+    @mock.patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF_L2", 0.5)
+    def test_token_handler_score(self):
+        """Test token handler for context when score is higher than threshold."""
+        retrieved_nodes = self._mock_retrieved_obj[:3]
+        context, available_tokens = self._token_handler_obj.truncate_rag_context(
+            retrieved_nodes
+        )
+
+        assert len(context) == len(("text", "docs_url"))
+        assert len(context["text"]) == 1
+        assert context["text"][0] == self._mock_retrieved_obj[0].get_text()
+        assert available_tokens == 495
+
+    @mock.patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF_L2", 0.9)
     def test_token_handler_token_limit(self):
         """Test token handler when token limit is reached."""
         context, available_tokens = self._token_handler_obj.truncate_rag_context(
@@ -84,20 +101,22 @@ class TestTokenHandler(TestCase):
         )
 
         assert len(context) == 2
+        assert len(context["text"]) == 2
         assert (
-            context[1]["text"].split()
+            context["text"][1].split()
             == self._mock_retrieved_obj[1].get_text().split()[:2]
         )
         assert available_tokens == 0
 
-    @mock.patch("ols.utils.token_handler.MINIMUM_CONTEXT_LIMIT", 3)
+    @mock.patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF_L2", 0.9)
+    @mock.patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 3)
     def test_token_handler_token_minimum(self):
         """Test token handler when token count reached minimum threshold."""
         context, available_tokens = self._token_handler_obj.truncate_rag_context(
             self._mock_retrieved_obj, 7
         )
 
-        assert len(context) == 1
+        assert len(context["text"]) == 1
         assert available_tokens == 2
 
     def test_token_handler_empty(self):
@@ -105,6 +124,7 @@ class TestTokenHandler(TestCase):
         context, available_tokens = self._token_handler_obj.truncate_rag_context([], 5)
 
         assert len(context) == 0
+        assert isinstance(context, dict)
         assert available_tokens == 5
 
     def test_message_length_string_content(self):


### PR DESCRIPTION
## Description

Use score to filter rag content.
Refactoring: remove additional methods, add constants to constant.py
logger info to debug

## Type of change

- [x] Refactor
- [x] New feature

## Related Tickets & Documents

- Related Issue # [OLS-399](https://issues.redhat.com//browse/OLS-399)
