### PR TITLE
OLS-375: added redaction of sensitive headers

### DIFF
--- a/ols/constants.py
+++ b/ols/constants.py
@@ -124,3 +124,11 @@ DEFAULT_USER_UID = "c1143120-551e-4a47-ad47-2748d6f3c81c"
 DEFAULT_USER_NAME = "OLS"
 # TO-DO: make this UUID dynamic per cluster (dynamic uuid for each cluster)
 DEFAULT_KUBEADMIN_UID = "b6553200-0f7b-4c82-b1c5-9303ff18e5f0"
+
+# HTTP headers to redact from FastAPI HTTP logs
+HTTP_REQUEST_HEADERS_TO_REDACT = frozenset(
+    {"authorization", "proxy-authorization", "cookie"}
+)
+HTTP_RESPONSE_HEADERS_TO_REDACT = frozenset(
+    {"www-authenticate", "proxy-authenticate", "set-cookie"}
+)


### PR DESCRIPTION
## Description

This is an improvement for https://github.com/openshift/lightspeed-service/pull/676 that adds redaction of sensitive HTTP headers, such as "authorization", "proxy-authorization", "cookie", "www-authenticate", "proxy-authenticate" and "set-cookie".

## Type of change

- [] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # https://issues.redhat.com/browse/OLS-375

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
Now sensitive header values are replaces with XXXXX:
```
2024-04-08 20:12:23,437 [ols.app.main:main.py:88] DEBUG: Request from 127.0.0.1:36978 Headers({"host":"127.0.0.1:8080", "user-agent":"curl/8.2.1", "authorization":"XXXXX", "accept":"application/json", "content-type":"application/json", "content-length":"29"}), Body: {"query": "What is the OLM?"}

```