### PR TITLE
Usefixtures in integration tests who activelly does not use the fixture

### DIFF
--- a/tests/integration/test_authorized.py
+++ b/tests/integration/test_authorized.py
@@ -39,7 +39,8 @@ def _enabled_auth():
     config.dev_config.disable_auth = False
 
 
-def test_post_authorized_disabled(_disabled_auth):
+@pytest.mark.usefixtures("_disabled_auth")
+def test_post_authorized_disabled():
     """Check the REST API /v1/query with POST HTTP method when no payload is posted."""
     # perform POST request with authentication disabled
     response = client.post("/authorized")
@@ -52,16 +53,18 @@ def test_post_authorized_disabled(_disabled_auth):
     }
 
 
-def test_post_authorized_no_token(_enabled_auth):
+@pytest.mark.usefixtures("_enabled_auth")
+def test_post_authorized_no_token():
     """Check the REST API /v1/query with POST HTTP method when no payload is posted."""
     # perform POST request without any payload
     response = client.post("/authorized")
     assert response.status_code == 401
 
 
+@pytest.mark.usefixtures("_enabled_auth")
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authn_api")
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authz_api")
-def test_is_user_authorized_valid_token(mock_authz_api, mock_authn_api, _enabled_auth):
+def test_is_user_authorized_valid_token(mock_authz_api, mock_authn_api):
     """Tests the is_user_authorized function with a mocked valid-token."""
     # Setup mock responses for valid token
     mock_authn_api.return_value.create_token_review.side_effect = (
@@ -81,11 +84,10 @@ def test_is_user_authorized_valid_token(mock_authz_api, mock_authn_api, _enabled
     assert response.json() == {"user_id": "valid-uid", "username": "valid-user"}
 
 
+@pytest.mark.usefixtures("_enabled_auth")
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authn_api")
 @patch("ols.utils.auth_dependency.K8sClientSingleton.get_authz_api")
-def test_is_user_authorized_invalid_token(
-    mock_authz_api, mock_authn_api, _enabled_auth
-):
+def test_is_user_authorized_invalid_token(mock_authz_api, mock_authn_api):
     """Test the is_user_authorized function with a mocked invalid-token."""
     # Setup mock responses for invalid token
     mock_authn_api.return_value.create_token_review.side_effect = (

--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -41,7 +41,8 @@ def _with_enabled_feedback(tmpdir):
     )
 
 
-def test_feedback_endpoints_disabled_when_set_in_config(_with_disabled_feedback):
+@pytest.mark.usefixtures("_with_disabled_feedback")
+def test_feedback_endpoints_disabled_when_set_in_config():
     """Check if feedback endpoints are disabled when set in config."""
     # status endpoint is always available
     response = client.get("/v1/feedback/status")
@@ -51,14 +52,16 @@ def test_feedback_endpoints_disabled_when_set_in_config(_with_disabled_feedback)
     assert response.status_code == requests.codes.forbidden
 
 
-def test_feedback_status(_with_enabled_feedback):
+@pytest.mark.usefixtures("_with_enabled_feedback")
+def test_feedback_status():
     """Check if feedback status is returned."""
     response = client.get("/v1/feedback/status")
     assert response.status_code == requests.codes.ok
     assert response.json() == {"functionality": "feedback", "status": {"enabled": True}}
 
 
-def test_feedback(_with_enabled_feedback):
+@pytest.mark.usefixtures("_with_enabled_feedback")
+def test_feedback():
     """Check if feedback with correct format is accepted by the service."""
     response = client.post(
         "/v1/feedback",
@@ -73,7 +76,8 @@ def test_feedback(_with_enabled_feedback):
     assert response.json() == {"response": "feedback received"}
 
 
-def test_feedback_improper_conversation_id(_with_enabled_feedback):
+@pytest.mark.usefixtures("_with_enabled_feedback")
+def test_feedback_improper_conversation_id():
     """Check if feedback with improper conversation ID is rejected."""
     response = client.post(
         "/v1/feedback",
@@ -87,7 +91,8 @@ def test_feedback_improper_conversation_id(_with_enabled_feedback):
     assert response.status_code == requests.codes.unprocessable_entity
 
 
-def test_feedback_improper_sentiment(_with_enabled_feedback):
+@pytest.mark.usefixtures("_with_enabled_feedback")
+def test_feedback_improper_sentiment():
     """Check if feedback with improper sentiment value is rejected."""
     response = client.post(
         "/v1/feedback",
@@ -112,7 +117,8 @@ def test_feedback_improper_sentiment(_with_enabled_feedback):
     assert response.status_code == requests.codes.unprocessable_entity
 
 
-def test_feedback_wrong_request(_with_enabled_feedback):
+@pytest.mark.usefixtures("_with_enabled_feedback")
+def test_feedback_wrong_request():
     """Check if feedback with wrong payload (empty one) is not accepted by the service."""
     response = client.post("/v1/feedback", json={})
     # for the request send w/o proper payload, the server
@@ -120,9 +126,8 @@ def test_feedback_wrong_request(_with_enabled_feedback):
     assert response.status_code == requests.codes.unprocessable_entity
 
 
-def test_feedback_mandatory_fields_not_provided_filled_in_request(
-    _with_enabled_feedback,
-):
+@pytest.mark.usefixtures("_with_enabled_feedback")
+def test_feedback_mandatory_fields_not_provided_filled_in_request():
     """Check if feedback without mandatory fields is not accepted by the service."""
     response = client.post(
         "/v1/feedback",
@@ -137,7 +142,8 @@ def test_feedback_mandatory_fields_not_provided_filled_in_request(
     assert response.status_code == requests.codes.unprocessable_entity
 
 
-def test_feedback_no_payload_send(_with_enabled_feedback):
+@pytest.mark.usefixtures("_with_enabled_feedback")
+def test_feedback_no_payload_send():
     """Check if feedback without feedback payload."""
     response = client.post("/v1/feedback")
     # for the request send w/o payload, the server
@@ -145,7 +151,8 @@ def test_feedback_no_payload_send(_with_enabled_feedback):
     assert response.status_code == requests.codes.unprocessable_entity
 
 
-def test_feedback_error_raised(_with_enabled_feedback):
+@pytest.mark.usefixtures("_with_enabled_feedback")
+def test_feedback_error_raised():
     """Check if feedback endpoint raises an exception when storing feedback fails."""
     with patch(
         "ols.app.endpoints.feedback.store_feedback",

--- a/tests/integration/test_liveness_readiness.py
+++ b/tests/integration/test_liveness_readiness.py
@@ -43,7 +43,7 @@ def test_readiness():
         assert response.status_code == requests.codes.ok
         assert response.json() == {"ready": False, "reason": "index is not ready"}
 
-    # llm is not ready
+    # index is ready, LLM is not ready
     with (
         patch("ols.app.endpoints.health.llm_is_ready", return_value=False),
         patch("ols.app.endpoints.health.index_is_ready", return_value=True),
@@ -52,7 +52,7 @@ def test_readiness():
         assert response.status_code == requests.codes.ok
         assert response.json() == {"ready": False, "reason": "LLM is not ready"}
 
-    # everything is ready
+    # both index and LLM are ready
     with (
         patch("ols.app.endpoints.health.llm_is_ready", return_value=True),
         patch("ols.app.endpoints.health.index_is_ready", return_value=True),


### PR DESCRIPTION
## Description

Usefixtures in integration tests

Fixtures can be injected either by passing them as parameters to the test
function, or by using the `@pytest.mark.usefixtures` decorator.

If the test function depends on the fixture being activated, but does not
use it in the test body or otherwise rely on its return value, prefer
the `@pytest.mark.usefixtures` decorator, to make the dependency explicit
and avoid the confusion caused by unused arguments.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
