### PR TITLE
Fix OLS-511: Bug when running `QueryFilter` unit tests alone

### DIFF
--- a/tests/unit/utils/test_query_filter.py
+++ b/tests/unit/utils/test_query_filter.py
@@ -3,6 +3,7 @@
 import re
 from unittest import TestCase
 
+from ols.utils import config
 from ols.utils.query_filter import QueryFilter, RegexFilter
 
 
@@ -11,6 +12,9 @@ class TestQueryFilter(TestCase):
 
     def setUp(self):
         """Set up the test."""
+        config.query_redactor = None
+        config.init_config("tests/config/valid_config_with_query_filter.yaml")
+        config.init_query_filter()
         self.query_filter = QueryFilter()
 
     def test_redact_question_image_ip(self):


### PR DESCRIPTION
## Description

Fix [OLS-511](https://issues.redhat.com//browse/OLS-511): Bug when running `QueryFilter` unit tests alone

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-511](https://issues.redhat.com//browse/OLS-511)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.
