### PR TITLE
Watsonxllm mock class should have method headers compatible with real WatsonxLLM class

### DIFF
--- a/tests/mock_classes/mock_watsonxllm.py
+++ b/tests/mock_classes/mock_watsonxllm.py
@@ -9,13 +9,15 @@ class WatsonxLLM(LLM):
     def __init__(self):
         """Initialize mocked WatsonxLLM."""
 
-    def _call(self):
+    def _call(self, prompt, stop=None, run_manager=None, **kwargs):
+        """Override abstract method from LLM abstract class."""
+        return "foo"
+
+    def __call__(self, prompt=None, stop=None, tags=None, **kwargs):
         """Override abstract method from LLM abstract class."""
         return self
 
-    def __call__(self, **kwargs):
-        """Override abstract method from LLM abstract class."""
-        return self
-
+    @property
     def _llm_type(self):
         """Override abstract method from LLM abstract class."""
+        return "baz"


### PR DESCRIPTION
## Description

Watsonxllm mock class should have method headers compatible with real WatsonxLLM class

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
