### PR TITLE
Fixed type: frozenset is not compatible with set

### DIFF
--- a/ols/app/main.py
+++ b/ols/app/main.py
@@ -56,7 +56,7 @@ async def rest_api_counter(
     return response
 
 
-def _log_headers(headers: Headers, to_redact: set[str]) -> str:
+def _log_headers(headers: Headers, to_redact: frozenset[str]) -> str:
     """Serialize headers into a string while redacting sensitive values."""
     pairs = []
     for h, v in headers.items():


### PR DESCRIPTION
## Description

Fixed type: `frozenset` is not compatible with `set`

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
