### PR TITLE
OLS-670: Readiness probe - cache check

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -196,26 +196,8 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/HealthResponse"
+                                    "$ref": "#/components/schemas/ReadinessResponse"
                                 }
-                            }
-                        }
-                    }
-                }
-            },
-            "head": {
-                "tags": [
-                    "health"
-                ],
-                "summary": "Readiness Probe Head Method",
-                "description": "Ready status of service.",
-                "operationId": "readiness_probe_head_method_readiness_head",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {}
                             }
                         }
                     }
@@ -647,6 +629,31 @@
                             "cause": "Prompt length exceeds LLM context window limit (8000 tokens)",
                             "response": "Prompt is too long"
                         }
+                    }
+                ]
+            },
+            "ReadinessResponse": {
+                "properties": {
+                    "ready": {
+                        "type": "boolean",
+                        "title": "Ready"
+                    },
+                    "reason": {
+                        "type": "string",
+                        "title": "Reason"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "ready",
+                    "reason"
+                ],
+                "title": "ReadinessResponse",
+                "description": "Model representing a response to a readiness request.\n\nAttributes:\n    ready: The readiness of the service.\n    reason: The reason for the readiness.\n\nExample:\n    ```python\n    readiness_response = ReadinessResponse(ready=True, reason=\"service is ready\")\n    ```",
+                "examples": [
+                    {
+                        "ready": true,
+                        "reason": "service is ready"
                     }
                 ]
             },

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -342,6 +342,35 @@ class HealthResponse(BaseModel):
     }
 
 
+class ReadinessResponse(BaseModel):
+    """Model representing a response to a readiness request.
+
+    Attributes:
+        ready: The readiness of the service.
+        reason: The reason for the readiness.
+
+    Example:
+        ```python
+        readiness_response = ReadinessResponse(ready=True, reason="service is ready")
+        ```
+    """
+
+    ready: bool
+    reason: str
+
+    # provides examples for /docs endpoint
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "ready": True,
+                    "reason": "service is ready",
+                }
+            ]
+        }
+    }
+
+
 class AuthorizationResponse(BaseModel):
     """Model representing a response to an authorization request.
 

--- a/ols/src/cache/cache.py
+++ b/ols/src/cache/cache.py
@@ -66,3 +66,11 @@ class Cache(ABC):
             conversation_id: Conversation ID unique for given user.
             value: The value to be stored in the cache.
         """
+
+    @abstractmethod
+    def is_ready(self) -> bool:
+        """Check if the cache is ready.
+
+        Returns:
+            True if the cache is ready, False otherwise.
+        """

--- a/ols/src/cache/in_memory_cache.py
+++ b/ols/src/cache/in_memory_cache.py
@@ -79,3 +79,12 @@ class InMemoryCache(Cache):
                 old_value.extend(value)
                 self.cache[key] = old_value
             self.deque.appendleft(key)
+
+    def is_ready(self) -> bool:
+        """Check if the cache is ready.
+
+        Returns:
+          `True` if the cache is ready, `False` otherwise.
+        """
+        # if we can execute this method, the cache is ready
+        return True

--- a/ols/src/cache/postgres_cache.py
+++ b/ols/src/cache/postgres_cache.py
@@ -221,3 +221,17 @@ class PostgresCache(Cache):
                 cursor.execute(
                     f"{PostgresCache.DELETE_CONVERSATION_HISTORY_STATEMENT} {count-capacity})"
                 )
+
+    def is_ready(self) -> bool:
+        """Check if the cache is ready.
+
+        Returns:
+            `True` if the cache is ready, `False` otherwise.
+        """
+        with self.conn.cursor() as cursor:
+            try:
+                cursor.execute("SELECT 1")
+                return True
+            except psycopg2.DatabaseError as e:
+                logger.error(f"failed to connect to database: {e}")
+                return False

--- a/ols/src/cache/redis_cache.py
+++ b/ols/src/cache/redis_cache.py
@@ -112,3 +112,15 @@ class RedisCache(Cache):
                 self.redis_client.set(key, json.dumps(old_value))
             else:
                 self.redis_client.set(key, json.dumps(value))
