### PR TITLE
revert argparser type change for resp eval

### DIFF
--- a/scripts/validate_response.py
+++ b/scripts/validate_response.py
@@ -34,7 +34,7 @@ def _args_parser(args):
         "--model",
         choices=["gpt", "granite"],
         default="gpt",
-        type=str,
+        type=lambda v: "gpt" if "gpt" in v else "granite",
         help="Model for which responses will be evaluated.",
     )
     parser.add_argument(


### PR DESCRIPTION
## Description

Change back to original functionality of argparser type.. (reverting https://github.com/openshift/lightspeed-service/pull/750)

Same change worked for e2e argparser.. as there was no option to limit different acceptable values. But for response evaluation, it is there and [pj-rehearse](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/50793/rehearse-50793-periodic-ci-openshift-lightspeed-service-main-response-sanity-check/1780208105762590720) is failing for weekly job PR https://github.com/openshift/release/pull/50793..

We can implement this correctly later, if we want to avoid function for argparser `type`.




