### PR TITLE
Use `OSError`, not `IOError`

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -60,7 +60,7 @@ def _read_secret(
     try:
         with open(filename, mode="r", encoding="utf-8") as f:
             return f.read().rstrip()
-    except IOError as e:
+    except OSError as e:
         # some files with secret must exist, so for such cases it is time
         # to inform about improper configuration
         if raise_on_error:


### PR DESCRIPTION
## Description

Use `OSError`, not `IOError`

`OSError` is the builtin error type used for exceptions that relate to the
operating system.

In Python 3.3, a variety of other exceptions, like `WindowsError` were
aliased to `OSError`. These aliases remain in place for compatibility with
older versions of Python, but may be removed in future versions.

Prefer using `OSError` directly, as it is more idiomatic and future-proof.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
