### PR TITLE
Buildah-6g applicable for 2024-07-23

### DIFF
--- a/.tekton/lightspeed-service-pull-request.yaml
+++ b/.tekton/lightspeed-service-pull-request.yaml
@@ -242,7 +242,7 @@ spec:
             - name: name
               value: buildah-6gb
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb:0.2@sha256:c85678ac22ac7dbeff2e9dff8b76fd4433494408ee492b326439cb6bf74c0c58
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb:0.2@sha256:82e1d62157c30388358a0fd47cadf91ac3ecaf1c4b9e37efbd123d977f12d8f7
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/lightspeed-service-push.yaml
+++ b/.tekton/lightspeed-service-push.yaml
@@ -239,7 +239,7 @@ spec:
             - name: name
               value: buildah-6gb
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb:0.2@sha256:c85678ac22ac7dbeff2e9dff8b76fd4433494408ee492b326439cb6bf74c0c58
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb:0.2@sha256:82e1d62157c30388358a0fd47cadf91ac3ecaf1c4b9e37efbd123d977f12d8f7
             - name: kind
               value: task
           resolver: bundles


### PR DESCRIPTION
## Description

Buildah-6g applicable for 2024-07-23

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] Tekton pipeline
