### PR TITLE
Add some config default values and load those in data collector

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -847,7 +847,7 @@ class OLSConfig(BaseModel):
     conversation_cache: Optional[ConversationCacheConfig] = None
     logging_config: Optional[LoggingConfig] = None
     reference_content: Optional[ReferenceContent] = None
-    authentication_config: Optional[AuthenticationConfig] = None
+    authentication_config: AuthenticationConfig = AuthenticationConfig()
     tls_config: Optional[TLSConfig] = None
 
     default_provider: Optional[str] = None
@@ -855,7 +855,7 @@ class OLSConfig(BaseModel):
     query_filters: Optional[list[QueryFilter]] = None
     query_validation_method: Optional[str] = constants.QueryValidationMethod.LLM
 
-    user_data_collection: Optional[UserDataCollection] = None
+    user_data_collection: UserDataCollection = UserDataCollection()
 
     def __init__(self, data: Optional[dict] = None) -> None:
         """Initialize configuration and perform basic validation."""

--- a/ols/user_data_collection/data_collector.py
+++ b/ols/user_data_collection/data_collector.py
@@ -24,7 +24,13 @@ import requests
 
 # we need to add the root directory to the path to import from ols
 sys.path.append(pathlib.Path(__file__).parent.parent.parent.as_posix())
-from ols.utils.auth_dependency import K8sClientSingleton
+
+# initialize config with default values
+from ols import config
+
+config.reload_empty()
+
+from ols.utils.auth_dependency import K8sClientSingleton  # noqa: E402
 
 OLS_USER_DATA_PATH = os.environ["OLS_USER_DATA_PATH"]
 OLS_USER_DATA_COLLECTION_INTERVAL = int(

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -1603,10 +1603,6 @@ def test_ols_config(tmpdir):
             "logging_config": {
                 "logging_level": "INFO",
             },
-            "user_data_collection": {
-                "feedback_disabled": False,
-                "feedback_storage": tmpdir.strpath,
-            },
         }
     )
     assert ols_config.default_provider == "test_default_provider"
@@ -1615,9 +1611,9 @@ def test_ols_config(tmpdir):
     assert ols_config.conversation_cache.memory.max_entries == 100
     assert ols_config.logging_config.app_log_level == logging.INFO
     assert ols_config.query_validation_method == constants.QueryValidationMethod.LLM
-    assert ols_config.user_data_collection.feedback_disabled is False
-    assert ols_config.user_data_collection.feedback_storage == tmpdir.strpath
+    assert ols_config.user_data_collection == UserDataCollection()
     assert ols_config.reference_content is None
+    assert ols_config.authentication_config == AuthenticationConfig()
 
 
 def test_config():


### PR DESCRIPTION
## Description

Add some config default values and load those in data collector.
Only subconfigs that are needed for data collector are initialized here. The proper approach should be to have defaults for all fields (subconfigs with its defaults instead of None's), but more changes are required in order to make it happen.

## Type of change

- [x] Refactor
- [x] New feature
- [x] Bug fix
