### PR TITLE
Enable BAM for e2e again after it was disabled in 1392

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -68,7 +68,7 @@ def pytest_addoption(parser):
         "--eval_provider_model_id",
         nargs="+",
         default=[
-            # "bam+granite13b-chatv2",
+            "bam+granite13b-chatv2",
             "watsonx+granite13b-chatv2",
             "openai+gpt35-turbo",
             "azure+gpt35-turbo-4k",

--- a/tests/scripts/test-e2e-cluster.sh
+++ b/tests/scripts/test-e2e-cluster.sh
@@ -28,9 +28,8 @@ function run_suites() {
   run_suite "azure_openai" "not model_evaluation" "azure_openai" "$AZUREOPENAI_PROVIDER_KEY_PATH" "gpt-3.5-turbo" "$OLS_IMAGE"
   (( rc = rc || $? ))
 
-  # BAM is currently not working, commenting for now
-  # run_suite "bam" "not model_evaluation" "bam" "$BAM_PROVIDER_KEY_PATH" "ibm/granite-13b-chat-v2" "$OLS_IMAGE"
-  # (( rc = rc || $? ))
+  run_suite "bam" "not model_evaluation" "bam" "$BAM_PROVIDER_KEY_PATH" "ibm/granite-13b-chat-v2" "$OLS_IMAGE"
+  (( rc = rc || $? ))
 
   run_suite "openai" "not model_evaluation" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-3.5-turbo" "$OLS_IMAGE"
   (( rc = rc || $? ))


### PR DESCRIPTION
## Description

Enable BAM for e2e again after it was disabled in #1392

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] e2e tests configuration
