### PR TITLE
Bump-up `task-init`

### DIFF
--- a/.tekton/lightspeed-service-pull-request.yaml
+++ b/.tekton/lightspeed-service-pull-request.yaml
@@ -158,7 +158,7 @@ spec:
             - name: name
               value: init
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:99c98d3e5195e9920482f2187590d6f9150c4b8a2001b1ce5dcd5077abda9481
+              value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:092c113b614f6551113f17605ae9cb7e822aa704d07f0e37ed209da23ce392cc
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/lightspeed-service-push.yaml
+++ b/.tekton/lightspeed-service-push.yaml
@@ -155,7 +155,7 @@ spec:
             - name: name
               value: init
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:99c98d3e5195e9920482f2187590d6f9150c4b8a2001b1ce5dcd5077abda9481
+              value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:092c113b614f6551113f17605ae9cb7e822aa704d07f0e37ed209da23ce392cc
             - name: kind
               value: task
           resolver: bundles


### PR DESCRIPTION
## Description

Bump-up `task-init`

```
  "key": "oci://quay.io/konflux-ci/tekton-catalog/task-init:0.2",
  "value": [
    {
      "effective_on": "2024-08-23T00:00:00Z",
      "ref": "sha256:092c113b614f6551113f17605ae9cb7e822aa704d07f0e37ed209da23ce392cc"
    },
    {
      "effective_on": "2024-08-10T00:00:00Z",
      "expires_on": "2024-08-23T00:00:00Z",
      "ref": "sha256:99c98d3e5195e9920482f2187590d6f9150c4b8a2001b1ce5dcd5077abda9481"
    },
```
