### PR TITLE
Correct L2 score range info

### DIFF
--- a/ols/constants.py
+++ b/ols/constants.py
@@ -79,7 +79,7 @@ RAG_CONTENT_LIMIT = 1
 # And if we set a very low value, then there is risk of discarding all the chunks,
 # as there won't be perfect matching chunk. This also depends on embedding model
 # used during index creation/retrieval.
-# Range: 0 to 1
+# Range: positive float value (can be > 1)
 RAG_SIMILARITY_CUTOFF_L2 = 0.5
 
 


### PR DESCRIPTION
As L2 is a distance metric, the value can be > 1. Faiss L2 index gives squared L2 as score. This is not normalized between 0 to 1.

Currently we are still using bge embedding model (for RAG), so it is not very evident but once we move to sentence-tranformers embedding model, we can see the value > 1 

