### PR TITLE
OLS-538: Better error message when token limit threshold is reached

### DIFF
--- a/ols/utils/token_handler.py
+++ b/ols/utils/token_handler.py
@@ -100,9 +100,10 @@ class TokenHandler:
         )
 
         if available_tokens <= 0:
-            limit = context_window_size
+            limit = context_window_size - response_token_limit
             raise PromptTooLongError(
-                f"Prompt length exceeds LLM context window limit ({limit} tokens)"
+                f"Prompt length {prompt_token_count} exceeds LLM "
+                f"available context window limit {limit} tokens"
             )
 
         return available_tokens

--- a/tests/unit/utils/test_token_handler.py
+++ b/tests/unit/utils/test_token_handler.py
@@ -105,9 +105,10 @@ class TestTokenHandler(TestCase):
         # this prompt will surely exceeds context window size
         prompt = "What is Kubernetes?" * 10000
 
-        with pytest.raises(
-            PromptTooLongError, match="Prompt length exceeds LLM context window limit"
-        ):
+        expected_error_messge = (
+            "Prompt length 40000 exceeds LLM available context window limit"
+        )
+        with pytest.raises(PromptTooLongError, match=expected_error_messge):
             self._token_handler_obj.get_available_tokens(prompt, model_config)
 
     def test_available_tokens_specific_model_config(self):


### PR DESCRIPTION
## Description

Better error message when token limit threshold is reached

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-538](https://issues.redhat.com//browse/OLS-538)
- Closes #
