### PR TITLE
Abstractproperty decorator is deprecated, use property+abstractmethod

### DIFF
--- a/ols/src/llms/providers/provider.py
+++ b/ols/src/llms/providers/provider.py
@@ -123,7 +123,8 @@ generic_to_llm_parameters: dict[str, dict[str, str]] = {
 class AbstractLLMProvider(abc.ABC):
     """Abstract class defining `LLMProvider` interface."""
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def default_params(self) -> dict:
         """Defaults LLM params.
 


### PR DESCRIPTION
## Description

`@abstractproperty` decorator is deprecated, use `@property`+`@abstractmethod` instead

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
