### PR TITLE
(Trivial) Removed redundant exception in raise

### DIFF
--- a/ols/src/cache/postgres_cache.py
+++ b/ols/src/cache/postgres_cache.py
@@ -93,7 +93,7 @@ class PostgresCache(Cache):
         except Exception as e:
             self.conn.close()
             logger.exception(f"Error initializing Postgres cache:\n{e}")
-            raise e
+            raise
         self.capacity = config.max_entries
 
     def initialize_cache(self) -> None:

--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -98,7 +98,7 @@ class AppConfig:
         except Exception as e:
             print(f"Failed to load config file {config_file}: {e!s}")
             print(traceback.format_exc())
-            raise e
+            raise
 
 
 config: AppConfig = AppConfig()


### PR DESCRIPTION
## Description

It's redundant to specify the exception name in a `raise` statement if the
exception is being re-raised.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
