### PR TITLE
OLS-524: Don't use mutable default value in mock object

### DIFF
--- a/tests/mock_classes/mock_summary.py
+++ b/tests/mock_classes/mock_summary.py
@@ -4,9 +4,11 @@
 class MockSummary:
     """Mocked summary returned from query engine."""
 
-    # TODO: OLS-524 Mutable objects used as function argument defaults
-    def __init__(self, query, nodes=[]):
+    def __init__(self, query, nodes=None):
         """Initialize all required object attributes."""
+        if nodes is None:
+            nodes = []
+
         self.query = query
         self.source_nodes = nodes
 


### PR DESCRIPTION
## Description

[OLS-524](https://issues.redhat.com//browse/OLS-524): Don't use mutable default value in mock object

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-524](https://issues.redhat.com//browse/OLS-524)
- Closes #

