### PR TITLE
OLS-413: Make LLMResponse include page titles for referenced documents

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # vim: set filetype=dockerfile
-ARG LIGHTSPEED_RAG_CONTENT_DIGEST=sha256:d15bf56776c40a8709b0e648e3b0f043de63b24ad8f59eeea6f8d965dfcbe4e3
+ARG LIGHTSPEED_RAG_CONTENT_DIGEST=sha256:c40bdfe55a827f46fd7775b4dcfec39bb915c8338bc6c0c085e0284ca8a08ebd
 
 FROM quay.io/openshift/lightspeed-rag-content@${LIGHTSPEED_RAG_CONTENT_DIGEST} as lightspeed-rag-content
 

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ schema:	## Generate OpenAPI schema file
 	python scripts/generate_openapi_schema.py docs/openapi.json
 
 get-rag: ## Download a copy of the RAG embedding model and vector database
-	podman create --replace --name tmp-rag-container quay.io/openshift/lightspeed-rag-content@sha256:d15bf56776c40a8709b0e648e3b0f043de63b24ad8f59eeea6f8d965dfcbe4e3 true
+	podman create --replace --name tmp-rag-container quay.io/openshift/lightspeed-rag-content@sha256:c40bdfe55a827f46fd7775b4dcfec39bb915c8338bc6c0c085e0284ca8a08ebd true
 	podman cp tmp-rag-container:/rag/vector_db vector_db
 	podman cp tmp-rag-container:/rag/embeddings_model embeddings_model
 	podman rm tmp-rag-container

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -634,7 +634,7 @@
                     },
                     "referenced_documents": {
                         "items": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/ReferencedDocument"
                         },
                         "type": "array",
                         "title": "Referenced Documents"
@@ -652,12 +652,15 @@
                     "truncated"
                 ],
                 "title": "LLMResponse",
-                "description": "Model representing a response from the LLM (Language Model).\n\nAttributes:\n    conversation_id: The optional conversation ID (UUID).\n    response: The optional response.\n    referenced_documents: The optional URLs for the documents used to generate the response.\n    truncated: Set to True if conversation history was truncated to be within context window.",
+                "description": "Model representing a response from the LLM (Language Model).\n\nAttributes:\n    conversation_id: The optional conversation ID (UUID).\n    response: The optional response.\n    referenced_documents: The optional URLs and titles for the documents used\n                          to generate the response.\n    truncated: Set to True if conversation history was truncated to be within context window.",
                 "examples": [
                     {
                         "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
                         "referenced_documents": [
-                            "https://docs.openshift.com/container-platform/4.14/operators/understanding/olm/olm-understanding-olm.html"
+                            {
+                                "docs_url": "https://docs.openshift.com/container-platform/4.15/operators/understanding/olm/olm-understanding-olm.html",
+                                "title": "Operator Lifecycle Manager concepts and resources"
+                            }
                         ],
                         "response": "Operator Lifecycle Manager (OLM) helps users install..."
                     }
@@ -687,6 +690,35 @@
                         }
                     }
                 ]
