### PR TITLE
Update ols-tls yaml in example for new CR perms

### DIFF
--- a/examples/openshift-lightspeed-tls.yaml
+++ b/examples/openshift-lightspeed-tls.yaml
@@ -54,6 +54,32 @@ rules:
   verbs:
     - "get"
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clusterversion-viewer
+  labels:
+    app: ols
+rules:
+- apiGroups: ["config.openshift.io"]
+  resources: ["clusterversions"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: clusterversion-viewer
+  labels:
+    app: ols
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clusterversion-viewer
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: openshift-lightspeed
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
## Description

Pull Request #882 introduced the need for additional ClusterRole permissions to be added to the openshift-lightspeed-tls.yaml file to enable the successful deployment of the OpenShift Lightspeed Service via that manifest

## Type of change

- [ ] Refactor
- [ ] New feature
- [x ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
