### PR TITLE
OLS-447: Check global provider configuration existence

### DIFF
--- a/ols/src/llms/llm_loader.py
+++ b/ols/src/llms/llm_loader.py
@@ -61,6 +61,7 @@ def load_llm(provider: str, model: str, llm_params: Optional[dict] = None) -> LL
         llm_params: The optional LLM parameters.
 
     Raises:
+        LLMConfigurationError: If the whole provider configuration is missing.
         UnsupportedProviderError: If the provider is not supported (implemented).
         UnknownProviderError: If the provider is not known.
         ModelConfigMissingError: If the model configuration is missing.
@@ -75,6 +76,8 @@ def load_llm(provider: str, model: str, llm_params: Optional[dict] = None) -> LL
         ```
     """
     providers_config = config.config.llm_providers
+    if providers_config is None:
+        raise LLMConfigurationError("Providers configuration missing in olsconfig.yaml")
     llm_providers_reg = LLMProvidersRegistry
 
     provider_config = _resolve_provider_config(provider, model, providers_config)

--- a/tests/unit/llms/test_llm_loader.py
+++ b/tests/unit/llms/test_llm_loader.py
@@ -90,3 +90,15 @@ def test_load_llm(_registered_fake_provider):
 
     llm = load_llm(provider="fake-provider", model="model")
     assert llm == "fake_llm"
+
+
+@patch("ols.constants.SUPPORTED_PROVIDER_TYPES", new=["fake-provider"])
+def test_load_llm_no_provider_config(_registered_fake_provider):
+    """Test load_llm function."""
+    config.init_empty_config()
+    config.config.llm_providers = None
+
+    with pytest.raises(
+        LLMConfigurationError, match="Providers configuration missing in olsconfig.yaml"
+    ):
+        load_llm(provider="fake-provider", model="model")


### PR DESCRIPTION
## Description

Check global provider configuration existence
Added unit test for this situation

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-447](https://issues.redhat.com//browse/OLS-447)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.
