### PR TITLE
`yaml_port` is used in `raise` block so it need to be defined outside `try` block

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -366,8 +366,8 @@ class RedisConfig(BaseModel):
             return
         self.host = data.get("host", constants.REDIS_CACHE_HOST)
 
+        yaml_port = data.get("port", constants.REDIS_CACHE_PORT)
         try:
-            yaml_port = data.get("port", constants.REDIS_CACHE_PORT)
             self.port = int(yaml_port)
             if not (0 < self.port < 65536):
                 raise ValueError


### PR DESCRIPTION
## Description

`yaml_port` is used in `raise` block so it need to be defined outside `try` block

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
