### PR TITLE
Proper names for fixtures not returning values

### DIFF
--- a/tests/integration/test_authorized.py
+++ b/tests/integration/test_authorized.py
@@ -15,7 +15,7 @@ from tests.mock_classes.mock_k8s_api import (
 
 
 @pytest.fixture(scope="module")
-def setup():
+def _setup():
     """Setups the test client."""
     global client
     config.init_config("tests/config/valid_config.yaml")
@@ -24,7 +24,7 @@ def setup():
     client = TestClient(app)
 
 
-def test_post_authorized_disabled(setup):
+def test_post_authorized_disabled(_setup):
     """Check the REST API /v1/query with POST HTTP method when no payload is posted."""
     # perform POST request with authentication disabled
     config.dev_config.disable_auth = True
@@ -38,7 +38,7 @@ def test_post_authorized_disabled(setup):
     }
 
 
-def test_post_authorized_no_token(setup):
+def test_post_authorized_no_token(_setup):
     """Check the REST API /v1/query with POST HTTP method when no payload is posted."""
     # perform POST request without any payload
     config.dev_config.disable_auth = False
@@ -48,7 +48,7 @@ def test_post_authorized_no_token(setup):
 
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authn_api")
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authz_api")
-def test_is_user_authorized_valid_token(mock_authz_api, mock_authn_api, setup):
+def test_is_user_authorized_valid_token(mock_authz_api, mock_authn_api, _setup):
     """Tests the is_user_authorized function with a mocked valid-token."""
     config.dev_config.disable_auth = False
     # Setup mock responses for valid token
@@ -71,7 +71,7 @@ def test_is_user_authorized_valid_token(mock_authz_api, mock_authn_api, setup):
 
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authn_api")
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authz_api")
-def test_is_user_authorized_invalid_token(mock_authz_api, mock_authn_api, setup):
+def test_is_user_authorized_invalid_token(mock_authz_api, mock_authn_api, _setup):
     """Test the is_user_authorized function with a mocked invalid-token."""
     config.dev_config.disable_auth = False
     # Setup mock responses for invalid token

--- a/tests/integration/test_liveness_readiness.py
+++ b/tests/integration/test_liveness_readiness.py
@@ -14,7 +14,7 @@ from ols.utils import config
 # config file before we import anything from main.py
 @pytest.fixture(scope="module")
 @patch.dict(os.environ, {"OLS_CONFIG_FILE": "tests/config/valid_config.yaml"})
-def setup():
+def _setup():
     """Setups the test client."""
     global client
     from ols.app.main import app
@@ -23,28 +23,28 @@ def setup():
     client = TestClient(app)
 
 
-def test_liveness(setup):
+def test_liveness(_setup):
     """Test handler for /liveness REST API endpoint."""
     response = client.get("/liveness")
     assert response.status_code == requests.codes.ok
     assert response.json() == {"status": {"status": "healthy"}}
 
 
-def test_readiness(setup):
+def test_readiness(_setup):
     """Test handler for /readiness REST API endpoint."""
     response = client.get("/readiness")
     assert response.status_code == requests.codes.ok
     assert response.json() == {"status": {"status": "healthy"}}
 
 
-def test_liveness_head_http_method(setup) -> None:
+def test_liveness_head_http_method(_setup) -> None:
     """Test handler for /liveness REST API endpoint when HEAD HTTP method is used."""
     response = client.head("/liveness")
     assert response.status_code == requests.codes.ok
     assert response.text == ""
 
 
-def test_readiness_head_http_method(setup) -> None:
+def test_readiness_head_http_method(_setup) -> None:
     """Test handler for /readiness REST API endpoint when HEAD HTTP method is used."""
     response = client.head("/readiness")
     assert response.status_code == requests.codes.ok

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -15,7 +15,7 @@ from ols.utils import config
 # config file before we import anything from main.py
 @pytest.fixture(scope="module")
 @patch.dict(os.environ, {"OLS_CONFIG_FILE": "tests/config/valid_config.yaml"})
-def setup():
+def _setup():
     """Setups the test client."""
     global client
     from ols.app.main import app
@@ -37,7 +37,7 @@ def retrieve_metrics(client):
     return response.text
 
 
