### PR TITLE
OLS-447: Unit tests: handling known and unknown parameters by BAM and Watsonx providers

### DIFF
--- a/tests/unit/llms/providers/test_bam.py
+++ b/tests/unit/llms/providers/test_bam.py
@@ -36,3 +36,98 @@ def test_basic_interface(provider_config):
     llm = bam.load()
     assert isinstance(llm, LangChainInterface)
     assert bam.default_params
+
+
+def test_params_handling(provider_config):
+    """Test that not allowed parameters are removed before model init."""
+    config.init_empty_config()  # needed for checking the config.dev_config.llm_params
+
+    # first two parameters should be removed before model init
+    # rest need to stay
+    params = {
+        "unknown_parameter": "foo",
+        "verbose": True,
+        "min_new_tokens": 1,
+        "max_new_tokens": 10,
+        "temperature": 0.3,
+    }
+
+    bam = BAM(model="uber-model", params=params, provider_config=provider_config)
+    llm = bam.load()
+    assert isinstance(llm, LangChainInterface)
+    assert bam.default_params
+    assert bam.params
+
+    # known parameters should be there
+    assert "min_new_tokens" in bam.params
+    assert bam.params["min_new_tokens"] == 1
+
+    assert "max_new_tokens" in bam.params
+    assert bam.params["max_new_tokens"] == 10
+
+    assert "temperature" in bam.params
+    assert bam.params["temperature"] == 0.3
+
+    # unknown parameters should be filtered out
+    assert "verbose" not in bam.params
+
+    assert "unknown_parameter" not in bam.params
+
+
+def test_params_handling_none_values(provider_config):
+    """Test handling parameters with None values."""
+    config.init_empty_config()  # needed for checking the config.dev_config.llm_params
+
+    # first two parameters should be removed before model init
+    # rest need to stay
+    params = {
+        "unknown_parameter": None,
+        "verbose": None,
+        "min_new_tokens": None,
+        "max_new_tokens": None,
+        "temperature": None,
+    }
+
+    bam = BAM(model="uber-model", params=params, provider_config=provider_config)
+    llm = bam.load()
+    assert isinstance(llm, LangChainInterface)
+    assert bam.default_params
+    assert bam.params
+
+    # known parameters should be there
+    assert "min_new_tokens" in bam.params
+    assert bam.params["min_new_tokens"] is None
+
+    assert "max_new_tokens" in bam.params
+    assert bam.params["max_new_tokens"] is None
+
+    assert "temperature" in bam.params
+    assert bam.params["temperature"] is None
+
+    # unknown parameters should be filtered out
+    assert "verbose" not in bam.params
+
+    assert "unknown_parameter" not in bam.params
+
+
+def test_params_replace_default_values_with_none(provider_config):
+    """Test if default values are replaced by None values."""
+    config.init_empty_config()  # needed for checking the config.dev_config.llm_params
+
+    # provider initialization with empty set of params
+    bam = BAM(model="uber-model", params={}, provider_config=provider_config)
+    bam.load()
+
+    # check default value
+    assert "decoding_method" in bam.params
+    assert bam.params["decoding_method"] == "sample"
+
+    # provider initialization where default parameter is overriden
+    params = {"decoding_method": None}
+
+    bam = BAM(model="uber-model", params=params, provider_config=provider_config)
+    bam.load()
+
+    # check default value overrided by None
+    assert "decoding_method" in bam.params
+    assert bam.params["decoding_method"] is None

--- a/tests/unit/llms/providers/test_watsonx.py
+++ b/tests/unit/llms/providers/test_watsonx.py
@@ -3,6 +3,9 @@
 from unittest.mock import patch
 
 import pytest
+from ibm_watson_machine_learning.metanames import (
+    GenTextParamsMetaNames as GenParams,
+)
 
 from ols.app.models.config import ProviderConfig
 from ols.src.llms.providers.watsonx import WatsonX
@@ -40,3 +43,102 @@ def test_basic_interface(provider_config):
     llm = watsonx.load()
     assert isinstance(llm, WatsonxLLM)
     assert watsonx.default_params
