### PR TITLE
Fix print whole Google sheet URL, not just the ID

### DIFF
--- a/scripts/data_collection/update_google_sheet.py
+++ b/scripts/data_collection/update_google_sheet.py
@@ -93,7 +93,7 @@ def upload_csv_files(
     sheet = gc.open(spreadsheet_title)
     logger.info(f"ID={sheet.id}")
     logger.info(f"Title={sheet.title}")
-    logger.info(f"URL={sheet.id}")
+    logger.info(f"URL={sheet.url}")
 
     upload_csv_file(sheet[0], feedback)
     upload_csv_file(sheet[1], feedback_with_history)


### PR DESCRIPTION
## Description

Fix print whole Google sheet URL, not just the ID

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
