### PR TITLE
OLS-688: install ols using operator for e2e

### DIFF
--- a/tests/config/operator_install/catalog.yaml
+++ b/tests/config/operator_install/catalog.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: lightspeed-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: LightSpeed Operator
+  sourceType: grpc
+  image: quay.io/openshift-lightspeed/lightspeed-catalog:latest
+  updateStrategy:
+    registryPoll:
+      interval: 10m

--- a/tests/config/operator_install/olsconfig.crd.azure_openai.yaml
+++ b/tests/config/operator_install/olsconfig.crd.azure_openai.yaml
@@ -1,0 +1,35 @@
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+  labels:
+    app.kubernetes.io/created-by: lightspeed-operator
+    app.kubernetes.io/instance: olsconfig-sample
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: olsconfig
+    app.kubernetes.io/part-of: lightspeed-operator
+spec:
+  llm:
+    providers:
+      - credentialsSecretRef:
+          name: llmcreds
+        deploymentName: gpt-35-turbo-16k
+        models:
+          - name: gpt-3.5-turbo
+        name: azure_openai
+        type: azure_openai
+        url: 'https://ols-test.openai.azure.com/'
+  ols:
+    defaultModel: gpt-3.5-turbo
+    defaultProvider: azure_openai
+    deployment:
+      replicas: 1
+    disableAuth: false
+    logLevel: DEBUG
+    queryFilters:
+      - name: foo_filter
+        pattern: '\b(?:foo)\b'
+        replaceWith: "deployment"
+      - name: bar_filter
+        pattern: '\b(?:bar)\b'
+        replaceWith: "openshift"

--- a/tests/config/operator_install/olsconfig.crd.bam.yaml
+++ b/tests/config/operator_install/olsconfig.crd.bam.yaml
@@ -1,0 +1,33 @@
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+  labels:
+    app.kubernetes.io/created-by: lightspeed-operator
+    app.kubernetes.io/instance: olsconfig-sample
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: olsconfig
+    app.kubernetes.io/part-of: lightspeed-operator
+spec:
+  llm:
+    providers:
+      - credentialsSecretRef:
+          name: llmcreds
+        models:
+          - name: ibm/granite-13b-chat-v2
+        name: bam
+        type: bam
+  ols:
+    defaultModel: ibm/granite-13b-chat-v2
+    defaultProvider: bam
+    deployment:
+      replicas: 1
+    disableAuth: false
+    logLevel: DEBUG
+    queryFilters:
+      - name: foo_filter
+        pattern: '\b(?:foo)\b'
+        replaceWith: "deployment"
+      - name: bar_filter
+        pattern: '\b(?:bar)\b'
+        replaceWith: "openshift"

--- a/tests/config/operator_install/olsconfig.crd.openai.yaml
+++ b/tests/config/operator_install/olsconfig.crd.openai.yaml
@@ -1,0 +1,33 @@
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+  labels:
+    app.kubernetes.io/created-by: lightspeed-operator
+    app.kubernetes.io/instance: olsconfig-sample
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: olsconfig
+    app.kubernetes.io/part-of: lightspeed-operator
+spec:
+  llm:
+    providers:
+      - credentialsSecretRef:
+          name: llmcreds
+        models:
+          - name: gpt-3.5-turbo
+        name: openai
+        type: openai
+  ols:
+    defaultModel: gpt-3.5-turbo
+    defaultProvider: openai
+    deployment:
+      replicas: 1
+    disableAuth: false
+    logLevel: DEBUG
+    queryFilters:
+      - name: foo_filter
+        pattern: '\b(?:foo)\b'
+        replaceWith: "deployment"
+      - name: bar_filter
+        pattern: '\b(?:bar)\b'
+        replaceWith: "openshift"

--- a/tests/config/operator_install/olsconfig.crd.watsonx.yaml
+++ b/tests/config/operator_install/olsconfig.crd.watsonx.yaml
@@ -1,0 +1,34 @@
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+  labels:
+    app.kubernetes.io/created-by: lightspeed-operator
+    app.kubernetes.io/instance: olsconfig-sample
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: olsconfig
+    app.kubernetes.io/part-of: lightspeed-operator
+spec:
+  llm:
+    providers:
+      - credentialsSecretRef:
+          name: llmcreds
+        projectID: ad629765-c373-4731-9d69-dc701724c081
+        models:
+          - name: ibm/granite-13b-chat-v2
+        name: watsonx
+        type: watsonx
+  ols:
+    defaultModel: ibm/granite-13b-chat-v2
+    defaultProvider: watsonx
+    deployment:
+      replicas: 1
+    disableAuth: false
+    logLevel: DEBUG
+    queryFilters:
+      - name: foo_filter
+        pattern: '\b(?:foo)\b'
+        replaceWith: "deployment"
+      - name: bar_filter
+        pattern: '\b(?:bar)\b'
+        replaceWith: "openshift"

--- a/tests/config/operator_install/operatorgroup.yaml
+++ b/tests/config/operator_install/operatorgroup.yaml
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: OLSConfig.v1alpha1.ols.openshift.io
+  name: openshift-lightspeed
+  namespace: openshift-lightspeed
+spec:
+  upgradeStrategy: Default

