### PR TITLE
remove min_new_tokens from question validation

### DIFF
--- a/ols/src/query_helpers/question_validator.py
+++ b/ols/src/query_helpers/question_validator.py
@@ -22,10 +22,7 @@ class QuestionValidator(QueryHelper):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the QuestionValidator."""
         # TODO: OLS-447 Refactor code that pass parameters into LLM in QuestionValidator
-        llm_params = {
-            "min_new_tokens": 1,
-            "max_new_tokens": 4,
-        }
+        llm_params = {"max_new_tokens": 4}
         super().__init__(*args, **dict(kwargs, llm_params=llm_params))
 
     def validate_question(

--- a/tests/unit/query_helpers/test_question_validator.py
+++ b/tests/unit/query_helpers/test_question_validator.py
@@ -27,11 +27,9 @@ def test_passing_parameters():
 
     question_validator = QuestionValidator()
     assert question_validator.llm_params is not None
-    assert "max_new_tokens" in question_validator.llm_params is not None
-    assert "min_new_tokens" in question_validator.llm_params is not None
+    assert "max_new_tokens" in question_validator.llm_params
 
     question_validator = QuestionValidator(llm_params={})
     # the llm_params should be rewritten in constructor
     assert question_validator.llm_params is not None
-    assert "max_new_tokens" in question_validator.llm_params is not None
-    assert "min_new_tokens" in question_validator.llm_params is not None
+    assert "max_new_tokens" in question_validator.llm_params


### PR DESCRIPTION
## Description

Setting up min_new_tokens=1 is not required in QuestionValidation as this is the default value.
remove copy/paste typo in test cases.