### PR TITLE
Add buffer to token count

### DIFF
--- a/ols/constants.py
+++ b/ols/constants.py
@@ -76,6 +76,9 @@ CONTEXT_WINDOW_SIZES = {
 
 DEFAULT_TOKENIZER_MODEL = "cl100k_base"
 
+# Example: 1.05 means we increase by 5%.
+TOKEN_BUFFER_WEIGHT = 1.1
+
 
 # RAG related constants
 


### PR DESCRIPTION
## Description
We are using precise context window now and token count is currently an approximation. So adding buffer to token count.
With this change we will increase token count by some weight.

Currently a single constant is used, but this can be extended further to have model/provider specific weights/percentage. Experimentation is required to understand in general how far off is our estimation.

Alternatively we could decrease context window by some buffer. But decided against that as error message may be confusing. Context window is well know and token calculation is an estimation anyway. So modifying count is more reasonable.

- Related Issue # [OLS-537](https://issues.redhat.com//browse/OLS-537)

cc: @bparees 