### PR TITLE
OLS-702: Use non-root user in Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -46,3 +46,6 @@ CMD ["python3.11", "runner.py"]
 LABEL io.k8s.display-name="OpenShift LightSpeed Service" \
       io.k8s.description="AI-powered OpenShift Assistant Service." \
       io.openshift.tags="openshift-lightspeed,ols"
+
+# no-root user is checked in Konflux 
+USER 1001


### PR DESCRIPTION
## Description

Use non-root user in Containerfile

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #[OLS-702](https://issues.redhat.com//browse/OLS-702)
- Closes #