+            },
+            "ReferencedDocument": {
+                "properties": {
+                    "docs_url": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Docs Url"
+                    },
+                    "title": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Title"
+                    }
+                },
+                "type": "object",
+                "title": "ReferencedDocument",
+                "description": "RAG referenced document.\n\nAttributes:\ndocs_url: URL of the corresponding OCP documentation page\ntitle: Title of the corresponding OCP documentation page"
             },
             "StatusResponse": {
                 "properties": {

--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -21,6 +21,7 @@ from ols.app.models.models import (
     LLMRequest,
     LLMResponse,
     PromptTooLongResponse,
+    ReferencedDocument,
     UnauthorizedResponse,
 )
 from ols.src.llms.llm_loader import LLMConfigurationError, load_llm
@@ -77,7 +78,7 @@ def conversation_request(
     """
     # Initialize variables
     previous_input = []
-    referenced_documents: list[str] = []
+    referenced_documents: list[ReferencedDocument] = []
 
     user_id = retrieve_user_id(auth)
     logger.info(f"User ID {user_id}")
@@ -202,7 +203,7 @@ def generate_response(
     conversation_id: str,
     llm_request: LLMRequest,
     previous_input: list[BaseMessage],
-) -> tuple[str, list[str], bool]:
+) -> tuple[str, list[ReferencedDocument], bool]:
     """Generate response based on validation result, previous input, and model output."""
     # Summarize documentation
     try:
@@ -395,7 +396,7 @@ def store_transcript(
     query_is_valid: bool,
     llm_request: LLMRequest,
     response: str,
-    referenced_documents: list[str],
+    referenced_documents: list[ReferencedDocument],
     truncated: bool,
 ) -> None:
     """Store transcript in the local filesystem.
@@ -430,7 +431,7 @@ def store_transcript(
         "redacted_query": llm_request.query,
         "query_is_valid": query_is_valid,
         "llm_response": response,
-        "referenced_documents": referenced_documents,
+        "referenced_documents": [doc.model_dump() for doc in referenced_documents],
         "truncated": truncated,
     }
 

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -80,7 +80,7 @@ RAG_CONTENT_LIMIT = 1
 # as there won't be perfect matching chunk. This also depends on embedding model
 # used during index creation/retrieval.
 # Range: positive float value (can be > 1)
-RAG_SIMILARITY_CUTOFF_L2 = 0.5
+RAG_SIMILARITY_CUTOFF_L2 = 0.75
 
 
 # cache constants

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -10,6 +10,7 @@ from llama_index.indices.vector_store.base import VectorStoreIndex
 
 from ols.app.metrics import TokenMetricUpdater
 from ols.app.models.config import ProviderConfig
+from ols.app.models.models import ReferencedDocument
 from ols.constants import NO_RAG_CONTENT_RESP, RAG_CONTENT_LIMIT
 from ols.src.prompts.prompt_generator import generate_prompt
 from ols.src.query_helpers.query_helper import QueryHelper
@@ -96,7 +97,12 @@ class DocsSummarizer(QueryHelper):
             logger.warning("Proceeding without RAG content. Check start up messages.")
 
         rag_context = "\n\n".join(rag_context_data.get("text", []))
-        referenced_documents = rag_context_data.get("docs_url", [])
+        referenced_documents = [
+            ReferencedDocument(docs_url=docs_url, title=title)
+            for docs_url, title in zip(
+                rag_context_data.get("docs_url", []), rag_context_data.get("title", [])
+            )
+        ]
 
         # Truncate history, if applicable
         history, truncated = token_handler.limit_conversation_history(

--- a/ols/utils/token_handler.py
+++ b/ols/utils/token_handler.py
@@ -122,7 +122,8 @@ class TokenHandler:
             Context Example:
                 {
                     "text": ["This is my doc1", "This is my doc2"],
-                    "doc_link": [doc_link1, doc_link2]
+                    "docs_url": ["https://doc_url1", "https://doc_url2"]
+                    "title": ["Title of doc 1", "Title of doc 2"]
                 }
         """
         context_dict = defaultdict(list)
@@ -152,6 +153,7 @@ class TokenHandler:
             context_dict["text"].append(self.tokens_to_text(tokens[:available_tokens]))
             # Add Metadata
             context_dict["docs_url"].append(node.metadata.get("docs_url", None))
+            context_dict["title"].append(node.metadata.get("title", None))
 
             max_tokens -= available_tokens
 

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -328,10 +329,10 @@ def test_valid_question(response_eval) -> None:
             "Kubernetes is" in json_response["response"]
             or "Kubernetes: It is" in json_response["response"]
         )
-        assert (
-            "orchestration tool" in json_response["response"]
-            or "orchestration system" in json_response["response"]
-            or "orchestration platform" in json_response["response"]
+        assert re.search(
+            r"orchestration (tool|system|platform|engine)",
+            json_response["response"],
+            re.IGNORECASE,
         )
         assert NO_RAG_CONTENT_RESP not in json_response["response"]
 
@@ -448,8 +449,9 @@ def test_rag_question(response_eval) -> None:
         json_response = response.json()
         assert "conversation_id" in json_response
         assert len(json_response["referenced_documents"]) > 0
-        assert "performance" in json_response["referenced_documents"][0]
-        assert "https://" in json_response["referenced_documents"][0]
+        assert "virt" in json_response["referenced_documents"][0]["docs_url"]
+        assert "https://" in json_response["referenced_documents"][0]["docs_url"]
+        assert json_response["referenced_documents"][0]["title"]
 
         assert NO_RAG_CONTENT_RESP not in json_response["response"]
 
@@ -971,4 +973,6 @@ def test_transcripts_storing_cluster():
     assert "query_is_valid" in transcript
     assert "llm_response" in transcript
     assert "referenced_documents" in transcript
+    assert transcript["referenced_documents"][0]["docs_url"]
+    assert transcript["referenced_documents"][0]["title"]
     assert "truncated" in transcript

--- a/tests/mock_classes/mock_query_engine.py
+++ b/tests/mock_classes/mock_query_engine.py
@@ -6,17 +6,17 @@ from .mock_summary import MockSummary
 class Node:
     """Node containing source node metadata."""
 
-    def __init__(self, docs_url):
+    def __init__(self, docs_url, title):
         """Initialize docs_url metadata."""
-        self.metadata = {"docs_url": docs_url}
+        self.metadata = {"docs_url": docs_url, "title": title}
 
 
 class SourceNode:
     """Node containing one reference to document."""
 
-    def __init__(self, docs_url):
+    def __init__(self, docs_url, title):
         """Initialize sub-node with metadata."""
-        self.node = Node(docs_url)
+        self.node = Node(docs_url, title)
 
 
 class MockQueryEngine:
@@ -31,8 +31,8 @@ class MockQueryEngine:
         """Return summary for given query."""
         # fill-in some documents for more realistic tests
         nodes = [
-            SourceNode("/docs/test."),
-            SourceNode("/known-bugs."),
-            SourceNode("/errata."),
+            SourceNode("/docs/test.", "Docs Test"),
+            SourceNode("/known-bugs.", "Known Bugs"),
+            SourceNode("/errata.", "Errata"),
         ]
         return MockSummary(query, nodes)

--- a/tests/mock_classes/mock_retrievers.py
+++ b/tests/mock_classes/mock_retrievers.py
@@ -25,7 +25,8 @@ class MockRetriever:
                     "score": 0.6,
                     "metadata": {
                         "docs_url": f"{constants.OCP_DOCS_ROOT_URL}/"
-                        f"{constants.OCP_DOCS_VERSION}/docs/test.html"
+                        f"{constants.OCP_DOCS_VERSION}/docs/test.html",
+                        "title": "Docs Test",
                     },
                 }
             )

--- a/tests/unit/app/endpoints/test_ols.py
+++ b/tests/unit/app/endpoints/test_ols.py
@@ -13,7 +13,7 @@ from langchain.schema import AIMessage, HumanMessage
 from ols import constants
 from ols.app.endpoints import ols
 from ols.app.models.config import UserDataCollection
-from ols.app.models.models import LLMRequest
+from ols.app.models.models import LLMRequest, ReferencedDocument
 from ols.src.llms.llm_loader import LLMConfigurationError
 from ols.utils import config, suid
 from ols.utils.query_filter import QueryFilter, RegexFilter
@@ -587,7 +587,10 @@ def test_store_transcript(transcripts_location):
     query = "Tell me about Kubernetes"
     llm_request = LLMRequest(query=query, conversation_id=conversation_id)
     response = "Kubernetes is ..."
-    ref_docs = ["d"]
+    ref_docs = [
+        ReferencedDocument("https://foo.bar", "Foo Bar"),
+        ReferencedDocument("https://bar.baz", "Bar Baz"),
+    ]
     truncated = True
 
     ols.store_transcript(
@@ -609,7 +612,9 @@ def test_store_transcript(transcripts_location):
 
     # check the transcript json content
     with open(transcripts[0]) as f:
-        transcript = json.loads(f.read())
+        transcript = json.loads(
+            f.read(), object_hook=ReferencedDocument.json_decode_object_hook
+        )
     # we don't really care about the timestamp, so let's just set it to
     # a fixed value
     transcript["metadata"]["timestamp"] = "fake-timestamp"

--- a/tests/unit/app/models/test_models.py
+++ b/tests/unit/app/models/test_models.py
@@ -9,6 +9,7 @@ from ols.app.models.models import (
     HealthResponse,
     LLMRequest,
     LLMResponse,
+    ReferencedDocument,
     StatusResponse,
 )
 from ols.utils import suid
@@ -70,7 +71,11 @@ class TestLLM:
         """Test the LLMResponse model."""
         conversation_id = "id"
         response = "response"
-        referenced_documents = ["https://foo.bar.com/index.html"]
+        referenced_documents = [
+            ReferencedDocument(
+                docs_url="https://foo.bar.com/index.html", title="Foo Bar"
+            )
+        ]
 
         llm_response = LLMResponse(
             conversation_id=conversation_id,

--- a/tests/unit/docs/test_doc_summarizer.py
+++ b/tests/unit/docs/test_doc_summarizer.py
@@ -33,7 +33,7 @@ def test_summarize():
     assert len(documents) > 0
     assert (
         f"{constants.OCP_DOCS_ROOT_URL}/{constants.OCP_DOCS_VERSION}/docs/test.html"
-        in documents
+        in [documents[0].docs_url]
     )
     assert not summary["history_truncated"]
 

--- a/tests/unit/utils/test_token_handler.py
+++ b/tests/unit/utils/test_token_handler.py
@@ -43,22 +43,22 @@ class TestTokenHandler(TestCase):
             {
                 "text": "a text text text text",
                 "score": 0.4,
-                "metadata": {"docs_url": "data/doc1.pdf"},
+                "metadata": {"docs_url": "data/doc1.pdf", "title": "Doc1"},
             },
             {
                 "text": "b text text text text",
                 "score": 0.55,
-                "metadata": {"docs_url": "data/doc2.pdf"},
+                "metadata": {"docs_url": "data/doc2.pdf", "title": "Doc2"},
             },
             {
                 "text": "c text text text text",
                 "score": 0.55,
-                "metadata": {"docs_url": "data/doc3.pdf"},
+                "metadata": {"docs_url": "data/doc3.pdf", "title": "Doc3"},
             },
             {
                 "text": "d text text text text",
                 "score": 0.6,
-                "metadata": {"docs_url": "data/doc4.pdf"},
+                "metadata": {"docs_url": "data/doc4.pdf", "title": "Doc4"},
             },
         ]
         self._mock_retrieved_obj = [MockRetrievedNode(data) for data in node_data]
@@ -143,7 +143,7 @@ class TestTokenHandler(TestCase):
             retrieved_nodes
         )
 
-        assert len(context) == len(("text", "docs_url"))
+        assert len(context) == len(("text", "docs_url", "title"))
         assert len(context["text"]) == 3
         for idx in range(3):
             assert context["text"][idx] == self._mock_retrieved_obj[idx].get_text()
@@ -161,7 +161,7 @@ class TestTokenHandler(TestCase):
             retrieved_nodes
         )
 
-        assert len(context) == len(("text", "docs_url"))
+        assert len(context) == len(("text", "docs_url", "title"))
         assert len(context["text"]) == 1
         assert context["text"][0] == self._mock_retrieved_obj[0].get_text()
         assert available_tokens == 495
@@ -173,7 +173,7 @@ class TestTokenHandler(TestCase):
             self._mock_retrieved_obj, 7
         )
 
-        assert len(context) == 2
+        assert len(context) == 3
         assert len(context["text"]) == 2
         assert (
             context["text"][1].split()


### PR DESCRIPTION
## Description

LLMResponse now contains referenced documents that are pairs of (docs_url, title). Title comes from the "title" element of metadata in embedding nodes, added in https://github.com/openshift/lightspeed-rag-content/pull/9, which needs to merge first.
RAG content is now based on the sentence-transformers/all-mpnet-base-v2 embedding model, which necessitated RAG_SIMILARITY_CUTOFF_L2 increase and changes to a few asserts about what documents are retrieved for what queries.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # https://issues.redhat.com/browse/OLS-413

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
