### PR TITLE
Update RAG content: OLS-517, OLS-530, page exclusion, OCP docs update

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # vim: set filetype=dockerfile
-ARG LIGHTSPEED_RAG_CONTENT_DIGEST=sha256:c40bdfe55a827f46fd7775b4dcfec39bb915c8338bc6c0c085e0284ca8a08ebd
+ARG LIGHTSPEED_RAG_CONTENT_DIGEST=sha256:69a805043f61fc999fd190263646f9c3ef91f30f0d025574dd7ebc542f07a6c5
 
 FROM quay.io/openshift/lightspeed-rag-content@${LIGHTSPEED_RAG_CONTENT_DIGEST} as lightspeed-rag-content
 

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ schema:	## Generate OpenAPI schema file
 	python scripts/generate_openapi_schema.py docs/openapi.json
 
 get-rag: ## Download a copy of the RAG embedding model and vector database
-	podman create --replace --name tmp-rag-container quay.io/openshift/lightspeed-rag-content@sha256:c40bdfe55a827f46fd7775b4dcfec39bb915c8338bc6c0c085e0284ca8a08ebd true
+	podman create --replace --name tmp-rag-container quay.io/openshift/lightspeed-rag-content@sha256:69a805043f61fc999fd190263646f9c3ef91f30f0d025574dd7ebc542f07a6c5 true
 	podman cp tmp-rag-container:/rag/vector_db vector_db
 	podman cp tmp-rag-container:/rag/embeddings_model embeddings_model
 	podman rm tmp-rag-container


### PR DESCRIPTION
## Description

Update RAG content, pick up the following updates: 
- [OLS-517](https://issues.redhat.com//browse/OLS-517) Handle encoded/image data in index
- [OLS-530](https://issues.redhat.com//browse/OLS-530) Use pdm to manage dependencies in the lightspeed-rag-content repo
- plaintext page exclusion
- OCP docs update as of 2024/04/26

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/OLS-517, https://issues.redhat.com/browse/OLS-530
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