+
+
+@patch("ols.src.llms.providers.watsonx.WatsonxLLM", new=WatsonxLLM())
+def test_params_handling(provider_config):
+    """Test that not allowed parameters are removed before model init."""
+    config.init_empty_config()  # needed for checking the config.dev_config.llm_params
+
+    # first two parameters should be removed before model init
+    # rest need to stay
+    params = {
+        "unknown_parameter": "foo",
+        "verbose": True,
+        "min_new_tokens": 1,
+        "max_new_tokens": 10,
+        "temperature": 0.3,
+    }
+
+    watsonx = WatsonX(
+        model="uber-model", params=params, provider_config=provider_config
+    )
+    llm = watsonx.load()
+    assert isinstance(llm, WatsonxLLM)
+    assert watsonx.default_params
+    assert watsonx.params
+
+    # known parameters should be there
+    assert GenParams.DECODING_METHOD in watsonx.params
+    assert watsonx.params[GenParams.DECODING_METHOD] == "sample"
+
+    assert GenParams.MAX_NEW_TOKENS in watsonx.params
+    assert watsonx.params[GenParams.MAX_NEW_TOKENS] == 10
+
+    # unknown parameters should be filtered out
+    assert "unknown_parameter" not in watsonx.params
+    assert "verbose" not in watsonx.params
+
+
+@patch("ols.src.llms.providers.watsonx.WatsonxLLM", new=WatsonxLLM())
+def test_params_handling_none_values(provider_config):
+    """Test handling parameters with None values."""
+    config.init_empty_config()  # needed for checking the config.dev_config.llm_params
+
+    # first three parameters should be removed before model init
+    # rest need to stay
+    params = {
+        "unknown_parameter": None,
+        "temperature": None,
+        "verbose": None,
+        "min_new_tokens": None,
+        "max_new_tokens": None,
+    }
+
+    watsonx = WatsonX(
+        model="uber-model", params=params, provider_config=provider_config
+    )
+    llm = watsonx.load()
+    assert isinstance(llm, WatsonxLLM)
+    assert watsonx.default_params
+    assert watsonx.params
+
+    # known parameters should be there
+    assert GenParams.MIN_NEW_TOKENS in watsonx.params
+    assert watsonx.params[GenParams.MIN_NEW_TOKENS] is None
+
+    assert GenParams.MAX_NEW_TOKENS in watsonx.params
+    assert watsonx.params[GenParams.MAX_NEW_TOKENS] is None
+
+    assert GenParams.TEMPERATURE in watsonx.params
+    assert watsonx.params[GenParams.TEMPERATURE] is None
+
+    # unknown parameters should be filtered out
+    assert "unknown_parameter" not in watsonx.params
+    assert "verbose" not in watsonx.params
+
+
+@patch("ols.src.llms.providers.watsonx.WatsonxLLM", new=WatsonxLLM())
+def test_params_replace_default_values_with_none(provider_config):
+    """Test if default values are replaced by None values."""
+    config.init_empty_config()  # needed for checking the config.dev_config.llm_params
+
+    # provider initialization with empty set of params
+    watsonx = WatsonX(model="uber-model", params={}, provider_config=provider_config)
+    watsonx.load()
+
+    # check default value
+    assert GenParams.DECODING_METHOD in watsonx.params
+    assert watsonx.params[GenParams.DECODING_METHOD] == "sample"
+
+    # provider initialization where default parameter is overriden
+    params = {"decoding_method": None}
+
+    watsonx = WatsonX(
+        model="uber-model", params=params, provider_config=provider_config
+    )
+    watsonx.load()
+
+    # check default value overrided by None
+    assert GenParams.DECODING_METHOD in watsonx.params
+    assert watsonx.params[GenParams.DECODING_METHOD] is None


### PR DESCRIPTION
## Description

Unit tests: handling known and unknown parameters by BAM and Watsonx providers

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Unit tests

## Related Tickets & Documents

- Related Issue #[OLS-447](https://issues.redhat.com//browse/OLS-447)
- Closes #
