### PR TITLE
OLS-694: Improve memory usage in collector script by lazily loading llama_index

### DIFF
--- a/ols/src/rag_index/index_loader.py
+++ b/ols/src/rag_index/index_loader.py
@@ -1,36 +1,44 @@
+# type: ignore
 """Module for loading index."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Optional
-
-from llama_index.core import Settings, StorageContext, load_index_from_storage
-from llama_index.core.embeddings.utils import EmbedType
-from llama_index.core.indices.base import BaseIndex
-from llama_index.core.llms.utils import resolve_llm
-from llama_index.vector_stores.faiss import FaissVectorStore
+from typing import Optional
 
 from ols.app.models.config import ReferenceContent
-
-# This is to avoid importing HuggingFaceEmbeddings in all cases, because in
-# runtime it is used only under some conditions. OTOH we need to make Python
-# interpreter happy in all circumstances, hence the definiton of Any symbol.
-if TYPE_CHECKING:
-    from llama_index.embeddings.huggingface import HuggingFaceEmbedding  # TCH004
-else:
-    HuggingFaceEmbedding = Any
 
 logger = logging.getLogger(__name__)
 
 
+# NOTE: Loading/importing something from llama_index bumps memory
+# consumption up to ~400MiB. To avoid loading llama_index in all cases,
+# we load it only when it is required.
+# As these dependencies are lazily loaded, we can't use them in type hints.
+# So this module is excluded from mypy checks as a whole.
+def load_llama_index_deps():
+    """Load llama_index dependencies."""
+    global Settings
+    global StorageContext
+    global load_index_from_storage
+    global EmbedType
+    global BaseIndex
+    global resolve_llm
+    global FaissVectorStore
+    global HuggingFaceEmbedding
+    from llama_index.core import Settings, StorageContext, load_index_from_storage
+    from llama_index.core.embeddings.utils import EmbedType
+    from llama_index.core.indices.base import BaseIndex
+    from llama_index.core.llms.utils import resolve_llm
+    from llama_index.vector_stores.faiss import FaissVectorStore
+
+
 # TODO: OLS-380 Config object mirrors configuration
-
-
 class IndexLoader:
     """Load index from local file storage."""
 
     def __init__(self, index_config: Optional[ReferenceContent]) -> None:
         """Initialize loader."""
-        self._index: Optional[BaseIndex] = None
+        load_llama_index_deps()
+        self._index = None
 
         self._index_config = index_config
         logger.debug(f"Config used for index load: {self._index_config}")
@@ -45,7 +53,7 @@ class IndexLoader:
             self._embed_model = self._get_embed_model()
             self._load_index()
 
-    def _get_embed_model(self) -> EmbedType:
+    def _get_embed_model(self):
         """Get embed model according to configuration."""
         if self._embed_model_path is not None:
             from llama_index.embeddings.huggingface import HuggingFaceEmbedding
@@ -63,7 +71,7 @@ class IndexLoader:
         """Set storage/service context required for index load."""
         logger.debug(f"Using {self._embed_model!s} as embedding model for index.")
         logger.info("Setting up settings for index load...")
-        Settings.embed_model = self._embed_model  # type: ignore [assignment]
+        Settings.embed_model = self._embed_model
         Settings.llm = resolve_llm(None)
         logger.info("Setting up storage context for index load...")
         self._storage_context = StorageContext.from_defaults(
@@ -88,7 +96,7 @@ class IndexLoader:
                 logger.exception(f"Error loading vector index:\n{err}")
 
     @property
-    def vector_index(self) -> Optional[BaseIndex]:
+    def vector_index(self):
         """Get index."""
         if self._index is None:
             logger.warning(

--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -5,13 +5,21 @@ from io import TextIOBase
 from typing import Any, Optional
 
 import yaml
-from llama_index.core.indices.base import BaseIndex
 
 import ols.app.models.config as config_model
 from ols.src.cache.cache import Cache
 from ols.src.cache.cache_factory import CacheFactory
-from ols.src.rag_index.index_loader import IndexLoader
+
+# as we the index_loader.py is excluded from type checks, it confuses
+# mypy a bit, hence the [attr-defined] bellow
+from ols.src.rag_index.index_loader import IndexLoader  # type: ignore [attr-defined]
 from ols.utils.redactor import Redactor
+
+# NOTE: Loading/importing something from llama_index bumps memory
+# consumption up to ~400MiB.
+# from llama_index.core.indices.base import BaseIndex
+# Here, we need it just for typing, so we use Any instead.
+BaseIndex = Any
 
 
 class AppConfig:
@@ -65,7 +73,7 @@ class AppConfig:
         return self._query_filters
 
     @property
-    def rag_index(self) -> Optional[BaseIndex[Any]]:
+    def rag_index(self) -> Optional[BaseIndex]:
         """Return the RAG index."""
         # TODO: OLS-380 Config object mirrors configuration
         if self._rag_index is None:

--- a/tests/config/cluster_install/ols_manifests.yaml
+++ b/tests/config/cluster_install/ols_manifests.yaml
@@ -87,10 +87,10 @@ spec:
         resources:
         limits:
           cpu: 100m
-          memory: 512Mi
+          memory: 128Mi
         requests:
           cpu: 50m
-          memory: 128Mi
+          memory: 64Mi
         volumeMounts:
           - name: ols-user-data
             mountPath: /app-root/ols-user-data

--- a/tests/unit/rag_index/test_index_loader.py
+++ b/tests/unit/rag_index/test_index_loader.py
@@ -19,7 +19,7 @@ def test_index_loader_empty_config(caplog):
     assert index is None
 
 
-@patch("ols.src.rag_index.index_loader.StorageContext.from_defaults")
+@patch("llama_index.core.StorageContext.from_defaults")
 def test_index_loader_no_id(storage_context):
     """Test index loader without index id."""
     config.ols_config.reference_content = ReferenceContent(None)
@@ -34,9 +34,9 @@ def test_index_loader_no_id(storage_context):
     assert index is None
 
 
-@patch("ols.src.rag_index.index_loader.StorageContext.from_defaults")
+@patch("llama_index.core.StorageContext.from_defaults")
 @patch("llama_index.vector_stores.faiss.FaissVectorStore.from_persist_dir")
-@patch("ols.src.rag_index.index_loader.load_index_from_storage", new=MockLlamaIndex)
+@patch("llama_index.core.load_index_from_storage", new=MockLlamaIndex)
 def test_index_loader(storage_context, from_persist_dir):
     """Test index loader."""
     config.ols_config.reference_content = ReferenceContent(None)


### PR DESCRIPTION
## Description

With this, the memory consumption for the sidecar falls from 500MiB under 100MiB.

## Type of change

- [x] Optimization
