### PR TITLE
OLS-595: Prolong wait interval for data collector in e2e test

### DIFF
--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -1120,7 +1120,9 @@ def test_user_data_collection():
         timeout=BASIC_ENDPOINTS_TIMEOUT,
     )
     assert response.status_code == requests.codes.ok
-    time.sleep(OLS_USER_DATA_COLLECTION_INTERVAL + 1)
+    # ensure the script have enought time to send the payload before
+    # we pull its logs
+    time.sleep(OLS_USER_DATA_COLLECTION_INTERVAL + 5)
 
     # check that data was packaged, sent and removed
     container_log = cluster_utils.get_container_log(


### PR DESCRIPTION
## Description

Prolong wait interval for data collector in e2e test.
The cause of the "bug story" is because we collected logs too fast. As seen from the logs, the last log was about posting the payload. We pulled the logs before the post was completed and logged.

The issue might occur again, eg. when console.stage.redhat.com is responding slowly, but the wait in this PR should be enough for standard situations.

## Type of change

- [x] Bug fix
