### PR TITLE
OLS-550: Use f-strings instead of str.format()

### DIFF
--- a/scripts/data_collection/list_objects_in_ceph.py
+++ b/scripts/data_collection/list_objects_in_ceph.py
@@ -28,13 +28,13 @@ def list_bucket_content(client, bucket_name):
         response = client.list_objects_v2(Bucket=bucket_name)
         print("DEBUG: \n", response)
         if "Contents" in response:
-            print("Contents of bucket '{}':".format(bucket_name))
+            print(f"Contents of bucket '{bucket_name}':")
             for obj in response["Contents"]:
                 print(obj["Key"])
         else:
-            print("Bucket '{}' is empty.".format(bucket_name))
+            print(f"Bucket '{bucket_name}' is empty.")
     except Exception as e:
-        print("Failed to list contents of bucket '{}':".format(bucket_name), e)
+        print(f"Failed to list contents of bucket '{bucket_name}':", e)
 
 
 pprint(client.list_buckets())


### PR DESCRIPTION
## Description

[OLS-550](https://issues.redhat.com//browse/OLS-550): Use f-strings instead of `str.format()`

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-550](https://issues.redhat.com//browse/OLS-550)
- Closes #
