### PR TITLE
(Minor) added missing types for `__init__` methods

### DIFF
--- a/ols/src/cache/postgres_cache.py
+++ b/ols/src/cache/postgres_cache.py
@@ -11,7 +11,7 @@ from ols.src.cache.cache import Cache
 class PostgresCache(Cache):
     """Cache that uses Postgres to store cached values."""
 
-    def __init__(self, config: PostgresConfig):
+    def __init__(self, config: PostgresConfig) -> None:
         """Create a new instance of Postgres cache."""
 
     def get(self, user_id: str, conversation_id: str) -> Optional[list[BaseMessage]]:

--- a/ols/utils/auth_dependency.py
+++ b/ols/utils/auth_dependency.py
@@ -163,7 +163,7 @@ def _extract_bearer_token(header: str) -> str:
 class AuthDependency:
     """Create an AuthDependency Class that allows customizing the acces Scope path to check."""
 
-    def __init__(self, virtual_path: str = "/ols-access"):
+    def __init__(self, virtual_path: str = "/ols-access") -> None:
         """Initialize the required allowed paths for authorization checks."""
         self.virtual_path = virtual_path
 


### PR DESCRIPTION
## Description

(Minor) added missing types for `__init__` methods

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
