### PR TITLE
OLS-697: Add CacheEntry model

### DIFF
--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -532,7 +532,6 @@ class CacheEntry(BaseModel):
         history = []
         for entry in cache_entries:
             history.append(f"human: {entry.query.strip()}")
-            if entry.response != "":
-                history.append(f"ai: {entry.response.strip()}")
+            history.append(f"ai: {entry.response.strip()}")
 
         return history

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -490,3 +490,49 @@ class SummarizerResponse:
     response: str
     rag_chunks: list[RagChunk]
     history_truncated: bool
+
+
+class CacheEntry(BaseModel):
+    """Model representing a cache entry.
+
+    Attributes:
+        query: The query string.
+        response: The response string.
+    """
+
+    query: str
+    response: Optional[str] = ""
+
+    @field_validator("response")
+    @classmethod
+    def set_none_response_to_empty_string(cls, v: Optional[str]) -> str:
+        """Convert None response to an empty string."""
+        if v is None:
+            return ""
+        return v
+
+    def to_dict(self) -> dict:
+        """Convert the cache entry to a dictionary."""
+        return {
+            "human_query": self.query,
+            "ai_response": self.response,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Self:
+        """Create a cache entry from a dictionary."""
+        return cls(
+            query=data["human_query"],
+            response=data["ai_response"],
+        )
+
+    @staticmethod
+    def cache_entries_to_history(cache_entries: list["CacheEntry"]) -> list[str]:
+        """Convert cache entries to a history."""
+        history = []
+        for entry in cache_entries:
+            history.append(f"human: {entry.query}")
+            if entry.response != "":
+                history.append(f"ai: {entry.response}")
+
+        return history

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -531,8 +531,8 @@ class CacheEntry(BaseModel):
         """Convert cache entries to a history."""
         history = []
         for entry in cache_entries:
-            history.append(f"human: {entry.query}")
+            history.append(f"human: {entry.query.strip()}")
             if entry.response != "":
-                history.append(f"ai: {entry.response}")
+                history.append(f"ai: {entry.response.strip()}")
 
         return history

--- a/ols/src/cache/cache.py
+++ b/ols/src/cache/cache.py
@@ -1,8 +1,8 @@
 """Abstract class that is parent for all cache implementations."""
 
 from abc import ABC, abstractmethod
-from typing import Literal, Optional
 
+from ols.app.models.models import CacheEntry
 from ols.utils.suid import check_suid
 
 
@@ -39,9 +39,7 @@ class Cache(ABC):
         return f"{user_id}{Cache.COMPOUND_KEY_SEPARATOR}{conversation_id}"
 
     @abstractmethod
-    def get(
-        self, user_id: str, conversation_id: str
-    ) -> Optional[list[dict[Literal["type", "content"], str]]]:
+    def get(self, user_id: str, conversation_id: str) -> list[CacheEntry]:
         """Abstract method to retrieve a value from the cache.
 
         Args:
@@ -49,7 +47,7 @@ class Cache(ABC):
             conversation_id: Conversation ID unique for given user.
 
         Returns:
-            The value associated with the key, or None if not found.
+            The value (CacheEntry(s)) associated with the key, or None if not found.
         """
 
     @abstractmethod
@@ -57,12 +55,12 @@ class Cache(ABC):
         self,
         user_id: str,
         conversation_id: str,
-        value: list[dict[Literal["type", "content"], str]],
+        cache_entry: CacheEntry,
     ) -> None:
         """Abstract method to store a value in the cache.
 
         Args:
             user_id: User identification.
             conversation_id: Conversation ID unique for given user.
-            value: The value to be stored in the cache.
+            cache_entry: The value to store.
         """

--- a/tests/integration/test_redis.py
+++ b/tests/integration/test_redis.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from ols.app.endpoints.ols import ai_msg, human_msg
 from ols.app.models.config import RedisConfig
+from ols.app.models.models import CacheEntry
 from ols.src.cache.redis_cache import RedisCache
 
 user_id = "00000000-0000-0000-0000-000000000001"
@@ -41,29 +41,26 @@ def test_conversation_in_redis():
     assert retrieved is None
 
     # insert some conversation
-    conversation = [
-        human_msg("First human message"),
-        ai_msg("First AI response"),
-    ]
-    redis_cache.insert_or_append(user_id, conversation_id, conversation)
+    cache_entry = CacheEntry(query="First human message", response="First AI response")
+    redis_cache.insert_or_append(user_id, conversation_id, cache_entry)
 
     # check what is stored in conversation cache
     retrieved = redis_cache.get(user_id, conversation_id)
     assert retrieved is not None
 
