### PR TITLE
OLS-447: Fixture in LLM providers unit tests

### DIFF
--- a/tests/unit/llms/providers/test_bam.py
+++ b/tests/unit/llms/providers/test_bam.py
@@ -1,5 +1,6 @@
-"""Unit tests for OpenAI provider."""
+"""Unit tests for BAM provider."""
 
+import pytest
 from genai.extensions.langchain import LangChainInterface
 
 from ols.app.models.config import ProviderConfig
@@ -7,10 +8,10 @@ from ols.src.llms.providers.bam import BAM
 from ols.utils import config
 
 
-def test_basic_interface():
-    """Test basic interface."""
-    config.init_empty_config()  # needed for checking the config.dev_config.llm_params
-    provider_cfg = ProviderConfig(
+@pytest.fixture
+def provider_config():
+    """Fixture with provider configuration for BAM."""
+    return ProviderConfig(
         {
             "name": "some_provider",
             "type": "bam",
@@ -26,7 +27,12 @@ def test_basic_interface():
         }
     )
 
-    bam = BAM(model="uber-model", params={}, provider_config=provider_cfg)
+
+def test_basic_interface(provider_config):
+    """Test basic interface."""
+    config.init_empty_config()  # needed for checking the config.dev_config.llm_params
+
+    bam = BAM(model="uber-model", params={}, provider_config=provider_config)
     llm = bam.load()
     assert isinstance(llm, LangChainInterface)
     assert bam.default_params

--- a/tests/unit/llms/providers/test_watsonx.py
+++ b/tests/unit/llms/providers/test_watsonx.py
@@ -1,6 +1,8 @@
-"""Unit tests for OpenAI provider."""
+"""Unit tests for Watsonx provider."""
 
 from unittest.mock import patch
+
+import pytest
 
 from ols.app.models.config import ProviderConfig
 from ols.src.llms.providers.watsonx import WatsonX
@@ -8,11 +10,10 @@ from ols.utils import config
 from tests.mock_classes.mock_watsonxllm import WatsonxLLM
 
 
-@patch("ols.src.llms.providers.watsonx.WatsonxLLM", new=WatsonxLLM())
-def test_basic_interface():
-    """Test basic interface."""
-    config.init_empty_config()  # needed for checking the config.dev_config.llm_params
-    provider_cfg = ProviderConfig(
+@pytest.fixture
+def provider_config():
+    """Fixture with provider configuration for Watsonx."""
+    return ProviderConfig(
         {
             "name": "some_provider",
             "type": "watsonx",
@@ -29,7 +30,13 @@ def test_basic_interface():
         }
     )
 
-    watsonx = WatsonX(model="uber-model", params={}, provider_config=provider_cfg)
+
+@patch("ols.src.llms.providers.watsonx.WatsonxLLM", new=WatsonxLLM())
+def test_basic_interface(provider_config):
+    """Test basic interface."""
+    config.init_empty_config()  # needed for checking the config.dev_config.llm_params
+
+    watsonx = WatsonX(model="uber-model", params={}, provider_config=provider_config)
     llm = watsonx.load()
     assert isinstance(llm, WatsonxLLM)
     assert watsonx.default_params


### PR DESCRIPTION
## Description

We are going to add new unit tests for LLM providers as part of OLS-447. Thus it is better to use fixtures with provider configurations as they will be used in new tests.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Unit tests

## Related Tickets & Documents

- Related Issue #OLS-447
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
