### PR TITLE
OLS-495: Keep default user UUID and set it to "nil" UUID

### DIFF
--- a/ols/constants.py
+++ b/ols/constants.py
@@ -132,7 +132,9 @@ POSTGRES_CACHE_SSL_MODE = "prefer"
 
 
 # default indentity for local testing and deployment
-DEFAULT_USER_UID = "c1143120-551e-4a47-ad47-2748d6f3c81c"
+# "nil" UUID is used on purpose, because it will be easier to
+# filter these values in CSV export with user feedbacks etc.
+DEFAULT_USER_UID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_USER_NAME = "OLS"
 # TO-DO: make this UUID dynamic per cluster (dynamic uuid for each cluster)
 DEFAULT_KUBEADMIN_UID = "b6553200-0f7b-4c82-b1c5-9303ff18e5f0"

--- a/ols/utils/auth_dependency.py
+++ b/ols/utils/auth_dependency.py
@@ -184,7 +184,10 @@ class AuthDependency:
         """
         if config.dev_config.disable_auth:
             logger.warning("Auth checks disabled, skipping")
-            # TODO: OLS-495 replace with constants for default identity
+            # Use constant user ID and user name in case auth. is disabled
+            # It will be needed for testing purposes because (for example)
+            # conversation history and user feedback depend on having any
+            # user ID (identity) in proper format (UUID)
             return DEFAULT_USER_UID, DEFAULT_USER_NAME
         authorization_header = request.headers.get("Authorization")
         if not authorization_header:


### PR DESCRIPTION
## Description

Keep default user UUID and set it to "nil" UUID

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-495](https://issues.redhat.com//browse/OLS-495)
