### PR TITLE
OLS-493: Change score as per faiss IP index

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # vim: set filetype=dockerfile
-ARG LIGHTSPEED_RAG_CONTENT_DIGEST=sha256:69a805043f61fc999fd190263646f9c3ef91f30f0d025574dd7ebc542f07a6c5
+ARG LIGHTSPEED_RAG_CONTENT_DIGEST=sha256:8dd07db7cfe7cba0dcbfe8eb3c53a6f9bbca324bbd98cd78fa8ffe05294c5e84
 
 FROM quay.io/openshift-lightspeed/lightspeed-rag-content@${LIGHTSPEED_RAG_CONTENT_DIGEST} as lightspeed-rag-content
 

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ schema:	## Generate OpenAPI schema file
 	python scripts/generate_openapi_schema.py docs/openapi.json
 
 get-rag: ## Download a copy of the RAG embedding model and vector database
-	podman create --replace --name tmp-rag-container quay.io/openshift-lightspeed/lightspeed-rag-content@sha256:69a805043f61fc999fd190263646f9c3ef91f30f0d025574dd7ebc542f07a6c5 true
+	podman create --replace --name tmp-rag-container quay.io/openshift-lightspeed/lightspeed-rag-content@sha256:8dd07db7cfe7cba0dcbfe8eb3c53a6f9bbca324bbd98cd78fa8ffe05294c5e84 true
 	podman cp tmp-rag-container:/rag/vector_db vector_db
 	podman cp tmp-rag-container:/rag/embeddings_model embeddings_model
 	podman rm tmp-rag-container

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -105,16 +105,13 @@ RAG_CONTENT_LIMIT = 1
 
 # Once the chunk is retrived we need to check similarity score, so that we won't
 # pick any random matching chunk.
-# Currently we use L2/KNN based FAISS index. And this cutoff signifies distance
-# between chunk and query in vector space. Lower distance means query & chunk are
-# more similar. So lower cutoff value is better.
-
-# If we set a very high cutoff, then we may end up picking irrelevant chunks.
-# And if we set a very low value, then there is risk of discarding all the chunks,
-# as there won't be perfect matching chunk. This also depends on embedding model
-# used during index creation/retrieval.
-# Range: positive float value (can be > 1)
-RAG_SIMILARITY_CUTOFF_L2 = 1.4
+# Currently we use Inner product based FAISS index. Higher score means query & chunk
+# are more similar. Chunk node score should be greater than the cutoff value.
+# If we set a very low cutoff, then we may end up picking irrelevant chunks.
+# And if we set a very high value, then there is risk of discarding all the chunks,
+# as there won't be perfect matching chunk.
+# Range: 0 to 1
+RAG_SIMILARITY_CUTOFF = 0.3
 
 
 # cache constants

--- a/ols/utils/token_handler.py
+++ b/ols/utils/token_handler.py
@@ -11,7 +11,7 @@ from ols.app.models.config import ModelConfig
 from ols.constants import (
     DEFAULT_TOKENIZER_MODEL,
     MINIMUM_CONTEXT_TOKEN_LIMIT,
-    RAG_SIMILARITY_CUTOFF_L2,
+    RAG_SIMILARITY_CUTOFF,
     TOKEN_BUFFER_WEIGHT,
 )
 
@@ -126,11 +126,10 @@ class TokenHandler:
         for node in retrieved_nodes:
 
             score = float(node.get_score(raise_error=False))
-            if score > RAG_SIMILARITY_CUTOFF_L2:
-                # L2 distance is checked here, lower score is better.
+            if score < RAG_SIMILARITY_CUTOFF:
                 logger.debug(
                     f"RAG content similarity score: {score} is "
-                    f"more than threshold {RAG_SIMILARITY_CUTOFF_L2}."
+                    f"less than threshold {RAG_SIMILARITY_CUTOFF}."
                 )
                 break
 

