### PR TITLE
OLS-663: Bug: When reference config is missing in config, use None instead of empty…

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -859,7 +859,8 @@ class OLSConfig(BaseModel):
             data.get("conversation_cache", None)
         )
         self.logging_config = LoggingConfig(data.get("logging_config", None))
-        self.reference_content = ReferenceContent(data.get("reference_content", None))
+        if data.get("reference_content") is not None:
+            self.reference_content = ReferenceContent(data.get("reference_content"))
         self.default_provider = data.get("default_provider", None)
         self.default_model = data.get("default_model", None)
         self.authentication_config = AuthenticationConfig(

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -1669,6 +1669,7 @@ def test_ols_config(tmpdir):
     assert ols_config.query_validation_method == constants.QueryValidationMethod.LLM
     assert ols_config.user_data_collection.feedback_disabled is False
     assert ols_config.user_data_collection.feedback_storage == tmpdir.strpath
+    assert ols_config.reference_content is None
 
 
 def test_config():


### PR DESCRIPTION
## Description

When reference config is missing in config, use None instead of empty object.

This behavior resulted in the following problem:

When config entry is missing, the empty `ReferenceContent` is used (we put it there in the `__init__`) instead of `None` as specified as the default value in the `OLSConfig`. The app started without RAG - that is valid, but the /readiness checks that `ols_config.reference_content` is explicitly `None` (as it should be) - resulting in the endpoint reporting false as the index is not ready (mistake).


## Type of change

- [x] Bug fix
