### PR TITLE
OLS-617: Add alert runbooks as a RAG content source

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # vim: set filetype=dockerfile
-ARG LIGHTSPEED_RAG_CONTENT_DIGEST=sha256:6a238245ec7da232bf64af0be95b8f5a3eede8127f4f49a123d5271e35667fc9
+ARG LIGHTSPEED_RAG_CONTENT_DIGEST=sha256:e0db77d709914e677e34658e21b4300b20a9f125c4f27f88429304aa8ad2e276
 
 FROM quay.io/openshift-lightspeed/lightspeed-rag-content@${LIGHTSPEED_RAG_CONTENT_DIGEST} as lightspeed-rag-content
 

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ verify-packages-completeness:	requirements.txt ## Verify that requirements.txt f
 	pip download -d /tmp/ --use-pep517 --verbose -r requirements.txt
 
 get-rag: ## Download a copy of the RAG embedding model and vector database
-	podman create --replace --name tmp-rag-container quay.io/openshift-lightspeed/lightspeed-rag-content@sha256:6a238245ec7da232bf64af0be95b8f5a3eede8127f4f49a123d5271e35667fc9 true
+	podman create --replace --name tmp-rag-container quay.io/openshift-lightspeed/lightspeed-rag-content@sha256:e0db77d709914e677e34658e21b4300b20a9f125c4f27f88429304aa8ad2e276 true
 	rm -rf vector_db embeddings_model
 	podman cp tmp-rag-container:/rag/vector_db vector_db
 	podman cp tmp-rag-container:/rag/embeddings_model embeddings_model


### PR DESCRIPTION
## Description

Switch to the rag-content image with the alert runbooks added to it as per [OLS-617](https://issues.redhat.com//browse/OLS-617).

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/OLS-617
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
