### PR TITLE
Use provider type, not provider name, as metrics label

### DIFF
--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -136,7 +136,7 @@ class DocsSummarizer(QueryHelper):
 
         with TokenMetricUpdater(
             llm=bare_llm,
-            provider=self.provider,
+            provider=provider_config.type,
             model=self.model,
         ) as token_counter:
             summary = chat_engine.invoke(

--- a/ols/src/query_helpers/question_validator.py
+++ b/ols/src/query_helpers/question_validator.py
@@ -78,7 +78,7 @@ class QuestionValidator(QueryHelper):
 
         with TokenMetricUpdater(
             llm=bare_llm,
-            provider=self.provider,
+            provider=provider_config.type,
             model=self.model,
         ) as token_counter:
             response = llm_chain.invoke(


### PR DESCRIPTION
## Description

provider name can be whatever the admin wants.  provider type has to be one of our explicit known values.  For purposes of us understanding which providers customers are using, we want the type(azure_openai, openai, watsonx, etc), not their arbitrary name for the provider config.

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.