### PR TITLE
OLS-538: Check final token count before reaching LLM

### DIFF
--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -121,6 +121,13 @@ class DocsSummarizer(QueryHelper):
             history,
             rag_context,
         )
+
+        # Final check if we don't use more tokens than permitted by provider+model
+        # Handles: OLS-538
+        token_handler.get_available_tokens(
+            final_prompt.format(**llm_input_values), model_config
+        )
+
         chat_engine = LLMChain(
             llm=bare_llm,
             prompt=final_prompt,


### PR DESCRIPTION
## Description

Check final token count before reaching LLM
That should avoid "Internal server error"

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-538](https://issues.redhat.com//browse/OLS-538)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
