### PR TITLE
Strings are concatenated implicitly, not need/want to use explicit concatenation

### DIFF
--- a/scripts/data_collection/user_data_aggregator.py
+++ b/scripts/data_collection/user_data_aggregator.py
@@ -157,7 +157,7 @@ def args_parser(args: list[str]) -> argparse.Namespace:
         # cluster UUID used by CCX monitoring infrastructure
         default="00000000-1111-0000-1111-000000000001",
         help="Cluster IDs to ignore during processing splited by comma: "
-        + "00000000-0000-0000-0000-000000000001, 00000000-0000-0000-0000-000000000002",
+        "00000000-0000-0000-0000-000000000001, 00000000-0000-0000-0000-000000000002",
     )
     parser.add_argument(
         "-k",

--- a/tests/unit/utils/test_redactor.py
+++ b/tests/unit/utils/test_redactor.py
@@ -32,7 +32,7 @@ class TestRedactor(TestCase):
         redacted_question = self.query_filter.redact("test_id", query)
         expected_output = (
             "write a deployment yaml for the mongodb REDACTED_image with nodeip "
-            + "as REDACTED_IP"
+            "as REDACTED_IP"
         )
         assert redacted_question == expected_output
 


### PR DESCRIPTION
## Description

Strings are concatenated implicitly, not need/want to use explicit concatenation

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
