### PR TITLE
Update query in test_transcripts_storing_cluster e2e test

### DIFF
--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -952,7 +952,7 @@ def test_transcripts_storing_cluster():
     response = client.post(
         "/v1/query",
         json={
-            "query": "what is kubernetes?",
+            "query": "How can I get cluster ID and how to deploy a MongoDB?",
             "attachments": [
                 {
                     "attachment_type": "log",


### PR DESCRIPTION
## Description

Update query in the test. This test is sometimes failing due to missing rag in the transcript. The query was too simple so the rag was not always pulled.

## Type of change

- [x] Refactor
- [x] Bug fix
