### PR TITLE
OLS-821: Update buildah-6b to latest 0.1

### DIFF
--- a/.tekton/lightspeed-service-pull-request.yaml
+++ b/.tekton/lightspeed-service-pull-request.yaml
@@ -242,7 +242,7 @@ spec:
             - name: name
               value: buildah-6gb
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb:0.1@sha256:a98162ee01d16a69eff7a366001958065ff68e9bc2063a8171585fa7fc76b898
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb:0.1@sha256:b79549b4fdd35cb0433ec3dda2f6a1bbbced8ae84f6c058b2cf50dd7dcd4caa8
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/lightspeed-service-push.yaml
+++ b/.tekton/lightspeed-service-push.yaml
@@ -239,7 +239,7 @@ spec:
             - name: name
               value: buildah-6gb
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb:0.1@sha256:a98162ee01d16a69eff7a366001958065ff68e9bc2063a8171585fa7fc76b898
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb:0.1@sha256:b79549b4fdd35cb0433ec3dda2f6a1bbbced8ae84f6c058b2cf50dd7dcd4caa8
             - name: kind
               value: task
           resolver: bundles


### PR DESCRIPTION
## Description

Update buildah-6b to latest 0.1

```
  "key": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah-6gb:0.1",
  "value": [
    {
      "effective_on": "2024-08-19T00:00:00Z",
      "ref": "sha256:b79549b4fdd35cb0433ec3dda2f6a1bbbced8ae84f6c058b2cf50dd7dcd4caa8"
    },
    {
      "effective_on": "2024-08-18T00:00:00Z",
      "expires_on": "2024-08-19T00:00:00Z",
      "ref": "sha256:a98162ee01d16a69eff7a366001958065ff68e9bc2063a8171585fa7fc76b898"
    },
```

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] Tekton pipeline update

## Task
#[OLS-821](https://issues.redhat.com//browse/OLS-821)
