### PR TITLE
fix readiness e2e test case

### DIFF
--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -98,11 +98,12 @@ def check_content_type(response, content_type, message=""):
     assert response.headers["content-type"].startswith(content_type), message
 
 
+@retry(max_attempts=3, wait_between_runs=10)
 def test_readiness():
     """Test handler for /readiness REST API endpoint."""
     endpoint = "/readiness"
     with metrics_utils.RestAPICallCounterChecker(metrics_client, endpoint):
-        response = client.get(endpoint, timeout=BASIC_ENDPOINTS_TIMEOUT)
+        response = client.get(endpoint, timeout=LLM_REST_API_TIMEOUT)
         assert response.status_code == requests.codes.ok
         check_content_type(response, "application/json")
         assert response.json() == {"ready": True, "reason": "service is ready"}


### PR DESCRIPTION
## Description

As we have added LLM call as part of readiness check (https://github.com/openshift/lightspeed-service/pull/1081). It will take more time to finish processing..
watsonx e2e readiness test case is failing as readiness call timeout value is very less. (failing for https://github.com/openshift/lightspeed-service/pull/1082 and other PR as well).

We could increase the timeout or do multiple retry. This PR contains both (we can remove one later, if we want)