-def test_metrics(setup):
+def test_metrics(_setup):
     """Check if service provides metrics endpoint with some expected counters."""
     response_text = retrieve_metrics(client)
 
@@ -77,7 +77,7 @@ def get_counter_value(client, counter_name, path, status_code):
     raise Exception(f"Counter {counter_name} was not found in metrics")
 
 
-def test_rest_api_call_counter_ok_status(setup):
+def test_rest_api_call_counter_ok_status(_setup):
     """Check if REST API call counter works as expected, label with 200 OK status."""
     endpoint = "/readiness"
 
@@ -93,7 +93,7 @@ def test_rest_api_call_counter_ok_status(setup):
     assert new == old + 1, "Counter has not been updated properly"
 
 
-def test_rest_api_call_counter_not_found_status(setup):
+def test_rest_api_call_counter_not_found_status(_setup):
     """Check if REST API call counter works as expected, label with 404 NotFound status."""
     endpoint = "/this-does-not-exists"
 
@@ -110,7 +110,7 @@ def test_rest_api_call_counter_not_found_status(setup):
     assert new == old + 1, "Counter for 404 NotFound  has not been updated properly"
 
 
-def test_metrics_duration(setup):
+def test_metrics_duration(_setup):
     """Check if service provides metrics for durations."""
     response_text = retrieve_metrics(client)
 
@@ -132,7 +132,7 @@ def test_metrics_duration(setup):
     assert re.findall(pattern, response_text)
 
 
-def test_provider_model_configuration_metrics(setup):
+def test_provider_model_configuration_metrics(_setup):
     """Check if provider_model_configuration metrics shows the expected information."""
     response_text = retrieve_metrics(client)
     print(response_text)

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -20,7 +20,7 @@ from tests.mock_classes.llm_loader import mock_llm_loader
 
 
 @pytest.fixture(scope="module")
-def setup():
+def _setup():
     """Setups the test client."""
     config.init_config("tests/config/valid_config.yaml")
     global client
@@ -30,7 +30,7 @@ def setup():
     client = TestClient(app)
 
 
-def test_post_question_on_unexpected_payload(setup):
+def test_post_question_on_unexpected_payload(_setup):
     """Check the REST API /v1/query with POST HTTP method when unexpected payload is posted."""
     response = client.post("/v1/query", json="this is really not proper payload")
     assert response.status_code == requests.codes.unprocessable
@@ -47,7 +47,7 @@ def test_post_question_on_unexpected_payload(setup):
     }
 
 
-def test_post_question_without_payload(setup):
+def test_post_question_without_payload(_setup):
     """Check the REST API /v1/query with POST HTTP method when no payload is posted."""
     # perform POST request without any payload
     response = client.post("/v1/query")
@@ -61,7 +61,7 @@ def test_post_question_without_payload(setup):
     assert "Field required" in detail["msg"]
 
 
