### PR TITLE
Enable new pygrep-hooks rules

### DIFF
--- a/ols/src/rag_index/index_loader.py
+++ b/ols/src/rag_index/index_loader.py
@@ -1,4 +1,4 @@
-# type: ignore
+# type: ignore  # noqa: PGH003
 """Module for loading index."""
 
 import logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 
 # description of all rules are available on https://docs.astral.sh/ruff/rules/
-lint.select = ["D", "E", "F", "W", "C", "S", "I", "TCH", "SLOT", "RUF", "C90", "N", "YTT", "ASYNC", "TRIO", "A", "C4", "T10"]
+lint.select = ["D", "E", "F", "W", "C", "S", "I", "TCH", "SLOT", "RUF", "C90", "N", "YTT", "ASYNC", "TRIO", "A", "C4", "T10", "PGH"]
 
 # we need to check 'mood' of all docstrings, this needs to be enabled explicitly
 lint.extend-select = ["D401"]


### PR DESCRIPTION
## Description

Enable new **pygrep-hooks** rules

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
