### PR TITLE
Fix user warning in model config

### DIFF
--- a/examples/olsconfig.yaml
+++ b/examples/olsconfig.yaml
@@ -6,7 +6,7 @@ llm_providers:
     models:
       - name: ibm/granite-13b-chat-v2
         context_window_size: 8000
-        model_parameters:
+        parameters:
           max_tokens_for_response: 500
   - name: my_openai
     type: openai

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -109,7 +109,7 @@ class ModelConfig(BaseModel):
     credentials: Optional[str] = None
 
     context_window_size: PositiveInt = constants.DEFAULT_CONTEXT_WINDOW_SIZE
-    model_parameters: ModelParameters = ModelParameters()
+    parameters: ModelParameters = ModelParameters()
 
     options: Optional[dict[str, Any]] = None
 
@@ -149,11 +149,11 @@ class ModelConfig(BaseModel):
     @model_validator(mode="after")
     def validate_context_window_and_max_tokens(self) -> Self:
         """Validate context window size and max tokens for response."""
-        if self.context_window_size <= self.model_parameters.max_tokens_for_response:  # type: ignore [operator]
+        if self.context_window_size <= self.parameters.max_tokens_for_response:  # type: ignore [operator]
             raise InvalidConfigurationError(
                 f"Context window size {self.context_window_size}, "
                 "should be greater than max_tokens_for_response "
-                f"{self.model_parameters.max_tokens_for_response}"
+                f"{self.parameters.max_tokens_for_response}"
             )
         return self
 

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -27,7 +27,7 @@ class DocsSummarizer(QueryHelper):
         provider_config = config.llm_config.providers.get(self.provider)
         model_config = provider_config.models.get(self.model)
         self.generic_llm_params = {
-            GenericLLMParameters.MAX_TOKENS_FOR_RESPONSE: model_config.model_parameters.max_tokens_for_response  # noqa: E501
+            GenericLLMParameters.MAX_TOKENS_FOR_RESPONSE: model_config.parameters.max_tokens_for_response  # noqa: E501
         }
 
     def _get_model_options(
@@ -91,7 +91,7 @@ class DocsSummarizer(QueryHelper):
         available_tokens = token_handler.calculate_and_check_available_tokens(
             temp_prompt.format(**temp_prompt_input),
             model_config.context_window_size,
-            model_config.model_parameters.max_tokens_for_response,
+            model_config.parameters.max_tokens_for_response,
         )
 
         if vector_index is not None:
@@ -125,7 +125,7 @@ class DocsSummarizer(QueryHelper):
         token_handler.calculate_and_check_available_tokens(
             final_prompt.format(**llm_input_values),
             model_config.context_window_size,
-            model_config.model_parameters.max_tokens_for_response,
+            model_config.parameters.max_tokens_for_response,
         )
 
         chat_engine = LLMChain(

--- a/tests/config/valid_config.yaml
+++ b/tests/config/valid_config.yaml
@@ -9,7 +9,7 @@ llm_providers:
         url: "https://murl1"
         credentials_path: tests/config/secret/apitoken
         context_window_size: 450
-        model_parameters:
+        parameters:
           max_tokens_for_response: 100
       - name: m2
         url: "https://murl2"

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -34,12 +34,10 @@ def test_model_parameters():
         == constants.DEFAULT_MAX_TOKENS_FOR_RESPONSE
     )
 
-    model_parameters = ModelParameters(
-        max_tokens_for_response=10, unknown_param="hello"
-    )
+    parameters = ModelParameters(max_tokens_for_response=10, unknown_param="hello")
 
-    assert model_parameters.max_tokens_for_response == 10
-    assert not hasattr(model_parameters, "unknown_param")
+    assert parameters.max_tokens_for_response == 10
+    assert not hasattr(parameters, "unknown_param")
 
     # max_tokens_for_response needs to be positive integer
     with pytest.raises(ValidationError, match="Input should be greater than 0"):
@@ -173,7 +171,7 @@ def test_model_config_higher_response_token():
         ModelConfig(
             name="test_model_name",
             context_window_size=2,
-            model_parameters=ModelParameters(max_tokens_for_response=2),
+            parameters=ModelParameters(max_tokens_for_response=2),
         )
 
 
@@ -209,9 +207,7 @@ def test_provider_config():
         == constants.DEFAULT_CONTEXT_WINDOW_SIZE
     )
     assert (
-        provider_config.models[
-            "test_model_name"
-        ].model_parameters.max_tokens_for_response
+        provider_config.models["test_model_name"].parameters.max_tokens_for_response
         == constants.DEFAULT_MAX_TOKENS_FOR_RESPONSE
     )
     assert provider_config.openai_config is None

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -780,7 +780,7 @@ def test_valid_config_file():
                                 "url": "https://murl1",
                                 "credentials_path": "tests/config/secret/apitoken",
                                 "context_window_size": 450,
-                                "model_parameters": {"max_tokens_for_response": 100},
+                                "parameters": {"max_tokens_for_response": 100},
                             },
                             {
                                 "name": "m2",


### PR DESCRIPTION
## Description

Without this, you can see warning at the app start
```
/home/ometelka/projects/lightspeed-service/.venv/lib/python3.11/site-packages/pydantic/_internal/_fields.py:160: UserWarning: Field "model_parameters" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
```

## Type of change

- [x] Bug fix
