### PR TITLE
Don't have to pass setup fixture, it is autoused

### DIFF
--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -41,9 +41,7 @@ def _with_enabled_feedback(tmpdir):
     )
 
 
-def test_feedback_endpoints_disabled_when_set_in_config(
-    _setup, _with_disabled_feedback
-):
+def test_feedback_endpoints_disabled_when_set_in_config(_with_disabled_feedback):
     """Check if feedback endpoints are disabled when set in config."""
     # status endpoint is always available
     response = client.get("/v1/feedback/status")


### PR DESCRIPTION
## Description

Don't have to pass `_setup` fixture, it is autoused

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