--- a/tests/unit/query_helpers/test_docs_summarizer.py
+++ b/tests/unit/query_helpers/test_docs_summarizer.py
@@ -30,7 +30,7 @@ def check_summary_result(summary, question):
     assert not summary["history_truncated"]
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF_L2", 0.7)
+@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
 @patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_empty_history():
     """Basic test for DocsSummarizer using mocked index and query engine."""
@@ -43,7 +43,7 @@ def test_summarize_empty_history():
     check_summary_result(summary, question)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF_L2", 0.7)
+@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
 @patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_no_history():
     """Basic test for DocsSummarizer using mocked index and query engine, no history is provided."""
@@ -56,7 +56,7 @@ def test_summarize_no_history():
     check_summary_result(summary, question)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF_L2", 0.7)
+@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
 @patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_history_provided():
     """Basic test for DocsSummarizer using mocked index and query engine, history is provided."""
@@ -85,7 +85,7 @@ def test_summarize_history_provided():
         check_summary_result(summary2, question)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF_L2", 0.7)
+@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
 @patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_truncation():
     """Basic test for DocsSummarizer to check if truncation is done."""

--- a/tests/unit/utils/test_token_handler.py
+++ b/tests/unit/utils/test_token_handler.py
@@ -19,7 +19,7 @@ class TestTokenHandler(TestCase):
         node_data = [
             {
                 "text": "a text text text text",
-                "score": 0.4,
+                "score": 0.6,
                 "metadata": {"docs_url": "data/doc1.pdf", "title": "Doc1"},
             },
             {
@@ -34,7 +34,7 @@ class TestTokenHandler(TestCase):
             },
             {
                 "text": "d text text text text",
-                "score": 0.6,
+                "score": 0.4,
                 "metadata": {"docs_url": "data/doc4.pdf", "title": "Doc4"},
             },
         ]
@@ -122,7 +122,7 @@ class TestTokenHandler(TestCase):
         assert available_tokens == expected_value
 
     @mock.patch("ols.utils.token_handler.TOKEN_BUFFER_WEIGHT", 1.05)
-    @mock.patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF_L2", 0.9)
+    @mock.patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
     def test_token_handler(self):
         """Test token handler for context."""
         retrieved_nodes = self._mock_retrieved_obj[:3]
@@ -141,7 +141,7 @@ class TestTokenHandler(TestCase):
         assert available_tokens == 482
 
     @mock.patch("ols.utils.token_handler.TOKEN_BUFFER_WEIGHT", 1.05)
-    @mock.patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF_L2", 0.5)
+    @mock.patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.6)
     def test_token_handler_score(self):
         """Test token handler for context when score is higher than threshold."""
         retrieved_nodes = self._mock_retrieved_obj[:3]
@@ -155,7 +155,7 @@ class TestTokenHandler(TestCase):
         assert available_tokens == 494
 
     @mock.patch("ols.utils.token_handler.TOKEN_BUFFER_WEIGHT", 1.05)
-    @mock.patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF_L2", 0.9)
+    @mock.patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
     def test_token_handler_token_limit(self):
         """Test token handler when token limit is reached."""
         context, available_tokens = self._token_handler_obj.truncate_rag_context(
@@ -171,7 +171,7 @@ class TestTokenHandler(TestCase):
         assert available_tokens == 0
 
     @mock.patch("ols.utils.token_handler.TOKEN_BUFFER_WEIGHT", 1.05)
-    @mock.patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF_L2", 0.9)
+    @mock.patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
     @mock.patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 3)
     def test_token_handler_token_minimum(self):
         """Test token handler when token count reached minimum threshold."""


### PR DESCRIPTION
## Description

Change score threshold and cut-off logic check as per faiss IP index.

Index was changed from L2 to IP with this PR https://github.com/openshift/lightspeed-rag-content/pull/23.

With current index, score range is 0 to 1 and higher score is better. Cut-off is set to 0.3 based on top retrieved chunks score for [sample queries](https://docs.google.com/spreadsheets/d/1wjYk8FdX12BCfuoU-7cGDTB_hnla42eti07EsjyZwi0/edit?usp=sharing).

cc: @syedriko 