### PR TITLE
Bump-up langchain-ibm to 0.1.12

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:3b44d5aa87274dae00c5529b9311a1332d7dc07751d01c76cb2dcbdf6ae3349f"
+content_hash = "sha256:684b43018ad50905a17bd1324eccd5913bfc8fdf9b834b6d15dfb7660ce0db30"
 
 [[package]]
 name = "absl-py"
@@ -1324,7 +1324,7 @@ files = [
 
 [[package]]
 name = "langchain-ibm"
-version = "0.1.9"
+version = "0.1.12"
 requires_python = "<4.0,>=3.10"
 summary = "An integration package connecting IBM watsonx.ai and LangChain"
 groups = ["default"]
@@ -1333,8 +1333,8 @@ dependencies = [
     "langchain-core<0.3,>=0.2.2",
 ]
 files = [
-    {file = "langchain_ibm-0.1.9-py3-none-any.whl", hash = "sha256:1a2c35b204fabea37eae2bce4b530d6c982be709449b01a531432e13caeaaa34"},
-    {file = "langchain_ibm-0.1.9.tar.gz", hash = "sha256:92fe243ba782e5826c774a6ad6fb1b5d79ab00b5bc1dd100cdccb3bc25660079"},
+    {file = "langchain_ibm-0.1.12-py3-none-any.whl", hash = "sha256:220b1be9317e29f1a3bb30cb27b6c454fd635ccd3ee1d97e46673dd8aa96a148"},
+    {file = "langchain_ibm-0.1.12.tar.gz", hash = "sha256:a2428d5b7754125bf8fd8545b25cfaafc75ff45b07cca172413da1c6ee907cae"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
     "pandas==2.1.4",
     "fastapi==0.111.0",
     "langchain==0.2.11",
-    "langchain-ibm==0.1.9",
+    "langchain-ibm==0.1.12",
     "llama-index==0.10.62",
     "llama-index-vector-stores-faiss==0.1.2",
     "llama-index-embeddings-huggingface==0.2.2",


### PR DESCRIPTION
## Description

Bump-up `langchain-ibm` to 0.1.12

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
