### PR TITLE
Evaluation - Update granite eval7 answer for 4.16

### DIFF
--- a/scripts/evaluation/eval_data/question_answer_pair.json
+++ b/scripts/evaluation/eval_data/question_answer_pair.json
@@ -230,11 +230,13 @@
             "answer": {
                 "bam+ibm/granite-13b-chat-v2+with_rag": {
                     "text": [
+                        "The provided document is a detailed guide on updating OpenShift clusters, including information on the Cluster Version Operator (CVO), ClusterVersion resource, and various update strategies such as canary rollouts.\n\nAdditionally, the document provides instructions on how to check compatibility and update installed Operators.\n\nFor more information on specific update strategies, refer to the \"Performing a canary rollout update\" section.\n\nFor a general overview of how updates work, see the \"Introduction to OpenShift updates\" section.",
                         "Yes, the Red Hat OpenShift Container Platform documentation covers updating clusters. You can find the relevant information in the \"Updating Clusters\" section of the documentation."
                     ]
                 },
                 "watsonx+ibm/granite-13b-chat-v2+with_rag": {
                     "text": [
+                        "The provided document is a detailed guide on updating OpenShift clusters, including information on the Cluster Version Operator (CVO), ClusterVersion resource, and various update strategies such as canary rollouts.\n\nAdditionally, the document provides instructions on how to check compatibility and update installed Operators.\n\nFor more information on specific update strategies, refer to the \"Performing a canary rollout update\" section.\n\nFor a general overview of how updates work, see the \"Introduction to OpenShift updates\" section.",
                         "Yes, the Red Hat OpenShift Container Platform documentation covers updating clusters. You can find the relevant information in the \"Updating Clusters\" section of the documentation."
                     ]
                 },


### PR DESCRIPTION
## Description

Update granite eval7 answer for 4.16

Note: 
How the response is formed for this query is subjective. This may not be the ideal answer but aligned as per chunk.
Generally granite gives us consistent answers, but for this query `Is there a doc on updating clusters?` some deviation is observed and very much dependent on slight variations in chunk texts (It got changed since I checked with 4.16 last time).

This should enable `OCP 4.16 rehearsal job` to pass for https://github.com/openshift/lightspeed-service/pull/1288