### PR TITLE
Ignore asserts in scripts the same way we ignored them in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,11 @@ check-types: ## Checks type hints in sources
 
 format: ## Format the code into unified format
 	black .
-	ruff check . --fix --per-file-ignores=tests/*:S101
+	ruff check . --fix --per-file-ignores=tests/*:S101 --per-file-ignores=scripts/*:S101
 
 verify: ## Verify the code using various linters
 	black . --check
-	ruff check . --per-file-ignores=tests/*:S101
+	ruff check . --per-file-ignores=tests/*:S101 --per-file-ignores=scripts/*:S101
 
 schema:	## Generate OpenAPI schema file
 	python scripts/generate_openapi_schema.py docs/openapi.json


### PR DESCRIPTION
## Description

Ignore asserts in scripts the same way we ignored them in tests
Does not change `ols` checking at all

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
