### PR TITLE
OLS-906: Benchmarks: real example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ run: ## Run the service locally
 
 test: test-unit test-integration test-e2e ## Run all tests
 
+benchmarks: ## Run benchmarks
+	@echo "Running benchmarks..."
+	python -m pytest tests/benchmarks
+
 test-unit: ## Run the unit tests
 	@echo "Running unit tests..."
 	@echo "Reports will be written to ${ARTIFACT_DIR}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ integration-tests-coverage-report = "pdm run make integration-tests-coverage-rep
 check-types = "pdm run make check-types"
 generate-schema = "pdm run make schema"
 security-check = "pdm run make security-check"
+benchmarks = "pdm run make benchmarks"
 
 [tool.setuptools]
 packages = ["ols"]

--- a/tests/benchmarks/pytest.ini
+++ b/tests/benchmarks/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+log_cli=false
+filterwarnings = 
+	ignore::DeprecationWarning
+junit_logging=system-out

--- a/tests/benchmarks/test_question_validator.py
+++ b/tests/benchmarks/test_question_validator.py
@@ -1,0 +1,35 @@
+"""Benchmarks for QuestionValidator class."""
+
+from unittest.mock import patch
+
+from ols import config
+from ols.constants import GenericLLMParameters
+from ols.src.query_helpers.question_validator import QuestionValidator
+from tests.mock_classes.mock_llm_chain import mock_llm_chain
+from tests.mock_classes.mock_llm_loader import mock_llm_loader
+
+
+@patch("ols.src.query_helpers.question_validator.LLMChain", new=mock_llm_chain(None))
+def test_validate_question_llm_loader(benchmark):
+    """Benchmarks the method QuestionValidator.validate_question."""
+    # it is needed to initialize configuration in order to be able
+    # to construct QuestionValidator instance
+    config.reload_from_yaml_file("tests/config/valid_config.yaml")
+
+    # when the LLM will be initialized the check for provided parameters will
+    # be performed
+    llm_loader = mock_llm_loader(
+        None,
+        expected_params=("p1", "m1", {GenericLLMParameters.MAX_TOKENS_FOR_RESPONSE: 4}),
+    )
+
+    # check that LLM loader was called with expected parameters
+    question_validator = QuestionValidator(llm_loader=llm_loader)
+
+    # just run the validation, we just need to check parameters passed to LLM
+    # that is performed in mock object
+    benchmark(
+        question_validator.validate_question,
+        "123e4567-e89b-12d3-a456-426614174000",
+        "query",
+    )


### PR DESCRIPTION
## Description

Benchmarks: real example
Any benchmark can be write in the same style - as unit test, but with `benchmark` parameter + the benchmarked
function or method needs to be called by `benchmark(function_method, parameters)`

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #[OLS-906](https://issues.redhat.com//browse/OLS-906)
