### PR TITLE
OLS-117: Refactor provider/model metrics

### DIFF
--- a/ols/app/main.py
+++ b/ols/app/main.py
@@ -33,7 +33,7 @@ else:
 
 # update provider and model as soon as possible so the metrics will be visible
 # even for first scraping
-metrics.setup_model_metrics(config)
+metrics.setup_model_metrics(config.config)
 
 
 @app.middleware("")

--- a/ols/app/metrics/__init__.py
+++ b/ols/app/metrics/__init__.py
@@ -6,9 +6,9 @@ from .metrics import (
     llm_calls_validation_errors_total,
     llm_token_received_total,
     llm_token_sent_total,
+    provider_model_configuration,
     response_duration_seconds,
     rest_api_calls_total,
-    selected_model,
     setup_model_metrics,
 )
 from .token_counter import GenericTokenCounter, TokenMetricUpdater
@@ -24,6 +24,6 @@ __all__ = [
     "metrics_app",
     "response_duration_seconds",
     "rest_api_calls_total",
-    "selected_model",
+    "provider_model_configuration",
     "setup_model_metrics",
 ]

--- a/ols/app/metrics/metrics.py
+++ b/ols/app/metrics/metrics.py
@@ -8,7 +8,6 @@ from prometheus_client import (
     Counter,
     Gauge,
     Histogram,
-    Info,
     generate_latest,
 )
 
@@ -39,13 +38,13 @@ llm_token_received_total = Counter(
     "llm_token_received_total", "LLM tokens received", ["provider", "model"]
 )
 
-# expose selected provider and model
-# (these are represented by counters, but the only meaning is presence of label)
-selected_model = Info("selected_model", "Selected model")
-
 # metric that indicates what provider + model customers are using so we can
 # understand what is popular/important
-model_enabled = Gauge("model_enabled", "Enabled LLM models", ["provider", "model"])
+provider_model_configuration = Gauge(
+    "provider_model_configuration",
+    "LLM provider/models combinations defined in configuration",
+    ["provider", "model"],
+)
 
 
 @router.get("/metrics")
@@ -63,14 +62,12 @@ def get_metrics(auth: Any = Depends(auth_dependency)) -> Response:
 
 def setup_model_metrics(config: config_model.Config) -> None:
     """Perform setup of all metrics related to LLM model and provider."""
-    selected_model.info(
-        {
-            "model": str(config.ols_config.default_model),
-            "provider": str(config.ols_config.default_provider),
-        }
-    )
-
-    for _, provider in config.llm_config.providers.items():
-        provider_type = provider.type
+    for _, provider in config.llm_providers.providers.items():
         for model_name, _ in provider.models.items():
-            model_enabled.labels(provider_type, model_name).inc()
+            if (
+                provider.name == config.ols_config.default_provider
+                and model_name == config.ols_config.default_model
+            ):
+                provider_model_configuration.labels(provider.type, model_name).set(1)
+            else:
+                provider_model_configuration.labels(provider.type, model_name).set(0)