-def test_post_question_on_invalid_question(setup):
+def test_post_question_on_invalid_question(_setup):
     """Check the REST API /v1/query with POST HTTP method for invalid question."""
     # let's pretend the question is invalid without even asking LLM
     with patch(
@@ -83,7 +83,7 @@ def test_post_question_on_invalid_question(setup):
         assert response.json() == expected_json
 
 
-def test_post_question_on_generic_response_type_summarize_error(setup):
+def test_post_question_on_generic_response_type_summarize_error(_setup):
     """Check the REST API /v1/query with POST HTTP method when generic response type is returned."""
     # let's pretend the question is valid and generic one
     answer = constants.SUBJECT_ALLOWED
@@ -113,7 +113,7 @@ def test_post_question_on_generic_response_type_summarize_error(setup):
         assert response.json() == expected_json
 
 
-def test_post_question_that_is_not_validated(setup):
+def test_post_question_that_is_not_validated(_setup):
     """Check the REST API /v1/query with POST HTTP method for question that is not validated."""
     # let's pretend the question can not be validated
     with patch(
@@ -137,7 +137,7 @@ def test_post_question_that_is_not_validated(setup):
         assert response.json() == expected_details
 
 
-def test_post_question_with_provider_but_not_model(setup):
+def test_post_question_with_provider_but_not_model(_setup):
     """Check how missing model is detected in request."""
     conversation_id = suid.get_suid()
     response = client.post(
@@ -157,7 +157,7 @@ def test_post_question_with_provider_but_not_model(setup):
     )
 
 
-def test_post_question_with_model_but_not_provider(setup):
+def test_post_question_with_model_but_not_provider(_setup):
     """Check how missing provider is detected in request."""
     conversation_id = suid.get_suid()
     response = client.post(
@@ -177,7 +177,7 @@ def test_post_question_with_model_but_not_provider(setup):
     )
 
 
-def test_unknown_provider_in_post(setup):
+def test_unknown_provider_in_post(_setup):
     """Check the REST API /v1/query with POST method when unknown provider is requested."""
     # empty config - no providers
     with patch("ols.utils.config.llm_config.providers", new={}):
@@ -202,7 +202,7 @@ def test_unknown_provider_in_post(setup):
         assert response.json() == expected_json
 
 
-def test_unsupported_model_in_post(setup):
+def test_unsupported_model_in_post(_setup):
     """Check the REST API /v1/query with POST method when unsupported model is requested."""
     test_provider = "test-provider"
     provider_config = ProviderConfig()
@@ -232,7 +232,7 @@ def test_unsupported_model_in_post(setup):
         assert response.json() == expected_json
 
 
-def test_post_question_on_noyaml_response_type(setup) -> None:
+def test_post_question_on_noyaml_response_type(_setup) -> None:
     """Check the REST API /v1/query with POST HTTP method when call is success."""
     config.ols_config.reference_content = ReferenceContent(None)
     config.ols_config.reference_content.product_docs_index_path = "./invalid_dir"
@@ -280,7 +280,7 @@ def test_post_question_on_noyaml_response_type(setup) -> None:
     constants.QueryValidationMethod.KEYWORD,
 )
 @patch("ols.app.endpoints.ols.QuestionValidator.validate_question")
-def test_post_question_with_keyword(mock_llm_validation, setup) -> None:
+def test_post_question_with_keyword(mock_llm_validation, _setup) -> None:
     """Check the REST API /v1/query with keyword validation."""
     query = "What is Openshift ?"
 
@@ -308,7 +308,7 @@ def test_post_question_with_keyword(mock_llm_validation, setup) -> None:
         assert mock_llm_validation.call_count == 0
 
 
-def test_post_query_with_query_filters_response_type(setup) -> None:
+def test_post_query_with_query_filters_response_type(_setup) -> None:
     """Check the REST API /v1/query with POST HTTP method with query filters."""
     config.dev_config.disable_auth = True
     answer = constants.SUBJECT_ALLOWED
@@ -360,7 +360,7 @@ def test_post_query_with_query_filters_response_type(setup) -> None:
             )
 
 
-def test_post_query_for_conversation_history(setup) -> None:
+def test_post_query_for_conversation_history(_setup) -> None:
     """Check the REST API /v1/query with same conversation_id for conversation history."""
     config.dev_config.disable_auth = True
     answer = constants.SUBJECT_ALLOWED

--- a/tests/integration/test_ols_debug.py
+++ b/tests/integration/test_ols_debug.py
@@ -16,7 +16,7 @@ from tests.mock_classes.llm_loader import mock_llm_loader
 # config file before we import anything from main.py
 @pytest.fixture(scope="module")
 @patch.dict(os.environ, {"OLS_CONFIG_FILE": "tests/config/valid_config.yaml"})
-def setup():
+def _setup():
     """Setups the test client."""
     global client
     from ols.app.main import app
@@ -29,7 +29,7 @@ def setup():
 @patch("ols.app.endpoints.ols.LLMChain", new=mock_llm_chain({"text": "test response"}))
 # during LLM init, exceptions will occur on CI, so let's mock that too
 @patch("ols.app.endpoints.ols.load_llm", new=mock_llm_loader(None))
