### PR TITLE
Complex config for integration tests

### DIFF
--- a/tests/config/config_for_integration_tests.yaml
+++ b/tests/config/config_for_integration_tests.yaml
@@ -1,0 +1,87 @@
+---
+llm_providers:
+  - name: p1
+    type: bam
+    url: "https://url1"
+    credentials_path: tests/config/secret/apitoken
+    bam_config:
+      url: "http://localhost:1234"
+      credentials_path: tests/config/secret/apitoken
+    models:
+      - name: m1
+        url: "https://murl1"
+        credentials_path: tests/config/secret/apitoken
+        context_window_size: 450
+        parameters:
+          max_tokens_for_response: 100
+      - name: m2
+        url: "https://murl2"
+  - name: p2
+    type: openai
+    url: "https://url2"
+    openai_config:
+      url: "http://localhost:1234"
+      credentials_path: tests/config/secret/apitoken
+    models:
+      - name: m1
+        url: "https://murl1"
+      - name: m2
+        url: "https://murl2"
+  - name: my_watsonx
+    type: watsonx
+    url: "https://us-south.ml.cloud.ibm.com"
+    credentials_path: tests/config/secret/apitoken
+    project_id: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+    watsonx_config:
+      url: "http://localhost:1234"
+      credentials_path: tests/config/secret/apitoken
+    models:
+      - name: ibm/granite-13b-chat-v2
+  - name: my_azure_openai
+    type: azure_openai
+    url: "https://ols-test.com"
+    project_id: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+    models:
+      - name: ibm/granite-13b-chat-v2
+    azure_openai_config:
+      url: "http://localhost:1234"
+      deployment_name: "*deployment name*"
+      credentials_path: tests/config/secret_azure_tenant_id_client_id_client_secret
+ols_config:
+  reference_content:
+    product_docs_index_path: "tests/config"
+    product_docs_index_id: product
+  conversation_cache:
+    type: memory
+    memory:
+      max_entries: 1000
+    redis:
+      host: "foobar.com"
+      port: "1234"
+      max_memory: 100MB
+      max_memory_policy: "allkeys-lru"
+      password_path: tests/config/redis_password.txt
+      ca_cert_path: tests/config/redis_ca_cert.crt
+    postgres:
+      host: "foobar.com"
+      port: "1234"
+      dbname: "test"
+      user: "user"
+      password_path: tests/config/postgres_password.txt
+      ca_cert_path: tests/config/postgres_cert.crt
+      ssl_mode: "require"
+  logging_config:
+    app_log_level: info
+    lib_log_level: warning
+  default_provider: p1
+  default_model: m1
+  user_data_collection:
+    transcripts_disabled: true
+  tls_config:
+    tls_certificate_path: tests/config/empty_cert.crt
+    tls_key_path: tests/config/key
+    tls_key_password_path: tests/config/password
+dev_config:
+  enable_dev_ui: true
+  disable_auth: true
+  disable_tls: true

--- a/tests/integration/test_authorized.py
+++ b/tests/integration/test_authorized.py
@@ -17,7 +17,7 @@ from tests.mock_classes.mock_k8s_api import (
 def _setup():
     """Setups the test client."""
     global client
-    config.reload_from_yaml_file("tests/config/valid_config.yaml")
+    config.reload_from_yaml_file("tests/config/config_for_integration_tests.yaml")
 
     # app.main need to be imported after the configuration is read
     from ols.app.main import app

--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -18,7 +18,7 @@ CONVERSATION_ID = suid.get_suid()
 def _setup():
     """Setups the test client."""
     global client
-    config.reload_from_yaml_file("tests/config/valid_config.yaml")
+    config.reload_from_yaml_file("tests/config/config_for_integration_tests.yaml")
 
     # app.main need to be imported after the configuration is read
     from ols.app.main import app

--- a/tests/integration/test_liveness_readiness.py
+++ b/tests/integration/test_liveness_readiness.py
@@ -13,11 +13,13 @@ from ols import config
 # we need to patch the config file path to point to the test
 # config file before we import anything from main.py
 @pytest.fixture(scope="function", autouse=True)
-@patch.dict(os.environ, {"OLS_CONFIG_FILE": "tests/config/valid_config.yaml"})
+@patch.dict(
+    os.environ, {"OLS_CONFIG_FILE": "tests/config/config_for_integration_tests.yaml"}
+)
 def _setup():
     """Setups the test client."""
     global client
-    config.reload_from_yaml_file("tests/config/valid_config.yaml")
+    config.reload_from_yaml_file("tests/config/config_for_integration_tests.yaml")
 
     # app.main need to be imported after the configuration is read
     from ols.app.main import app

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -14,11 +14,13 @@ from ols import config
 # we need to patch the config file path to point to the test
 # config file before we import anything from main.py
 @pytest.fixture(scope="function", autouse=True)
-@patch.dict(os.environ, {"OLS_CONFIG_FILE": "tests/config/valid_config.yaml"})
+@patch.dict(
+    os.environ, {"OLS_CONFIG_FILE": "tests/config/config_for_integration_tests.yaml"}
+)
 def _setup():
     """Setups the test client."""
     global client
-    config.reload_from_yaml_file("tests/config/valid_config.yaml")
+    config.reload_from_yaml_file("tests/config/config_for_integration_tests.yaml")
     from ols.app.main import app
 
     client = TestClient(app)

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -19,7 +19,7 @@ from tests.mock_classes.mock_llm_loader import mock_llm_loader
 @pytest.fixture(scope="function")
 def _setup():
     """Setups the test client."""
-    config.reload_from_yaml_file("tests/config/valid_config.yaml")
+    config.reload_from_yaml_file("tests/config/config_for_integration_tests.yaml")
     global client
 
     # app.main need to be imported after the configuration is read

--- a/tests/integration/test_openapi.py
+++ b/tests/integration/test_openapi.py
@@ -14,11 +14,13 @@ from ols import config
 # we need to patch the config file path to point to the test
 # config file before we import anything from main.py
 @pytest.fixture(scope="function", autouse=True)
-@patch.dict(os.environ, {"OLS_CONFIG_FILE": "tests/config/valid_config.yaml"})
+@patch.dict(
+    os.environ, {"OLS_CONFIG_FILE": "tests/config/config_for_integration_tests.yaml"}
+)
 def _setup():
     """Setups the test client."""
     global client
-    config.reload_from_yaml_file("tests/config/valid_config.yaml")
+    config.reload_from_yaml_file("tests/config/config_for_integration_tests.yaml")
 
     # app.main need to be imported after the configuration is read
     from ols.app.main import app


### PR DESCRIPTION
## Description

Integration tests should ideally hit as many source code lines as possible. We have a big modules `models.py` and `config.py` so would be nice to test them. Thus complex configuration file to be used just by integration tests were created. It is loaded for all tests and used accordingly.

The code coverage is better by approx. 70 lines, that's pretty nice number.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] Integration tests

