### PR TITLE
OLS-641: URL and credentials are part of provider objects

### DIFF
--- a/ols/src/llms/providers/azure_openai.py
+++ b/ols/src/llms/providers/azure_openai.py
@@ -1,7 +1,7 @@
 """Azure OpenAI provider implementation."""
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from langchain.llms.base import LLM
 from langchain_openai import AzureChatOpenAI
@@ -18,24 +18,25 @@ class AzureOpenAI(LLMProvider):
     """Azure OpenAI provider."""
 
     url: str = "https://thiswillalwaysfail.openai.azure.com"
+    credentials: Optional[str] = None
 
     @property
     def default_params(self) -> dict[str, Any]:
         """Default LLM params."""
-        azure_endpoint = self.provider_config.url or self.url
-        credentials = self.provider_config.credentials
+        self.url = self.provider_config.url or self.url
+        self.credentials = self.provider_config.credentials
         deployment_name = self.provider_config.deployment_name
 
         # provider-specific configuration has precendence over regular configuration
         if self.provider_config.azure_config is not None:
             azure_config = self.provider_config.azure_config
-            azure_endpoint = str(azure_config.url)
+            self.url = str(azure_config.url)
             deployment_name = azure_config.deployment_name
-            credentials = azure_config.api_key
+            self.credentials = azure_config.api_key
 
         return {
-            "azure_endpoint": azure_endpoint,
-            "api_key": credentials,
+            "azure_endpoint": self.url,
+            "api_key": self.credentials,
             "api_version": "2024-02-01",
             "deployment_name": deployment_name,
             "model": self.model,

--- a/ols/src/llms/providers/openai.py
+++ b/ols/src/llms/providers/openai.py
@@ -1,7 +1,7 @@
 """OpenAI provider implementation."""
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from langchain.llms.base import LLM
 from langchain_openai import ChatOpenAI
@@ -18,21 +18,22 @@ class OpenAI(LLMProvider):
     """OpenAI provider."""
 
     url: str = "https://api.openai.com/v1"
+    credentials: Optional[str] = None
 
     @property
     def default_params(self) -> dict[str, Any]:
         """Default LLM params."""
-        openai_endpoint = self.provider_config.url or self.url
-        credentials = self.provider_config.credentials
+        self.url = self.provider_config.url or self.url
+        self.credentials = self.provider_config.credentials
         # provider-specific configuration has precendence over regular configuration
         if self.provider_config.openai_config is not None:
             openai_config = self.provider_config.openai_config
-            openai_endpoint = str(openai_config.url)
-            credentials = openai_config.api_key
+            self.url = str(openai_config.url)
+            self.credentials = openai_config.api_key
 
         return {
-            "base_url": openai_endpoint,
-            "openai_api_key": credentials,
+            "base_url": self.url,
+            "openai_api_key": self.credentials,
             "model": self.model,
             "model_kwargs": {
                 "top_p": 0.95,

--- a/tests/unit/llms/providers/test_azure_openai.py
+++ b/tests/unit/llms/providers/test_azure_openai.py
@@ -105,6 +105,11 @@ def test_loading_provider_specific_parameters(provider_config_with_specific_para
     # API key should be loaded from secret
     assert azure_openai.default_params["api_key"] == "secret_key_2"
 
+    # parameters taken from provier-specific configuration
+    # which takes precedence over regular configuration
+    assert azure_openai.url == "http://azure.com/"
+    assert azure_openai.credentials == "secret_key_2"
+
 
 def test_params_handling(provider_config):
     """Test that not allowed parameters are removed before model init."""
@@ -139,6 +144,10 @@ def test_params_handling(provider_config):
     assert "min_new_tokens" not in azure_openai.params
     assert "max_new_tokens" not in azure_openai.params
     assert "unknown_parameter" not in azure_openai.params
+
+    # taken from configuration
+    assert azure_openai.url == "test_url"
+    assert azure_openai.credentials == "secret_key"
 
 
 def test_api_version_can_not_be_none(provider_config):

--- a/tests/unit/llms/providers/test_openai.py
+++ b/tests/unit/llms/providers/test_openai.py
@@ -91,6 +91,10 @@ def test_params_handling(provider_config):
     assert "max_new_tokens" not in openai.params
     assert "unknown_parameter" not in openai.params
 
+    # taken from configuration
+    assert openai.url == "test_url"
+    assert openai.credentials == "secret_key"
+
     # API key should be loaded from secret
     assert openai.default_params["openai_api_key"] == "secret_key"
 
@@ -113,8 +117,11 @@ def test_loading_provider_specific_parameters(provider_config_with_specific_para
     assert "model" in openai.default_params
     assert "max_tokens" in openai.default_params
 
-    # provider-specific configuration should take precedence
-    # API key should be loaded from secret
+    # parameters taken from provier-specific configuration
+    # which takes precedence over regular configuration
+    assert openai.url == "http://openai.com/"
+    assert openai.credentials == "secret_key_2"
+
     assert openai.default_params["openai_api_key"] == "secret_key_2"
     assert openai.default_params["base_url"] == "http://openai.com/"
 


### PR DESCRIPTION
## Description

URL and credentials are part of provider objects
Will be used especially in Azure OpenAI where credentials might be `None`

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #[OLS-641](https://issues.redhat.com//browse/OLS-641)
- Closes #
