### PR TITLE
fix test case with sample attachment - pass query_val

### DIFF
--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -957,7 +957,8 @@ def test_transcripts_storing_cluster():
                 {
                     "attachment_type": "log",
                     "content_type": "text/plain",
-                    "content": "this is attachment",
+                    # Sample content
+                    "content": "Kubernetes is a core component of OpenShift.",
                 }
             ],
         },
@@ -975,6 +976,8 @@ def test_transcripts_storing_cluster():
     assert "query_is_valid" in transcript
     assert "llm_response" in transcript
     assert "rag_chunks" in transcript
+
+    assert transcript["query_is_valid"]
     assert isinstance(transcript["rag_chunks"], list)
     assert len(transcript["rag_chunks"])
     assert transcript["rag_chunks"][0]["text"]
@@ -989,7 +992,7 @@ def test_transcripts_storing_cluster():
         {
             "attachment_type": "log",
             "content_type": "text/plain",
-            "content": "this is attachment",
+            "content": "Kubernetes is a core component of OpenShift.",
         }
     ]
     assert transcript["attachments"] == expected_attachment_node
@@ -1097,7 +1100,7 @@ def test_valid_question_with_one_attachment() -> None:
                     {
                         "attachment_type": "log",
                         "content_type": "text/plain",
-                        "content": "this is attachment",
+                        "content": "Kubernetes is a core component of OpenShift.",
                     },
                 ],
             },
@@ -1127,7 +1130,7 @@ def test_valid_question_with_more_attachments() -> None:
                     {
                         "attachment_type": "log",
                         "content_type": "text/plain",
-                        "content": "this is attachment",
+                        "content": "Kubernetes is a core component of OpenShift.",
                     },
                     {
                         "attachment_type": "configuration",


### PR DESCRIPTION
## Description
test_transcripts_storing_cluster  test case is failing for openai (no rag content). This is due to query validation marked this as non-ocp query sometime. Modifying the text, to make it more relevant (this is an assumption). As the error is intermittent, not able reproduce. 
> query: what is kubernetes?
> 
> 
> ```
> this is attachment
> ```

modified to `this is attachment` -> `Kubernetes is a core component of OpenShift.`

Also added `assert transcript["query_is_valid"]` to identify the issue (if occurs again).

This scenario may become obsolete, once we start processing attachment separately.
