### PR TITLE
OLS-758: Fix CI job failures caused by newest Mypy version 1.10.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ images: ## Build container images
 
 install-tools:	install-woke ## Install required utilities/tools
 	@command -v pdm > /dev/null || { echo >&2 "pdm is not installed. Installing..."; pip install pdm; }
+	# this is quick fix for OLS-758: "Verify" CI job is broken after new Mypy 1.10.1 was released 2 days ago
+	# CI job configuration would need to be updated in follow-up task
+	pip uninstall -y mypy
+	pdm install --dev
+	mypy --version
 
 install-woke: ## Install woke, required for Inclusive Naming scan
 	@command -v ./woke > /dev/null || { echo >&2 "woke is not installed. Installing..."; curl -sSfL https://git.io/getwoke | bash -s -- -b ./; }


### PR DESCRIPTION
[OLS-758](https://issues.redhat.com//browse/OLS-758): Fix CI job failures caused by newest Mypy version 1.10.1
We install Mypy with pinned version as configured in `pyproject.toml` and `pdm.lock`