### PR TITLE
Use colon when specifying rule code

### DIFF
--- a/ols/constants.py
+++ b/ols/constants.py
@@ -191,7 +191,7 @@ ATTACHMENT_CONTENT_TYPES = frozenset(
 )
 
 # Default name of file containing API token
-API_TOKEN_FILENAME = "apitoken"  # noqa S105
+API_TOKEN_FILENAME = "apitoken"  # noqa: S105
 
 # Default name of file containing client ID to Azure OpenAI
 AZURE_CLIENT_ID_FILENAME = "client_id"
@@ -200,7 +200,7 @@ AZURE_CLIENT_ID_FILENAME = "client_id"
 AZURE_TENANT_ID_FILENAME = "tenant_id"
 
 # Default name of file containing client secret to Azure OpenAI
-AZURE_CLIENT_SECRET_FILENAME = "client_secret"  # noqa S105
+AZURE_CLIENT_SECRET_FILENAME = "client_secret"  # noqa: S105
 
 # Selectors for fields from configuration structure
 CREDENTIALS_PATH_SELECTOR = "credentials_path"

--- a/scripts/generate_packages_to_prefetch.py
+++ b/scripts/generate_packages_to_prefetch.py
@@ -43,7 +43,7 @@ BUILDDEPS_SCRIPT_NAME = "pip_find_builddeps.py"
 
 def shell(command, directory):
     """Run command via shell inside specified directory."""
-    return subprocess.check_output(command, cwd=directory, shell=True)  # noqa S602
+    return subprocess.check_output(command, cwd=directory, shell=True)  # noqa: S602
 
 
 def copy_project_stub(directory):
@@ -99,7 +99,7 @@ def download_wheel(directory, registry, wheel):
     """Download selected wheel from registry."""
     url = wheel_url(registry, wheel)
     into = join(directory, wheel)
-    urlretrieve(url, into)  # noqa S310
+    urlretrieve(url, into)  # noqa: S310
 
 
 def generate_hash(directory, registry, wheel, target):
@@ -132,7 +132,7 @@ def generate_packages_to_be_build(work_directory):
     # download helper script to generate list of packages
     url = f"{CACHITO_URL}/{BUILDDEPS_SCRIPT_PATH}/{BUILDDEPS_SCRIPT_NAME}"
     into = join(work_directory, BUILDDEPS_SCRIPT_NAME)
-    urlretrieve(url, into)  # noqa S310
+    urlretrieve(url, into)  # noqa: S310
 
     infile = "requirements-build.in"
     outfile = "requirements-build.txt"

--- a/tests/mock_classes/mock_llm_chain.py
+++ b/tests/mock_classes/mock_llm_chain.py
@@ -27,7 +27,7 @@ def mock_llm_chain(retval):
         def __call__(self, *args, **kwargs):
             return retval
 
-        def invoke(self, input, config=None, **kwargs):  # noqa A002
+        def invoke(self, input, config=None, **kwargs):  # noqa: A002
             if retval is not None:
                 return retval
             input["text"] = input["query"]

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -717,7 +717,7 @@ def test_multiple_provider_specific_configs():
     """Test if check for multiple provider-specific configs is performed."""
     with pytest.raises(
         InvalidConfigurationError,
-        match="multiple provider-specific configurations found, but just one is expected for provider bam",  # noqa E501
+        match="multiple provider-specific configurations found, but just one is expected for provider bam",  # noqa: E501
     ):
         # two provider-specific configurations is in the configuration
         ProviderConfig(
@@ -1547,7 +1547,7 @@ def test_conversation_cache_config():
 
     with pytest.raises(
         InvalidConfigurationError,
-        match="Postgres conversation cache type is specified, but Postgres configuration is missing",  # noqa E101
+        match="Postgres conversation cache type is specified, but Postgres configuration is missing",  # noqa: E501
     ):
         ConversationCacheConfig({"type": "postgres"})
 

--- a/tests/unit/llms/providers/test_azure_openai.py
+++ b/tests/unit/llms/providers/test_azure_openai.py
@@ -395,7 +395,7 @@ class MockedAccessToken:
 
     def __init__(self):
         """Construct mocked access token class."""
-        self.token = "this-is-access-token"  # noqa S105
+        self.token = "this-is-access-token"  # noqa: S105
         self.expires_on = 3600  # random value
 
 
@@ -426,7 +426,7 @@ def mocked_token_cache():
     """Fake token cache."""
 
     class MockedTokenCache:
-        access_token = "cached_token"  # noqa S105
+        access_token = "cached_token"  # noqa: S105
         expires_on = 0
 
     return MockedTokenCache
@@ -445,7 +445,7 @@ def test_retrieve_access_token(provider_config_access_token_related_parameters):
     assert "api_key" not in azure_openai.default_params
     assert (
         azure_openai.default_params["azure_ad_token"]
-        == "this-is-access-token"  # noqa S105
+        == "this-is-access-token"  # noqa: S105
     )
 
 

--- a/tests/unit/utils/test_token_handler.py
+++ b/tests/unit/utils/test_token_handler.py
@@ -41,7 +41,7 @@ class TestTokenHandler(TestCase):
         self._token_handler_obj = TokenHandler()
 
     def test_available_tokens_for_empty_prompt(self):
-        """Test the method to calculate available tokens and check if there are any available tokens for default model config."""  # noqa E501
+        """Test the method to calculate available tokens and check if there are any available tokens for default model config."""  # noqa: E501
         context_window_size = 500
         max_tokens_for_response = 20
 
@@ -53,7 +53,7 @@ class TestTokenHandler(TestCase):
         assert available_tokens == context_window_size - max_tokens_for_response
 
     def test_available_tokens_for_regular_prompt(self):
-        """Test the method to calculate available tokens and check if there are any available tokens for default model config."""  # noqa E501
+        """Test the method to calculate available tokens and check if there are any available tokens for default model config."""  # noqa: E501
         context_window_size = 500
         max_tokens_for_response = 20
 
@@ -71,7 +71,7 @@ class TestTokenHandler(TestCase):
         assert available_tokens == expected_value
 
     def test_available_tokens_for_large_prompt(self):
-        """Test the method to calculate available tokens and check if there are any available tokens for default model config."""  # noqa E501
+        """Test the method to calculate available tokens and check if there are any available tokens for default model config."""  # noqa: E501
         context_window_size = 500
         max_tokens_for_response = 20
         context_limit = context_window_size - max_tokens_for_response
@@ -91,7 +91,7 @@ class TestTokenHandler(TestCase):
             )
 
     def test_available_tokens_with_buffer_weight(self):
-        """Test the method to calculate available tokens and check if there are any available tokens for specific model config."""  # noqa E501
+        """Test the method to calculate available tokens and check if there are any available tokens for specific model config."""  # noqa: E501
         context_window_size = 500
         max_tokens_for_response = 20
 


### PR DESCRIPTION
## Description

When the colon is not used, the rule is interpreted as `noqa: ALL` which is wrong as it can hide another problems in the code.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
