### PR TITLE
fix: only debug level logging includes access log

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -65,7 +65,12 @@ if __name__ == "__main__":
     if config.dev_config.disable_tls:
         # TLS is disabled, run without SSL configuration
         uvicorn.run(
-            "ols.app.main:app", host=host, port=8080, log_level=log_level, workers=1
+            "ols.app.main:app",
+            host=host,
+            port=8080,
+            log_level=log_level,
+            workers=1,
+            access_log=log_level < logging.INFO,
         )
     else:
         uvicorn.run(
@@ -77,4 +82,5 @@ if __name__ == "__main__":
             ssl_keyfile=config.ols_config.tls_config.tls_key_path,
             ssl_certfile=config.ols_config.tls_config.tls_certificate_path,
             ssl_keyfile_password=config.ols_config.tls_config.tls_key_password,
+            access_log=log_level < logging.INFO,
         )


### PR DESCRIPTION
## Description

This fix will log access on HTTP endpoints unless the log level is set below info.
This avoid excessive logging on readiness and liveness probe.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