--- a/tests/e2e/metrics_utils.py
+++ b/tests/e2e/metrics_utils.py
@@ -59,7 +59,7 @@ def get_model_provider_counter_value(
     return get_counter_value(counter_name, prefix, response, default)
 
 
-def get_metric_labels(lines, info_node_name) -> Optional[dict]:
+def get_metric_labels(lines, info_node_name, value=None) -> Optional[dict]:
     """Get labels associated with a metric string as printed from /metrics."""
     prefix = info_node_name
 
@@ -68,13 +68,13 @@ def get_metric_labels(lines, info_node_name) -> Optional[dict]:
         if line.startswith(prefix):
             # strip prefix
             metric = line[len(prefix) + 1 :]
-
+            if value and not line.endswith(value):
+                continue
             # strip suffix
             labels = metric[: metric.find("} ")]
             labels = labels.split(",")
             for label in labels:
                 kv = label.split("=")
-                print(f"kv: {kv}")
                 # strip leading/trailing quotation from value
                 attrs[kv[0]] = kv[1][1:-1]
             return attrs
@@ -83,12 +83,12 @@ def get_metric_labels(lines, info_node_name) -> Optional[dict]:
     return None
 
 
-def get_model_and_provider(client):
+def get_enabled_model_and_provider(client):
     """Read configured model and provider from metrics."""
     response = read_metrics(client)
     lines = [line.strip() for line in response.split("\n")]
 
-    labels = get_metric_labels(lines, "selected_model_info")
+    labels = get_metric_labels(lines, "provider_model_configuration", "1.0")
 
     return labels["model"], labels["provider"]
 

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -225,7 +225,7 @@ def test_valid_question(response_eval) -> None:
 
 def test_valid_question_tokens_counter() -> None:
     """Check how the tokens counter are updated accordingly."""
-    model, provider = metrics_utils.get_model_and_provider(metrics_client)
+    model, provider = metrics_utils.get_enabled_model_and_provider(metrics_client)
 
     endpoint = "/v1/query"
     with (
@@ -242,7 +242,7 @@ def test_valid_question_tokens_counter() -> None:
 
 def test_invalid_question_tokens_counter() -> None:
     """Check how the tokens counter are updated accordingly."""
-    model, provider = metrics_utils.get_model_and_provider(metrics_client)
+    model, provider = metrics_utils.get_enabled_model_and_provider(metrics_client)
 
     endpoint = "/v1/query"
     with (
@@ -259,7 +259,7 @@ def test_invalid_question_tokens_counter() -> None:
 
 def test_token_counters_for_query_call_without_payload() -> None:
     """Check how the tokens counter are updated accordingly."""
-    model, provider = metrics_utils.get_model_and_provider(metrics_client)
+    model, provider = metrics_utils.get_enabled_model_and_provider(metrics_client)
 
     endpoint = "/v1/query"
     with (
@@ -283,7 +283,7 @@ def test_token_counters_for_query_call_without_payload() -> None:
 
 def test_token_counters_for_query_call_with_improper_payload() -> None:
     """Check how the tokens counter are updated accordingly."""
-    model, provider = metrics_utils.get_model_and_provider(metrics_client)
+    model, provider = metrics_utils.get_enabled_model_and_provider(metrics_client)
 
     endpoint = "/v1/query"
     with (
@@ -401,8 +401,7 @@ def test_metrics() -> None:
         "llm_validation_errors_total",
         "llm_token_sent_total",
         "llm_token_received_total",
-        "selected_model_info",
-        "model_enabled",
+        "provider_model_configuration",
     )
 
     # check if all counters are present
@@ -416,9 +415,9 @@ def test_metrics() -> None:
 
 def test_model_provider():
     """Read configured model and provider from metrics."""
-    model, provider = metrics_utils.get_model_and_provider(metrics_client)
+    model, provider = metrics_utils.get_enabled_model_and_provider(metrics_client)
 
-    # check available compbinations
+    # enabled model must be one of our expected combinations
     assert model, provider in {
         ("gpt-3.5-turbo", "openai"),
         ("gpt-3.5-turbo", "azure_openai"),

--- a/tests/integration/test_liveness_readiness.py
+++ b/tests/integration/test_liveness_readiness.py
@@ -7,6 +7,8 @@ import pytest
 import requests
 from fastapi.testclient import TestClient
 
+from ols.utils import config
+
 
 # we need to patch the config file path to point to the test
 # config file before we import anything from main.py
@@ -17,6 +19,7 @@ def setup():
     global client
     from ols.app.main import app
 
+    config.init_config("tests/config/valid_config.yaml")
     client = TestClient(app)
 
 

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -24,6 +24,7 @@ def setup():
     global client
     from ols.app.main import app
 
+    config.init_config("tests/config/valid_config.yaml")
     client = TestClient(app)
 
 

--- a/tests/integration/test_ols_debug.py
+++ b/tests/integration/test_ols_debug.py
@@ -7,7 +7,7 @@ import pytest
 import requests
 from fastapi.testclient import TestClient
 
-from ols.utils import suid
+from ols.utils import config, suid
 from tests.mock_classes.llm_chain import mock_llm_chain
 from tests.mock_classes.llm_loader import mock_llm_loader
 
@@ -21,6 +21,7 @@ def setup():
     global client
     from ols.app.main import app
 
+    config.init_config("tests/config/valid_config.yaml")
     client = TestClient(app)
 
 

--- a/tests/integration/test_openapi.py
+++ b/tests/integration/test_openapi.py
@@ -8,6 +8,8 @@ import pytest
 import requests
 from fastapi.testclient import TestClient
 
+from ols.utils import config
+
 
 # we need to patch the config file path to point to the test
 # config file before we import anything from main.py
@@ -18,6 +20,7 @@ def setup():
     global client
     from ols.app.main import app
 
+    config.init_config("tests/config/valid_config.yaml")
     client = TestClient(app)
 
 


### PR DESCRIPTION
we will now have just a single provider/model metric:

```
provider_model_configuration{model="ibm/granite-13b-chat-v2",provider="bam"} 0.0
provider_model_configuration{model="gpt-3.5-turbo",provider="openai"} 0.0
provider_model_configuration{model="ibm/granite-13b-chat-v2",provider="watsonx"} 1.0
```

the value of 0.0 means configured but not enabled, the value of 1.0 means it is the enabled provider/model.

this is following recommendations from the monitoring team in order to reduce our timeseries for telemetry:

https://issues.redhat.com/browse/MON-3778?focusedId=24456791&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-24456791

