### PR TITLE
Fixes: location is `tuple`, mapping is `dict`

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -21,8 +21,8 @@ def pytest_runtest_makereport(item, call) -> TestReport:
         makereport_called = True
         return TestReport(
             "test_wait_for_ols",
-            ["", 0, ""],
-            None,
+            ("", 0, ""),
+            {},
             "failed",
             "wait for OLS to startup before running tests",
             "call",


### PR DESCRIPTION
## Description

Improper values were passed to `TestReport` constructor
Fixes:
- location is `tuple`, not a `list`
- mapping is `dict`, not `None`

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
