### PR TITLE
Type fix: attributes won't be `None` in runtime

### DIFF
--- a/ols/utils/auth_dependency.py
+++ b/ols/utils/auth_dependency.py
@@ -23,8 +23,8 @@ class K8sClientSingleton:
 
     _instance = None
     _api_client = None
-    _authn_api: kubernetes.client.AuthenticationV1Api = None
-    _authz_api: kubernetes.client.AuthorizationV1Api = None
+    _authn_api: kubernetes.client.AuthenticationV1Api
+    _authz_api: kubernetes.client.AuthorizationV1Api
 
     def __new__(cls: type[Self]) -> Self:
         """Create a new instance of the singleton, or returns the existing instance.


### PR DESCRIPTION
## Description

Type fix: attributes won't be `None` in runtime

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