-    # just the initial conversation should be stored
-    assert retrieved == conversation
+    # just the initial cache_entry should be stored
+    assert retrieved == cache_entry
 
     # append more conversation
-    conversation2 = [
-        human_msg("Second human message"),
-        ai_msg("Second AI response"),
-    ]
-    redis_cache.insert_or_append(user_id, conversation_id, conversation2)
+    cache_entry_2 = CacheEntry(
+        query="Second human message", response="Second AI response"
+    )
+
+    redis_cache.insert_or_append(user_id, conversation_id, cache_entry_2)
 
     # check what is stored in conversation cache
     retrieved = redis_cache.get(user_id, conversation_id)
     assert retrieved is not None
 
     # now both conversations should be stored
-    assert retrieved == conversation + conversation2
+    assert retrieved == [cache_entry, cache_entry_2]

--- a/tests/unit/app/models/test_models.py
+++ b/tests/unit/app/models/test_models.py
@@ -363,3 +363,15 @@ class TestCacheEntry:
             "human: query2",
             "ai: response2",
         ]
+
+    @staticmethod
+    def test_cache_entries_to_history_no_whitespace():
+        """Test content is stripped."""
+        cache_entries = [
+            CacheEntry(query="\ngood\nmorning\n", response="\ngood\nnight\n"),
+        ]
+        history = CacheEntry.cache_entries_to_history(cache_entries)
+        assert history == [
+            "human: good\nmorning",
+            "ai: good\nnight",
+        ]

--- a/tests/unit/app/models/test_models.py
+++ b/tests/unit/app/models/test_models.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from ols.app.models.models import (
+    CacheEntry,
     FeedbackRequest,
     FeedbackResponse,
     LivenessResponse,
@@ -310,3 +311,55 @@ class TestReadiness:
 
         assert readiness_request.ready == ready
         assert readiness_request.reason == reason
+
+
+class TestCacheEntry:
+    """Unit test for the CacheEntry model."""
+
+    @staticmethod
+    def test_basic_interface():
+        """Test the CacheEntry model."""
+        cache_entry = CacheEntry(query="query")
+        assert cache_entry.query == "query"
+        assert cache_entry.response == ""
+
+        cache_entry = CacheEntry(query="query", response=None)
+        assert cache_entry.query == "query"
+        assert cache_entry.response == ""
+
+        cache_entry = CacheEntry(query="query", response="response")
+        assert cache_entry.query == "query"
+        assert cache_entry.response == "response"
+
+    @staticmethod
+    def test_to_dict():
+        """Test the to_dict method of the CacheEntry model."""
+        cache_entry = CacheEntry(query="query", response="response")
+        assert cache_entry.to_dict() == {
+            "human_query": "query",
+            "ai_response": "response",
+        }
+
+    @staticmethod
+    def test_from_dict():
+        """Test the from_dict method of the CacheEntry model."""
+        cache_entry = CacheEntry.from_dict(
+            {"human_query": "query", "ai_response": "response"}
+        )
+        assert cache_entry.query == "query"
+        assert cache_entry.response == "response"
+
+    @staticmethod
+    def test_cache_entries_to_history():
+        """Test the cache_entries_to_history method of the CacheEntry model."""
+        cache_entries = [
+            CacheEntry(query="query1", response="response1"),
+            CacheEntry(query="query2", response="response2"),
+        ]
+        history = CacheEntry.cache_entries_to_history(cache_entries)
+        assert history == [
+            "human: query1",
+            "ai: response1",
+            "human: query2",
+            "ai: response2",
+        ]

--- a/tests/unit/app/models/test_models.py
+++ b/tests/unit/app/models/test_models.py
@@ -375,3 +375,15 @@ class TestCacheEntry:
             "human: good\nmorning",
             "ai: good\nnight",
         ]
+
+    @staticmethod
+    def test_cache_entries_to_history_no_content():
+        """Test empty AI response is handled."""
+        cache_entries = [
+            CacheEntry(query="what?", response=""),
+        ]
+        history = CacheEntry.cache_entries_to_history(cache_entries)
+        assert history == [
+            "human: what?",
+            "ai: ",
+        ]


### PR DESCRIPTION
## Description

Add CacheEntry model.
The history format we send in the prompt is unchanged.
The follow-up is adding the attachments to the model.
The insert_or_append method can be used to store only single cache entry - which is exactly what is happening in the ols endpoint.

Question:
- Should Redis cache be updated? Or finally, removed?
   - not now

## Type of change

- [x] New feature
