### PR TITLE
Use idiomatic dict call

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -116,7 +116,7 @@ class ModelConfig(BaseModel):
         """Validate model options which must be dict[str, Any]."""
         if not isinstance(options, dict):
             raise InvalidConfigurationError("model options must be dictionary")
-        for key in options.keys():
+        for key in options:
             if not isinstance(key, str):
                 raise InvalidConfigurationError("key for model option must be string")
 


### PR DESCRIPTION
## Description

Iterating over dictionary keys, using
`key in dict` is more readable and efficient than `key in dict.keys()`,
while having the same semantics.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
