### PR TITLE
OLS-549: Strip whitespaces from response

### DIFF
--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -139,7 +139,9 @@ class DocsSummarizer(QueryHelper):
                 config={"callbacks": [token_counter]},
             )
 
-        response = summary["text"]
+        # retrieve text response returned from LLM, strip whitespace characters from beginning/end
+        response = summary["text"].strip()
+
         if len(rag_context) == 0:
             logger.debug("Using llm to answer the query without reference content")
         logger.debug(f"{conversation_id} Summary response: {response}")


### PR DESCRIPTION
## Description

[OLS-549](https://issues.redhat.com//browse/OLS-549): Strip whitespaces from response
(+ save one or more tokens in history)

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
