### PR TITLE
OLS-884: use the bug-free latest setuptools on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,10 @@ install-tools:	install-woke ## Install required utilities/tools
 	# this is quick fix for OLS-758: "Verify" CI job is broken after new Mypy 1.10.1 was released 2 days ago
 	# CI job configuration would need to be updated in follow-up task
 	pip uninstall -y mypy 2> /dev/null || true
-	# force install older setuptools version
-	# https://issues.redhat.com/browse/OLS-882
-	pip install -I --force-reinstall setuptools==71.0.0
+	# display setuptools version
 	pip show setuptools
-	export PIP_CONSTRAINT=constraints.txt
-	pdm install --no-isolation --dev -v
+	# install all dependencies, including devel ones
+	pdm install --dev
 	# check that correct mypy version is installed
 	mypy --version
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:c381380c1948bc9c03230df24b734c1be12f33dd3b17f3848fced71b72907dd2"
+content_hash = "sha256:dc830e26d098b89d9f34f3564736f722f1053b9dc969af4b4487fcfbe4715513"
 
 [[package]]
 name = "absl-py"
@@ -2770,13 +2770,13 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "70.3.0"
+version = "71.1.0"
 requires_python = ">=3.8"
 summary = "Easily download, build, install, upgrade, and uninstall Python packages"
 groups = ["default"]
 files = [
-    {file = "setuptools-70.3.0-py3-none-any.whl", hash = "sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc"},
-    {file = "setuptools-70.3.0.tar.gz", hash = "sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5"},
+    {file = "setuptools-71.1.0-py3-none-any.whl", hash = "sha256:33874fdc59b3188304b2e7c80d9029097ea31627180896fb549c578ceb8a0855"},
+    {file = "setuptools-71.1.0.tar.gz", hash = "sha256:032d42ee9fb536e33087fb66cac5f840eb9391ed05637b3f2a76a7c8fb477936"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ dependencies = [
     "ibm-cos-sdk==2.13.6",
     "langchain-openai==0.1.15",
     "pydantic==2.8.2",
-    "setuptools==70.3.0",
+    "setuptools==71.1.0",
     "prometheus-client==0.20.0",
     "kubernetes==30.1.0",
     "pytest-asyncio==0.23.7",


### PR DESCRIPTION
## Description

[OLS-884](https://issues.redhat.com//browse/OLS-884): use the bug-free latest setuptools on CI

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #[OLS-884](https://issues.redhat.com//browse/OLS-884)
