### PR TITLE
OLS-648: Fix for currently unsupported Mypy multiple-line-statement behavior

### DIFF
--- a/ols/utils/auth_dependency.py
+++ b/ols/utils/auth_dependency.py
@@ -22,6 +22,8 @@ class ClusterIDUnavailableError(Exception):
     """Cluster ID is not available."""
 
 
+# mypy: ignore-errors
+# TODO: remove in OLS-648
 class K8sClientSingleton:
     """Return the Kubernetes client instances.
 
@@ -54,7 +56,7 @@ class K8sClientSingleton:
                     None,
                     "None",
                     "",
-                }:  # type: ignore
+                }:
                     logger.info("loading kubeconfig from app Config config")
                     configuration.api_key["authorization"] = (
                         config.dev_config.k8s_auth_token


### PR DESCRIPTION
## Description

Fix for currently unsupported Mypy multiple-line-statement behavior
It basically don't allow us to use `#types ignore` in conditions that spread over multiple lines.
(which is ugly and IMHO against PEP-8)

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #[OLS-648](https://issues.redhat.com//browse/OLS-648)
- Closes #
