### PR TITLE
OLS-586: Exclude parameter is of type set

### DIFF
--- a/ols/app/endpoints/feedback.py
+++ b/ols/app/endpoints/feedback.py
@@ -128,7 +128,7 @@ def store_user_feedback(
 
     user_id = retrieve_user_id(auth)
     try:
-        store_feedback(user_id, feedback_request.model_dump(exclude=["model_config"]))
+        store_feedback(user_id, feedback_request.model_dump(exclude={"model_config"}))
     except Exception as e:
         logger.error(f"Error storing user feedback: {e}")
         raise HTTPException(


### PR DESCRIPTION
## Description

This is actually an interesting bug that is not manifested because the `in` operator works for lists too (but in newer version of library it can fail).

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-586](https://issues.redhat.com//browse/OLS-586)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
