### PR TITLE
OLS-779: Bump-up llama_index_embeddings_huggingface to 0.2.1

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:f0d5a657a10cd3aea0a2505ed303b781367a0c659b1aced1d884e7305672b27d"
+content_hash = "sha256:6c4e852ca13ab3b3fa372e1ce0b459d740d02b12798e455f59e95058c36ac414"
 
 [[package]]
 name = "aiofiles"
@@ -1395,7 +1395,7 @@ files = [
 
 [[package]]
 name = "llama-index-embeddings-huggingface"
-version = "0.2.0"
+version = "0.2.1"
 requires_python = "<4.0,>=3.8.1"
 summary = "llama-index embeddings huggingface integration"
 groups = ["default"]
@@ -1405,8 +1405,8 @@ dependencies = [
     "sentence-transformers<3.0.0,>=2.6.1",
 ]
 files = [
-    {file = "llama_index_embeddings_huggingface-0.2.0-py3-none-any.whl", hash = "sha256:e8beb7cbdea36bcee26a0282809f8329b0c55b2b4949a590a8da0f348aac066e"},
-    {file = "llama_index_embeddings_huggingface-0.2.0.tar.gz", hash = "sha256:dcf0a99455f37c4e1a2fdd5cd65c9dd1a451bb868c3f80c335c4d0c9b69d0071"},
+    {file = "llama_index_embeddings_huggingface-0.2.1-py3-none-any.whl", hash = "sha256:326468966e269acc7fbc77cad4f65ec061133ea91b0063fe181e72d01a6a8511"},
+    {file = "llama_index_embeddings_huggingface-0.2.1.tar.gz", hash = "sha256:bac68a13ad5131a055da3ef174cca70e15230426eec7d471b372e81e8489d888"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
     "langchain-ibm==0.1.7",
     "llama-index==0.10.38",
     "llama-index-vector-stores-faiss==0.1.2",
-    "llama-index-embeddings-huggingface==0.2.0",
+    "llama-index-embeddings-huggingface==0.2.1",
     "uvicorn==0.30.1",
     "redis==5.0.4",
     "faiss-cpu==1.8.0",


### PR DESCRIPTION
## Description

Bump-up llama_index_embeddings_huggingface to 0.2.1

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #[OLS-779](https://issues.redhat.com//browse/OLS-779)
