### PR TITLE
OSL-721: Makefile target to generate requirements.txt file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,9 @@ verify:	install-woke install-deps-test ## Verify the code using various linters
 schema:	## Generate OpenAPI schema file
 	python scripts/generate_openapi_schema.py docs/openapi.json
 
+requirements.txt:	pyproject.toml pdm.lock ## Generate requirements.txt file containing hashes for all non-devel packages
+	pdm export --prod --format requirements --output requirements.txt
+
 get-rag: ## Download a copy of the RAG embedding model and vector database
 	podman create --replace --name tmp-rag-container quay.io/openshift-lightspeed/lightspeed-rag-content@sha256:6a238245ec7da232bf64af0be95b8f5a3eede8127f4f49a123d5271e35667fc9 true
 	rm -rf vector_db embeddings_model
@@ -94,6 +97,6 @@ help: ## Show this help screen
 	@echo ''
 	@echo 'Available targets are:'
 	@echo ''
-	@grep -E '^[ a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	@grep -E '^[ a-zA-Z0-9_.-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
 	@echo ''


### PR DESCRIPTION
## Description

Makefile target to generate `requirements.txt` file. That file will be used later by tooling (`pip_find_builddeps.py`) to generate `requirement-build.in` file used by Konflux for hermetic builds.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #[OLS-721](https://issues.redhat.com//browse/OLS-721)
- Closes #
