### PR TITLE
OLS-779: Bump-up OpenAI to version 1.31.1

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:6babf118e298643f5b033f5630918b4c06ead1f46e814e5b55b3bf86cca8e5d5"
+content_hash = "sha256:f0d5a657a10cd3aea0a2505ed303b781367a0c659b1aced1d884e7305672b27d"
 
 [[package]]
 name = "aiofiles"
@@ -1897,7 +1897,7 @@ files = [
 
 [[package]]
 name = "openai"
-version = "1.30.1"
+version = "1.31.0"
 requires_python = ">=3.7.1"
 summary = "The official Python library for the openai API"
 groups = ["default"]
@@ -1911,8 +1911,8 @@ dependencies = [
     "typing-extensions<5,>=4.7",
 ]
 files = [
-    {file = "openai-1.30.1-py3-none-any.whl", hash = "sha256:c9fb3c3545c118bbce8deb824397b9433a66d0d0ede6a96f7009c95b76de4a46"},
-    {file = "openai-1.30.1.tar.gz", hash = "sha256:4f85190e577cba0b066e1950b8eb9b11d25bc7ebcc43a86b326ce1bfa564ec74"},
+    {file = "openai-1.31.0-py3-none-any.whl", hash = "sha256:82044ee3122113f2a468a1f308a8882324d09556ba5348687c535d3655ee331c"},
+    {file = "openai-1.31.0.tar.gz", hash = "sha256:54ae0625b005d6a3b895db2b8438dae1059cffff0cd262a26e9015c13a29ab06"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "redis==5.0.4",
     "faiss-cpu==1.8.0",
     "sentence-transformers==2.7.0",
-    "openai==1.30.1",
+    "openai==1.31.0",
     "ibm-watson-machine-learning==1.0.359",
     "ibm-generative-ai==3.0.0",
     "langchain-openai==0.1.8",


### PR DESCRIPTION
## Description

Bump-up OpenAI to version 1.31.1

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #[OLS-779](https://issues.redhat.com//browse/OLS-779)
