### PR TITLE
OLS-490: Refactor ModelConfig

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -103,10 +103,8 @@ class ModelConfig(BaseModel):
     url: Optional[AnyHttpUrl] = None
     credentials: Optional[str] = None
 
-    context_window_size: Optional[PositiveInt] = None
-    max_tokens_for_response: Optional[PositiveInt] = (
-        constants.DEFAULT_MAX_TOKENS_FOR_RESPONSE
-    )
+    context_window_size: PositiveInt = constants.DEFAULT_CONTEXT_WINDOW_SIZE
+    max_tokens_for_response: PositiveInt = constants.DEFAULT_MAX_TOKENS_FOR_RESPONSE
 
     options: Optional[dict[str, Any]] = None
 

--- a/tests/unit/llms/providers/test_bam.py
+++ b/tests/unit/llms/providers/test_bam.py
@@ -19,7 +19,7 @@ def provider_config():
             "models": [
                 {
                     "name": "test_model_name",
-                    "url": "test_model_url",
+                    "url": "http://test_model_url/",
                     "credentials_path": "tests/config/secret/apitoken",
                 }
             ],
@@ -39,7 +39,7 @@ def provider_config_credentials_directory():
             "models": [
                 {
                     "name": "test_model_name",
-                    "url": "test_model_url",
+                    "url": "http://test_model_url/",
                     "credentials_path": "tests/config/secret/apitoken",
                 }
             ],
@@ -58,7 +58,7 @@ def provider_config_without_credentials():
             "models": [
                 {
                     "name": "test_model_name",
-                    "url": "test_model_url",
+                    "url": "http://test_model_url/",
                     "credentials_path": "tests/config/secret/apitoken",
                 }
             ],
@@ -82,7 +82,7 @@ def provider_config_with_specific_params():
             "models": [
                 {
                     "name": "test_model_name",
-                    "url": "test_model_url",
+                    "url": "http://test_model_url/",
                     "credentials_path": "tests/config/secret/apitoken",
                 }
             ],

--- a/tests/unit/llms/providers/test_openai.py
+++ b/tests/unit/llms/providers/test_openai.py
@@ -19,7 +19,7 @@ def provider_config():
             "models": [
                 {
                     "name": "test_model_name",
-                    "url": "test_model_url",
+                    "url": "http://test_model_url/",
                     "credentials_path": "tests/config/secret/apitoken",
                 }
             ],
@@ -39,7 +39,7 @@ def provider_config_credentials_directory():
             "models": [
                 {
                     "name": "test_model_name",
-                    "url": "test_model_url",
+                    "url": "http://test_model_url/",
                     "credentials_path": "tests/config/secret/apitoken",
                 }
             ],
@@ -63,7 +63,7 @@ def provider_config_with_specific_parameters():
             "models": [
                 {
                     "name": "test_model_name",
-                    "url": "test_model_url",
+                    "url": "http://test_model_url/",
                     "credentials_path": "tests/config/secret/apitoken",
                 }
             ],

--- a/tests/unit/llms/providers/test_watsonx.py
+++ b/tests/unit/llms/providers/test_watsonx.py
@@ -26,7 +26,7 @@ def provider_config():
             "models": [
                 {
                     "name": "test_model_name",
-                    "url": "test_model_url",
+                    "url": "http://test_model_url/",
                     "credentials_path": "tests/config/secret/apitoken",
                 }
             ],
@@ -47,7 +47,7 @@ def provider_config_credentials_directory():
             "models": [
                 {
                     "name": "test_model_name",
-                    "url": "test_model_url",
+                    "url": "http://test_model_url/",
                     "credentials_path": "tests/config/secret/apitoken",
                 }
             ],
@@ -67,7 +67,7 @@ def provider_config_without_credentials():
             "models": [
                 {
                     "name": "test_model_name",
-                    "url": "test_model_url",
+                    "url": "http://test_model_url/",
                     "credentials_path": "tests/config/secret/apitoken",
                 }
             ],
@@ -93,7 +93,7 @@ def provider_config_with_specific_params():
             "models": [
                 {
                     "name": "test_model_name",
-                    "url": "test_model_url",
+                    "url": "http://test_model_url/",
                     "credentials_path": "tests/config/secret/apitoken",
                 }
             ],

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -8,6 +8,7 @@ from typing import TypeVar
 from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 from yaml.parser import ParserError
 
 from ols import config
@@ -150,8 +151,8 @@ ols_config:
     memory:
       max_entries: 1000
 """,
-        InvalidConfigurationError,
-        "model URL is invalid",
+        ValidationError,
+        "Input should be a valid URL, relative URL without a base",
     )
 
 


### PR DESCRIPTION
## Description

Refactor ModelConfig.
Next step is to add `model_parameters`, eg.:
```yaml
    models:
      - name: ibm/granite-13b-chat-v2
        context_window_size: 1000
        model_parameters:
           max_tokens_for_response: 20
```

## Type of change

- [x] Refactor
