### PR TITLE
OLS-924: Bump-up Ruff to 0.6.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ install-tools:	install-woke ## Install required utilities/tools
 	mypy --version
 	# check that correct Black version is installed
 	black --version
+	# check that correct Ruff version is installed
+	ruff --version
 
 
 install-woke: ## Install woke, required for Inclusive Naming scan

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:882a15209e6491bfee2db46c7e272224d26ca1b769cb20bff9a3e383e6611680"
+content_hash = "sha256:b79f87c64bc32f5737364abc542b2761989a42f238a01533cc752e3dc3857a22"
 
 [[package]]
 name = "absl-py"
@@ -2716,13 +2716,13 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.5.6"
+version = "0.6.1"
 requires_python = ">=3.7"
 summary = "An extremely fast Python linter and code formatter, written in Rust."
 groups = ["dev"]
 files = [
-    {file = "ruff-0.5.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c94e084ba3eaa80c2172918c2ca2eb2230c3f15925f4ed8b6297260c6ef179ad"},
-    {file = "ruff-0.5.6.tar.gz", hash = "sha256:07c9e3c2a8e1fe377dd460371c3462671a728c981c3205a5217291422209f642"},
+    {file = "ruff-0.6.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d812615525a34ecfc07fd93f906ef5b93656be01dfae9a819e31caa6cfe758a1"},
+    {file = "ruff-0.6.1.tar.gz", hash = "sha256:af3ffd8c6563acb8848d33cd19a69b9bfe943667f0419ca083f8ebe4224a3436"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
     "pytest-asyncio==0.23.7",
     "pydantic==2.8.2",
     "rouge-score==0.1.2",  # Required for model evaluation
-    "ruff==0.5.6",
+    "ruff==0.6.1",
     "bandit==1.7.9",
     "types-requests==2.32.0.20240622",
     "gradio==4.37.2",


### PR DESCRIPTION
## Description

Bump-up Ruff to 0.6.1

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #[OLS-924](https://issues.redhat.com//browse/OLS-924)
