### PR TITLE
increase l2 threshold cut-off

### DIFF
--- a/ols/constants.py
+++ b/ols/constants.py
@@ -104,7 +104,7 @@ RAG_CONTENT_LIMIT = 1
 # as there won't be perfect matching chunk. This also depends on embedding model
 # used during index creation/retrieval.
 # Range: positive float value (can be > 1)
-RAG_SIMILARITY_CUTOFF_L2 = 0.75
+RAG_SIMILARITY_CUTOFF_L2 = 1.4
 
 
 # cache constants


### PR DESCRIPTION
## Description

Currently L2 threshold score is set to a very low value. hence we are discarding relevant docs/chunks.
[OLS-571](https://issues.redhat.com/browse/OLS-571)

[Document](https://docs.google.com/spreadsheets/d/12dPNombnsYjP95yzWyoHxKMej7l5y9lX1pi7ZpffHeg/edit?usp=sharing)

Above file has few sample questions along with score for top matching chunk. Based on this Threshold score cut-off is increased to 1.4.
With this increase, it is possible that few irrelevant chunks will be included, but it is trade off  