### PR TITLE
OLS-641: Unit tests: loading tenant-id, client-id, and client-secret

### DIFF
--- a/tests/config/valid_config_with_azure_openai_tenant_and_client_id.yaml
+++ b/tests/config/valid_config_with_azure_openai_tenant_and_client_id.yaml
@@ -1,0 +1,31 @@
+---
+llm_providers:
+  - name: p1
+    type: azure_openai
+    url: "https://url1"
+    deployment_name: "test"
+    azure_openai_config:
+      url: "http://localhost:1234"
+      deployment_name: "*deployment name*"
+      tenant_id: "00000000-0000-0000-0000-000000000001"
+      client_id: "00000000-0000-0000-0000-000000000002"
+      client_secret_path: "tests/config/secret.txt"
+    models:
+      - name: m1
+        url: "https://murl1"
+ols_config:
+  conversation_cache:
+    type: postgres
+    postgres:
+      host: "foobar.com"
+      port: "1234"
+      dbname: "test"
+      user: "user"
+      password_path: tests/config/postgres_password.txt
+      ca_cert_path: tests/config/postgres_cert.crt
+      ssl_mode: "require"
+  default_provider: p1
+  default_model: m1
+dev_config:
+  disable_auth: true
+  disable_tls: true

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -1031,6 +1031,63 @@ def test_valid_config_with_azure_openai_api_version():
         pytest.fail(f"loading valid configuration failed: {e}")
 
 
+def test_valid_config_with_azure_openai_tenant_and_client_settings():
+    """Check if a valid configuration file with Azure OpenAI is handled correctly."""
+    try:
+        config.reload_from_yaml_file(
+            "tests/config/valid_config_with_azure_openai_tenant_and_client_id.yaml"
+        )
+
+        expected_config = Config(
+            {
+                "llm_providers": [
+                    {
+                        "name": "p1",
+                        "type": "azure_openai",
+                        "url": "https://url1",
+                        "credentials": "secret_key",
+                        "deployment_name": "test",
+                        "api_version": "2023-12-31",
+                        "azure_openai_config": {
+                            "url": "http://localhost:1234",
+                            "deployment_name": "*deployment name*",
+                            "tenant_id": "00000000-0000-0000-0000-000000000001",
+                            "client_id": "00000000-0000-0000-0000-000000000002",
+                            "client_secret_path": "tests/config/secret.txt",
+                            "client_secret": "secret_key",
+                        },
+                        "models": [
+                            {
+                                "name": "m1",
+                                "url": "https://murl1",
+                            },
+                        ],
+                    },
+                ],
+                "ols_config": {
+                    "conversation_cache": {
+                        "type": "postgres",
+                        "postgres": {
+                            "host": "foobar.com",
+                            "port": "1234",
+                            "dbname": "test",
+                            "user": "user",
+                            "password_path": "tests/config/postgres_password.txt",
+                            "ca_cert_path": "tests/config/postgres_cert.crt",
+                            "ssl_mode": "require",
+                        },
+                    },
+                    "default_provider": "p1",
+                    "default_model": "m1",
+                },
+            }
+        )
+        assert config.config == expected_config
+    except Exception as e:
+        print(traceback.format_exc())
+        pytest.fail(f"loading valid configuration failed: {e}")
+
+
 def test_valid_config_with_bam():
     """Check if a valid configuration file with BAM is handled correctly."""
     try:


### PR DESCRIPTION
## Description

Unit tests: loading `tenant-id`, `client-id`, and `client-secret` from config file

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] Unit tests

## Related Tickets & Documents

- Related Issue #OLS-641
- Closes #
