### PR TITLE
Use freeform prompt template for conversation

### DIFF
--- a/ols/src/prompts/prompt_generator.py
+++ b/ols/src/prompts/prompt_generator.py
@@ -1,22 +1,15 @@
 """Prompt generator based on model / context."""
 
 from collections import namedtuple
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any, Optional
 
-if TYPE_CHECKING:
-    from langchain_core.prompts.chat import MessageLike
-
-from langchain.prompts import (
-    ChatPromptTemplate,
-    HumanMessagePromptTemplate,
-    MessagesPlaceholder,
-    SystemMessagePromptTemplate,
-)
+from langchain.prompts import PromptTemplate
 from langchain_core.messages.base import BaseMessage
 
 from ols.constants import (
     GPT35_TURBO,
     GRANITE_13B_CHAT_V2,
+    NO_RAG_CONTENT_RESP,
     PROVIDER_AZURE_OPENAI,
     PROVIDER_BAM,
     PROVIDER_OPENAI,
@@ -24,9 +17,12 @@ from ols.constants import (
 )
 
 from .prompts import (
-    QUERY_SYSTEM_PROMPT,
-    USE_PREVIOUS_HISTORY,
-    USE_RETRIEVED_CONTEXT,
+    CONTEXT_PLACEHOLDER,
+    HISTORY_PLACEHOLDER,
+    QUERY_PLACEHOLDER,
+    QUERY_SYSTEM_INSTRUCTION,
+    USE_CONTEXT_INSTRUCTION,
+    USE_HISTORY_INSTRUCTION,
 )
 
 PromptConfiguration = namedtuple("PromptConfiguration", "provider model")
@@ -34,39 +30,13 @@ PromptConfiguration = namedtuple("PromptConfiguration", "provider model")
 # This dictionary might be expanded in the future, if some combination of model+provider
 # requires specifically updated prompt.
 prompt_configurations = {
-    PromptConfiguration(PROVIDER_BAM, GRANITE_13B_CHAT_V2): QUERY_SYSTEM_PROMPT,
-    PromptConfiguration(PROVIDER_OPENAI, GPT35_TURBO): QUERY_SYSTEM_PROMPT,
-    PromptConfiguration(PROVIDER_WATSONX, GRANITE_13B_CHAT_V2): QUERY_SYSTEM_PROMPT,
-    PromptConfiguration(PROVIDER_AZURE_OPENAI, GPT35_TURBO): QUERY_SYSTEM_PROMPT,
+    PromptConfiguration(PROVIDER_BAM, GRANITE_13B_CHAT_V2): QUERY_SYSTEM_INSTRUCTION,
+    PromptConfiguration(PROVIDER_OPENAI, GPT35_TURBO): QUERY_SYSTEM_INSTRUCTION,
+    PromptConfiguration(
+        PROVIDER_WATSONX, GRANITE_13B_CHAT_V2
+    ): QUERY_SYSTEM_INSTRUCTION,
+    PromptConfiguration(PROVIDER_AZURE_OPENAI, GPT35_TURBO): QUERY_SYSTEM_INSTRUCTION,
 }
-
-
-def prompt_for_configuration(
-    provider: str,
-    model: str,
-    rag_exists: bool,
-    history_exists: bool,
-    default_prompt: str,
-) -> ChatPromptTemplate:
-    """Find prompt for given configuration parameters or return the default one."""
-    # construct system prompt first
-    selector = PromptConfiguration(provider, model)
-    system_prompt = prompt_configurations.get(selector, default_prompt)
-
-    # add optional parts into system prompt
-    if rag_exists:
-        system_prompt += USE_RETRIEVED_CONTEXT
-    if history_exists:
-        system_prompt += USE_PREVIOUS_HISTORY
-
-    # construct chat prompt from sequence of messages
-    messages: list[MessageLike] = []
-    messages.append(SystemMessagePromptTemplate.from_template(system_prompt))
-    if history_exists:
-        messages.append(MessagesPlaceholder(variable_name="chat_history"))
-    messages.append(HumanMessagePromptTemplate.from_template("{query}"))
-
-    return ChatPromptTemplate.from_messages(messages)
 
 
 def generate_prompt(
@@ -76,7 +46,7 @@ def generate_prompt(
     query: str,
     history: list[BaseMessage],
     rag_context: str,
-) -> tuple[ChatPromptTemplate, dict[str, Any]]:
+) -> tuple[PromptTemplate, dict[str, Any]]:
     """Dynamically creates prompt template and input values specification for LLM.
 
     Prompt template is created by combining these values:
@@ -88,32 +58,30 @@ def generate_prompt(
     - system prompt
     - user query
     """
-    rag_exists = len(rag_context) > 0
-    history_exists = len(history) > 0
-    prompt = prompt_for_configuration(
-        provider, model, rag_exists, history_exists, QUERY_SYSTEM_PROMPT
-    )
+    # Add system instruction to the prompt first.
+    selector = PromptConfiguration(provider, model)
+    prompt = prompt_configurations.get(selector, QUERY_SYSTEM_INSTRUCTION)
+    llm_input_values = {"query": query}
 
-    # construct LLM input values
-    llm_input_values: dict[str, Any] = {"query": query}
-    if rag_exists:
+    # Add optional instruction to the prompt & create prompt inputs.
+    if len(rag_context) > 0:
+        prompt += USE_CONTEXT_INSTRUCTION
+        prompt += CONTEXT_PLACEHOLDER
+
         llm_input_values["context"] = rag_context
-    if history_exists:
-        llm_input_values["chat_history"] = history
 
-    # this is place to insert program logic there for specific cases, for example:
-    #
-    # ```python
-    # if model == PROVIDER_BAM and len(rag_context) > model_options.max_rag_context:
-    #    prompt.expand(whatever is needed)
-    #    llm_input_values["foo"] = "bar"
-    #    del llm_input_values["xyzzy"]
-    #    ...
-    #    ...
-    #    ...
-    # ```
-    #
-    # any condition can be used and any modification of `prompt` and
-    # `llm_input_values` can be made
+    if len(history) > 0:
+        prompt += USE_HISTORY_INSTRUCTION
+        prompt += HISTORY_PLACEHOLDER
+        formatted_history = [
+            conversation.type.capitalize()
+            + ": "
+            + conversation.content.strip().replace(NO_RAG_CONTENT_RESP, "")
+            for conversation in history
+            if conversation
+        ]
+        llm_input_values["chat_history"] = "\n".join(formatted_history)
 
-    return prompt, llm_input_values
+    prompt += QUERY_PLACEHOLDER
+
+    return PromptTemplate.from_template(prompt), llm_input_values

--- a/ols/src/prompts/prompts.py
+++ b/ols/src/prompts/prompts.py
@@ -6,18 +6,49 @@
 from ols.constants import SUBJECT_ALLOWED, SUBJECT_REJECTED
 
 # TODO: OLS-503 Fine tune system prompt
-QUERY_SYSTEM_PROMPT = """You are an assistant for question-answering tasks \
-related to the openshift and kubernetes container orchestration platforms. \
+
+# Note::
+# Right now templates are somewhat alligned to make granite work better.
+# GPT still works well with this. Ideally we should have model specific tags.
+# For history we can laverage ChatPromptTemplate from langchain,
+# but that is not done as granite was adding role tags like `Human:` in the response.
+# With PromptTemplate, we have more control how we want to structure the prompt.
+
+QUERY_SYSTEM_INSTRUCTION = """
+You are an assistant for question-answering tasks \
+related to the openshift and kubernetes container orchestration platforms.
+
 """
 
-USE_PREVIOUS_HISTORY = """
+USE_CONTEXT_INSTRUCTION = """
+Use the retrieved document to answer the question.
+"""
+
+CONTEXT_PLACEHOLDER = """
+
+[DOCUMENT]
+{context}
+[END]
+
+"""
+
+USE_HISTORY_INSTRUCTION = """
 Use the previous chat history to interact and help the user.
 """
 
-USE_RETRIEVED_CONTEXT = """
-Use the following pieces of retrieved context to answer the question.
+HISTORY_PLACEHOLDER = """
 
-{context}
+[HISTORY]
+{chat_history}
+[END]
+
+"""
+
+QUERY_PLACEHOLDER = """
+<|user|>
+{query}
+<|assistant|>
+
 """
 
 # {{query}} is escaped because it will be replaced as a parameter at time of use

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -349,10 +349,7 @@ def test_valid_question(response_eval) -> None:
 
         # checking a few major information from response
         assert json_response["conversation_id"] == cid
-        assert (
-            "Kubernetes is" in json_response["response"]
-            or "Kubernetes: It is" in json_response["response"]
-        )
+        assert "Kubernetes is" in json_response["response"]
         assert re.search(
             r"orchestration (tool|system|platform|engine)",
             json_response["response"],

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 import pytest
 import requests
 from fastapi.testclient import TestClient
-from langchain.schema import AIMessage, HumanMessage
 
 from ols import constants
 from ols.app.models.config import (
@@ -441,10 +440,11 @@ def test_post_query_for_conversation_history(_setup) -> None:
                     "query": "Query2",
                 },
             )
-            chat_history_expected = [
-                HumanMessage(content="Query1"),
-                AIMessage(content=response.json()["response"]),
-            ]
+            chat_history_expected = (
+                "Human: Query1"
+                "\n"
+                f"Ai: {response.json()['response'].replace(constants.NO_RAG_CONTENT_RESP, '')}"
+            )
             invoke.assert_called_once_with(
                 input={
                     "query": "Query2",

--- a/tests/unit/prompts/test_prompt_generator.py
+++ b/tests/unit/prompts/test_prompt_generator.py
@@ -1,17 +1,13 @@
 """Unit tests for PromptGenerator."""
 
 import pytest
-from langchain.prompts import (
-    ChatPromptTemplate,
-    HumanMessagePromptTemplate,
-    MessagesPlaceholder,
-    SystemMessagePromptTemplate,
-)
+from langchain.prompts import PromptTemplate
 from langchain.schema import AIMessage, HumanMessage
 
 from ols.constants import (
     GPT35_TURBO,
     GRANITE_13B_CHAT_V2,
+    NO_RAG_CONTENT_RESP,
     PROVIDER_AZURE_OPENAI,
     PROVIDER_BAM,
     PROVIDER_OPENAI,
@@ -19,9 +15,12 @@ from ols.constants import (
 )
 from ols.src.prompts.prompt_generator import generate_prompt
 from ols.src.prompts.prompts import (
-    QUERY_SYSTEM_PROMPT,
-    USE_PREVIOUS_HISTORY,
-    USE_RETRIEVED_CONTEXT,
+    CONTEXT_PLACEHOLDER,
+    HISTORY_PLACEHOLDER,
+    QUERY_PLACEHOLDER,
+    QUERY_SYSTEM_INSTRUCTION,
+    USE_CONTEXT_INSTRUCTION,
+    USE_HISTORY_INSTRUCTION,
 )
 
 provider_and_model = (
@@ -61,16 +60,14 @@ def test_generate_prompt_default_prompt(provider, model, query, conversation_his
 
     # prompt with system message, history, and query, should be returned
     # system message should mention context and history
-    expected_prompt = ChatPromptTemplate.from_messages(
-        [
-            SystemMessagePromptTemplate.from_template(
-                QUERY_SYSTEM_PROMPT + USE_RETRIEVED_CONTEXT + USE_PREVIOUS_HISTORY
-            ),
-            MessagesPlaceholder(variable_name="chat_history"),
-            HumanMessagePromptTemplate.from_template("{query}"),
-        ]
+    assert prompt == PromptTemplate.from_template(
+        QUERY_SYSTEM_INSTRUCTION
+        + USE_CONTEXT_INSTRUCTION
+        + CONTEXT_PLACEHOLDER
+        + USE_HISTORY_INSTRUCTION
+        + HISTORY_PLACEHOLDER
+        + QUERY_PLACEHOLDER
     )
-    assert prompt == expected_prompt
     assert "context" in llm_input_values
     assert "query" in llm_input_values
     assert "chat_history" in llm_input_values
@@ -78,12 +75,14 @@ def test_generate_prompt_default_prompt(provider, model, query, conversation_his
 
 @pytest.mark.parametrize(("provider", "model"), provider_and_model)
 @pytest.mark.parametrize("query", queries)
-def test_generate_prompt_without_rag_context(
-    provider, model, query, conversation_history
-):
+def test_generate_prompt_without_rag_context(provider, model, query):
     """Test what prompt will be returned for non-existent RAG context."""
     model_options = {}
     rag_context = ""
+    conversation_history = [
+        HumanMessage(content="First human message"),
+        AIMessage(content=f"\n\n{NO_RAG_CONTENT_RESP}First AI response\n"),
+    ]
 
     prompt, llm_input_values = generate_prompt(
         provider,
@@ -96,19 +95,19 @@ def test_generate_prompt_without_rag_context(
 
     # prompt with system message, history, and query, should be returned
     # system message should mention history, but not context
-    expected_prompt = ChatPromptTemplate.from_messages(
-        [
-            SystemMessagePromptTemplate.from_template(
-                QUERY_SYSTEM_PROMPT + USE_PREVIOUS_HISTORY
-            ),
-            MessagesPlaceholder(variable_name="chat_history"),
-            HumanMessagePromptTemplate.from_template("{query}"),
-        ]
+    assert prompt == PromptTemplate.from_template(
+        QUERY_SYSTEM_INSTRUCTION
+        + USE_HISTORY_INSTRUCTION
+        + HISTORY_PLACEHOLDER
+        + QUERY_PLACEHOLDER
     )
-    assert prompt == expected_prompt
     assert "context" not in llm_input_values
     assert "query" in llm_input_values
     assert "chat_history" in llm_input_values
+    assert (
+        "Human: First human message\nAi: First AI response"
+        == llm_input_values["chat_history"]
+    )
 
 
 @pytest.mark.parametrize(("provider", "model"), provider_and_model)
@@ -130,15 +129,12 @@ def test_generate_prompt_without_history(provider, model, query):
 
     # prompt with system message and query, should be returned
     # system message should mention context, but not history
-    expected_prompt = ChatPromptTemplate.from_messages(
-        [
-            SystemMessagePromptTemplate.from_template(
-                QUERY_SYSTEM_PROMPT + USE_RETRIEVED_CONTEXT
-            ),
-            HumanMessagePromptTemplate.from_template("{query}"),
-        ]
+    assert prompt == PromptTemplate.from_template(
+        QUERY_SYSTEM_INSTRUCTION
+        + USE_CONTEXT_INSTRUCTION
+        + CONTEXT_PLACEHOLDER
+        + QUERY_PLACEHOLDER
     )
-    assert prompt == expected_prompt
     assert "context" in llm_input_values
     assert "query" in llm_input_values
     assert "chat_history" not in llm_input_values
@@ -163,13 +159,9 @@ def test_generate_prompt_without_rag_without_history(provider, model, query):
 
     # prompt with system message and query, should be returned
     # system message should not mention context nor history
-    expected_prompt = ChatPromptTemplate.from_messages(
-        [
-            SystemMessagePromptTemplate.from_template(QUERY_SYSTEM_PROMPT),
-            HumanMessagePromptTemplate.from_template("{query}"),
-        ]
+    assert prompt == PromptTemplate.from_template(
+        QUERY_SYSTEM_INSTRUCTION + QUERY_PLACEHOLDER
     )
-    assert prompt == expected_prompt
     assert "context" not in llm_input_values
     assert "query" in llm_input_values
     assert "chat_history" not in llm_input_values


### PR DESCRIPTION
## Description

Use freeform text as prompt. This is done to avoid ChatPromptTemplate, as granite was adding role tag to the response.. This also gives us more control how we want to modify prompt and add model specific prompt.
Currently the prompt has few granite specific tags.. GPT still works well with this prompt..

This is as per the experimentation done in [OLS-452](https://issues.redhat.com/browse/OLS-452)

Possible future works:

- As we are not using chat template anymore, we can think of alternate/more generic way of saving history.
- Model specific prompts.