### PR TITLE
OLS-524: default parameter for history

### DIFF
--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -30,13 +30,12 @@ class DocsSummarizer(QueryHelper):
             model_config = provider_config.models.get(self.model)
             return model_config.options
 
-    # TODO: OLS-524 Mutable objects used as function argument defaults
     def summarize(
         self,
         conversation_id: str,
         query: str,
         vector_index: Optional[VectorStoreIndex] = None,
-        history: list[BaseMessage] = [],
+        history: Optional[list[BaseMessage]] = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Summarize the given query based on the provided conversation context.
@@ -55,6 +54,10 @@ class DocsSummarizer(QueryHelper):
             - flag indicating that conversation history has been truncated
               to fit within context window.
         """
+        # if history is not provided, initialize to empty history
+        if history is None:
+            history = []
+
         verbose = kwargs.get("verbose", "").lower() == "true"
         settings_string = (
             f"conversation_id: {conversation_id}, "


### PR DESCRIPTION
## Description

[OLS-524](https://issues.redhat.com//browse/OLS-524): default parameter for history
Added more unit tests to cover this situation + to cover truncation too

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Unit tests

## Related Tickets & Documents

- Related Issue #[OLS-524](https://issues.redhat.com//browse/OLS-524)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.
