### PR TITLE
Don't fool linters: AI response is stored as a string, including empty string if response is not provided

### DIFF
--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -537,6 +537,7 @@ class CacheEntry(BaseModel):
         history = []
         for entry in cache_entries:
             history.append(f"human: {entry.query.strip()}")
-            history.append(f"ai: {entry.response.strip()}")
+            # the real response or empty string when response is not recorded
+            history.append(f"ai: {str(entry.response).strip()}")
 
         return history

--- a/tests/unit/app/models/test_models.py
+++ b/tests/unit/app/models/test_models.py
@@ -433,3 +433,15 @@ class TestCacheEntry:
             "human: what?",
             "ai: ",
         ]
+
+    @staticmethod
+    def test_cache_entries_to_history_no_response():
+        """Test no AI response is handled."""
+        cache_entries = [
+            CacheEntry(query="what?", response=None),
+        ]
+        history = CacheEntry.cache_entries_to_history(cache_entries)
+        assert history == [
+            "human: what?",
+            "ai: ",
+        ]


### PR DESCRIPTION
## Description

Don't fool linters: AI response is stored as a string, including empty string if response is not provided

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
