### PR TITLE
Change rule name according to updated Ruff naming

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 
 # description of all rules are available on https://docs.astral.sh/ruff/rules/
-lint.select = ["D", "E", "F", "W", "C", "S", "I", "TCH", "SLOT", "RUF", "C90", "N", "YTT", "ASYNC", "TRIO", "A", "C4", "T10", "PGH"]
+lint.select = ["D", "E", "F", "W", "C", "S", "I", "TCH", "SLOT", "RUF", "C90", "N", "YTT", "ASYNC", "A", "C4", "T10", "PGH"]
 
 # we need to check 'mood' of all docstrings, this needs to be enabled explicitly
 lint.extend-select = ["D401"]


### PR DESCRIPTION
## Description

Change rule name according to updated Ruff naming

The following rules have been remapped to new rule codes:
- `ASYNC102` has been merged into `ASYNC220` and `ASYNC221`
- `TRIO100` to `ASYNC100`
- `TRIO105` to `ASYNC105`
- `TRIO110` to `ASYNC110`
- `TRIO115` to `ASYNC115`

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
