### PR TITLE
OLS-884: Bump-up to latest setuptools 72.1.0

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:dc830e26d098b89d9f34f3564736f722f1053b9dc969af4b4487fcfbe4715513"
+content_hash = "sha256:ce9a157d44c9ca1d1848a1a981bd1ad1277cb33ef5063d650ca27a01cd94d350"
 
 [[package]]
 name = "absl-py"
@@ -2770,13 +2770,13 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "71.1.0"
+version = "72.1.0"
 requires_python = ">=3.8"
 summary = "Easily download, build, install, upgrade, and uninstall Python packages"
 groups = ["default"]
 files = [
-    {file = "setuptools-71.1.0-py3-none-any.whl", hash = "sha256:33874fdc59b3188304b2e7c80d9029097ea31627180896fb549c578ceb8a0855"},
-    {file = "setuptools-71.1.0.tar.gz", hash = "sha256:032d42ee9fb536e33087fb66cac5f840eb9391ed05637b3f2a76a7c8fb477936"},
+    {file = "setuptools-72.1.0-py3-none-any.whl", hash = "sha256:5a03e1860cf56bb6ef48ce186b0e557fdba433237481a9a625176c2831be15d1"},
+    {file = "setuptools-72.1.0.tar.gz", hash = "sha256:8d243eff56d095e5817f796ede6ae32941278f542e0f941867cc05ae52b162ec"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ dependencies = [
     "ibm-cos-sdk==2.13.6",
     "langchain-openai==0.1.15",
     "pydantic==2.8.2",
-    "setuptools==71.1.0",
+    "setuptools==72.1.0",
     "prometheus-client==0.20.0",
     "kubernetes==30.1.0",
     "pytest-asyncio==0.23.7",


### PR DESCRIPTION
## Description

According to https://github.com/pypa/setuptools/issues/4519#issuecomment-2256426150 it would be possible to
use https://github.com/pypa/setuptools/releases/tag/v72.1.0

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
- [x] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #[OLS-884](https://issues.redhat.com//browse/OLS-884)
