### PR TITLE
OLS-624: Disable additional properties + basic REST API tests with attachments

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -615,6 +615,7 @@
                         "title": "Attachments"
                     }
                 },
+                "additionalProperties": false,
                 "type": "object",
                 "required": [
                     "query"

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -66,6 +66,7 @@ class LLMRequest(BaseModel):
 
     # provides examples for /docs endpoint
     model_config = {
+        "extra": "forbid",
         "json_schema_extra": {
             "examples": [
                 {
@@ -87,7 +88,7 @@ class LLMRequest(BaseModel):
                     ],
                 }
             ]
-        }
+        },
     }
 
     @model_validator(mode="after")

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -981,6 +981,175 @@ def _perform_query(client, conversation_id, query):
     print(vars(response))
 
 
+@retry(max_attempts=3, wait_between_runs=10)
+def test_valid_question_with_empty_attachment_list() -> None:
+    """Check the REST API /v1/query with POST HTTP method using empty attachment list."""
+    endpoint = "/v1/query"
+
+    with metrics_utils.RestAPICallCounterChecker(
+        metrics_client, endpoint, status_code=requests.codes.ok
+    ):
+        response = client.post(
+            endpoint,
+            json={
+                "conversation_id": "",
+                "query": "what is kubernetes?",
+                "attachments": [],
+            },
+            timeout=LLM_REST_API_TIMEOUT,
+        )
+
+        # HTTP OK should be returned
+        assert response.status_code == requests.codes.ok
+
+        check_content_type(response, "application/json")
+
+
+@retry(max_attempts=3, wait_between_runs=10)
+def test_valid_question_with_one_attachment() -> None:
+    """Check the REST API /v1/query with POST HTTP method using one attachment."""
+    endpoint = "/v1/query"
+
+    with metrics_utils.RestAPICallCounterChecker(
+        metrics_client, endpoint, status_code=requests.codes.ok
+    ):
+        response = client.post(
+            endpoint,
+            json={
+                "conversation_id": "",
+                "query": "what is kubernetes?",
+                "attachments": [
+                    {
+                        "attachment_type": "log",
+                        "content_type": "text/plain",
+                        "content": "this is attachment",
+                    },
+                ],
+            },
+            timeout=LLM_REST_API_TIMEOUT,
+        )
+
+        # HTTP OK should be returned
+        assert response.status_code == requests.codes.ok
+
+        check_content_type(response, "application/json")
+
+
+@retry(max_attempts=3, wait_between_runs=10)
+def test_valid_question_with_more_attachments() -> None:
+    """Check the REST API /v1/query with POST HTTP method using two attachments."""
+    endpoint = "/v1/query"
+
+    with metrics_utils.RestAPICallCounterChecker(
+        metrics_client, endpoint, status_code=requests.codes.ok
+    ):
+        response = client.post(
+            endpoint,
+            json={
+                "conversation_id": "",
+                "query": "what is kubernetes?",
+                "attachments": [
+                    {
+                        "attachment_type": "log",
+                        "content_type": "text/plain",
+                        "content": "this is attachment",
+                    },
+                    {
+                        "attachment_type": "configuration",
+                        "content_type": "application/json",
+                        "content": "{'foo': 'bar'}",
+                    },
+                ],
+            },
+            timeout=LLM_REST_API_TIMEOUT,
+        )
+
+        # HTTP OK should be returned
+        assert response.status_code == requests.codes.ok
+
+        check_content_type(response, "application/json")
+
+
+@retry(max_attempts=3, wait_between_runs=10)
+def test_valid_question_with_wrong_attachment_format_unknown_field() -> None:
+    """Check the REST API /v1/query with POST HTTP method using attachment with wrong format."""
+    endpoint = "/v1/query"
+
+    with metrics_utils.RestAPICallCounterChecker(
+        metrics_client, endpoint, status_code=requests.codes.unprocessable_entity
+    ):
+        response = client.post(
+            endpoint,
+            json={
+                "conversation_id": "",
+                "query": "what is kubernetes?",
+                "attachments": [
+                    {
+                        "xyzzy": "log",  # unknown field
+                        "content_type": "text/plain",
+                        "content": "this is attachment",
+                    },
+                ],
+            },
+            timeout=LLM_REST_API_TIMEOUT,
+        )
+
+        # the attachment should not be processed correctly
+        assert response.status_code == requests.codes.unprocessable_entity
+
+
+@retry(max_attempts=3, wait_between_runs=10)
+def test_valid_question_with_wrong_attachment_format_missing_fields() -> None:
+    """Check the REST API /v1/query with POST HTTP method using attachment with wrong format."""
+    endpoint = "/v1/query"
+
+    with metrics_utils.RestAPICallCounterChecker(
+        metrics_client, endpoint, status_code=requests.codes.unprocessable_entity
+    ):
+        response = client.post(
+            endpoint,
+            json={
+                "conversation_id": "",
+                "query": "what is kubernetes?",
+                "attachments": [  # missing fields
+                    {},
+                ],
+            },
+            timeout=LLM_REST_API_TIMEOUT,
+        )
+
+        # the attachment should not be processed correctly
+        assert response.status_code == requests.codes.unprocessable_entity
+
+
+@retry(max_attempts=3, wait_between_runs=10)
+def test_valid_question_with_wrong_attachment_format_field_of_different_type() -> None:
+    """Check the REST API /v1/query with POST HTTP method using attachment with wrong value type."""
+    endpoint = "/v1/query"
+
+    with metrics_utils.RestAPICallCounterChecker(
+        metrics_client, endpoint, status_code=requests.codes.unprocessable_entity
+    ):
+        response = client.post(
+            endpoint,
+            json={
+                "conversation_id": "",
+                "query": "what is kubernetes?",
+                "attachments": [
+                    {
+                        "attachment_type": 42,  # not a string
+                        "content_type": "application/json",
+                        "content": "{'foo': 'bar'}",
+                    },
+                ],
+            },
+            timeout=LLM_REST_API_TIMEOUT,
+        )
+
+        # the attachment should not be processed correctly
+        assert response.status_code == requests.codes.unprocessable_entity
+
+
 def test_conversation_in_postgres_cache(postgres_connection) -> None:
     """Check how/if the conversation is stored in cache."""
     if postgres_connection is None:


### PR DESCRIPTION
## Description

Disable additional properties + basic REST API tests with attachments

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] e2e tests

## Related Tickets & Documents

- Related Issue #[OLS-624](https://issues.redhat.com//browse/OLS-624)
- Closes #

