### PR TITLE
Assign before return statement is not needed

### DIFF
--- a/ols/src/cache/in_memory_cache.py
+++ b/ols/src/cache/in_memory_cache.py
@@ -51,8 +51,7 @@ class InMemoryCache(Cache):
         self.deque.remove(key)
         self.deque.appendleft(key)
         value = self.cache[key].copy()
-        cache_entry = [CacheEntry.from_dict(cache_entry) for cache_entry in value]
-        return cache_entry
+        return [CacheEntry.from_dict(cache_entry) for cache_entry in value]
 
     def insert_or_append(
         self,

--- a/ols/src/cache/postgres_cache.py
+++ b/ols/src/cache/postgres_cache.py
@@ -119,10 +119,7 @@ class PostgresCache(Cache):
             try:
                 value = PostgresCache._select(cursor, user_id, conversation_id)
                 if value is not None:
-                    cache_entry = [
-                        CacheEntry.from_dict(cache_entry) for cache_entry in value
-                    ]
-                    return cache_entry
+                    return [CacheEntry.from_dict(cache_entry) for cache_entry in value]
                 else:
                     return []
             except psycopg2.DatabaseError as e:


### PR DESCRIPTION
## Description

Assign before `return` statement is not needed

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
