### PR TITLE
OLS-644: Use version-aligned OCP docs for RAG

### DIFF
--- a/tests/config/cluster_install/ols_configmap.yaml
+++ b/tests/config/cluster_install/ols_configmap.yaml
@@ -23,8 +23,8 @@ data:
           - name: "$MODEL"
     ols_config:
       reference_content:
-        product_docs_index_path: "./vector_db/ocp_product_docs/4.15"
-        product_docs_index_id: ocp-product-docs-4_15
+        product_docs_index_path: "./vector_db/ocp_product_docs/${CLUSTER_VERSION_MAJOR}.${CLUSTER_VERSION_MINOR}"
+        product_docs_index_id: ocp-product-docs-${CLUSTER_VERSION_MAJOR}_${CLUSTER_VERSION_MINOR}
         embeddings_model_path: "./embeddings_model"
       conversation_cache:
         type: memory

--- a/tests/e2e/utils/cluster.py
+++ b/tests/e2e/utils/cluster.py
@@ -45,6 +45,24 @@ def get_cluster_id() -> str:
         raise Exception("Error getting cluster ID") from e
 
 
+def get_cluster_version() -> tuple[str, str]:
+    """Get the cluster version: major and minor."""
+    try:
+        result = run_oc(
+            [
+                "get",
+                "clusterversions",
+                "version",
+                "-o",
+                "jsonpath='{.status.desired.version}'",
+            ]
+        )
+        major, minor, rest = result.stdout.strip("'").split(".", 2)
+        return major, minor
+    except subprocess.CalledProcessError as e:
+        raise Exception("Error getting cluster version") from e
+
+
 def create_user(name: str) -> None:
     """Create a service account user for testing."""
     try:

--- a/tests/scripts/utils.sh
+++ b/tests/scripts/utils.sh
@@ -56,6 +56,12 @@ function install_ols() {
     export MODEL=$7
     export OLS_IMAGE=$8
 
+    # get and export cluster version
+    local lines
+    mapfile -t lines <<< "$(oc version | grep Server | awk '{print $3}' | awk 'BEGIN{FS="."}{printf("%s\n%s\n", $1, $2)}')"
+    export CLUSTER_VERSION_MAJOR="${lines[0]}"
+    export CLUSTER_VERSION_MINOR="${lines[1]}"
+
     oc create ns openshift-lightspeed
     oc project openshift-lightspeed
 


### PR DESCRIPTION
## Description

Added a test to check that the version of OCP docs in the RAG database matches that of the cluster we're running on.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/OLS-644
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
