### PR TITLE
Reinstate build.args to pick up Konflux RAG for Konflux builds

### DIFF
--- a/.tekton/lightspeed-service-pull-request.yaml
+++ b/.tekton/lightspeed-service-pull-request.yaml
@@ -226,7 +226,7 @@ spec:
             value:
               - $(params.build-args[*])
           - name: BUILD_ARGS_FILE
-            value: $(params.build-args-file)
+            value: build.args
         runAfter:
           - prefetch-dependencies
         taskRef:

--- a/.tekton/lightspeed-service-push.yaml
+++ b/.tekton/lightspeed-service-push.yaml
@@ -225,7 +225,7 @@ spec:
             value:
               - $(params.build-args[*])
           - name: BUILD_ARGS_FILE
-            value: $(params.build-args-file)
+            value: build.args
         runAfter:
           - prefetch-dependencies
         taskRef:


### PR DESCRIPTION
## Description

Reinstate build.args to pick up Konflux RAG for Konflux builds.
build.args got lost in a migration and we've been building on Konflux with the Prow RAG image.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