--- a/tests/config/operator_install/route.yaml
+++ b/tests/config/operator_install/route.yaml
@@ -1,0 +1,17 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+ labels:
+   app: ols
+ name: ols
+spec:
+ port:
+   targetPort: https
+ tls:
+   insecureEdgeTerminationPolicy: Redirect
+   termination: reencrypt
+ to:
+   kind: Service
+   name: lightspeed-app-server
+   weight: 100
+ wildcardPolicy: None

--- a/tests/config/operator_install/subscription.yaml
+++ b/tests/config/operator_install/subscription.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/lightspeed-operator.openshift-lightspeed: ""
+  name: lightspeed-operator
+  namespace: openshift-lightspeed
+spec:
+  channel: preview
+  installPlanApproval: Automatic
+  name: lightspeed-operator
+  source: lightspeed-operator-catalog
+  sourceNamespace: openshift-marketplace

--- a/tests/e2e/utils/metrics.py
+++ b/tests/e2e/utils/metrics.py
@@ -28,7 +28,7 @@ def get_rest_api_counter_value(
     # rest_api_calls_total{path="/openapi.json",status_code="200"} 1.0
     prefix = f'{counter_name}{{path="{path}",status_code="{status_code}"}} '
 
-    return get_counter_value(counter_name, prefix, response, default)
+    return get_counter_value(prefix, response, default)
 
 
 def get_response_duration_seconds_value(client, path, default=None):
@@ -40,7 +40,7 @@ def get_response_duration_seconds_value(client, path, default=None):
     # response_duration_seconds_sum{path="/v1/query"} 0.123
     prefix = f'{counter_name}{{path="{path}"}} '
 
-    return get_counter_value(counter_name, prefix, response, default, to_int=False)
+    return get_counter_value(prefix, response, default, to_int=False)
 
 
 def get_model_provider_counter_value(
@@ -54,7 +54,7 @@ def get_model_provider_counter_value(
     # llm_token_received_total{model="ibm/granite-13b-chat-v2",provider="bam"} 2465.0
     prefix = f'{counter_name}{{model="{model}",provider="{provider}"}} '
 
-    return get_counter_value(counter_name, prefix, response, default)
+    return get_counter_value(prefix, response, default)
 
 
 def get_all_metric_counters(response, metric_name) -> list[float]:
@@ -109,14 +109,14 @@ def get_enable_status_for_all_models(client):
     return [counter == 1.0 for counter in counters]
 
 
-def get_counter_value(counter_name, prefix, response, default=None, to_int=True):
+def get_counter_value(counter_name, response, default=None, to_int=True):
     """Try to retrieve counter value from response with all metrics."""
     lines = [line.strip() for line in response.split("\n")]
 
     # try to find the given counter
     for line in lines:
-        if line.startswith(prefix):
-            without_prefix = line[len(prefix) :]
+        if line.startswith(counter_name):
+            without_prefix = line[len(counter_name) :]
             # parse counter value as float
             value = float(without_prefix)
             # convert that float to integer if needed
@@ -128,6 +128,7 @@ def get_counter_value(counter_name, prefix, response, default=None, to_int=True)
     if default is not None:
         return default
 
+    print(f"Counter {counter_name} was not found in metrics: {response}")
     raise Exception(f"Counter {counter_name} was not found in metrics")
 
 

--- a/tests/e2e/utils/wait_for_ols.py
+++ b/tests/e2e/utils/wait_for_ols.py
@@ -14,7 +14,7 @@ warnings.filterwarnings("ignore", category=InsecureRequestWarning)
 
 
 # ruff: noqa: S501
-def wait_for_ols(url, timeout=600, interval=10):
+def wait_for_ols(url, timeout=300, interval=10):
     """Wait for the OLS to become ready by checking its readiness endpoint.
 
     Args:
@@ -25,7 +25,7 @@ def wait_for_ols(url, timeout=600, interval=10):
     Returns:
         bool: True if OLS becomes ready within the timeout, False otherwise.
     """
-    print("Starting wait_for_ols")
+    print(f"Starting wait_for_ols at url {url}")
     attempts = int(timeout / interval)
     for attempt in range(1, attempts + 1):
         print(f"Checking OLS readiness, attempt {attempt} of {attempts}")

--- a/tests/scripts/must_gather.py
+++ b/tests/scripts/must_gather.py
@@ -20,17 +20,125 @@ def must_gather():
     suite_id = os.environ.get("SUITE_ID", "nosuite")
     cluster_dir = Path(artifact_dir) / suite_id / "cluster"
     cluster_dir.mkdir(parents=True, exist_ok=True)
+
     cluster_utils.run_oc_and_store_stdout(
         [
             "get",
-            "all",
+            "pods",
             "-n",
             "openshift-lightspeed",
             "-o",
             "yaml",
         ],
-        f"{cluster_dir.as_posix()}/resources.yaml",
+        f"{cluster_dir.as_posix()}/pods.yaml",
     )
+    cluster_utils.run_oc_and_store_stdout(
+        [
+            "get",
+            "services",
+            "-n",
+            "openshift-lightspeed",
+            "-o",
+            "yaml",
+        ],
+        f"{cluster_dir.as_posix()}/services.yaml",
+    )
+    cluster_utils.run_oc_and_store_stdout(
+        [
+            "get",
+            "deployments",
+            "-n",
+            "openshift-lightspeed",
+            "-o",
+            "yaml",
+        ],
+        f"{cluster_dir.as_posix()}/deployments.yaml",
+    )
+    cluster_utils.run_oc_and_store_stdout(
+        [
+            "get",
+            "replicasets",
+            "-n",
+            "openshift-lightspeed",
+            "-o",
+            "yaml",
+        ],
+        f"{cluster_dir.as_posix()}/replicasets.yaml",
+    )
+    cluster_utils.run_oc_and_store_stdout(
+        [
+            "get",
+            "routes",
+            "-n",
+            "openshift-lightspeed",
+            "-o",
+            "yaml",
+        ],
+        f"{cluster_dir.as_posix()}/routes.yaml",
+    )
+    cluster_utils.run_oc_and_store_stdout(
+        [
+            "get",
+            "rolebindings",
+            "-n",
+            "openshift-lightspeed",
+            "-o",
+            "yaml",
+        ],
+        f"{cluster_dir.as_posix()}/rolebindings.yaml",
+    )
+    cluster_utils.run_oc_and_store_stdout(
+        [
+            "get",
+            "serviceaccounts",
+            "-n",
+            "openshift-lightspeed",
+            "-o",
+            "yaml",
+        ],
+        f"{cluster_dir.as_posix()}/serviceaccounts.yaml",
+    )
+
+    # olsconfig CR
+    cluster_utils.run_oc_and_store_stdout(
+        [
+            "get",
+            "olsconfig",
+            "-n",
+            "openshift-lightspeed",
+            "-o",
+            "yaml",
+        ],
+        f"{cluster_dir.as_posix()}/olsconfig.yaml",
+    )
+
+    # clusterserviceversion
+    cluster_utils.run_oc_and_store_stdout(
+        [
+            "get",
+            "clusterserviceversion",
+            "-n",
+            "openshift-lightspeed",
+            "-o",
+            "yaml",
+        ],
+        f"{cluster_dir.as_posix()}/clusterserviceversion.yaml",
+    )
+
+    # installplan
+    cluster_utils.run_oc_and_store_stdout(
+        [
+            "get",
+            "installplan",
+            "-n",
+            "openshift-lightspeed",
+            "-o",
+            "yaml",
+        ],
+        f"{cluster_dir.as_posix()}/installplan.yaml",
+    )
+
+    # pod logs
     pod_logs_dir = cluster_dir / "podlogs"
     pod_logs_dir.mkdir(exist_ok=True)
     for pod in cluster_utils.get_pods():

--- a/tests/scripts/test-e2e-cluster.sh
+++ b/tests/scripts/test-e2e-cluster.sh
@@ -23,18 +23,18 @@ function run_suites() {
 
   set +e
   # runsuite arguments:
-  # suiteid test_tags provider provider_keypath provider_url provider_project_id provider provider_deployment_name llm_model ols_image
+  # suiteid test_tags provider provider_keypath model ols_image
   # empty test_tags means run all tests
-  run_suite "azure_openai" "not model_evaluation" "azure_openai" "$AZUREOPENAI_PROVIDER_KEY_PATH" "https://ols-test.openai.azure.com/" "" "gpt-35-turbo-16k" "gpt-3.5-turbo" "$OLS_IMAGE"
+  run_suite "azure_openai" "not model_evaluation" "azure_openai" "$AZUREOPENAI_PROVIDER_KEY_PATH" "gpt-3.5-turbo" "$OLS_IMAGE"
   (( rc = rc || $? ))
 
-  run_suite "bam" "not model_evaluation" "bam" "$BAM_PROVIDER_KEY_PATH" "" "" "" "ibm/granite-13b-chat-v2" "$OLS_IMAGE"
+  run_suite "bam" "not model_evaluation" "bam" "$BAM_PROVIDER_KEY_PATH" "ibm/granite-13b-chat-v2" "$OLS_IMAGE"
   (( rc = rc || $? ))
 
-  run_suite "openai" "not model_evaluation" "openai" "$OPENAI_PROVIDER_KEY_PATH" "" "" "" "gpt-3.5-turbo" "$OLS_IMAGE"
+  run_suite "openai" "not model_evaluation" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-3.5-turbo" "$OLS_IMAGE"
   (( rc = rc || $? ))
 
-  run_suite "watsonx" "" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "" "ad629765-c373-4731-9d69-dc701724c081" "" "ibm/granite-13b-chat-v2" "$OLS_IMAGE"
+  run_suite "watsonx" "" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-13b-chat-v2" "$OLS_IMAGE"
   (( rc = rc || $? ))
   set -e
 


### PR DESCRIPTION
## Description

attempting to refactor the e2e ols installer logic to install using the latest OLS
operator instead of manually creating resources


## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.