### PR TITLE
OLS-622: Forbid unknown provider-specific parameters

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -6,7 +6,14 @@ import re
 from typing import Any, Optional, Self
 from urllib.parse import urlparse
 
-from pydantic import AnyHttpUrl, BaseModel, FilePath, PositiveInt, model_validator
+from pydantic import (
+    AnyHttpUrl,
+    BaseModel,
+    Extra,
+    FilePath,
+    PositiveInt,
+    model_validator,
+)
 
 from ols import constants
 
@@ -219,7 +226,7 @@ class AuthenticationConfig(BaseModel):
                 )
 
 
-class ProviderSpecificConfig(BaseModel):
+class ProviderSpecificConfig(BaseModel, extra=Extra.forbid):  # type: ignore
     """Base class with common provider specific configurations."""
 
     url: AnyHttpUrl  # required attribute
@@ -227,13 +234,13 @@ class ProviderSpecificConfig(BaseModel):
     api_key: Optional[str] = None
 
 
-class OpenAIConfig(ProviderSpecificConfig):
+class OpenAIConfig(ProviderSpecificConfig, extra=Extra.forbid):  # type: ignore
     """Configuration specific to OpenAI provider."""
 
     credentials_path: str  # required attribute
 
 
-class AzureOpenAIConfig(ProviderSpecificConfig):
+class AzureOpenAIConfig(ProviderSpecificConfig, extra=Extra.forbid):  # type: ignore
     """Configuration specific to Azure OpenAI provider."""
 
     deployment_name: str  # required attribute
@@ -244,14 +251,14 @@ class AzureOpenAIConfig(ProviderSpecificConfig):
     client_secret: Optional[str] = None
 
 
-class WatsonxConfig(ProviderSpecificConfig):
+class WatsonxConfig(ProviderSpecificConfig, extra=Extra.forbid):  # type: ignore
     """Configuration specific to Watsonx provider."""
 
     credentials_path: str  # required attribute
     project_id: Optional[str] = None
 
 
-class BAMConfig(ProviderSpecificConfig):
+class BAMConfig(ProviderSpecificConfig, extra=Extra.forbid):  # type: ignore
     """Configuration specific to BAM provider."""
 
     credentials_path: str  # required attribute

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -520,6 +520,37 @@ def test_provider_config_azure_openai_specific():
     assert provider_config.bam_config is None
 
 
+def test_provider_config_azure_openai_unknown_parameters():
+    """Test if unknown Azure OpenAI parameters are detected."""
+    # provider type is set to "azure_openai" and Azure OpenAI-specific configuration is there
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ProviderConfig(
+            {
+                "name": "test_name",
+                "type": "azure_openai",
+                "url": "test_url",
+                "credentials_path": "tests/config/secret.txt",
+                "deployment_name": "deploment-name",
+                "azure_openai_config": {
+                    "unknown_parameter": "unknown value",
+                    "url": "http://localhost",
+                    "tenant_id": "tenant-ID",
+                    "client_id": "client-ID",
+                    "client_secret_path": "tests/config/secret.txt",
+                    "credentials_path": "tests/config/secret.txt",
+                    "deployment_name": "deployment-name",
+                },
+                "models": [
+                    {
+                        "name": "test_model_name",
+                        "url": "test_model_url",
+                        "credentials_path": "tests/config/secret.txt",
+                    }
+                ],
+            }
+        )
+
+
 def test_provider_config_openai_specific():
     """Test if OpenAI-specific config is loaded and validated."""
     # provider type is set to "openai" and OpenAI-specific configuration is there
@@ -552,6 +583,37 @@ def test_provider_config_openai_specific():
     assert provider_config.azure_config is None
     assert provider_config.watsonx_config is None
     assert provider_config.bam_config is None
+
+
+def test_provider_config_openai_unknown_parameters():
+    """Test if unknown OpenAI parameters are detected."""
+    # provider type is set to "openai" and OpenAI-specific configuration is there
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ProviderConfig(
+            {
+                "name": "test_name",
+                "type": "openai",
+                "url": "test_url",
+                "credentials_path": "tests/config/secret.txt",
+                "deployment_name": "deploment-name",
+                "openai_config": {
+                    "unknown_parameter": "unknown value",
+                    "url": "http://localhost",
+                    "tenant_id": "tenant-ID",
+                    "client_id": "client-ID",
+                    "client_secret_path": "tests/config/secret.txt",
+                    "credentials_path": "tests/config/secret.txt",
+                    "deployment_name": "deployment-name",
+                },
+                "models": [
+                    {
+                        "name": "test_model_name",
+                        "url": "test_model_url",
+                        "credentials_path": "tests/config/secret.txt",
+                    }
+                ],
+            }
+        )
 
 
 def test_provider_config_watsonx_specific():
@@ -590,6 +652,34 @@ def test_provider_config_watsonx_specific():
     assert provider_config.bam_config is None
 
 
+def test_provider_config_watsonx_unknown_parameters():
+    """Test if unknown Watsonx parameters are detected."""
+    # provider type is set to "watsonx" and Watsonx-specific configuration is there
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ProviderConfig(
+            {
+                "name": "test_name",
+                "type": "watsonx",
+                "url": "test_url",
+                "credentials_path": "tests/config/secret.txt",
+                "project_id": "test_project_id",
+                "watsonx_config": {
+                    "unknown_parameter": "unknown value",
+                    "url": "http://localhost",
+                    "credentials_path": "tests/config/secret.txt",
+                    "project_id": "*project id*",
+                },
+                "models": [
+                    {
+                        "name": "test_model_name",
+                        "url": "test_model_url",
+                        "credentials_path": "tests/config/secret.txt",
+                    }
+                ],
+            }
+        )
+
+
 def test_provider_config_bam_specific():
     """Test if BAM-specific config is loaded and validated."""
     # provider type is set to "bam" and BAM-specific configuration is there
@@ -622,6 +712,33 @@ def test_provider_config_bam_specific():
     assert provider_config.azure_config is None
     assert provider_config.openai_config is None
     assert provider_config.watsonx_config is None
+
+
+def test_provider_config_bam_unknown_parameters():
+    """Test if unknown BAM parameters are detected."""
+    # provider type is set to "bam" and BAM-specific configuration is there
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ProviderConfig(
+            {
+                "name": "test_name",
+                "type": "bam",
+                "url": "test_url",
+                "credentials_path": "tests/config/secret.txt",
+                "project_id": "test_project_id",
+                "bam_config": {
+                    "unknown_parameter": "unknown value",
+                    "url": "http://localhost",
+                    "credentials_path": "tests/config/secret.txt",
+                },
+                "models": [
+                    {
+                        "name": "test_model_name",
+                        "url": "test_model_url",
+                        "credentials_path": "tests/config/secret.txt",
+                    }
+                ],
+            }
+        )
 
 
 def test_improper_provider_specific_config():


### PR DESCRIPTION
## Description

- Forbid unknown provider-specific parameters
- 100% backed by unit tests

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-622](https://issues.redhat.com//browse/OLS-622)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.
