### PR TITLE
Move the RAG content image reference for Konflux to the build.args file

### DIFF
--- a/.tekton/lightspeed-service-pull-request.yaml
+++ b/.tekton/lightspeed-service-pull-request.yaml
@@ -224,7 +224,7 @@ spec:
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS_FILE
-        value: $(params.build-args-file)
+        value: build.args
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/lightspeed-service-push.yaml
+++ b/.tekton/lightspeed-service-push.yaml
@@ -221,7 +221,7 @@ spec:
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS_FILE
-        value: $(params.build-args-file)
+        value: build.args
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 # vim: set filetype=dockerfile
-ARG LIGHTSPEED_RAG_CONTENT_DIGEST=sha256:e0db77d709914e677e34658e21b4300b20a9f125c4f27f88429304aa8ad2e276
+ARG LIGHTSPEED_RAG_CONTENT_IMAGE=quay.io/openshift-lightspeed/lightspeed-rag-content@sha256:e0db77d709914e677e34658e21b4300b20a9f125c4f27f88429304aa8ad2e276
 
-FROM quay.io/openshift-lightspeed/lightspeed-rag-content@${LIGHTSPEED_RAG_CONTENT_DIGEST} as lightspeed-rag-content
+FROM ${LIGHTSPEED_RAG_CONTENT_IMAGE} as lightspeed-rag-content
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ verify-packages-completeness:	requirements.txt ## Verify that requirements.txt f
 	pip download -d /tmp/ --use-pep517 --verbose -r requirements.txt
 
 get-rag: ## Download a copy of the RAG embedding model and vector database
-	podman create --replace --name tmp-rag-container quay.io/openshift-lightspeed/lightspeed-rag-content@sha256:e0db77d709914e677e34658e21b4300b20a9f125c4f27f88429304aa8ad2e276 true
+	podman create --replace --name tmp-rag-container $$(cat build.args | awk 'BEGIN{FS="="}{print $$2}') true
 	rm -rf vector_db embeddings_model
 	podman cp tmp-rag-container:/rag/vector_db vector_db
 	podman cp tmp-rag-container:/rag/embeddings_model embeddings_model

--- a/build.args
+++ b/build.args
@@ -1,0 +1,1 @@
+LIGHTSPEED_RAG_CONTENT_IMAGE=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-rag-content@sha256:3cfe4126ec2440e07004c0dcbc7cb4e8393be66da1ba517ed2bc9eb90f7cca1b


### PR DESCRIPTION
## Description

Move the RAG content image reference to the build.args file. This file contains reference to the RAG content image as built by Konflux and will be kept up to date by nudges from the lightspeed-rag-content Konflux component.
For Prow CI and local environments, the RAG content image reference used by the service-api image build remains the same and is taken from the Containerfile. The get-rag make target always takes the RAG content image reference for from the build.args file.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/OLS-484
- Closes # 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
