### PR TITLE
Change logging level for libs in CI

### DIFF
--- a/tests/config/cluster_install/ols_configmap.yaml
+++ b/tests/config/cluster_install/ols_configmap.yaml
@@ -32,7 +32,10 @@ data:
           max_entries: 1000
       logging_config:
         app_log_level: debug
-        lib_log_level: debug
+        # one of our libs logs a secrets in debug mode which causes the
+        # pod logs beying redacted/removed completely - we need log at
+        # info level and above
+        lib_log_level: info
       default_provider: "$PROVIDER"
       default_model: "$MODEL"
       query_filters:


### PR DESCRIPTION
## Description

Currently, there are no pod logs for the server in CI artifacts. It just shows
```
This file contained potentially sensitive information and has been removed.
```
Check the reason here - https://redhat-internal.slack.com/archives/C068JAU4Y0P/p1721372504787769

This fixes the issue.

## Type of change

- [x] Bug fix
