### PR TITLE
Fix: metrics_app does not exists anymore

### DIFF
--- a/ols/app/metrics/__init__.py
+++ b/ols/app/metrics/__init__.py
@@ -21,7 +21,6 @@ __all__ = [
     "llm_calls_validation_errors_total",
     "llm_token_received_total",
     "llm_token_sent_total",
-    "metrics_app",
     "response_duration_seconds",
     "rest_api_calls_total",
     "provider_model_configuration",


### PR DESCRIPTION
## Description

Fix: `metrics_app` does not exists anymore

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
