### PR TITLE
Fix: `dockerconfig` technically is unbound variable in circumstances when `TypeError` is thrown from different statement

### DIFF
--- a/ols/user_data_collection/data_collector.py
+++ b/ols/user_data_collection/data_collector.py
@@ -119,6 +119,7 @@ def get_cloud_openshift_pull_secret() -> str:
     """Get the pull secret token from the cluster."""
     kubernetes.config.load_incluster_config()
     v1 = kubernetes.client.CoreV1Api()
+    dockerconfig: Any = None
 
     try:
         secret = v1.read_namespaced_secret("pull-secret", "openshift-config")


### PR DESCRIPTION
## Description

Fix: `dockerconfig` technically is unbound variable in circumstances when `TypeError` is thrown from different statement

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
