### PR TITLE
OLS-538: Refactor get_token_handler method

### DIFF
--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -83,7 +83,7 @@ class DocsSummarizer(QueryHelper):
             ["dummy"],
             "dummy",
         )
-        available_tokens = token_handler.get_available_tokens(
+        available_tokens = token_handler.calculate_and_check_available_tokens(
             temp_prompt.format(**temp_prompt_input), model_config
         )
 
@@ -124,7 +124,7 @@ class DocsSummarizer(QueryHelper):
 
         # Final check if we don't use more tokens than permitted by provider+model
         # Handles: OLS-538
-        token_handler.get_available_tokens(
+        token_handler.calculate_and_check_available_tokens(
             final_prompt.format(**llm_input_values), model_config
         )
 

--- a/ols/src/query_helpers/question_validator.py
+++ b/ols/src/query_helpers/question_validator.py
@@ -57,7 +57,7 @@ class QuestionValidator(QueryHelper):
         # if it's in context window limit
         provider_config = config.llm_config.providers.get(self.provider)
         model_config = provider_config.models.get(self.model)
-        TokenHandler().get_available_tokens(query, model_config)
+        TokenHandler().calculate_and_check_available_tokens(query, model_config)
 
         llm_chain = LLMChain(
             llm=bare_llm,

--- a/ols/utils/token_handler.py
+++ b/ols/utils/token_handler.py
@@ -66,7 +66,9 @@ class TokenHandler:
         # We increase by certain percentage to nearest integer (ceil).
         return ceil(len(tokens) * TOKEN_BUFFER_WEIGHT)
 
-    def get_available_tokens(self, prompt: str, model_config: ModelConfig) -> int:
+    def calculate_and_check_available_tokens(
+        self, prompt: str, model_config: ModelConfig
+    ) -> int:
         """Get available tokens that can be used for prompt augmentation.
 
         Args:

--- a/tests/unit/utils/test_token_handler.py
+++ b/tests/unit/utils/test_token_handler.py
@@ -66,13 +66,13 @@ class TestTokenHandler(TestCase):
         self._token_handler_obj = TokenHandler()
 
     def test_available_tokens_for_empty_prompt(self):
-        """Test the get_available_tokens method for default model config."""
+        """Test the method to calculate available tokens and check if there are any available tokens for default model config."""  # noqa E501
         # use default model config
         model_config = ModelConfig({})
 
         prompt = ""
 
-        available_tokens = self._token_handler_obj.get_available_tokens(
+        available_tokens = self._token_handler_obj.calculate_and_check_available_tokens(
             prompt, model_config
         )
         assert (
@@ -81,14 +81,14 @@ class TestTokenHandler(TestCase):
         )
 
     def test_available_tokens_for_regular_prompt(self):
-        """Test the get_available_tokens method for default model config."""
+        """Test the method to calculate available tokens and check if there are any available tokens for default model config."""  # noqa E501
         # use default model config
         model_config = ModelConfig({})
 
         prompt = "What is Kubernetes?"
         prompt_length = len(self._token_handler_obj.text_to_tokens(prompt))
 
-        available_tokens = self._token_handler_obj.get_available_tokens(
+        available_tokens = self._token_handler_obj.calculate_and_check_available_tokens(
             prompt, model_config
         )
         expected_value = (
@@ -99,7 +99,7 @@ class TestTokenHandler(TestCase):
         assert available_tokens == expected_value
 
     def test_available_tokens_for_large_prompt(self):
-        """Test the get_available_tokens method for default model config."""
+        """Test the method to calculate available tokens and check if there are any available tokens for default model config."""  # noqa E501
         # use default model config
         model_config = ModelConfig({})
         context_limit = (
@@ -116,10 +116,12 @@ class TestTokenHandler(TestCase):
             f"LLM available context window limit {context_limit} tokens"
         )
         with pytest.raises(PromptTooLongError, match=expected_error_messge):
-            self._token_handler_obj.get_available_tokens(prompt, model_config)
+            self._token_handler_obj.calculate_and_check_available_tokens(
+                prompt, model_config
+            )
 
     def test_available_tokens_specific_model_config(self):
-        """Test the get_available_tokens method for specific model config."""
+        """Test the method to calculate available tokens and check if there are any available tokens for specific model config."""  # noqa E501
         # use specific model config
         model_config = ModelConfig(
             {
@@ -133,7 +135,7 @@ class TestTokenHandler(TestCase):
         prompt = "What is Kubernetes?"
         prompt_length = len(self._token_handler_obj.text_to_tokens(prompt))
 
-        available_tokens = self._token_handler_obj.get_available_tokens(
+        available_tokens = self._token_handler_obj.calculate_and_check_available_tokens(
             prompt, model_config
         )
         expected_value = (


### PR DESCRIPTION
## Description

Refactor `get_token_handler method`. That method used to do two operations:
1. calculate available tokens
2. throws exception when no token are left

It leads to semantic misuse.
It's better to have two methods sharing the same code logic put into private method.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-538](https://issues.redhat.com//browse/OLS-538)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
