### PR TITLE
OLS-779: Bump-up OpenAI to version 1.35.7

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:ca7533549b21be01319371df060a1f13ad4b929aa5b5a33917600809eb06c306"
+content_hash = "sha256:ac794a655d56e5fba1e9cc7e7d2093853c4592695f3f6c4429c32c0ee67c3a95"
 
 [[package]]
 name = "absl-py"
@@ -1973,7 +1973,7 @@ files = [
 
 [[package]]
 name = "openai"
-version = "1.31.0"
+version = "1.35.7"
 requires_python = ">=3.7.1"
 summary = "The official Python library for the openai API"
 groups = ["default"]
@@ -1987,8 +1987,8 @@ dependencies = [
     "typing-extensions<5,>=4.7",
 ]
 files = [
-    {file = "openai-1.31.0-py3-none-any.whl", hash = "sha256:82044ee3122113f2a468a1f308a8882324d09556ba5348687c535d3655ee331c"},
-    {file = "openai-1.31.0.tar.gz", hash = "sha256:54ae0625b005d6a3b895db2b8438dae1059cffff0cd262a26e9015c13a29ab06"},
+    {file = "openai-1.35.7-py3-none-any.whl", hash = "sha256:3d1e0b0aac9b0db69a972d36dc7efa7563f8e8d65550b27a48f2a0c2ec207e80"},
+    {file = "openai-1.35.7.tar.gz", hash = "sha256:009bfa1504c9c7ef64d87be55936d142325656bbc6d98c68b669d6472e4beb09"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
     "redis==5.0.4",
     "faiss-cpu==1.8.0",
     "sentence-transformers==2.7.0",
-    "openai==1.31.0",
+    "openai==1.35.7",
     "ibm-watson-machine-learning==1.0.359",
     "ibm-generative-ai==3.0.0",
     "langchain-openai==0.1.8",


### PR DESCRIPTION
## Description

Bump-up OpenAI to version 1.35.7
(that library seems to progress very quickly, but the newest version are not compat with other packages ATM)

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #[OLS-779](https://issues.redhat.com//browse/OLS-779)
