### PR TITLE
OLS-624: REST API schema for /query endpoint with optional list of attachments

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -339,6 +339,42 @@
     },
     "components": {
         "schemas": {
+            "Attachment": {
+                "properties": {
+                    "attachment_type": {
+                        "type": "string",
+                        "title": "Attachment Type"
+                    },
+                    "content_type": {
+                        "type": "string",
+                        "title": "Content Type"
+                    },
+                    "content": {
+                        "type": "string",
+                        "title": "Content"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "attachment_type",
+                    "content_type",
+                    "content"
+                ],
+                "title": "Attachment",
+                "description": "Model representing an attachment that can be send from UI as part of query.\n\nList of attachments can be optional part of 'query' request.\n\nAttributes:\n    attachment_type: The attachment type, like \"log\", \"configuration\" etc.\n    content_type: The content type as defined in MIME standard\n    content: The actual attachment content",
+                "examples": [
+                    {
+                        "attachment_type": "log",
+                        "content": "this is attachment",
+                        "content_type": "text/plain"
+                    },
+                    {
+                        "attachment_type": "configuration",
+                        "content": "foo: bar",
+                        "content_type": "application/yaml"
+                    }
+                ]
+            },
             "AuthorizationResponse": {
                 "properties": {
                     "user_id": {
@@ -563,6 +599,20 @@
                             }
                         ],
                         "title": "Model"
+                    },
+                    "attachments": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/Attachment"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Attachments"
                     }
                 },
                 "type": "object",
@@ -570,9 +620,21 @@
                     "query"
                 ],
                 "title": "LLMRequest",
-                "description": "Model representing a request for the LLM (Language Model).\n\nAttributes:\n    query: The query string.\n    conversation_id: The optional conversation ID (UUID).\n    provider: The optional provider.\n    model: The optional model.\n\nExample:\n    ```python\n    llm_request = LLMRequest(query=\"Tell me about Kubernetes\")\n    ```",
+                "description": "Model representing a request for the LLM (Language Model) send into OLS service.\n\nAttributes:\n    query: The query string.\n    conversation_id: The optional conversation ID (UUID).\n    provider: The optional provider.\n    model: The optional model.\n    attachments: The optional attachments.\n\nExample:\n    ```python\n    llm_request = LLMRequest(query=\"Tell me about Kubernetes\")\n    ```",
                 "examples": [
                     {
+                        "attachments": [
+                            {
+                                "attachment_type": "log",
+                                "content": "this is attachment",
+                                "content_type": "text/plain"
+                            },
+                            {
+                                "attachment_type": "configuration",
+                                "content": "foo: bar",
+                                "content_type": "application/yaml"
+                            }
+                        ],
                         "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
                         "model": "gpt-3.5-turbo",
                         "provider": "openai",

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -8,14 +8,49 @@ from pydantic.dataclasses import dataclass
 from ols.utils import suid
 
 
+class Attachment(BaseModel):
+    """Model representing an attachment that can be send from UI as part of query.
+
+    List of attachments can be optional part of 'query' request.
+
+    Attributes:
+        attachment_type: The attachment type, like "log", "configuration" etc.
+        content_type: The content type as defined in MIME standard
+        content: The actual attachment content
+    """
+
+    attachment_type: str
+    content_type: str
+    content: str
+
+    # provides examples for /docs endpoint
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "attachment_type": "log",
+                    "content_type": "text/plain",
+                    "content": "this is attachment",
+                },
+                {
+                    "attachment_type": "configuration",
+                    "content_type": "application/yaml",
+                    "content": "foo: bar",
+                },
+            ]
+        }
+    }
+
+
 class LLMRequest(BaseModel):
-    """Model representing a request for the LLM (Language Model).
+    """Model representing a request for the LLM (Language Model) send into OLS service.
 
     Attributes:
         query: The query string.
         conversation_id: The optional conversation ID (UUID).
         provider: The optional provider.
         model: The optional model.
+        attachments: The optional attachments.
 
     Example:
         ```python
@@ -27,6 +62,7 @@ class LLMRequest(BaseModel):
     conversation_id: Optional[str] = None
     provider: Optional[str] = None
     model: Optional[str] = None
+    attachments: Optional[list[Attachment]] = None
 
     # provides examples for /docs endpoint
     model_config = {
@@ -37,6 +73,18 @@ class LLMRequest(BaseModel):
                     "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
                     "provider": "openai",
                     "model": "gpt-3.5-turbo",
+                    "attachments": [
+                        {
+                            "attachment_type": "log",
+                            "content_type": "text/plain",
+                            "content": "this is attachment",
+                        },
+                        {
+                            "attachment_type": "configuration",
+                            "content_type": "application/yaml",
+                            "content": "foo: bar",
+                        },
+                    ],
                 }
             ]
         }


### PR DESCRIPTION
## Description

REST API schema for `/query` endpoint with optional list of attachments

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #[OLS-624](https://issues.redhat.com//browse/OLS-624)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Start the OLS and go to `/docs`
- Try the new feature there in interactive UI
