### PR TITLE
Remove check for deployment name existence

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -340,14 +340,10 @@ class ProviderConfig(BaseModel):
 
         self.setup_models_config(data)
 
-        # OLS-622: Provider-specific configuration parameters in olsconfig.yaml
         if self.type == constants.PROVIDER_AZURE_OPENAI:
             # deployment_name only required when using Azure OpenAI
             self.deployment_name = data.get("deployment_name", None)
-            if self.deployment_name is None:
-                raise InvalidConfigurationError(
-                    f"deployment_name is required for Azure OpenAI provider {self.name}"
-                )
+            # note: it can be overwritten in azure_config
 
     def set_provider_type(self, data: dict) -> None:
         """Set the provider type."""

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -312,22 +312,6 @@ def test_provider_config():
         )
     assert "model name is missing" in str(excinfo.value)
 
-    with pytest.raises(InvalidConfigurationError) as excinfo:
-        ProviderConfig(
-            {
-                "name": "azure_openai",
-                "type": "azure_openai",
-                "url": "test_url",
-                "credentials_path": "tests/config/secret/apitoken",
-                "models": [
-                    {
-                        "name": "test_model",
-                    }
-                ],
-            }
-        )
-    assert "deployment_name is required" in str(excinfo.value)
-
 
 def test_that_url_is_required_provider_parameter():
     """Test that provider-specific URL is required attribute."""


### PR DESCRIPTION
## Description

Remove check for deployment name existence - it is optional and can be overwritten in azure-specific config section
