### PR TITLE
OLS-506: Remove redundant standalone tests

### DIFF
--- a/tests/e2e/pytest.ini
+++ b/tests/e2e/pytest.ini
@@ -14,4 +14,3 @@ markers =
 	provider_openai
 	provider_azure_openai
 	provider_watsonx
-


### PR DESCRIPTION
## Description

Remove redundant (last) standalone tests.
These test scenarios are covered in "cluster" alternatives.
This PR paves the road for the complete removal of the standalone CI suite (the "cluster" suite is running everything except "standalone"). 

## Type of change

- [x] Refactor
