### PR TITLE
TLS settings itself is not optional - but it's attributes are

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -848,7 +848,7 @@ class OLSConfig(BaseModel):
     logging_config: Optional[LoggingConfig] = None
     reference_content: Optional[ReferenceContent] = None
     authentication_config: AuthenticationConfig = AuthenticationConfig()
-    tls_config: Optional[TLSConfig] = None
+    tls_config: TLSConfig = TLSConfig()
 
     default_provider: Optional[str] = None
     default_model: Optional[str] = None


### PR DESCRIPTION
## Description

TLS settings itself is not optional - but it's attributes are
(it makes type checker a bit more precise w/o the need to add `tls != None` everywhere)

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
