### PR TITLE
Just set global variable type, don't initialize to silly value

### DIFF
--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -9,6 +9,7 @@ import time
 
 import pytest
 import requests
+from httpx import Client
 
 from ols.constants import (
     HTTP_REQUEST_HEADERS_TO_REDACT,
@@ -47,8 +48,8 @@ if "localhost" not in ols_url:
 
 # generic http client for talking to OLS, when OLS is run on a cluster
 # this client will be preconfigured with a valid user token header.
-client = None
-metrics_client = None
+client: Client
+metrics_client: Client
 
 
 # constant from tests/config/cluster_install/ols_manifests.yaml


### PR DESCRIPTION
## Description

Just set global variable type, don't initialize to silly value
It is improper, these client will be always set **or** the test setup fails
Also it allows the IDEs and type checkers to infer the type correctly

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
