### PR TITLE
Add azure_ad_token as valid parameter

### DIFF
--- a/ols/src/llms/providers/provider.py
+++ b/ols/src/llms/providers/provider.py
@@ -36,6 +36,7 @@ AzureOpenAIParameters = {
     ProviderParameter("azure_endpoint", str),
     ProviderParameter("api_key", str),
     ProviderParameter("api_version", str),
+    ProviderParameter("azure_ad_token", str),
     ProviderParameter("base_url", str),
     ProviderParameter("deployment_name", str),
     ProviderParameter("model", str),


### PR DESCRIPTION
## Description

Add azure_ad_token as a valid parameter. This should be there as either this or `api_key` is used for auth to access azure.

## Type of change

- [x] Bug fix
