### PR TITLE
OLS-837: Bump-up setuptools to 70.3.0

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:e2b4f0ca39b35be8ba1cd2586ecb3b783266d603aa12ec05cda71d5abf2fa09a"
+content_hash = "sha256:c14e1e775da9be925f3def99d04f369f5d9eb5997882b7394dd5c09cb4c4eb8d"
 
 [[package]]
 name = "absl-py"
@@ -2771,13 +2771,13 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "69.5.1"
+version = "70.3.0"
 requires_python = ">=3.8"
 summary = "Easily download, build, install, upgrade, and uninstall Python packages"
 groups = ["default"]
 files = [
-    {file = "setuptools-69.5.1-py3-none-any.whl", hash = "sha256:c636ac361bc47580504644275c9ad802c50415c7522212252c033bd15f301f32"},
-    {file = "setuptools-69.5.1.tar.gz", hash = "sha256:6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987"},
+    {file = "setuptools-70.3.0-py3-none-any.whl", hash = "sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc"},
+    {file = "setuptools-70.3.0.tar.gz", hash = "sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dependencies = [
     "ibm-generative-ai==3.0.0",
     "langchain-openai==0.1.8",
     "pydantic==2.8.2",
-    "setuptools==69.5.1",
+    "setuptools==70.3.0",
     "prometheus-client==0.20.0",
     "kubernetes==29.0.0",
     "pytest-asyncio==0.23.7",


### PR DESCRIPTION
## Description

Bump-up setuptools to 70.3.0

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #[OLS-837](https://issues.redhat.com//browse/OLS-837)
