### PR TITLE
model specific dynamic prompt creation

### DIFF
--- a/ols/constants.py
+++ b/ols/constants.py
@@ -45,6 +45,14 @@ SUPPORTED_PROVIDER_TYPES = frozenset(
 
 # models
 
+
+class ModelFamily(StrEnum):
+    """Different LLM models family/group."""
+
+    GPT = "gpt"
+    GRANITE = "granite"
+
+
 # BAM
 GRANITE_13B_CHAT_V2 = "ibm/granite-13b-chat-v2"
 
@@ -70,7 +78,9 @@ class GenericLLMParameters:
 DEFAULT_CONTEXT_WINDOW_SIZE = 8192
 DEFAULT_MIN_TOKENS_FOR_RESPONSE = 1
 DEFAULT_MAX_TOKENS_FOR_RESPONSE = 512
-MINIMUM_CONTEXT_TOKEN_LIMIT = 1
+
+# Minimum tokens to have some meaningful RAG context including special tags.
+MINIMUM_CONTEXT_TOKEN_LIMIT = 10
 
 
 # Provider and Model-specific context window size

--- a/ols/src/prompts/prompt_generator.py
+++ b/ols/src/prompts/prompt_generator.py
@@ -1,80 +1,125 @@
 """Prompt generator based on model / context."""
 
-from collections import namedtuple
-from typing import Any, Optional
-
-from langchain.prompts import PromptTemplate
-
-from ols.constants import (
-    GPT35_TURBO,
-    GRANITE_13B_CHAT_V2,
-    PROVIDER_AZURE_OPENAI,
-    PROVIDER_BAM,
-    PROVIDER_OPENAI,
-    PROVIDER_RHOAI_VLLM,
-    PROVIDER_WATSONX,
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.prompts import (
+    ChatPromptTemplate,
+    HumanMessagePromptTemplate,
+    MessagesPlaceholder,
+    PromptTemplate,
+    SystemMessagePromptTemplate,
 )
 
+from ols.constants import ModelFamily
+
 from .prompts import (
-    CONTEXT_PLACEHOLDER,
-    HISTORY_PLACEHOLDER,
-    QUERY_PLACEHOLDER,
     QUERY_SYSTEM_INSTRUCTION,
     USE_CONTEXT_INSTRUCTION,
     USE_HISTORY_INSTRUCTION,
 )
 
-PromptConfiguration = namedtuple("PromptConfiguration", "provider model")
 
-# This dictionary might be expanded in the future, if some combination of model+provider
-# requires specifically updated prompt.
-prompt_configurations = {
-    PromptConfiguration(PROVIDER_BAM, GRANITE_13B_CHAT_V2): QUERY_SYSTEM_INSTRUCTION,
-    PromptConfiguration(PROVIDER_OPENAI, GPT35_TURBO): QUERY_SYSTEM_INSTRUCTION,
-    PromptConfiguration(
-        PROVIDER_WATSONX, GRANITE_13B_CHAT_V2
-    ): QUERY_SYSTEM_INSTRUCTION,
-    PromptConfiguration(PROVIDER_AZURE_OPENAI, GPT35_TURBO): QUERY_SYSTEM_INSTRUCTION,
-    PromptConfiguration(PROVIDER_RHOAI_VLLM, GPT35_TURBO): QUERY_SYSTEM_INSTRUCTION,
-}
+def restructure_rag_context_pre(text: str, model: str) -> str:
+    """Restructure rag text - pre truncation."""
+    if ModelFamily.GRANITE in model:
+        return "\n[End]\n[Document]\n" + text
+    else:
+        return "\n\nDocument:\n" + text
 
 
-def generate_prompt(
-    provider: str,
-    model: str,
-    model_options: Optional[dict[str, Any]],
-    query: str,
-    history: list[str],
-    rag_context: str,
-) -> tuple[PromptTemplate, dict[str, Any]]:
-    """Dynamically creates prompt template and input values specification for LLM.
+def restructure_rag_context_post(text: str, model: str) -> str:
+    """Restructure rag text - post truncation."""
+    if ModelFamily.GRANITE in model:
+        return text.removeprefix("\n[End]") + "\n[End]"
+    else:
+        return "\n" + text.lstrip("\n") + "\n"
 
-    Prompt template is created by combining these values:
-    - provider
-    - model
-    - model-specific configuration
-    - RAG (if enabled and exists)
-    - history
-    - system prompt
-    - user query
-    """
-    # Add system instruction to the prompt first.
-    selector = PromptConfiguration(provider, model)
-    prompt = prompt_configurations.get(selector, QUERY_SYSTEM_INSTRUCTION)
-    llm_input_values = {"query": query}
 
-    # Add optional instruction to the prompt & create prompt inputs.
-    if len(rag_context) > 0:
-        prompt += USE_CONTEXT_INSTRUCTION
-        prompt += CONTEXT_PLACEHOLDER
+def restructure_history(text: str, model: str) -> str:
+    """Restructure history."""
+    if ModelFamily.GRANITE not in model:
+        # No processing required here for gpt.
+        return text
 
-        llm_input_values["context"] = rag_context
+    # Granite specific formatting for history
+    if text.startswith("human: "):
+        return "\n<|user|>\n" + text.removeprefix("human: ")
+    return "\n<|assistant|>\n" + text.removeprefix("ai: ")
 
-    if len(history) > 0:
-        prompt += USE_HISTORY_INSTRUCTION
-        prompt += HISTORY_PLACEHOLDER
-        llm_input_values["chat_history"] = "\n".join(history)
 
-    prompt += QUERY_PLACEHOLDER
+class GeneratePrompt:
+    """Generate prompt dynamically."""
 
-    return PromptTemplate.from_template(prompt), llm_input_values
+    def __init__(
+        self,
+        query: str,
+        rag_context: list[str] = [],
+        history: list[str] = [],
+        system_instruction: str = QUERY_SYSTEM_INSTRUCTION,
+    ):
+        """Initialize prompt generator."""
+        self._query = query
+        self._rag_context = rag_context
+        self._history = history
+        self._sys_instruction = system_instruction
+
+    def _generate_prompt_gpt(self) -> tuple[ChatPromptTemplate, dict]:
+        """Generate prompt for GPT."""
+        prompt_message = []
+        sys_intruction = self._sys_instruction.strip() + "\n"
+        llm_input_values: dict = {"query": self._query}
+
+        if len(self._rag_context) > 0:
+            llm_input_values["context"] = "".join(self._rag_context)
+            sys_intruction = sys_intruction + "\n" + USE_CONTEXT_INSTRUCTION.strip()
+
+        if len(self._history) > 0:
+            chat_history = []
+            for h in self._history:
+                if h.startswith("human: "):
+                    chat_history.append(HumanMessage(content=h.removeprefix("human: ")))
+                else:
+                    chat_history.append(AIMessage(content=h.removeprefix("ai: ")))
+            llm_input_values["chat_history"] = chat_history
+
+            sys_intruction = sys_intruction + "\n" + USE_HISTORY_INSTRUCTION.strip()
+
+        if "context" in llm_input_values:
+            sys_intruction = sys_intruction + "\n{context}"
+
+        prompt_message.append(SystemMessagePromptTemplate.from_template(sys_intruction))
+
+        if "chat_history" in llm_input_values:
+            prompt_message.append(MessagesPlaceholder("chat_history"))
+
+        prompt_message.append(HumanMessagePromptTemplate.from_template("{query}"))
+        return ChatPromptTemplate.from_messages(prompt_message), llm_input_values
+
+    def _generate_prompt_granite(self) -> tuple[PromptTemplate, dict]:
+        """Generate prompt for Granite."""
+        prompt_message = "<|system|>\n" + self._sys_instruction.strip() + "\n"
+        llm_input_values = {"query": self._query}
+
+        if len(self._rag_context) > 0:
+            llm_input_values["context"] = "".join(self._rag_context)
+            prompt_message = prompt_message + "\n" + USE_CONTEXT_INSTRUCTION.strip()
+
+        if len(self._history) > 0:
+            prompt_message = prompt_message + "\n" + USE_HISTORY_INSTRUCTION.strip()
+            llm_input_values["chat_history"] = "".join(self._history)
+
+        if "context" in llm_input_values:
+            prompt_message = prompt_message + "\n{context}"
+        if "chat_history" in llm_input_values:
+            prompt_message = prompt_message + "\n{chat_history}"
+
+        prompt_message = prompt_message + "\n<|user|>\n{query}\n<|assistant|>\n"
+        return PromptTemplate.from_template(prompt_message), llm_input_values
+
+    def generate_prompt(
+        self, model: str
+    ) -> tuple[ChatPromptTemplate | PromptTemplate, dict]:
+        """Generate prompt."""
+        if ModelFamily.GRANITE in model:
+            return self._generate_prompt_granite()
+        else:
+            return self._generate_prompt_gpt()

--- a/ols/src/prompts/prompts.py
+++ b/ols/src/prompts/prompts.py
@@ -35,31 +35,8 @@ USE_CONTEXT_INSTRUCTION = """
 Use the retrieved document to answer the question.
 """
 
-CONTEXT_PLACEHOLDER = """
-
-[DOCUMENT]
-{context}
-[END]
-
-"""
-
 USE_HISTORY_INSTRUCTION = """
 Use the previous chat history to interact and help the user.
-"""
-
-HISTORY_PLACEHOLDER = """
-
-[HISTORY]
-{chat_history}
-[END]
-
-"""
-
-QUERY_PLACEHOLDER = """
-<|user|>
-{query}
-<|assistant|>
-
 """
 
 # {{query}} is escaped because it will be replaced as a parameter at time of use

--- a/scripts/evaluation/eval_data/question_answer_pair.json
+++ b/scripts/evaluation/eval_data/question_answer_pair.json
@@ -13,18 +13,17 @@
                 },
                 "watsonx+ibm/granite-13b-chat-v2+with_rag": {
                     "text": [
-                        "Kubernetes is an open source container orchestration tool developed by Google. It allows you to run and manage container-based workloads, and is commonly used to deploy interconnected microservices in a cloud-native way. Kubernetes clusters can span hosts across on-premise, public, private, or hybrid clouds.",
-                        "Kubernetes is an open-source container orchestration engine for automating deployment, scaling, and management of containerized applications. It uses a declarative model, meaning it defines a desired state and automatically works towards achieving that state. Kubernetes was originally developed by Google and has since become widely adopted in the industry for its ability to manage large-scale container deployments. It provides features such as self-healing, automated rollouts, and service discovery, making it easier to manage and scale complex applications."
+                        "Kubernetes is an open source container orchestration tool developed by Google that you can use to run and manage container-based workloads. It is commonly used to deploy an array of interconnected microservices, building an application in a cloud native way. Kubernetes can span hosts across on-premise, public, private, or hybrid clouds."
                     ]
                 },
                 "openai+gpt-3.5-turbo+with_rag": {
                     "text": [
-                        "Kubernetes is an open-source container orchestration engine that automates the deployment, scaling, and management of containerized applications. It serves as the engine for various applications such as telecommunications, streaming video, gaming, banking, and more. Kubernetes allows you to run container workloads on multiple worker nodes managed by control plane nodes. It uses pods to group containers and provides additional metadata for easier management."
+                        "Kubernetes is an open-source container orchestration engine that automates the deployment, scaling, and management of containerized applications. It serves as a reliable and flexible distribution system for running container workloads at scale. Kubernetes allows you to manage the deployment of container workloads from control plane nodes, wrap containers in pods for additional metadata and grouping capabilities, and create assets like services to define how they are accessed."
                     ]
                 },
                 "azure_openai+gpt-3.5-turbo+with_rag": {
                     "text": [
-                        "Kubernetes is an open source container orchestration engine for automating the deployment, scaling, and management of containerized applications. It allows you to run and manage container-based workloads across multiple machines and environments. Kubernetes is widely used in various industries such as telecommunications, streaming video, gaming, banking, and more. It provides a reliable and flexible distribution system for running containers at scale."
+                        "Kubernetes is an open-source container orchestration engine for automating the deployment, scaling, and management of containerized applications. It provides a platform for running and managing containers at scale, allowing you to easily deploy and manage applications across multiple machines or environments. Kubernetes enables efficient resource utilization, automatic scaling, self-healing capabilities, and seamless integration with various cloud providers. It is widely used in modern application development to build scalable and resilient cloud-native applications."
                     ]
                 },
                 "bam+ibm/granite-13b-chat-v2+without_rag": {
@@ -79,22 +78,21 @@
                     ]
                 },
                 "watsonx+ibm/granite-13b-chat-v2+with_rag": {
-                    "cutoff_score": 0.01,
+                    "cutoff_score": 0.3,
                     "text": [
-                        "OpenShift Virtualization is a feature of Red Hat OpenShift Container Platform that allows traditional virtual machines (VMs) to be brought into the platform and run alongside containers. It represents the icon and can be used with either the OVN-Kubernetes or the OpenShiftSDN default Container Network Interface (CNI) network provider. OpenShift Virtualization is certified in Microsoft's Windows Server Virtualization Validation Program (SVVP) to run Windows Server workloads.",
-                        "OpenShift Virtualization is an add-on to Red Hat OpenShift Container Platform that allows you to run and manage virtual machine workloads alongside container workloads. It adds new objects into your Red Hat OpenShift Container Platform cluster by using Kubernetes custom resources to enable virtualization tasks such as creating and managing Linux and Windows virtual machines, running pod and VM workloads alongside each other in a cluster, connecting to virtual machines through a variety of consoles and CLI tools, importing and cloning existing virtual machines, managing network interface controllers and storage disks attached to virtual machines, live migrating virtual machines between nodes, and providing an enhanced web console for managing these virtualized resources alongside the Red Hat OpenShift Container Platform cluster containers and infrastructure."
+                        "OpenShift Virtualization is a feature of Red Hat OpenShift Container Platform that allows traditional virtual machines (VMs) to be brought into the platform and run alongside containers. It is represented by the icon and can be used with either the OVN-Kubernetes or the OpenShiftSDN default Container Network Interface (CNI) network provider."
                     ]
                 },
                 "openai+gpt-3.5-turbo+with_rag": {
+                    "cutoff_score": 0.3,
                     "text": [
-                        "OpenShift Virtualization allows you to bring traditional virtual machines (VMs) into the Red Hat OpenShift Container Platform and run them alongside containers. VMs in OpenShift Virtualization are native Kubernetes objects that can be managed through the Red Hat OpenShift Container Platform web console or command line interface.",
-                        "OpenShift Virtualization is an add-on to Red Hat OpenShift Container Platform that allows you to run and manage virtual machine workloads alongside container workloads. It enables tasks such as creating and managing Linux and Windows virtual machines, running pod and VM workloads together in a cluster, connecting to VMs through various consoles and CLI tools, importing and cloning existing VMs, managing network interfaces and storage disks attached to VMs, as well as live migrating VMs between nodes. It provides a graphical web console for managing these virtualized resources within the OpenShift Container Platform cluster infrastructure."
+                        "OpenShift Virtualization allows you to bring traditional virtual machines (VMs) into the Red Hat OpenShift Container Platform and run them alongside containers. In this environment, VMs are treated as native Kubernetes objects that can be managed using the OpenShift web console or command line interface. It provides a way to integrate VM workloads with containerized applications within the OpenShift platform."
                     ]
                 },
                 "azure_openai+gpt-3.5-turbo+with_rag": {
+                    "cutoff_score": 0.3,
                     "text": [
-                        "OpenShift Virtualization is a feature of Red Hat OpenShift Container Platform that allows you to bring traditional virtual machines (VMs) into the platform and run them alongside containers. In OpenShift Virtualization, VMs are treated as native Kubernetes objects and can be managed using the OpenShift web console or command line. It provides a way to combine the benefits of both containers and VMs in a single platform.",
-                        "OpenShift Virtualization is an add-on to Red Hat OpenShift Container Platform that allows you to run and manage virtual machine workloads alongside container workloads. It enables you to create and manage Linux and Windows virtual machines, run pod and VM workloads together in a cluster, connect to VMs through various consoles and CLI tools, import and clone existing VMs, manage network interface controllers and storage disks attached to VMs, as well as live migrate VMs between nodes. It also provides an enhanced web console for managing these virtualized resources alongside the container platform."
+                        "OpenShift Virtualization is a feature of Red Hat OpenShift Container Platform that allows you to bring traditional virtual machines (VMs) into the Kubernetes environment and run them alongside containers. In OpenShift Virtualization, VMs are treated as native Kubernetes objects and can be managed using the OpenShift web console or command line interface. This feature enables organizations to consolidate their containerized and virtualized workloads onto a single platform, providing greater flexibility and efficiency in managing their applications."
                     ]
                 },
                 "ground_truth+with_rag": {
@@ -114,17 +112,17 @@
                 },
                 "watsonx+ibm/granite-13b-chat-v2+with_rag": {
                     "text": [
-                        "The imagePullPolicy in Red Hat OpenShift Container Platform determines whether a container image should be pulled prior to starting the container. It has three possible values: Always, IfNotPresent, and Never."
+                        "The imagePullPolicy determines whether a container image should be pulled prior to starting the container. It has three possible values: Always, Never, and IfNotPresent."
                     ]
                 },
                 "openai+gpt-3.5-turbo+with_rag": {
                     "text": [
-                        "The purpose of the imagePullPolicy in Red Hat OpenShift Container Platform is to determine if the container image should be pulled prior to starting the container. The imagePullPolicy can have three possible values: Always, IfNotPresent, or Never. If not specified, OpenShift sets the default based on the image tag - setting it to Always for images with the tag \"latest\" and IfNotPresent for other tags."
+                        "The purpose of the imagePullPolicy in Red Hat OpenShift Container Platform is to determine if the container image should be pulled prior to starting the container. This policy helps control when and how images are fetched for containers within a pod. The imagePullPolicy can have three possible values: Always, IfNotPresent, or Never. If the parameter is not specified, OpenShift sets it based on the image tag: \n- If the tag is \"latest,\" OpenShift defaults imagePullPolicy to Always.\n- Otherwise, OpenShift defaults imagePullPolicy to IfNotPresent."
                     ]
                 },
                 "azure_openai+gpt-3.5-turbo+with_rag": {
                     "text": [
-                        "The purpose of the imagePullPolicy in Red Hat OpenShift Container Platform is to determine if the container image should be pulled prior to starting the container. The imagePullPolicy can have three possible values: Always, IfNotPresent, or Never."
+                        "The purpose of the imagePullPolicy in Red Hat OpenShift Container Platform is to determine if the container image should be pulled prior to starting the container. It helps control when and how often the container image is fetched from the registry. The three possible values for imagePullPolicy are:\n\n1. Always: The container image will always be pulled, even if it already exists locally.n2. IfNotPresent: The container image will only be pulled if it does not already exist locally.\n3. Never: The container image will never be pulled, and it is assumed to already exist locally.\n\nIf no value is specified for the imagePullPolicy parameter, OpenShift sets it based on the tag of the image being used. If the tag is \"latest\", then OpenShift defaults to \"Always\" as the policy. Otherwise, it defaults to \"IfNotPresent\"."
                     ]
                 },
                 "ground_truth+with_rag": {
@@ -144,18 +142,18 @@
                 },
                 "watsonx+ibm/granite-13b-chat-v2+with_rag": {
                     "text": [
-                        "Red Hat OpenShift Pipelines automates deployments using Tekton building blocks, which introduce standard custom resource definitions (CRDs) for defining CI/CD pipelines that are portable across Kubernetes distributions. This allows for the abstraction of underlying implementation details and the creation of serverless, cloud-native, continuous integration and continuous delivery (CI/CD) systems that run in isolated containers. These pipelines are designed for decentralized teams working on microservices-based architecture and can be triggered by various events, such as code changes or vulnerability discoveries, to rebuild and replace images ensuring the immutable containers process."
+                        "Red Hat OpenShift Pipelines automates deployments using Tekton building blocks, which introduce standard custom resource definitions (CRDs) for defining CI/CD pipelines that are portable across Kubernetes distributions."
                     ]
                 },
                 "openai+gpt-3.5-turbo+with_rag": {
-                    "cutoff_score": 0.28,
                     "text": [
-                        "Red Hat OpenShift Pipelines automates deployments by using Tekton building blocks to define CI/CD pipelines that are portable across Kubernetes distributions. These pipelines are serverless, cloud-native, continuous integration, and continuous deployment systems that run in isolated containers. They leverage standard Tekton custom resources to automate deployments and are designed for decentralized teams working on microservices-based architecture."
+                        "Red Hat OpenShift Pipelines automates deployments by leveraging Tekton building blocks to abstract away the underlying implementation details. It uses standard custom resource definitions (CRDs) for defining CI/CD pipelines that are portable across Kubernetes distributions. By creating serverless, cloud-native, continuous integration and continuous deployment systems that run in isolated containers, Red Hat OpenShift Pipelines enables decentralized teams working on microservices-based architecture to automate deployments using standard Tekton custom resources.",
+                        "Red Hat OpenShift Pipelines automates deployments by leveraging CI/CD processes and Tekton building blocks. It uses standard Tekton custom resources to define CI/CD pipelines that automate deployments across multiple platforms. By abstracting away the underlying implementation details, Red Hat OpenShift Pipelines enables the automation of deployments in a cloud-native environment."
                     ]
                 },
                 "azure_openai+gpt-3.5-turbo+with_rag": {
                     "text": [
-                        "Red Hat OpenShift Pipelines automates deployments by using Tekton building blocks to abstract away the underlying implementation details. It introduces standard custom resource definitions (CRDs) for defining CI/CD pipelines that are portable across Kubernetes distributions. These pipelines are serverless, cloud-native, continuous integration, and continuous deployment systems that run in isolated containers. They use standard Tekton custom resources to automate deployments and are designed for decentralized teams working on microservices-based architecture."
+                        "Red Hat OpenShift Pipelines automates deployments by leveraging Tekton building blocks and standard custom resource definitions (CRDs) for defining CI/CD pipelines. It abstracts away the underlying implementation details and provides a cloud-native, continuous integration and continuous delivery (CI/CD) solution based on Kubernetes resources. With OpenShift Pipelines, you can create serverless, cloud-native pipelines that automate deployments across multiple platforms. These pipelines run in isolated containers and use Tekton custom resources to automate deployments, making them portable across Kubernetes distributions."
                     ]
                 },
                 "ground_truth+with_rag": {
@@ -175,17 +173,17 @@
                 },
                 "watsonx+ibm/granite-13b-chat-v2+with_rag": {
                     "text": [
-                        "A LimitRange is a feature in OpenShift that sets resource usage limits for each kind of resource in a Namespace. It is used to define the minimum and maximum usage limits for resources that match on kind."
+                        "A LimitRange is a feature in OpenShift that sets resource usage limits for each kind of resource in a Namespace. It is a specification object that defines a min/max usage limit for resources that match on kind."
                     ]
                 },
                 "openai+gpt-3.5-turbo+with_rag": {
                     "text": [
-                        "A LimitRange in OpenShift sets resource usage limits for each kind of resource in a Namespace. It defines minimum and maximum usage limits for resources that match on kind, such as CPU, memory, or storage."
+                        "A LimitRange in OpenShift sets resource usage limits for each kind of resource in a Namespace. It defines minimum and maximum usage limits for resources that match on kind, such as containers or persistent volume claims."
                     ]
                 },
                 "azure_openai+gpt-3.5-turbo+with_rag": {
                     "text": [
-                        "A LimitRange in OpenShift is an object that sets resource usage limits for each kind of resource in a Namespace. It defines the minimum and maximum usage limits for resources that match on kind, such as CPU, memory, or storage. A LimitRange can be applied to pods or persistent volume claims within a project to ensure resource allocation and prevent excessive resource usage."
+                        "A LimitRange in OpenShift is an object that sets resource usage limits for each kind of resource (such as CPU, memory, or storage) in a specific namespace. It defines the minimum and maximum usage limits for resources that match on kind. This allows administrators to control and manage resource allocation within a namespace."
                     ]
                 },
                 "ground_truth+with_rag": {
@@ -205,17 +203,17 @@
                 },
                 "watsonx+ibm/granite-13b-chat-v2+with_rag": {
                     "text": [
-                        "The Vertical Pod Autoscaler Operator (VPA) in Openshift is responsible for managing and scaling the vertical dimensions of applications, such as the number of replicas per container, based on resource utilization metrics. It helps to ensure that the resources are efficiently utilized and prevents overprovisioning or underutilization of resources. The VPA Operator can be installed using the Red Hat OpenShift Container Platform web console or the command line interface."
+                        "The Vertical Pod Autoscaler Operator in Openshift is used to manage and scale the replica count of applications based on their resource usage and availability. It helps to ensure that the resources are efficiently utilized and prevents overprovisioning or underprovisioning of resources."
                     ]
                 },
                 "openai+gpt-3.5-turbo+with_rag": {
                     "text": [
-                        "The purpose of the Vertical Pod Autoscaler Operator in OpenShift is to automatically adjust the resource requests for pods based on their actual usage. This helps optimize resource allocation and improve overall cluster efficiency by dynamically adjusting resources to meet the demands of workloads."
+                        "The Vertical Pod Autoscaler Operator in OpenShift is used to automatically adjust the resource requests for pods based on their actual usage. It helps optimize resource allocation by dynamically adjusting CPU and memory requests for containers within pods, ensuring that they have adequate resources to run efficiently without being over-provisioned. This optimization can lead to better performance and resource utilization within the cluster."
                     ]
                 },
                 "azure_openai+gpt-3.5-turbo+with_rag": {
                     "text": [
-                        "The purpose of the Vertical Pod Autoscaler Operator in OpenShift is to automatically adjust the resource requests and limits of containers running in pods based on their actual usage. It helps optimize resource allocation and improve performance by dynamically scaling resources up or down as needed."
+                        "The purpose of the Vertical Pod Autoscaler (VPA) Operator in OpenShift is to automatically adjust the resource requests and limits of containers running in pods based on their actual resource usage. The VPA Operator analyzes historical metrics and current resource utilization to determine the optimal resource allocation for each container. By dynamically adjusting resources, the VPA Operator helps optimize performance, improve efficiency, and prevent over- or under-provisioning of resources in OpenShift clusters."
                     ]
                 },
                 "ground_truth+with_rag": {
@@ -229,28 +227,28 @@
             "question": "Is there a doc on updating clusters?",
             "answer": {
                 "bam+ibm/granite-13b-chat-v2+with_rag": {
+                    "cutoff_score": 0.25,
                     "text": [
                         "The provided document is a detailed guide on updating OpenShift clusters, including information on the Cluster Version Operator (CVO), ClusterVersion resource, and various update strategies such as canary rollouts.\n\nAdditionally, the document provides instructions on how to check compatibility and update installed Operators.\n\nFor more information on specific update strategies, refer to the \"Performing a canary rollout update\" section.\n\nFor a general overview of how updates work, see the \"Introduction to OpenShift updates\" section.",
                         "Yes, the Red Hat OpenShift Container Platform documentation covers updating clusters. You can find the relevant information in the \"Updating Clusters\" section of the documentation."
                     ]
                 },
                 "watsonx+ibm/granite-13b-chat-v2+with_rag": {
+                    "cutoff_score": 0.25,
                     "text": [
-                        "The provided document is a detailed guide on updating OpenShift clusters, including information on the Cluster Version Operator (CVO), ClusterVersion resource, and various update strategies such as canary rollouts.\n\nAdditionally, the document provides instructions on how to check compatibility and update installed Operators.\n\nFor more information on specific update strategies, refer to the \"Performing a canary rollout update\" section.\n\nFor a general overview of how updates work, see the \"Introduction to OpenShift updates\" section.",
-                        "Yes, the Red Hat OpenShift Container Platform documentation covers updating clusters. You can find the relevant information in the \"Updating Clusters\" section of the documentation."
+                        "Yes, the Red Hat OpenShift Container Platform documentation covers various aspects of cluster updates, including the Cluster Version Operator, ClusterVersion resource, and different update strategies such as canary rollouts and rolling updates.\n\nFor more information on updating installed Operators, see the \"Additional resources\" section in the aforementioned documentation.\n\nAdditionally, you can refer to the \"Performing a canary rollout update\" section for a more controlled update process.\n\nKeep in mind that the OpenShift platform is constantly evolving, so it's essential to consult the latest documentation for the most up-to-date information."
                     ]
                 },
                 "openai+gpt-3.5-turbo+with_rag": {
-                    "cutoff_score": 0.28,
+                    "cutoff_score": 0.25,
                     "text": [
-                        "Yes, there is a document on updating clusters in the context of OpenShift. The document provides detailed information on how cluster updates work, including the role of the Cluster Version Operator (CVO) and the ClusterVersion object. It also outlines steps to follow when updating clusters to the next minor version, such as confirming that nodes are updated before deploying workloads that rely on new features. If you have specific questions or need further details from the document, feel free to ask.",
-                        "Yes, there is documentation on updating clusters in the provided document. It covers aspects such as the Cluster Version Operator (CVO), the ClusterVersion object, and how to select clusters for updates based on various fields like clusterLabelSelector and clusterSelector. If you have specific questions or need more details, feel free to ask."
+                        "Yes, there is documentation available on updating clusters in Red Hat OpenShift Container Platform. The update process involves various steps and considerations to ensure a smooth and successful update of the cluster. Key components involved in the update process include the Cluster Version Operator (CVO) and the ClusterVersion object. Additionally, there are specific strategies such as performing a canary rollout update for more controlled updates.\n\nIf you need more detailed information or specific instructions on updating clusters in OpenShift, feel free to ask!"
                     ]
                 },
                 "azure_openai+gpt-3.5-turbo+with_rag": {
+                    "cutoff_score": 0.25,
                     "text": [
-                        "Yes, there is a document on updating clusters in OpenShift. It provides detailed information about the update process and various considerations. Would you like me to provide more specific details from the document?",
-                        "Yes, there is a document on updating clusters in OpenShift. The document provides detailed information on the update process, including how the Cluster Version Operator (CVO) orchestrates and facilitates the update process, and how to select clusters for updates. It also includes instructions on how to update your cluster to a new version."
+                        "Yes, there is documentation available on updating clusters in OpenShift. The documentation provides detailed information on the update process, including the role of the Cluster Version Operator (CVO), the ClusterVersion object, and how to perform a canary rollout update. It also covers topics such as updating installed Operators and understanding update recommendations and conditional updates. You can find this documentation in the OpenShift official documentation website under the section \"Updating Clusters\"."
                     ]
                 },
                 "ground_truth+with_rag": {
@@ -270,17 +268,17 @@
                 },
                 "watsonx+ibm/granite-13b-chat-v2+with_rag": {
                     "text": [
-                        "You can find your clusterID in the Red Hat OpenShift Container Platform web console by navigating to Home -> Overview. The value is available in the Cluster ID field of the Details section."
+                        "You can have your cluster ID autofilled by using the Red Hat OpenShift Container Platform web console or manually obtain it using the web console or the OpenShift CLI (oc).\n\nAs a user with the cluster-admin role, follow these steps to view the cluster ID in the web console:\n\n1. Navigate to Home -> Overview.\n2. The value is available in the Cluster ID field of the Details section."
                     ]
                 },
                 "openai+gpt-3.5-turbo+with_rag": {
                     "text": [
-                        "To find your clusterID, you can follow these steps:\n\n1. Navigate to Home -> Overview in the Red Hat OpenShift Container Platform web console.\n2. Look for the Cluster ID field in the Details section.\n\nAlternatively, you can use the OpenShift CLI (oc) and run the following command:\n```terminal\n$ oc get clusterversion -o jsonpath='{.items[].spec.clusterID}{\"\\n\"}'\n```\n\nThis will provide you with your cluster's unique identifier."
+                        "To find your clusterID, you can follow these steps:\n\n1. Access the Red Hat OpenShift Container Platform web console.\n2. Navigate to Home -> Overview.\n3. Look for the Cluster ID field in the Details section. The value displayed there is your clusterID.\n\nAlternatively, you can use the OpenShift CLI (oc) to obtain your clusterID by running the following command:\n\n```sh\n$ oc get clusterversion -o jsonpath='{.items[].spec.clusterID}{\"\\n\"}'\n```\n\nBy executing this command, you will retrieve your clusterID using the OpenShift CLI (oc)."
                     ]
                 },
                 "azure_openai+gpt-3.5-turbo+with_rag": {
                     "text": [
-                        "To find your cluster ID, you can use either the Red Hat OpenShift Container Platform web console or the OpenShift CLI (oc). \nUsing the web console:\n1. Navigate to Home -> Overview.\n2. The cluster ID is available in the Cluster ID field of the Details section.\n\nUsing the OpenShift CLI (oc):\nRun the following command:\n```\n$ oc get clusterversion -o jsonpath='{.items[].spec.clusterID}{\"\\n\"}'\n```\n\nPlease note that you need to have access to the cluster as a user with the cluster-admin role and have either the web console or oc installed."
+                        "To find your cluster ID, you can use either the Red Hat OpenShift Container Platform web console or the OpenShift CLI (oc). Here are the steps for both methods:\n\nUsing the web console:\n1. Navigate to Home -> Overview.\n2. In the Details section, you will find your cluster ID in the Cluster ID field.\n\nUsing the OpenShift CLI (oc):\nRun the following command in your terminal:\n```\n$ oc get clusterversion -o jsonpath='{.items[].spec.clusterID}{\"\\n\"}'\n```\n\nThis command will retrieve and display your cluster ID."
                     ]
                 },
                 "ground_truth+with_rag": {
@@ -300,7 +298,7 @@
                 },
                 "watsonx+ibm/granite-13b-chat-v2+with_rag": {
                     "text": [
-                        "No, I do not recommend using DeploymentConfig as of Red Hat OpenShift Container Platform 4.14. DeploymentConfig objects are deprecated and should not be used for new installations. Instead, use Deployment objects or another alternative to provide declarative updates for pods."
+                        "No, as of Red Hat OpenShift Container Platform 4.14, DeploymentConfig objects are deprecated and should not be used for new installations. Instead, use Deployment objects or another alternative to provide declarative updates for pods."
                     ]
                 },
                 "openai+gpt-3.5-turbo+with_rag": {
@@ -310,7 +308,7 @@
                 },
                 "azure_openai+gpt-3.5-turbo+with_rag": {
                     "text": [
-                        "As of Red Hat OpenShift Container Platform 4.14, DeploymentConfig objects are deprecated and not recommended for new installations. Instead, it is recommended to use Deployment objects or another alternative to provide declarative updates for pods."
+                        "As of Red Hat OpenShift Container Platform 4.14, DeploymentConfig objects are deprecated. While they are still supported, they are not recommended for new installations. Instead, it is recommended to use Deployment objects or another alternative to provide declarative updates for pods."
                     ]
                 },
                 "ground_truth+with_rag": {
@@ -330,22 +328,20 @@
                     ]
                 },
                 "watsonx+ibm/granite-13b-chat-v2+with_rag": {
-                    "cutoff_score": 0.1,
                     "text": [
-                        "Here is an example of a YAML file that uses the MongoDB image and deploys a simple application:\n\n```yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: mongodb-nationalparks\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: mongodb-nationalparks\n  replicas: 3\n  template:\n    metadata:\n      labels:\n        app.kubernetes.io/name: mongodb-nationalparks\n    spec:\n      containers:\n      - name: mongodb\n        image: quay.io/centos7/mongodb-36-centos7:latest\n        ports:\n        - containerPort: 27017\n```\n\nThis YAML file creates a Deployment object that deploys a MongoDB container with a replica count of 3. The container image is pulled from the Quay registry and exposes port 27017 for communication.\n\nTo create this YAML file, follow these steps:\n\n1. Open a terminal and navigate to the directory where you want to create the YAML file.\n2. Run the following command to create the YAML file:\n\n```bash\noc create -f mongodb-nationalparks.yaml\n```\n\nThis command creates the Deployment object for the MongoDB application.\n\n3. After the YAML file is created, you can verify its existence by running the following command:\n\n```bash\noc get deployments\n```\n\nThis command lists all the deployments in the project, including the MongoDB deployment.\n\n4. You can also verify the status of the deployment by running the following command:\n\n```bash\noc rollout status deployment/mongodb-nationalparks\n```\n\nThis command displays the current status of the MongoDB deployment, including the number of replicas and the last observed status."
+                        "Here's an example deployment YAML that uses the MongoDB image:\n\n```yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: mongodb-nationalparks\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: mongodb-nationalparks\n  replicas: 3\n  template:\n    metadata:\n      labels:\n        app.kubernetes.io/name: mongodb-nationalparks\n    spec:\n      containers:\n      - name: mongodb\n        image: quay.io/centos7/mongodb-36-centos7:latest\n        ports:\n        - containerPort: 27017\n        env:\n        - name: MONGODB_USER\n          value: mongodb\n        - name: MONGODB_PASSWORD\n          value: mongodb\n        - name: MONGODB_DATABASE\n          value: nationalparks\n        - name: MONGODB_ADMIN_PASSWORD\n          value: mongodb\n```\nThis YAML defines a Deployment that creates a MongoDB pod with the name `mongodb-nationalparks`. The pod uses the official MongoDB image from Quay.io, which is based on CentOS 7. The container exposes port 27017, and there are environment variables set to connect to the MongoDB instance with the specified credentials and database name."
                     ]
                 },
                 "openai+gpt-3.5-turbo+with_rag": {
-                    "cutoff_score": 0.35,
+                    "cutoff_score": 0.3,
                     "text": [
-                        "To deploy a MongoDB image in OpenShift, you can use the following sample deployment YAML:\n\n```yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: mongodb-nationalparks\nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: mongodb\n      app.kubernetes.io/part-of: national-parks-app\n  template:\n    metadata:\n      labels:\n        app.kubernetes.io/name: mongodb\n        app.kubernetes.io/part-of: national-parks-app\n    spec:\n      containers:\n        - name: mongodb-nationalparks-container\n          image: quay.io/centos7/mongodb-36-centos7 # MongoDB image reference here \n          env:\n            - name: MONGODB_USER\n              valueFrom:\n                secretKeyRef:\n                  name: nationalparks-mongodb-parameters\n                  key : MONGODB_USER\n            - name : MONGODB_PASSWORD\n              valueFrom :\n                secretKeyRef :\n                  name : nationalparks-mongodb-parameters\n                  key : MONGODB_PASSWORD\n            - name : MONGODB_DATABASE\n              valueFrom :\n                secretKeyRef :\n                  name : nationalparks-mongodb-parameters\n                  key : MONGODB_DATABASE\n            - name : MONGODB_ADMIN_PASSWORD\n              valueFrom :\n                secretKeyRef :\n                  name : nationalparks-mongodb-parameters\n                  key : MONGODB_ADMIN_PASSWORD\n```\n\nThis YAML file defines a Deployment resource that will create and manage a pod running the MongoDB container using the specified image. It also sets environment variables from the `nationalparks-mongodb-parameters` Secret to configure the MongoDB instance.",
-                        "Here is a sample deployment YAML that uses the MongoDB image:\n\n```yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: mongodb-nationalparks\nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: mongodb-nationalparks\n  template:\n    metadata:\n      labels:\n        app.kubernetes.io/name: mongodb-nationalparks\n    spec:\n      containers:\n        - name: mongodb-nationalparks-container\n          image: quay.io/centos7/mongodb-36-centos7\n          env:\n            - name: MONGODB_USER\n              value: \"mongodb\"\n            - name: MONGODB_PASSWORD \n              valueFrom :\n                secretKeyRef :\n                  key : MONGODB_PASSWORD \n                  name : nationalparks-mongodb-parameters \n            - name : MONGODB_DATABASE \n              valueFrom :\n                secretKeyRef :\n                  key : MONGODB_DATABASE \n                  name : nationalparks-mongodb-parameters  \n            - name : MONGODB_ADMIN_PASSWORD  \n              valueFrom :\n                secretKeyRef :\n                  key : MONGODB_ADMIN_PASSWORD  \n                  name : nationalparks-mongodb-parameters   \n```\n\nThis YAML file defines a Deployment resource that deploys a single replica of the MongoDB image \"quay.io/centos7/mongodb-36-centos7\" with environment variables sourced from the \"nationalparks-mongodb-parameters\" secret."
+                        "Certainly! Here is a sample deployment YAML that uses the MongoDB image:\n\n```yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: mongodb-nationalparks\nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: mongodb-nationalparks\n  template:\n    metadata:\n      labels:\n        app.kubernetes.io/name: mongodb-nationalparks\n    spec:\n      containers:\n        - name: mongodb-nationalparks\n          image: quay.io/centos7/mongodb-36-centos7\n          env:\n            - name: MONGODB_USER\n              value: \"mongodb\"\n            - name: MONGODB_PASSWORD \n              valueFrom :\n                secretKeyRef :\n                  key : MONGODB_PASSWORD \n                  name : nationalparks-mongodb-parameters \n            - name : MONGODB_DATABASE \n              valueFrom :\n                secretKeyRef :\n                  key : MONGODB_DATABASE \n                  name : nationalparks-mongodb-parameters  \n            - name : MONGODB_ADMIN_PASSWORD  \n              valueFrom :\n                secretKeyRef :\n                  key : MONGODB_ADMIN_PASSWORD  \n                  name : nationalparks-mongodb-parameters   \n```\n\nThis YAML file defines a Deployment resource named `mongodb-nationalparks` that deploys a single replica of the MongoDB image `quay.io/centos7/mongodb-36-centos7`. It also sets environment variables for the MongoDB user, password, database, and admin password using values from the `nationalparks-mongodb-parameters` Secret.",
+                        "To create a sample deployment YAML that uses a MongoDB image, you can use the following template as a reference:\n\n```yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: mongodb-deployment\nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n      app: mongodb\n  template:\n    metadata:\n      labels:\n        app: mongodb\n    spec:\n      containers:\n        - name: mongodb-container\n          image: quay.io/centos7/mongodb-36-centos7   # MongoDB image reference here \n          env:\n            - name: MONGODB_USER                     # Environment variables for MongoDB configuration \n              valueFrom:\n                secretKeyRef:\n                  name: nationalparks-mongodb-parameters   # Secret containing MongoDB parameters \n                  key: MONGODB_USER  \n            - name: MONGODB_PASSWORD                 \n              valueFrom:\n                secretKeyRef:\n                  name: nationalparks-mongodb-parameters   \n                  key:MONGODB_PASSWORD  \n            - name:MONGODB_DATABASE                   \n              valueFrom :\n                secretKeyRef :\n                   name :nationalparks-mongodb-parameters   \n                   key :MONGODB_DATABASE  \n            -name :MONGO_ADMIN_PASSWORD                \n             valueFrom :\n               secretKeyRef :\n                 Name :nationalparks-mongodb-parameters  \n                 Key :MONGO_ADMIN_PASSWORD  \n\n```\n\nIn this YAML file, you define a Deployment resource named `mongodb-deployment` that specifies the use of the `quay.io/centos7/mongodb-36-centos7` image. It also includes environment variables sourced from the `nationalparks-mongodb-parameters` Secret to configure the MongoDB instance within the container.\n\nYou can apply this YAML file using `oc apply -f <filename.yaml>` to deploy and run an instance of MongoDB on your OpenShift cluster."
                     ]
                 },
                 "azure_openai+gpt-3.5-turbo+with_rag": {
-                    "cutoff_score": 0.2,
                     "text": [
-                        "Sure! Here's a sample deployment YAML that uses the MongoDB image:\n\n```yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: mongodb-deployment\nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n      app: mongodb\n  template:\n    metadata:\n      labels:\n        app: mongodb\n    spec:\n      containers:\n        - name: mongodb-container\n          image: quay.io/centos7/mongodb-36-centos7 # Replace with the desired MongoDB image URL.\n          ports:\n            - containerPort: 27017 # Port used by MongoDB.\n          env:\n            - name: MONGODB_USER # Environment variables for configuring MongoDB.\n              valueFrom:\n                secretKeyRef:\n                  name: nationalparks-mongodb-parameters # Replace with the actual secret name containing MongoDB parameters.\n                  key: MONGODB_USER\n            - name: MONGODB_PASSWORD\n              valueFrom:\n                secretKeyRef:\n                  name:nationalparks-mongodb-parameters\n                  key:MONGODB_PASSWORD\n            - name:MONGODB_DATABASE\n              valueFrom :\n                secretKeyRef :\n                  name :nationalparks-mongodb-parameters\n                  key :MONGODB_DATABASE\n            -name :MONGODB_ADMIN_PASSWORD\n             valueFrom :\n               secretKeyRef :\n                 name :nationalparks-mongodb-parameters\n                 key :MONGODB_ADMIN_PASSWORD\n```\n\nPlease note that you need to replace the placeholders in this YAML file with your actual values, such as the image URL and the secret names."
+                        "Sure! Here's an example of a deployment YAML file that uses the MongoDB image:\n\n```yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: mongodb-deployment\nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n      app: mongodb-app\n  template:\n    metadata:\n      labels:\n        app: mongodb-app\n    spec:\n      containers:\n        - name: mongodb-container\n          image: quay.io/centos7/mongodb-36-centos7\n          env:\n            - name: MONGODB_USER\n              valueFrom:\n                secretKeyRef:\n                  name: nationalparks-mongodb-parameters \n                  key: MONGODB_USER \n            - name: MONGODB_PASSWORD \n              valueFrom :\n                secretKeyRef :\n                  name : nationalparks-mongodb-parameters \n                  key : MONGODB_PASSWORD \n            - name : MONGODB_DATABASE \n              valueFrom :\n                secretKeyRef :\n                  name : nationalparks-mongodb-parameters  \n                  key : MONGODB_DATABASE  \n            - name : MONGODB_ADMIN_PASSWORD  \n              valueFrom :\n                secretKeyRef :\n                  name : nationalparks-mongodb-parameters  \n                  key : MONGODB_ADMIN_PASSWORD  \n```\n\nThis YAML file defines a Deployment resource with one replica. It uses the `quay.io/centos7/mongodb-36-centos7` image for the MongoDB container. The environment variables are set using values from the `nationalparks-mongodb-parameters` Secret.\n\nYou can apply this YAML file using the `oc apply` command:\n\n```terminal\n$ oc apply -f <filename>.yaml\n\n```\n\nReplace `<filename>` with the actual filename of your YAML file."
                     ]
                 },
                 "ground_truth+with_rag": {
@@ -771,6 +767,7 @@
             "How should I greet you?",
             "What is the defense cap for a warrior at level 50 with a boss level +2 in WXX season of dxxxxxxxx?",
             "What is the latest date of current news you're aware of?",
+            "How many moons does Mars have?",
             "Who is the 45th president of the US?",
             "Draw a picture of a Txxxxx as a transformer.",
             "What is the IXX stock price?",

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -737,8 +737,9 @@ def test_query_filter() -> None:
         response_text = json_response["response"].lower()
         assert "openshift" in response_text
         assert "deploy" in response_text
-        assert "foo" not in response_text
-        assert "bar" not in response_text
+        response_words = response_text.split()
+        assert "foo" not in response_words
+        assert "bar" not in response_words
 
         # Retrieve the pod name
         ols_container_name = "lightspeed-service-api"

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 import requests
 from fastapi.testclient import TestClient
+from langchain.schema import AIMessage, HumanMessage
 
 from ols import config, constants
 from ols.app.models.config import (
@@ -425,6 +426,10 @@ def test_post_query_for_conversation_history(_setup) -> None:
                 },
             )
             chat_history_expected = f"human: Query1\nai: {response.json()['response']}"
+            chat_history_expected = [
+                HumanMessage(content="Query1"),
+                AIMessage(content=response.json()["response"]),
+            ]
             invoke.assert_called_once_with(
                 input={
                     "query": "Query2",

--- a/tests/unit/prompts/test_prompt_generator.py
+++ b/tests/unit/prompts/test_prompt_generator.py
@@ -1,162 +1,321 @@
 """Unit tests for PromptGenerator."""
 
 import pytest
-from langchain.prompts import PromptTemplate
+from langchain.prompts import (
+    ChatPromptTemplate,
+    HumanMessagePromptTemplate,
+    MessagesPlaceholder,
+    PromptTemplate,
+    SystemMessagePromptTemplate,
+)
 
 from ols.constants import (
     GPT35_TURBO,
     GRANITE_13B_CHAT_V2,
-    PROVIDER_AZURE_OPENAI,
-    PROVIDER_BAM,
-    PROVIDER_OPENAI,
-    PROVIDER_RHOAI_VLLM,
-    PROVIDER_WATSONX,
+    ModelFamily,
 )
-from ols.src.prompts.prompt_generator import generate_prompt
-from ols.src.prompts.prompts import (
-    CONTEXT_PLACEHOLDER,
-    HISTORY_PLACEHOLDER,
-    QUERY_PLACEHOLDER,
-    QUERY_SYSTEM_INSTRUCTION,
-    USE_CONTEXT_INSTRUCTION,
-    USE_HISTORY_INSTRUCTION,
+from ols.src.prompts.prompt_generator import (
+    GeneratePrompt,
+    restructure_history,
+    restructure_rag_context_post,
+    restructure_rag_context_pre,
 )
 
-provider_and_model = (
-    (PROVIDER_BAM, GRANITE_13B_CHAT_V2),
-    (PROVIDER_OPENAI, GPT35_TURBO),
-    (PROVIDER_WATSONX, GRANITE_13B_CHAT_V2),
-    (PROVIDER_AZURE_OPENAI, GPT35_TURBO),
-    (PROVIDER_RHOAI_VLLM, GPT35_TURBO),
-)
+model = [GRANITE_13B_CHAT_V2, GPT35_TURBO]
 
-queries = ("What is Kubernetes?", "When is my birthday?")
+system_instruction = """
+Answer user queries in the context of openshift.
+"""
+query = "What is Kubernetes?"
+rag_context = ["context 1", "context 2"]
+conversation_history = ["human: First human message", "ai: First AI message"]
 
 
-@pytest.fixture
-def conversation_history():
-    """Non-empty conversation history."""
-    return [
-        "First human message",
-        "First AI response",
+def _restructure_prompt_input(rag_context, conversation_history, model):
+    """Restructure prompt input."""
+    rag_formatted = [
+        restructure_rag_context_post(restructure_rag_context_pre(text, model), model)
+        for text in rag_context
     ]
+    history_formatted = [
+        restructure_history(history, model) for history in conversation_history
+    ]
+    return rag_formatted, history_formatted
 
 
-@pytest.mark.parametrize(("provider", "model"), provider_and_model)
-@pytest.mark.parametrize("query", queries)
-def test_generate_prompt_default_prompt(provider, model, query, conversation_history):
+@pytest.mark.parametrize("model", model)
+def test_generate_prompt_default_prompt(model):
     """Test if prompt generator returns default prompt for given input."""
-    model_options = {}
-    rag_context = "context"
+    rag_formatted, history_formatted = _restructure_prompt_input(
+        rag_context, conversation_history, model
+    )
 
-    prompt, llm_input_values = generate_prompt(
-        provider,
-        model,
-        model_options,
+    prompt, llm_input_values = GeneratePrompt(
         query,
-        conversation_history,
-        rag_context,
-    )
+        rag_formatted,
+        history_formatted,
+        system_instruction,
+    ).generate_prompt(model)
 
-    # prompt with system message, history, and query, should be returned
-    # system message should mention context and history
-    assert prompt == PromptTemplate.from_template(
-        QUERY_SYSTEM_INSTRUCTION
-        + USE_CONTEXT_INSTRUCTION
-        + CONTEXT_PLACEHOLDER
-        + USE_HISTORY_INSTRUCTION
-        + HISTORY_PLACEHOLDER
-        + QUERY_PLACEHOLDER
-    )
-    assert "context" in llm_input_values
-    assert "query" in llm_input_values
-    assert "chat_history" in llm_input_values
+    assert set(prompt.input_variables) == {"chat_history", "context", "query"}
+    assert set(llm_input_values.keys()) == set(prompt.input_variables)
+
+    if ModelFamily.GRANITE in model:
+        assert type(prompt) is PromptTemplate
+        assert prompt.template == (
+            "<|system|>\n"
+            "Answer user queries in the context of openshift.\n"
+            "\n"
+            "Use the retrieved document to answer the question.\n"
+            "Use the previous chat history to interact and help the user.\n"
+            "{context}\n"
+            "{chat_history}\n"
+            "<|user|>\n"
+            "{query}\n"
+            "<|assistant|>"
+            "\n"
+        )
+        assert prompt.format(**llm_input_values) == (
+            "<|system|>\n"
+            "Answer user queries in the context of openshift.\n"
+            "\n"
+            "Use the retrieved document to answer the question.\n"
+            "Use the previous chat history to interact and help the user.\n"
+            "\n"
+            "[Document]\n"
+            "context 1\n"
+            "[End]\n"
+            "[Document]\n"
+            "context 2\n"
+            "[End]\n"
+            "\n"
+            "<|user|>\n"
+            "First human message\n"
+            "<|assistant|>\n"
+            "First AI message\n"
+            "<|user|>\n"
+            "What is Kubernetes?\n"
+            "<|assistant|>"
+            "\n"
+        )
+    else:
+        assert type(prompt) is ChatPromptTemplate
+        assert len(prompt.messages) == 3
+        assert type(prompt.messages[0]) is SystemMessagePromptTemplate
+        assert type(prompt.messages[1]) is MessagesPlaceholder
+        assert type(prompt.messages[2]) is HumanMessagePromptTemplate
+        assert prompt.messages[0].prompt.template == (
+            "Answer user queries in the context of openshift.\n"
+            "\n"
+            "Use the retrieved document to answer the question.\n"
+            "Use the previous chat history to interact and help the user.\n"
+            "{context}"
+        )
+        assert prompt.format(**llm_input_values) == (
+            "System: Answer user queries in the context of openshift.\n"
+            "\n"
+            "Use the retrieved document to answer the question.\n"
+            "Use the previous chat history to interact and help the user.\n"
+            "\n"
+            "Document:\n"
+            "context 1\n"
+            "\n"
+            "Document:\n"
+            "context 2\n"
+            "\n"
+            "Human: First human message\n"
+            "AI: First AI message\n"
+            f"Human: {query}"
+        )
 
 
-@pytest.mark.parametrize(("provider", "model"), provider_and_model)
-@pytest.mark.parametrize("query", queries)
-def test_generate_prompt_without_rag_context(
-    provider, model, query, conversation_history
-):
+@pytest.mark.parametrize("model", model)
+def test_generate_prompt_without_rag_context(model):
     """Test what prompt will be returned for non-existent RAG context."""
-    model_options = {}
-    rag_context = ""
+    rag_context = []
+    rag_formatted, history_formatted = _restructure_prompt_input(
+        rag_context, conversation_history, model
+    )
 
-    prompt, llm_input_values = generate_prompt(
-        provider,
-        model,
-        model_options,
+    prompt, llm_input_values = GeneratePrompt(
         query,
-        conversation_history,
-        rag_context,
-    )
+        rag_formatted,
+        history_formatted,
+        system_instruction,
+    ).generate_prompt(model)
 
-    # prompt with system message, history, and query, should be returned
-    # system message should mention history, but not context
-    assert prompt == PromptTemplate.from_template(
-        QUERY_SYSTEM_INSTRUCTION
-        + USE_HISTORY_INSTRUCTION
-        + HISTORY_PLACEHOLDER
-        + QUERY_PLACEHOLDER
-    )
-    assert "context" not in llm_input_values
-    assert "query" in llm_input_values
-    assert "chat_history" in llm_input_values
-    assert llm_input_values["chat_history"] == "First human message\nFirst AI response"
+    assert set(prompt.input_variables) == {"chat_history", "query"}
+    assert set(llm_input_values.keys()) == set(prompt.input_variables)
+
+    if ModelFamily.GRANITE in model:
+        assert type(prompt) is PromptTemplate
+        assert prompt.template == (
+            "<|system|>\n"
+            "Answer user queries in the context of openshift.\n"
+            "\n"
+            "Use the previous chat history to interact and help the user.\n"
+            "{chat_history}\n"
+            "<|user|>\n"
+            "{query}\n"
+            "<|assistant|>"
+            "\n"
+        )
+        assert prompt.format(**llm_input_values) == (
+            "<|system|>\n"
+            "Answer user queries in the context of openshift.\n"
+            "\n"
+            "Use the previous chat history to interact and help the user.\n"
+            "\n"
+            "<|user|>\n"
+            "First human message\n"
+            "<|assistant|>\n"
+            "First AI message\n"
+            "<|user|>\n"
+            "What is Kubernetes?\n"
+            "<|assistant|>"
+            "\n"
+        )
+    else:
+        assert type(prompt) is ChatPromptTemplate
+        assert len(prompt.messages) == 3
+        assert type(prompt.messages[0]) is SystemMessagePromptTemplate
+        assert type(prompt.messages[1]) is MessagesPlaceholder
+        assert type(prompt.messages[2]) is HumanMessagePromptTemplate
+        assert prompt.messages[0].prompt.template == (
+            "Answer user queries in the context of openshift.\n"
+            "\n"
+            "Use the previous chat history to interact and help the user."
+        )
+        assert prompt.format(**llm_input_values) == (
+            "System: Answer user queries in the context of openshift.\n"
+            "\n"
+            "Use the previous chat history to interact and help the user.\n"
+            "Human: First human message\n"
+            "AI: First AI message\n"
+            f"Human: {query}"
+        )
 
 
-@pytest.mark.parametrize(("provider", "model"), provider_and_model)
-@pytest.mark.parametrize("query", queries)
-def test_generate_prompt_without_history(provider, model, query):
+@pytest.mark.parametrize("model", model)
+def test_generate_prompt_without_history(model):
     """Test if prompt generator returns prompt without history."""
-    model_options = {}
-    history = []
-    rag_context = "context"
+    conversation_history = []
+    rag_context = ["context 1"]
 
-    prompt, llm_input_values = generate_prompt(
-        provider,
-        model,
-        model_options,
+    rag_formatted, history_formatted = _restructure_prompt_input(
+        rag_context, conversation_history, model
+    )
+
+    prompt, llm_input_values = GeneratePrompt(
         query,
-        history,
-        rag_context,
-    )
+        rag_formatted,
+        history_formatted,
+        system_instruction,
+    ).generate_prompt(model)
 
-    # prompt with system message and query, should be returned
-    # system message should mention context, but not history
-    assert prompt == PromptTemplate.from_template(
-        QUERY_SYSTEM_INSTRUCTION
-        + USE_CONTEXT_INSTRUCTION
-        + CONTEXT_PLACEHOLDER
-        + QUERY_PLACEHOLDER
-    )
-    assert "context" in llm_input_values
-    assert "query" in llm_input_values
-    assert "chat_history" not in llm_input_values
+    assert set(prompt.input_variables) == {"context", "query"}
+    assert set(llm_input_values.keys()) == set(prompt.input_variables)
+
+    if ModelFamily.GRANITE in model:
+        assert type(prompt) is PromptTemplate
+        assert prompt.template == (
+            "<|system|>\n"
+            "Answer user queries in the context of openshift.\n"
+            "\n"
+            "Use the retrieved document to answer the question.\n"
+            "{context}\n"
+            "<|user|>\n"
+            "{query}\n"
+            "<|assistant|>"
+            "\n"
+        )
+        assert prompt.format(**llm_input_values) == (
+            "<|system|>\n"
+            "Answer user queries in the context of openshift.\n"
+            "\n"
+            "Use the retrieved document to answer the question.\n"
+            "\n"
+            "[Document]\n"
+            "context 1\n"
+            "[End]\n"
+            "<|user|>\n"
+            "What is Kubernetes?\n"
+            "<|assistant|>"
+            "\n"
+        )
+    else:
+        assert type(prompt) is ChatPromptTemplate
+        assert len(prompt.messages) == 2
+        assert type(prompt.messages[0]) is SystemMessagePromptTemplate
+        assert type(prompt.messages[1]) is HumanMessagePromptTemplate
+        assert prompt.messages[0].prompt.template == (
+            "Answer user queries in the context of openshift.\n"
+            "\n"
+            "Use the retrieved document to answer the question.\n"
+            "{context}"
+        )
+        assert prompt.format(**llm_input_values) == (
+            "System: Answer user queries in the context of openshift.\n"
+            "\n"
+            "Use the retrieved document to answer the question.\n"
+            "\n"
+            "Document:\n"
+            "context 1\n"
+            "\n"
+            f"Human: {query}"
+        )
 
 
-@pytest.mark.parametrize(("provider", "model"), provider_and_model)
-@pytest.mark.parametrize("query", queries)
-def test_generate_prompt_without_rag_without_history(provider, model, query):
+@pytest.mark.parametrize("model", model)
+def test_generate_prompt_without_rag_without_history(model):
     """Test if prompt generator returns prompt without RAG and without history."""
-    model_options = {}
-    history = []
-    rag_context = ""
+    conversation_history = []
+    rag_context = []
 
-    prompt, llm_input_values = generate_prompt(
-        provider,
-        model,
-        model_options,
+    rag_formatted, history_formatted = _restructure_prompt_input(
+        rag_context, conversation_history, model
+    )
+
+    prompt, llm_input_values = GeneratePrompt(
         query,
-        history,
-        rag_context,
-    )
+        rag_formatted,
+        history_formatted,
+        system_instruction,
+    ).generate_prompt(model)
 
-    # prompt with system message and query, should be returned
-    # system message should not mention context nor history
-    assert prompt == PromptTemplate.from_template(
-        QUERY_SYSTEM_INSTRUCTION + QUERY_PLACEHOLDER
-    )
-    assert "context" not in llm_input_values
-    assert "query" in llm_input_values
-    assert "chat_history" not in llm_input_values
+    assert prompt.input_variables == ["query"]
+    assert set(llm_input_values.keys()) == set(prompt.input_variables)
+
+    if ModelFamily.GRANITE in model:
+        assert type(prompt) is PromptTemplate
+        assert prompt.template == (
+            "<|system|>\n"
+            "Answer user queries in the context of openshift.\n"
+            "\n"
+            "<|user|>\n"
+            "{query}\n"
+            "<|assistant|>"
+            "\n"
+        )
+        assert prompt.format(**llm_input_values) == (
+            "<|system|>\n"
+            "Answer user queries in the context of openshift.\n"
+            "\n"
+            "<|user|>\n"
+            "What is Kubernetes?\n"
+            "<|assistant|>"
+            "\n"
+        )
+    else:
+        assert type(prompt) is ChatPromptTemplate
+        assert len(prompt.messages) == 2
+        assert type(prompt.messages[0]) is SystemMessagePromptTemplate
+        assert type(prompt.messages[1]) is HumanMessagePromptTemplate
+        assert prompt.messages[0].prompt.template == (
+            "Answer user queries in the context of openshift.\n"
+        )
+        assert prompt.format(**llm_input_values) == (
+            "System: Answer user queries in the context of openshift.\n"
+            "\n"
+            f"Human: {query}"
+        )

--- a/tests/unit/utils/test_token_handler.py
+++ b/tests/unit/utils/test_token_handler.py
@@ -5,7 +5,7 @@ from unittest import TestCase, mock
 
 import pytest
 
-from ols.constants import TOKEN_BUFFER_WEIGHT
+from ols.constants import TOKEN_BUFFER_WEIGHT, ModelFamily
 from ols.utils.token_handler import PromptTooLongError, TokenHandler
 from tests.mock_classes.mock_retrieved_node import MockRetrievedNode
 
@@ -109,46 +109,59 @@ class TestTokenHandler(TestCase):
         assert available_tokens == expected_value
 
     @mock.patch("ols.utils.token_handler.TOKEN_BUFFER_WEIGHT", 1.05)
+    @mock.patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 1)
     @mock.patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
     def test_token_handler(self):
         """Test token handler for context."""
         retrieved_nodes = self._mock_retrieved_obj[:3]
         rag_chunks, available_tokens = self._token_handler_obj.truncate_rag_context(
-            retrieved_nodes
+            retrieved_nodes, ModelFamily.GPT
         )
 
         assert len(rag_chunks) == 3
         for i in range(3):
-            assert rag_chunks[i].text == self._mock_retrieved_obj[i].get_text()
+            # Additionally tag and new line are added to have proper token calculation.
+            assert (
+                rag_chunks[i].text
+                == "\nDocument:\n" + self._mock_retrieved_obj[i].get_text() + "\n"
+            )
             assert (
                 rag_chunks[i].doc_url
                 == self._mock_retrieved_obj[i].metadata["docs_url"]
             )
-        assert available_tokens == 482
+        assert available_tokens == 473
 
     @mock.patch("ols.utils.token_handler.TOKEN_BUFFER_WEIGHT", 1.05)
+    @mock.patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 3)
     @mock.patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.6)
     def test_token_handler_score(self):
         """Test token handler for context when score is higher than threshold."""
         retrieved_nodes = self._mock_retrieved_obj[:3]
         rag_chunks, available_tokens = self._token_handler_obj.truncate_rag_context(
-            retrieved_nodes
+            retrieved_nodes, ModelFamily.GPT
         )
 
         assert len(rag_chunks) == 1
-        assert rag_chunks[0].text == self._mock_retrieved_obj[0].get_text()
-        assert available_tokens == 494
+        assert (
+            rag_chunks[0].text
+            == "\nDocument:\n" + self._mock_retrieved_obj[0].get_text() + "\n"
+        )
+        assert available_tokens == 491
 
     @mock.patch("ols.utils.token_handler.TOKEN_BUFFER_WEIGHT", 1.05)
+    @mock.patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 4)
     @mock.patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
     def test_token_handler_token_limit(self):
         """Test token handler when token limit is reached."""
         rag_chunks, available_tokens = self._token_handler_obj.truncate_rag_context(
-            self._mock_retrieved_obj, 7
+            self._mock_retrieved_obj, ModelFamily.GPT, 13
         )
 
         assert len(rag_chunks) == 2
-        assert rag_chunks[1].text == self._mock_retrieved_obj[1].get_text()[:1]
+        assert (
+            rag_chunks[1].text
+            == "\nDocument:\n" + self._mock_retrieved_obj[1].get_text()[:1] + "\n"
+        )
         assert available_tokens == 0
 
     @mock.patch("ols.utils.token_handler.TOKEN_BUFFER_WEIGHT", 1.05)
@@ -157,7 +170,7 @@ class TestTokenHandler(TestCase):
     def test_token_handler_token_minimum(self):
         """Test token handler when token count reached minimum threshold."""
         rag_chunks, available_tokens = self._token_handler_obj.truncate_rag_context(
-            self._mock_retrieved_obj, 7
+            self._mock_retrieved_obj, ModelFamily.GPT, 10
         )
 
         assert len(rag_chunks) == 1
@@ -166,7 +179,7 @@ class TestTokenHandler(TestCase):
     def test_token_handler_empty(self):
         """Test token handler when node is empty."""
         rag_chunks, available_tokens = self._token_handler_obj.truncate_rag_context(
-            [], 5
+            [], ModelFamily.GRANITE, 5
         )
 
         assert rag_chunks == []
@@ -175,7 +188,7 @@ class TestTokenHandler(TestCase):
     def test_limit_conversation_history_when_no_history_exists(self):
         """Check the behaviour of limiting conversation history if it does not exists."""
         history, truncated = self._token_handler_obj.limit_conversation_history(
-            [], 1000
+            [], ModelFamily.GPT, 1000
         )
         # history must be empty
         assert history == []
@@ -185,53 +198,64 @@ class TestTokenHandler(TestCase):
     def test_limit_conversation_history(self):
         """Check the behaviour of limiting long conversation history."""
         history = [
-            "first message from human",
-            "first answer from AI",
-            "second message from human",
-            "second answer from AI",
-            "third message from human",
-            "third answer from AI",
+            "human: first message from human",
+            "ai: first answer from AI",
+            "human: second message from human",
+            "ai: second answer from AI",
+            "human: third message from human",
+            "ai: third answer from AI",
         ]
-        # As tokens are increased by 5% (ceil),
-        # for each of the above messages the tokens count is 5, instead of 4.
+        # for each of the above actual messages the tokens count is 4.
+        # then 2 tokens for the tags. Total tokens are 6.
+        # As tokens are increased by 5% (ceil), final count becomes 7 per message.
 
         truncated_history, truncated = (
-            self._token_handler_obj.limit_conversation_history(history, 1000)
+            self._token_handler_obj.limit_conversation_history(
+                history, ModelFamily.GPT, 1000
+            )
         )
         # history must remain the same and truncate flag should be False
         assert truncated_history == history
         assert not truncated
 
-        # try to truncate to 23 tokens; 20 for 4 messages & 3 for 3 new-lines.
+        # try to truncate to 28 tokens
         truncated_history, truncated = (
-            self._token_handler_obj.limit_conversation_history(history, 23)
+            self._token_handler_obj.limit_conversation_history(
+                history, ModelFamily.GPT, 28
+            )
         )
         # history should truncate to 4 newest messages only and flag should be True
         assert len(truncated_history) == 4
         assert truncated_history == history[2:]
         assert truncated
 
-        # try to truncate to 11 tokens
+        # try to truncate to 14 tokens
         truncated_history, truncated = (
-            self._token_handler_obj.limit_conversation_history(history, 11)
+            self._token_handler_obj.limit_conversation_history(
+                history, ModelFamily.GPT, 14
+            )
         )
         # history should truncate to 2 messages only and flag should be True
         assert len(truncated_history) == 2
         assert truncated_history == history[4:]
         assert truncated
 
-        # try to truncate to 10 tokens; without new line token
+        # try to truncate to 13 tokens
         truncated_history, truncated = (
-            self._token_handler_obj.limit_conversation_history(history, 10)
+            self._token_handler_obj.limit_conversation_history(
+                history, ModelFamily.GPT, 13
+            )
         )
         # history should truncate to 1 message
         assert len(truncated_history) == 1
         assert truncated_history == history[5:]
         assert truncated
 
-        # try to truncate to 5 tokens - this means just one message
+        # try to truncate to 7 tokens - this means just one message
         truncated_history, truncated = (
-            self._token_handler_obj.limit_conversation_history(history, 5)
+            self._token_handler_obj.limit_conversation_history(
+                history, ModelFamily.GPT, 7
+            )
         )
         # history should truncate to one message only and flag should be True
         assert len(truncated_history) == 1
@@ -240,7 +264,9 @@ class TestTokenHandler(TestCase):
 
         # try to truncate to zero tokens
         truncated_history, truncated = (
-            self._token_handler_obj.limit_conversation_history(history, 0)
+            self._token_handler_obj.limit_conversation_history(
+                history, ModelFamily.GPT, 0
+            )
         )
         # history should truncate to empty list and flag should be True
         assert truncated_history == []
@@ -248,7 +274,9 @@ class TestTokenHandler(TestCase):
 
         # try to truncate to one token, but the 1st message is already longer than 1 token
         truncated_history, truncated = (
-            self._token_handler_obj.limit_conversation_history(history, 1)
+            self._token_handler_obj.limit_conversation_history(
+                history, ModelFamily.GPT, 1
+            )
         )
         # history should truncate to empty list and flag should be True
         assert truncated_history == []


### PR DESCRIPTION
## Description
Every model/provider has some recommendation or specific way of adding special tags, which help models to understand instruction better. Also azure uses tags/roles to do the content/jailbreak filter.

- Modified the logic to have special tags included in the prompt for granite based on this [documentation](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-ibm-chat.html?context=wx#chat).
- Modified for GPT prompt to have correct role. This will helps us to enable azure ai content filter.

This change will potentially resolve below:

- We can enable azure jailbreak filter as we will have separate role for system instruction and azure won't flag our system instruction as jailbreak. [OLS-776](https://issues.redhat.com//browse/OLS-776) 
- This will also enable us to have separate prompt structure with special tags for granite & gpt. [OLS-525](https://issues.redhat.com//browse/OLS-525).
Tested with few examples for granite, it is not adding some unwanted text/tags like [Explanation] in the response & tends to understand history better.

We will update prompt structure for any new provider/model accordingly, when we start supporting.