### PR TITLE
OLS-506: Remove unused tests markers

### DIFF
--- a/tests/e2e/pytest.ini
+++ b/tests/e2e/pytest.ini
@@ -9,8 +9,3 @@ markers =
 	cluster
 	standalone
 	rag
-	norag
-	provider_bam
-	provider_openai
-	provider_azure_openai
-	provider_watsonx


### PR DESCRIPTION
## Description

Remove unused tests markers.
The `standalone` marker will be removed in a separate PR with the rest of the relevant code.

## Type of change

- [x] Refactor
