### PR TITLE
Refactor: query-redactor is not optional anymore

### DIFF
--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -65,7 +65,7 @@ class AppConfig:
         return self._conversation_cache
 
     @property
-    def query_redactor(self) -> Optional[Redactor]:
+    def query_redactor(self) -> Redactor:
         """Return the query redactor."""
         # TODO: OLS-380 Config object mirrors configuration
         if self._query_filters is None:


### PR DESCRIPTION
## Description

Refactor: query-redactor is not optional anymore

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
