### PR TITLE
OLS-583: Bump-up langchain-ibm to 0.1.7

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:7f8cb5982775eff8205f4a25fe31e7fc243fdfab856407e149c3165ce3dbcb80"
+content_hash = "sha256:70b34cf8b1b8c06eafc3c7bd3e922589fe8114831082b2a67f561f10b635e2b9"
 
 [[package]]
 name = "aiofiles"
@@ -850,16 +850,24 @@ files = [
 
 [[package]]
 name = "ibm-watsonx-ai"
-version = "0.2.6"
+version = "1.0.4"
 requires_python = ">=3.10"
 summary = "IBM watsonx.ai API Client"
 groups = ["default"]
 dependencies = [
-    "ibm-watson-machine-learning>=1.0.349",
+    "certifi",
+    "ibm-cos-sdk<2.14.0,>=2.12.0",
+    "importlib-metadata",
+    "lomond",
+    "packaging",
+    "pandas<2.2.0,>=0.24.2",
+    "requests",
+    "tabulate",
+    "urllib3",
 ]
 files = [
-    {file = "ibm_watsonx_ai-0.2.6-py3-none-any.whl", hash = "sha256:94328b2599222737cf8247557815867e962a61603446339e7326afed012410d0"},
-    {file = "ibm_watsonx_ai-0.2.6.tar.gz", hash = "sha256:76ae8ba5b83cf4e81c800b66844163246ea95f28291048fe4b9582daabdd5fc7"},
+    {file = "ibm_watsonx_ai-1.0.4-py3-none-any.whl", hash = "sha256:0a5589418cd3a66ac198949f824c3d44d21c7b345787235c69acaa9c08327f38"},
+    {file = "ibm_watsonx_ai-1.0.4.tar.gz", hash = "sha256:b13eeff566baa138d0e8fd91d020b2e98f101e9e73d031eecc2a0844f8bb1f19"},
 ]
 
 [[package]]
@@ -1114,7 +1122,7 @@ files = [
 
 [[package]]
 name = "langchain-core"
-version = "0.1.48"
+version = "0.1.52"
 requires_python = "<4.0,>=3.8.1"
 summary = "Building applications with LLMs through composability"
 groups = ["default"]
@@ -1127,23 +1135,23 @@ dependencies = [
     "tenacity<9.0.0,>=8.1.0",
 ]
 files = [
-    {file = "langchain_core-0.1.48-py3-none-any.whl", hash = "sha256:f3078d97a38ac79083cf5a9f3dfd2bb340c08fd93d0064c608be9aa40a73b038"},
-    {file = "langchain_core-0.1.48.tar.gz", hash = "sha256:f0a9b0a8f22f219ef6fd84e2b1d92a8014e84514c0a1b553370fd40296813c16"},
+    {file = "langchain_core-0.1.52-py3-none-any.whl", hash = "sha256:62566749c92e8a1181c255c788548dc16dbc319d896cd6b9c95dc17af9b2a6db"},
+    {file = "langchain_core-0.1.52.tar.gz", hash = "sha256:084c3fc452f5a6966c28ab3ec5dbc8b8d26fc3f63378073928f4e29d90b6393f"},
 ]
 
 [[package]]
 name = "langchain-ibm"
-version = "0.1.4"
+version = "0.1.7"
 requires_python = "<4.0,>=3.10"
 summary = "An integration package connecting IBM watsonx.ai and LangChain"
 groups = ["default"]
 dependencies = [
-    "ibm-watsonx-ai<0.3.0,>=0.2.6",
-    "langchain-core<0.2.0,>=0.1.42",
+    "ibm-watsonx-ai<2.0.0,>=1.0.1",
+    "langchain-core<0.3,>=0.1.50",
 ]
 files = [
-    {file = "langchain_ibm-0.1.4-py3-none-any.whl", hash = "sha256:7825129e3d1c55fefcbb98cbe4adbe892dd25f4784aa1e7688a6fd01067404a9"},
-    {file = "langchain_ibm-0.1.4.tar.gz", hash = "sha256:f92f6413d49ff9cd49e4e91e219db0b3765bbb925eca7970639b3127b7a62296"},
+    {file = "langchain_ibm-0.1.7-py3-none-any.whl", hash = "sha256:11aa78accccd839a1e0bf4f0fc2e6c88dab9e349b2be519639ee8a5732295f30"},
+    {file = "langchain_ibm-0.1.7.tar.gz", hash = "sha256:219934f0b55a2b243cd1abc41e86e142e8b8e91a317599f7367a1ee895035b39"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "fastapi==0.111.0",
     "gradio==4.31.2",
     "langchain==0.1.16",
-    "langchain-ibm==0.1.4",
+    "langchain-ibm==0.1.7",
     "llama-index==0.10.33",
     "llama-index-vector-stores-faiss==0.1.2",
     "llama-index-embeddings-huggingface==0.2.0",


### PR DESCRIPTION
## Description

Bump-up langchain-ibm to 0.1.7

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
