### PR TITLE
Fix linter warnings when provider-specific config is None

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -382,8 +382,10 @@ class ProviderConfig(BaseModel):
                     )
 
     @staticmethod
-    def read_api_key(config: dict) -> None:
+    def read_api_key(config: Optional[dict]) -> None:
         """Read API key from file with secret."""
+        if config is None:
+            return
         config["api_key"] = _read_secret(
             config,
             constants.CREDENTIALS_PATH_SELECTOR,


### PR DESCRIPTION
## Description

Fix linter warnings when provider-specific config is `None`

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
