### PR TITLE
OLS-631: Switch ReferencedDocument from BaseModel to dataclass

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -653,29 +653,19 @@
             "ReferencedDocument": {
                 "properties": {
                     "docs_url": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
+                        "type": "string",
                         "title": "Docs Url"
                     },
                     "title": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
+                        "type": "string",
                         "title": "Title"
                     }
                 },
                 "type": "object",
+                "required": [
+                    "docs_url",
+                    "title"
+                ],
                 "title": "ReferencedDocument",
                 "description": "RAG referenced document.\n\nAttributes:\ndocs_url: URL of the corresponding OCP documentation page\ntitle: Title of the corresponding OCP documentation page"
             },

--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -1,5 +1,6 @@
 """Handlers for all OLS-related REST API endpoints."""
 
+import dataclasses
 import json
 import logging
 from datetime import datetime
@@ -407,7 +408,9 @@ def store_transcript(
         "redacted_query": llm_request.query,
         "query_is_valid": query_is_valid,
         "llm_response": response,
-        "referenced_documents": [doc.model_dump() for doc in referenced_documents],
+        "referenced_documents": [
+            dataclasses.asdict(doc) for doc in referenced_documents  # type: ignore
+        ],
         "truncated": truncated,
     }
 

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -3,6 +3,7 @@
 from typing import Any, Optional, Self
 
 from pydantic import BaseModel, field_validator, model_validator
+from pydantic.dataclasses import dataclass
 
 from ols.utils import suid
 
@@ -55,7 +56,8 @@ class LLMRequest(BaseModel):
         return self
 
 
-class ReferencedDocument(BaseModel):
+@dataclass
+class ReferencedDocument:
     """RAG referenced document.
 
     Attributes:
@@ -63,20 +65,8 @@ class ReferencedDocument(BaseModel):
     title: Title of the corresponding OCP documentation page
     """
 
-    docs_url: Optional[str] = None
-    title: Optional[str] = None
-
-    def __init__(self, docs_url: str, title: str) -> None:
-        """Initialize a ReferencedDocument."""
-        super().__init__()
-        self.docs_url = docs_url
-        self.title = title
-
-    def __eq__(self, other: object) -> bool:
-        """Compare two objects for equality."""
-        if isinstance(other, ReferencedDocument):
-            return self.docs_url == other.docs_url and self.title == other.title
-        return False
+    docs_url: str
+    title: str
 
     @staticmethod
     def json_decode_object_hook(dct: dict[str, Any]) -> Any:

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -100,7 +100,7 @@ class DocsSummarizer(QueryHelper):
 
         rag_context = "\n\n".join(rag_context_data.get("text", []))
         referenced_documents = [
-            ReferencedDocument(docs_url=docs_url, title=title)
+            ReferencedDocument(docs_url=docs_url, title=title)  # type: ignore
             for docs_url, title in zip(
                 rag_context_data.get("docs_url", []),
                 rag_context_data.get("title", []),


### PR DESCRIPTION
## Description

**For consideration.**

Change `ReferencedDocument` definition to pydantic dataclass (standard dataclass but with pydantic typing).
IMHO it is a better fit. You can also create an instance with direct args/kwargs instead of feeding it with dict.


## Type of change

- [x] Refactor
