### PR TITLE
OLS-622: provider-specific configuration

### DIFF
--- a/tests/config/valid_config_with_azure_openai.yaml
+++ b/tests/config/valid_config_with_azure_openai.yaml
@@ -5,6 +5,8 @@ llm_providers:
     url: "https://url1"
     deployment_name: "test"
     credentials_path": tests/config/secret.txt
+    azure_openai_config:
+      url: "http://localhost:1234"
     models:
       - name: m1
         url: "https://murl1"

--- a/tests/config/valid_config_with_azure_openai_api_version.yaml
+++ b/tests/config/valid_config_with_azure_openai_api_version.yaml
@@ -6,6 +6,8 @@ llm_providers:
     deployment_name: "test"
     credentials_path": tests/config/secret.txt
     api_version: 2024-12-31
+    azure_openai_config:
+      url: "http://localhost:1234"
     models:
       - name: m1
         url: "https://murl1"

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -884,6 +884,9 @@ def test_valid_config_with_azure_openai():
                         "url": "https://url1",
                         "credentials": "secret_key",
                         "deployment_name": "test",
+                        "azure_openai_config": {
+                            "url": "http://localhost:1234",
+                        },
                         "models": [
                             {
                                 "name": "m1",
@@ -933,6 +936,9 @@ def test_valid_config_with_azure_openai_api_version():
                         "credentials": "secret_key",
                         "deployment_name": "test",
                         "api_version": "2023-12-31",
+                        "azure_openai_config": {
+                            "url": "http://localhost:1234",
+                        },
                         "models": [
                             {
                                 "name": "m1",


### PR DESCRIPTION
## Description

Provider-specific configuration

Please note that discriminated unions are not used in the end. It would be possible to use them in following manner:

```python
class AzureOpenAIConfig(BaseModel):
    url: str
    api_key: str


class WatsonxConfig(BaseModel):
    url: str


class ProviderSpecificConfig(RootModel):
    root: Union[AzureOpenAIConfig, WatsonxConfig]


class ProviderConfig(BaseModel):
    """LLM provider configuration."""

    name: Optional[str] = None
    type: Optional[str] = None
    provider_config: Optional[ProviderSpecificConfig] = None
```

but in the end we'll need to re-cast everytime config is used, no proper checks against type could be done and the type hints will become unusable at the same time. So I prefer to be dumb&specific, not overthink it;)

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-622](https://issues.redhat.com//browse/OLS-622)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
