### PR TITLE
OLS-739: Security fix: bump-up langchain and langchain-community

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:0739da8f9100789d5c89b6b15857cdd3b621883eda0a88bd567c791c9b36cbe5"
+content_hash = "sha256:57198b76f270fdbac2d41341c3d1426741c1c6c6fa532f0f7a527c23543e5258"
 
 [[package]]
 name = "aiofiles"
@@ -1176,7 +1176,7 @@ files = [
 
 [[package]]
 name = "langchain"
-version = "0.2.2"
+version = "0.2.5"
 requires_python = "<4.0,>=3.8.1"
 summary = "Building applications with LLMs through composability"
 groups = ["default"]
@@ -1184,22 +1184,22 @@ dependencies = [
     "PyYAML>=5.3",
     "SQLAlchemy<3,>=1.4",
     "aiohttp<4.0.0,>=3.8.3",
-    "langchain-core<0.3.0,>=0.2.0",
+    "langchain-core<0.3.0,>=0.2.7",
     "langchain-text-splitters<0.3.0,>=0.2.0",
     "langsmith<0.2.0,>=0.1.17",
-    "numpy<2,>=1",
+    "numpy<2,>=1; python_version < \"3.12\"",
     "pydantic<3,>=1",
     "requests<3,>=2",
     "tenacity<9.0.0,>=8.1.0",
 ]
 files = [
-    {file = "langchain-0.2.2-py3-none-any.whl", hash = "sha256:58ca0c47bcdd156da66f50a0a4fcedc49bf6950827f4a6b06c8c4842d55805f3"},
-    {file = "langchain-0.2.2.tar.gz", hash = "sha256:9d61e50e9cdc2bea659bc5e6c03650ba048fda63a307490ae368e539f61a0d3a"},
+    {file = "langchain-0.2.5-py3-none-any.whl", hash = "sha256:9aded9a65348254e1c93dcdaacffe4d1b6a5e7f74ef80c160c88ff78ad299228"},
+    {file = "langchain-0.2.5.tar.gz", hash = "sha256:ffdbf4fcea46a10d461bcbda2402220fcfd72a0c70e9f4161ae0510067b9b3bd"},
 ]
 
 [[package]]
 name = "langchain-community"
-version = "0.2.0"
+version = "0.2.5"
 requires_python = "<4.0,>=3.8.1"
 summary = "Community contributed LangChain integrations."
 groups = ["default"]
@@ -1208,35 +1208,35 @@ dependencies = [
     "SQLAlchemy<3,>=1.4",
     "aiohttp<4.0.0,>=3.8.3",
     "dataclasses-json<0.7,>=0.5.7",
-    "langchain-core<0.3.0,>=0.2.0",
-    "langchain<0.3.0,>=0.2.0",
+    "langchain-core<0.3.0,>=0.2.7",
+    "langchain<0.3.0,>=0.2.5",
     "langsmith<0.2.0,>=0.1.0",
-    "numpy<2,>=1",
+    "numpy<2,>=1; python_version < \"3.12\"",
     "requests<3,>=2",
     "tenacity<9.0.0,>=8.1.0",
 ]
 files = [
-    {file = "langchain_community-0.2.0-py3-none-any.whl", hash = "sha256:4d069d280fd2dc1219df13d580338729dbaebf581160bc42c73d5ed208258d57"},
-    {file = "langchain_community-0.2.0.tar.gz", hash = "sha256:15c7e8f2547d9e9f03eef0704ef1c68a0074c462e9bd635662d5ea4b0eace87b"},
+    {file = "langchain_community-0.2.5-py3-none-any.whl", hash = "sha256:bf37a334952e42c7676d083cf2d2c4cbfbb7de1949c4149fe19913e2b06c485f"},
+    {file = "langchain_community-0.2.5.tar.gz", hash = "sha256:476787b8c8c213b67e7b0eceb53346e787f00fbae12d8e680985bd4f93b0bf64"},
 ]
 
 [[package]]
 name = "langchain-core"
-version = "0.2.3"
+version = "0.2.7"
 requires_python = "<4.0,>=3.8.1"
 summary = "Building applications with LLMs through composability"
 groups = ["default"]
 dependencies = [
     "PyYAML>=5.3",
     "jsonpatch<2.0,>=1.33",
-    "langsmith<0.2.0,>=0.1.65",
-    "packaging<24.0,>=23.2",
+    "langsmith<0.2.0,>=0.1.75",
+    "packaging<25,>=23.2",
     "pydantic<3,>=1",
     "tenacity<9.0.0,>=8.1.0",
 ]
 files = [
-    {file = "langchain_core-0.2.3-py3-none-any.whl", hash = "sha256:22189b5a3a30bfd65eb995f95e627f7c2c3acb322feb89f5f5f2fb7df21833a7"},
-    {file = "langchain_core-0.2.3.tar.gz", hash = "sha256:fbc75a64b9c0b7655d96ca57a707df1e6c09efc1539c36adbd73260612549810"},
+    {file = "langchain_core-0.2.7-py3-none-any.whl", hash = "sha256:fd02e153c898486dd728d634684ffc64bc257ff2ba443dc7e53d017ac0bf4658"},
+    {file = "langchain_core-0.2.7.tar.gz", hash = "sha256:b0b1b6dfbdedb39426fcb8bd3f07e40eec7964856e3fc384c420ca6dba61b34e"},
 ]
 
 [[package]]
@@ -1286,7 +1286,7 @@ files = [
 
 [[package]]
 name = "langsmith"
-version = "0.1.69"
+version = "0.1.77"
 requires_python = "<4.0,>=3.8.1"
 summary = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 groups = ["default"]
@@ -1296,8 +1296,8 @@ dependencies = [
     "requests<3,>=2",
 ]
 files = [
-    {file = "langsmith-0.1.69-py3-none-any.whl", hash = "sha256:3d7bd6fadb0852fc4cd2e7cf8a1593306046900052da3970bb2b48ed21cc73d8"},
-    {file = "langsmith-0.1.69.tar.gz", hash = "sha256:0146764904a8e479620b7e73efcba1cf172b621799564dd7e7342859c05c264a"},
+    {file = "langsmith-0.1.77-py3-none-any.whl", hash = "sha256:2202cc21b1ed7e7b9e5d2af2694be28898afa048c09fdf09f620cbd9301755ae"},
+    {file = "langsmith-0.1.77.tar.gz", hash = "sha256:4ace09077a9a4e412afeb4b517ca68e7de7b07f36e4792dc8236ac5207c0c0c7"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
     "torch==2.2.2+cpu",
     "fastapi==0.111.0",
     "gradio==4.36.1",
-    "langchain==0.2.2",
+    "langchain==0.2.5",
     "langchain-ibm==0.1.7",
     "llama-index==0.10.38",
     "llama-index-vector-stores-faiss==0.1.2",
@@ -81,7 +81,7 @@ dependencies = [
     "pytest-asyncio==0.23.7",
     "psycopg2-binary==2.9.9",
     "azure-identity==1.16.1",
-    "langchain-community==0.2.0",
+    "langchain-community==0.2.5",
 ]
 requires-python = "==3.11.*"
 readme = "README.md"


### PR DESCRIPTION
## Description

Security fix: bump-up `langchain` and `langchain-community` packages

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] Security fix

## Related Tickets & Documents

- Related Issue #[OLS-739](https://issues.redhat.com//browse/OLS-739)
