### PR TITLE
Don't override credentials when they are not specified in provider specific config

### DIFF
--- a/ols/src/llms/providers/azure_openai.py
+++ b/ols/src/llms/providers/azure_openai.py
@@ -55,7 +55,8 @@ class AzureOpenAI(LLMProvider):
         if azure_config is not None:
             self.url = str(azure_config.url)
             deployment_name = azure_config.deployment_name
-            self.credentials = azure_config.api_key
+            if azure_config.api_key is not None:
+                self.credentials = azure_config.api_key
 
         default_parameters = {
             "azure_endpoint": self.url,

--- a/ols/src/llms/providers/bam.py
+++ b/ols/src/llms/providers/bam.py
@@ -45,7 +45,8 @@ class BAM(LLMProvider):
         if self.provider_config.bam_config is not None:
             bam_config = self.provider_config.bam_config
             self.url = str(bam_config.url)
-            self.credentials = bam_config.api_key
+            if bam_config.api_key is not None:
+                self.credentials = bam_config.api_key
 
         if self.credentials is None:
             raise ValueError("Credentials must be specified")

--- a/ols/src/llms/providers/openai.py
+++ b/ols/src/llms/providers/openai.py
@@ -29,7 +29,8 @@ class OpenAI(LLMProvider):
         if self.provider_config.openai_config is not None:
             openai_config = self.provider_config.openai_config
             self.url = str(openai_config.url)
-            self.credentials = openai_config.api_key
+            if openai_config.api_key is not None:
+                self.credentials = openai_config.api_key
 
         return {
             "base_url": self.url,

--- a/ols/src/llms/providers/watsonx.py
+++ b/ols/src/llms/providers/watsonx.py
@@ -49,8 +49,9 @@ class Watsonx(LLMProvider):
         if self.provider_config.watsonx_config is not None:
             watsonx_config = self.provider_config.watsonx_config
             self.url = str(watsonx_config.url)
-            self.credentials = watsonx_config.api_key
             self.project_id = watsonx_config.project_id
+            if watsonx_config.api_key is not None:
+                self.credentials = watsonx_config.api_key
 
         if self.credentials is None:
             raise ValueError("Credentials must be specified")


### PR DESCRIPTION
## Description

Don't override credentials when they are not specified in provider specific config.

## Type of change

- [x] Bug fix
