### PR TITLE
Fix: Remove default test tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .PHONY: test test-unit test-e2e images run format verify
 
 ARTIFACT_DIR := $(if $(ARTIFACT_DIR),$(ARTIFACT_DIR),tests/test_results)
-TEST_TAGS := $(if $(TEST_TAGS),$(TEST_TAGS),not cluster)
+TEST_TAGS := $(if $(TEST_TAGS),$(TEST_TAGS),"")
 SUITE_ID := $(if $(SUITE_ID),$(SUITE_ID),"nosuite")
 PROVIDER := $(if $(PROVIDER),$(PROVIDER),"openai")
 MODEL := $(if $(MODEL),$(MODEL),"gpt-3.5-turbo")


### PR DESCRIPTION
## Description

Remove default test tag.

My intention was that cluster tests are omitted when running locally, but the result was that tests were omitted in CI too as the TEST_TAGS was set to "" -> default with "not cluster" was used.

## Type of change

- [x] Bug fix