+
+    def is_ready(self) -> bool:
+        """Check if the cache is ready.
+
+        Returns:
+            True if the cache is ready, False otherwise.
+        """
+        try:
+            self.redis_client.ping()
+            return True
+        except RedisError:
+            return False

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -130,7 +130,7 @@ def test_readiness():
         response = client.get(endpoint, timeout=BASIC_ENDPOINTS_TIMEOUT)
         assert response.status_code == requests.codes.ok
         check_content_type(response, "application/json")
-        assert response.json() == {"status": {"status": "healthy"}}
+        assert response.json() == {"ready": True, "reason": "service is ready"}
 
 
 def test_liveness():
@@ -1180,3 +1180,11 @@ def test_http_header_redaction():
     for header in HTTP_REQUEST_HEADERS_TO_REDACT:
         assert f'"{header}":"XXXXX"' in container_log
         assert f'"{header}":"some_value"' not in container_log
+
+
+def test_readiness_endpoint():
+    """Test the /readiness endpoint."""
+    response = client.get("/readiness", timeout=BASIC_ENDPOINTS_TIMEOUT)
+    assert response.status_code == requests.codes.ok
+    check_content_type(response, "application/json")
+    assert response.json() == {"ready": True, "reason": "service is ready"}

--- a/tests/integration/test_liveness_readiness.py
+++ b/tests/integration/test_liveness_readiness.py
@@ -36,18 +36,11 @@ def test_readiness(_setup):
     """Test handler for /readiness REST API endpoint."""
     response = client.get("/readiness")
     assert response.status_code == requests.codes.ok
-    assert response.json() == {"status": {"status": "healthy"}}
+    assert response.json() == {"ready": True, "reason": "service is ready"}
 
 
 def test_liveness_head_http_method(_setup) -> None:
     """Test handler for /liveness REST API endpoint when HEAD HTTP method is used."""
     response = client.head("/liveness")
-    assert response.status_code == requests.codes.ok
-    assert response.text == ""
-
-
-def test_readiness_head_http_method(_setup) -> None:
-    """Test handler for /readiness REST API endpoint when HEAD HTTP method is used."""
-    response = client.head("/readiness")
     assert response.status_code == requests.codes.ok
     assert response.text == ""

--- a/tests/unit/app/endpoints/test_health.py
+++ b/tests/unit/app/endpoints/test_health.py
@@ -1,20 +1,34 @@
 """Unit tests for health endpoints handlers."""
 
+import pytest
+
+from ols import config
 from ols.app.endpoints.health import (
     liveness_probe_get_method,
     liveness_probe_head_method,
     readiness_probe_get_method,
-    readiness_probe_head_method,
 )
-from ols.app.models.models import HealthResponse
+from ols.app.models.config import ConversationCacheConfig
+from ols.app.models.models import HealthResponse, ReadinessResponse
 
 
-def test_readiness_probe_get_method():
+@pytest.fixture(scope="function")
+def _config_with_conversation_cache():
+    """Fixture to set up the config with conversation cache."""
+    # NOTE: The `conversation_cache` in config is a (cached) instance of
+    # `Cache` class returned by the `CacheFactory`.
+    # The cache is not used in the current test, so we can just return True.
+    config.ols_config.conversation_cache = ConversationCacheConfig(
+        {"type": "memory", "memory": {"max_size": 100}}
+    )
+
+
+def test_readiness_probe_get_method(_config_with_conversation_cache):
     """Test the readiness_probe function."""
     # the tested function returns constant right now
     # i.e. it does not depend on application state
     response = readiness_probe_get_method()
-    assert response == HealthResponse(status={"status": "healthy"})
+    assert response == ReadinessResponse(ready="True", reason="service is ready")
 
 
 def test_liveness_probe_get_method():
@@ -23,14 +37,6 @@ def test_liveness_probe_get_method():
     # i.e. it does not depend on application state
     response = liveness_probe_get_method()
     assert response == HealthResponse(status={"status": "healthy"})
-
-
-def test_readiness_probe_head_method():
-    """Test the readiness_probe function."""
-    # the tested function returns constant right now
-    # i.e. it does not depend on application state
-    response = readiness_probe_head_method()
-    assert response is None
 
 
 def test_liveness_probe_head_method():


### PR DESCRIPTION
## Description

Refactor /readiness probe
- Add cache database check in readiness probe
- Remove readiness HEAD method.
  - AFAIK the readiness HEAD provides the same information as the liveness probe. It just tells if the endpoint is reachable. It seems redundant.

## Type of change

- [x] Refactor
- [x] New feature