-def test_debug_query(setup):
+def test_debug_query(_setup):
     """Check the REST API /v1/debug/query with POST HTTP method when expected payload is posted."""
     conversation_id = suid.get_suid()
     response = client.post(
@@ -50,7 +50,7 @@ def test_debug_query(setup):
 @patch("ols.app.endpoints.ols.LLMChain", new=mock_llm_chain({"text": "test response"}))
 # during LLM init, exceptions will occur on CI, so let's mock that too
 @patch("ols.app.endpoints.ols.load_llm", new=mock_llm_loader(None))
-def test_debug_query_no_conversation_id(setup):
+def test_debug_query_no_conversation_id(_setup):
     """Check the REST API /v1/debug/query with POST HTTP method conversation ID is not provided."""
     response = client.post(
         "/v1/debug/query",
@@ -72,7 +72,7 @@ def test_debug_query_no_conversation_id(setup):
 @patch("ols.app.endpoints.ols.LLMChain", new=mock_llm_chain({"text": "test response"}))
 # during LLM init, exceptions will occur on CI, so let's mock that too
 @patch("ols.app.endpoints.ols.load_llm", new=mock_llm_loader(None))
-def test_debug_query_no_query(setup):
+def test_debug_query_no_query(_setup):
     """Check the REST API /v1/debug/query with POST HTTP method when query is not specified."""
     conversation_id = suid.get_suid()
     response = client.post(
@@ -88,7 +88,7 @@ def test_debug_query_no_query(setup):
 @patch("ols.app.endpoints.ols.LLMChain", new=mock_llm_chain({"text": "test response"}))
 # during LLM init, exceptions will occur on CI, so let's mock that too
 @patch("ols.app.endpoints.ols.load_llm", new=mock_llm_loader(None))
-def test_debug_query_no_payload(setup):
+def test_debug_query_no_payload(_setup):
     """Check the REST API /v1/debug/query with POST HTTP method when payload is empty."""
     response = client.post("/v1/debug/query")
 

--- a/tests/integration/test_openapi.py
+++ b/tests/integration/test_openapi.py
@@ -15,7 +15,7 @@ from ols.utils import config
 # config file before we import anything from main.py
 @pytest.fixture(scope="module")
 @patch.dict(os.environ, {"OLS_CONFIG_FILE": "tests/config/valid_config.yaml"})
-def setup():
+def _setup():
     """Setups the test client."""
     global client
     from ols.app.main import app
@@ -24,7 +24,7 @@ def setup():
     client = TestClient(app)
 
 
-def test_openapi_endpoint(setup):
+def test_openapi_endpoint(_setup):
     """Check if REST API provides endpoint with OpenAPI specification."""
     response = client.get("/openapi.json")
     assert response.status_code == requests.codes.ok
@@ -50,14 +50,14 @@ def test_openapi_endpoint(setup):
         assert endpoint in paths, f"Endpoint {endpoint} is not described"
 
 
-def test_openapi_endpoint_head_method(setup):
+def test_openapi_endpoint_head_method(_setup):
     """Check if REST API allows HEAD HTTP method for endpoint with OpenAPI specification."""
     response = client.head("/openapi.json")
     assert response.status_code == requests.codes.ok
     assert response.text == ""
 
 
-def test_openapi_content(setup):
+def test_openapi_content(_setup):
     """Check if the pre-generated OpenAPI schema is up-to date."""
     # retrieve pre-generated OpenAPI schema
     with open("docs/openapi.json") as fin:

--- a/tests/unit/app/endpoints/test_ols.py
+++ b/tests/unit/app/endpoints/test_ols.py
@@ -22,7 +22,7 @@ from tests.mock_classes.llm_loader import mock_llm_loader
 
 
 @pytest.fixture(scope="module")
-def load_config():
+def _load_config():
     """Load config before unit tests."""
     config.init_config("tests/config/test_app_endpoints.yaml")
 
@@ -34,14 +34,14 @@ def auth():
     return ("2a3dfd17-1f42-4831-aaa6-e28e7cb8e26b", "name")
 
 
-def test_retrieve_conversation_new_id(load_config):
+def test_retrieve_conversation_new_id(_load_config):
     """Check the function to retrieve conversation ID."""
     llm_request = LLMRequest(query="Tell me about Kubernetes", conversation_id=None)
     new_id = ols.retrieve_conversation_id(llm_request)
     assert suid.check_suid(new_id), "Improper conversation ID generated"
 
 
-def test_retrieve_conversation_id_existing_id(load_config):
+def test_retrieve_conversation_id_existing_id(_load_config):
     """Check the function to retrieve conversation ID when one already exists."""
     old_id = suid.get_suid()
     llm_request = LLMRequest(query="Tell me about Kubernetes", conversation_id=old_id)
@@ -49,14 +49,14 @@ def test_retrieve_conversation_id_existing_id(load_config):
     assert new_id == old_id, "Old (existing) ID should be retrieved." ""
 
 
-def test_retrieve_previous_input_no_previous_history(load_config):
+def test_retrieve_previous_input_no_previous_history(_load_config):
     """Check how function to retrieve previous input handle empty history."""
     llm_request = LLMRequest(query="Tell me about Kubernetes", conversation_id=None)
     input = ols.retrieve_previous_input(constants.DEFAULT_USER_UID, llm_request)
     assert input == []
 
 
-def test_retrieve_previous_input_empty_user_id(load_config):
+def test_retrieve_previous_input_empty_user_id(_load_config):
     """Check how function to retrieve previous input handle empty user ID."""
     conversation_id = suid.get_suid()
     llm_request = LLMRequest(
@@ -69,7 +69,7 @@ def test_retrieve_previous_input_empty_user_id(load_config):
         ols.retrieve_previous_input(None, llm_request)
 
 
-def test_retrieve_previous_input_improper_user_id(load_config):
+def test_retrieve_previous_input_improper_user_id(_load_config):
     """Check how function to retrieve previous input handle improper user ID."""
     conversation_id = suid.get_suid()
     llm_request = LLMRequest(
@@ -81,7 +81,7 @@ def test_retrieve_previous_input_improper_user_id(load_config):
 
 
 @patch("ols.utils.config.conversation_cache.get")
-def test_retrieve_previous_input_for_previous_history(get, load_config):
+def test_retrieve_previous_input_for_previous_history(get, _load_config):
     """Check how function to retrieve previous input handle existing history."""
     conversation_id = suid.get_suid()
     get.return_value = "input"
@@ -95,7 +95,7 @@ def test_retrieve_previous_input_for_previous_history(get, load_config):
 
 
 @patch("ols.utils.config.conversation_cache.insert_or_append")
-def test_store_conversation_history(insert_or_append, load_config):
+def test_store_conversation_history(insert_or_append, _load_config):
     """Test if operation to store conversation history to cache is called."""
     conversation_id = suid.get_suid()
     query = "Tell me about Kubernetes"
@@ -114,7 +114,7 @@ def test_store_conversation_history(insert_or_append, load_config):
 
 
 @patch("ols.utils.config.conversation_cache.insert_or_append")
-def test_store_conversation_history_some_response(insert_or_append, load_config):
+def test_store_conversation_history_some_response(insert_or_append, _load_config):
     """Test if operation to store conversation history to cache is called."""
     user_id = "1234"
     conversation_id = suid.get_suid()
@@ -129,7 +129,7 @@ def test_store_conversation_history_some_response(insert_or_append, load_config)
     insert_or_append.assert_called_with(user_id, conversation_id, expected_history)
 
 
-def test_store_conversation_history_empty_user_id(load_config):
+def test_store_conversation_history_empty_user_id(_load_config):
     """Test if basic input verification is done during history store operation."""
     user_id = ""
     conversation_id = suid.get_suid()
@@ -140,7 +140,7 @@ def test_store_conversation_history_empty_user_id(load_config):
         ols.store_conversation_history(user_id, conversation_id, llm_request, None)
 
 
-def test_store_conversation_history_improper_user_id(load_config):
+def test_store_conversation_history_improper_user_id(_load_config):
     """Test if basic input verification is done during history store operation."""
     user_id = "::::"
     conversation_id = suid.get_suid()
@@ -149,7 +149,7 @@ def test_store_conversation_history_improper_user_id(load_config):
         ols.store_conversation_history(user_id, conversation_id, llm_request, "")
 
 
-def test_store_conversation_history_improper_conversation_id(load_config):
+def test_store_conversation_history_improper_conversation_id(_load_config):
     """Test if basic input verification is done during history store operation."""
     conversation_id = "::::"
     llm_request = LLMRequest(query="Tell me about Kubernetes")
@@ -164,7 +164,7 @@ def test_store_conversation_history_improper_conversation_id(load_config):
     constants.QueryValidationMethod.KEYWORD,
 )
 @patch("ols.src.query_helpers.question_validator.QuestionValidator.validate_question")
-def test_validate_question_valid_kw(llm_validate_question_mock, load_config):
+def test_validate_question_valid_kw(llm_validate_question_mock, _load_config):
     """Check the behaviour of validate_question function using valid keyword."""
     conversation_id = suid.get_suid()
     query = "Tell me about Kubernetes?"
@@ -179,7 +179,7 @@ def test_validate_question_valid_kw(llm_validate_question_mock, load_config):
     "ols.app.endpoints.ols.config.ols_config.query_validation_method",
     constants.QueryValidationMethod.KEYWORD,
 )
-def test_validate_question_invalid_kw(load_config):
+def test_validate_question_invalid_kw(_load_config):
     """Check the behaviour of validate_question function using invalid keyword."""
     conversation_id = suid.get_suid()
     query = "What does 42 signify ?"
@@ -189,7 +189,7 @@ def test_validate_question_invalid_kw(load_config):
 
 
 @patch("ols.src.query_helpers.question_validator.QuestionValidator.validate_question")
-def test_validate_question(validate_question_mock, load_config):
+def test_validate_question(validate_question_mock, _load_config):
     """Check the behaviour of validate_question function."""
     conversation_id = suid.get_suid()
     query = "Tell me about Kubernetes"
@@ -199,7 +199,7 @@ def test_validate_question(validate_question_mock, load_config):
 
 
 @patch("ols.src.query_helpers.question_validator.QuestionValidator.validate_question")
-def test_validate_question_on_configuration_error(validate_question_mock, load_config):
+def test_validate_question_on_configuration_error(validate_question_mock, _load_config):
     """Check the behaviour of validate_question function when wrong configuration is detected."""
     conversation_id = suid.get_suid()
     query = "Tell me about Kubernetes"
@@ -212,7 +212,7 @@ def test_validate_question_on_configuration_error(validate_question_mock, load_c
 
 
 @patch("ols.src.query_helpers.question_validator.QuestionValidator.validate_question")
-def test_validate_question_on_validation_error(validate_question_mock, load_config):
+def test_validate_question_on_validation_error(validate_question_mock, _load_config):
     """Check the behaviour of validate_question function when query is not validated properly."""
     conversation_id = suid.get_suid()
     query = "Tell me about Kubernetes"
@@ -246,7 +246,7 @@ def test_validate_question_disabled(
     assert resp
 
 
-def test_query_filter_no_redact_filters(load_config):
+def test_query_filter_no_redact_filters(_load_config):
     """Test the function to redact query when no filters are setup."""
     conversation_id = suid.get_suid()
     query = "Tell me about Kubernetes"
@@ -256,7 +256,7 @@ def test_query_filter_no_redact_filters(load_config):
     assert result.query == query
 
 
-def test_query_filter_with_one_redact_filter(load_config):
+def test_query_filter_with_one_redact_filter(_load_config):
     """Test the function to redact query when filter is setup."""
     conversation_id = suid.get_suid()
     query = "Tell me about Kubernetes"
@@ -278,7 +278,7 @@ def test_query_filter_with_one_redact_filter(load_config):
     assert result.query == "Tell me about FooBar"
 
 
-def test_query_filter_with_two_redact_filters(load_config):
+def test_query_filter_with_two_redact_filters(_load_config):
     """Test the function to redact query when multiple filters are setup."""
     conversation_id = suid.get_suid()
     query = "Tell me about Kubernetes"
@@ -306,7 +306,7 @@ def test_query_filter_with_two_redact_filters(load_config):
 
 
 @patch("ols.utils.config.query_redactor")
-def test_query_filter_on_redact_error(mock_redact_query, load_config):
+def test_query_filter_on_redact_error(mock_redact_query, _load_config):
     """Test the function to redact query when redactor raises an error."""
     conversation_id = suid.get_suid()
     query = "Tell me about Kubernetes"
@@ -324,7 +324,7 @@ def test_conversation_request(
     mock_conversation_cache_get,
     mock_summarize,
     mock_validate_question,
-    load_config,
+    _load_config,
     auth,
 ):
     """Test conversation request API endpoint."""
@@ -371,7 +371,7 @@ def test_conversation_request(
 def test_conversation_request_on_wrong_configuration(
     mock_conversation_cache_get,
     mock_validate_question,
-    load_config,
+    _load_config,
     auth,
 ):
     """Test conversation request API endpoint."""
@@ -392,7 +392,7 @@ def test_conversation_request_on_wrong_configuration(
     "ols.app.endpoints.ols.validate_question",
     new=Mock(return_value=False),
 )
-def test_question_validation_in_conversation_start(load_config, auth):
+def test_question_validation_in_conversation_start(_load_config, auth):
     """Test if question validation is skipped in follow-up conversation."""
     # note the `validate_question` is patched to always return as `SUBJECT_REJECTED`
     # this should resolve in rejection in summarization
@@ -414,7 +414,7 @@ def test_question_validation_in_conversation_start(load_config, auth):
 )
 @patch("ols.src.query_helpers.docs_summarizer.DocsSummarizer.summarize")
 def test_no_question_validation_in_follow_up_conversation(
-    mock_summarize, load_config, auth
+    mock_summarize, _load_config, auth
 ):
     """Test if question validation is skipped in follow-up conversation."""
     # note the `validate_question` is patched to always return as `SUBJECT_REJECTED`
@@ -435,7 +435,7 @@ def test_no_question_validation_in_follow_up_conversation(
 
 @patch("ols.app.endpoints.ols.LLMChain", new=mock_llm_chain({"text": "llm response"}))
 @patch("ols.app.endpoints.ols.load_llm", new=mock_llm_loader(None))
-def test_conversation_request_debug_api_no_conversation_id(load_config):
+def test_conversation_request_debug_api_no_conversation_id(_load_config):
     """Test conversation request debug API endpoint."""
     llm_request = LLMRequest(query="Tell me about Kubernetes")
     response = ols.conversation_request_debug_api(llm_request)
@@ -444,7 +444,7 @@ def test_conversation_request_debug_api_no_conversation_id(load_config):
 
 @patch("ols.app.endpoints.ols.LLMChain", new=mock_llm_chain({"text": "llm response"}))
 @patch("ols.app.endpoints.ols.load_llm", new=mock_llm_loader(None))
-def test_conversation_request_debug_api_with_conversation_id(load_config):
+def test_conversation_request_debug_api_with_conversation_id(_load_config):
     """Test conversation request debug API endpoint."""
     conversation_id = suid.get_suid()
     llm_request = LLMRequest(
@@ -455,7 +455,7 @@ def test_conversation_request_debug_api_with_conversation_id(load_config):
 
 
 @patch("ols.app.endpoints.ols.validate_question")
-def test_conversation_request_invalid_subject(mock_validate, load_config, auth):
+def test_conversation_request_invalid_subject(mock_validate, _load_config, auth):
     """Test how generate_response function checks validation results."""
     # prepare arguments for DocsSummarizer
     llm_request = LLMRequest(query="Tell me about Kubernetes")
@@ -468,7 +468,7 @@ def test_conversation_request_invalid_subject(mock_validate, load_config, auth):
 
 
 @patch("ols.src.query_helpers.docs_summarizer.DocsSummarizer.summarize")
-def test_generate_response_valid_subject(mock_summarize, load_config):
+def test_generate_response_valid_subject(mock_summarize, _load_config):
     """Test how generate_response function checks validation results."""
     # mock the DocsSummarizer
     mock_response = (
@@ -497,7 +497,7 @@ def test_generate_response_valid_subject(mock_summarize, load_config):
 
 
 @patch("ols.src.query_helpers.docs_summarizer.DocsSummarizer.summarize")
-def test_generate_response_on_summarizer_error(mock_summarize, load_config):
+def test_generate_response_on_summarizer_error(mock_summarize, _load_config):
     """Test how generate_response function checks validation results."""
     # mock the DocsSummarizer
     mock_response = Mock()
@@ -522,7 +522,7 @@ def test_generate_response_on_summarizer_error(mock_summarize, load_config):
     "ols.src.query_helpers.question_validator.QuestionValidator.validate_question",
     side_effect=Exception("mocked exception"),
 )
-def test_generate_response_unknown_validation_result(load_config):
+def test_generate_response_unknown_validation_result(_load_config):
     """Test how generate_response function checks validation results."""
     # prepare arguments for DocsSummarizer
     conversation_id = suid.get_suid()
@@ -538,7 +538,7 @@ def test_generate_response_unknown_validation_result(load_config):
 
 @patch("ols.app.endpoints.ols.LLMChain", new=mock_llm_chain({"text": "llm response"}))
 @patch("ols.app.endpoints.ols.load_llm", new=mock_llm_loader(None))
-def test_generate_bare_response(load_config):
+def test_generate_bare_response(_load_config):
     """Test the generation of bare response for debug endpoint."""
     llm_request = LLMRequest(query="Tell me about Kubernetes", conversation_id=None)
     response = ols.generate_bare_response(None, llm_request)

--- a/tests/unit/llms/test_llm_loader.py
+++ b/tests/unit/llms/test_llm_loader.py
@@ -18,7 +18,7 @@ from ols.utils import config
 
 
 @pytest.fixture
-def registered_fake_provider():
+def _registered_fake_provider():
     """Register fake provider."""
 
     @register_llm_provider_as("fake-provider")
@@ -74,7 +74,7 @@ def test_unsupported_provider_error():
 
 
 @patch("ols.constants.SUPPORTED_PROVIDER_TYPES", new=["fake-provider"])
-def test_load_llm(registered_fake_provider):
+def test_load_llm(_registered_fake_provider):
     """Test load_llm function."""
     providers = LLMProviders(
         [

--- a/tests/unit/utils/test_auth_dependency.py
+++ b/tests/unit/utils/test_auth_dependency.py
@@ -17,7 +17,7 @@ from tests.mock_classes.mock_k8s_api import (
 
 @pytest.fixture(scope="module")
 @patch.dict(os.environ, {"OLS_CONFIG_FILE": "tests/config/auth_config.yaml"})
-def setup():
+def _setup():
     """Setups and load config."""
     global auth_dependency
     config.init_config("tests/config/auth_config.yaml")
@@ -25,7 +25,7 @@ def setup():
     auth_dependency = AuthDependency(virtual_path="/ols-access")
 
 
-def test_singleton_pattern(setup):
+def test_singleton_pattern(_setup):
     """Test if K8sClientSingleton is really a singleton."""
     k1 = K8sClientSingleton()
     k2 = K8sClientSingleton()
@@ -35,7 +35,7 @@ def test_singleton_pattern(setup):
 @pytest.mark.asyncio()
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authn_api")
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authz_api")
-async def test_auth_dependency_valid_token(mock_authz_api, mock_authn_api, setup):
+async def test_auth_dependency_valid_token(mock_authz_api, mock_authn_api, _setup):
     """Tests the auth dependency with a mocked valid-token."""
     # Setup mock responses for valid token
     mock_authn_api.return_value.create_token_review.side_effect = (
@@ -60,7 +60,7 @@ async def test_auth_dependency_valid_token(mock_authz_api, mock_authn_api, setup
 @pytest.mark.asyncio()
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authn_api")
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authz_api")
-async def test_auth_dependency_invalid_token(mock_authz_api, mock_authn_api, setup):
+async def test_auth_dependency_invalid_token(mock_authz_api, mock_authn_api, _setup):
     """Test the auth dependency with a mocked invalid-token."""
     # Setup mock responses for invalid token
     mock_authn_api.return_value.create_token_review.side_effect = (
@@ -84,7 +84,7 @@ async def test_auth_dependency_invalid_token(mock_authz_api, mock_authn_api, set
 
 
 @patch.dict(os.environ, {"KUBECONFIG": "tests/config/kubeconfig"})
-def test_auth_dependency_config(setup):
+def test_auth_dependency_config(_setup):
     """Test the auth dependency can load kubeconfig file."""
     from ols.utils.auth_dependency import K8sClientSingleton
 


### PR DESCRIPTION
## Description

By convention, fixtures that don't return a value should be named with a
leading underscore, while fixtures that do return a value should not.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
