### PR TITLE
OLS-708: Security fix: bump-up Azure identity to 1.16.1

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:37a78cefd81d2e0818f7c48e26351510a7941ee5d89a3a81e86809d0a20151e2"
+content_hash = "sha256:f80901b550468022ae97e044cc72da15d9aa3ab116c01e9b93ea2eced1864972"
 
 [[package]]
 name = "aiofiles"
@@ -161,7 +161,7 @@ files = [
 
 [[package]]
 name = "azure-identity"
-version = "1.16.0"
+version = "1.16.1"
 requires_python = ">=3.8"
 summary = "Microsoft Azure Identity Library for Python"
 groups = ["default"]
@@ -172,8 +172,8 @@ dependencies = [
     "msal>=1.24.0",
 ]
 files = [
-    {file = "azure-identity-1.16.0.tar.gz", hash = "sha256:6ff1d667cdcd81da1ceab42f80a0be63ca846629f518a922f7317a7e3c844e1b"},
-    {file = "azure_identity-1.16.0-py3-none-any.whl", hash = "sha256:722fdb60b8fdd55fa44dc378b8072f4b419b56a5e54c0de391f644949f3a826f"},
+    {file = "azure-identity-1.16.1.tar.gz", hash = "sha256:6d93f04468f240d59246d8afde3091494a5040d4f141cad0f49fc0c399d0d91e"},
+    {file = "azure_identity-1.16.1-py3-none-any.whl", hash = "sha256:8fb07c25642cd4ac422559a8b50d3e77f73dcc2bbfaba419d06d6c9d7cff6726"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "kubernetes==29.0.0",
     "pytest-asyncio==0.23.7",
     "psycopg2-binary==2.9.9",
-    "azure-identity==1.16.0",
+    "azure-identity==1.16.1",
     "langchain-community==0.2.0",
 ]
 requires-python = "==3.11.*"


### PR DESCRIPTION
## Description

Security fix: bump-up Azure identity to 1.16.1

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #[OLS-708](https://issues.redhat.com//browse/OLS-708)
- Closes #
