### PR TITLE
Removed redundant open modes

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -31,7 +31,7 @@ def _get_attribute_from_file(data: dict, file_name_key: str) -> Optional[str]:
     """Retrieve value of an attribute from a file."""
     file_path = data.get(file_name_key)
     if file_path is not None:
-        with open(file_path, mode="r", encoding="utf-8") as f:
+        with open(file_path, encoding="utf-8") as f:
             return f.read().rstrip()
     return None
 
@@ -59,7 +59,7 @@ def _read_secret(
         return None
 
     try:
-        with open(filename, mode="r", encoding="utf-8") as f:
+        with open(filename, encoding="utf-8") as f:
             return f.read().rstrip()
     except OSError as e:
         # some files with secret must exist, so for such cases it is time

--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -97,7 +97,7 @@ class AppConfig:
     def reload_from_yaml_file(self, config_file: str) -> None:
         """Reload the configuration from the YAML file."""
         try:
-            with open(config_file, "r", encoding="utf-8") as f:
+            with open(config_file, encoding="utf-8") as f:
                 self.config = self._load_config_from_yaml_stream(f)
             # reset the query filters and rag index to not use cached
             # values


### PR DESCRIPTION
## Description

Redundant `open` mode parameters are unnecessary and should be removed to
avoid confusion.

## Example
```python
with open("foo.txt", "r") as f:
    ...
```

Use instead:
```python
with open("foo.txt") as f:
    ...
```

## References
- [Python documentation: `open`](https://docs.python.org/3/library/functions.html#open)
