### PR TITLE
OLS-673: Fix the error "error: Too many arguments for "SummarizerResponse" [call-arg]"

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -102,7 +102,7 @@ def conversation_request(
             constants.INVALID_QUERY_RESP,
             [],
             False,
-        )  # type: ignore [call-arg]
+        )
     else:
         summarizer_response = generate_response(
             conversation_id, llm_request, previous_input

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -1,9 +1,14 @@
 """Data models representing payloads for REST API calls."""
 
-from typing import Any, Optional, Self
+from typing import TYPE_CHECKING, Any, Optional, Self
 
 from pydantic import BaseModel, field_validator, model_validator
-from pydantic.dataclasses import dataclass
+
+# fixes OLS-673: Type checker reports "too many arguments" when the dataclass is constructed
+if TYPE_CHECKING:
+    from dataclasses import dataclass
+else:
+    from pydantic.dataclasses import dataclass
 
 from ols.utils import suid
 


### PR DESCRIPTION
## Description

[OLS-673](https://issues.redhat.com//browse/OLS-673): Fix the error "error: Too many arguments for "SummarizerResponse"  [call-arg]"

Fixes: [OLS-673](https://issues.redhat.com//browse/OLS-673)
