### PR TITLE
Refactoring: don't use f-strings to log exceptions

### DIFF
--- a/scripts/data_collection/user_data_aggregator.py
+++ b/scripts/data_collection/user_data_aggregator.py
@@ -257,7 +257,7 @@ def ping_ceph(args: argparse.Namespace) -> None:
         client.head_bucket(Bucket=args.bucket)
         logger.info("Bucket is accessible")
     except Exception as e:
-        logger.exception(f"Bucket is not accessible: {e}")
+        logger.exception("Bucket is not accessible: %s", e)
 
 
 def list_objects(args: argparse.Namespace) -> None:
@@ -274,7 +274,7 @@ def list_objects(args: argparse.Namespace) -> None:
         else:
             logger.warning(f"Bucket '{bucket_name}' is empty.")
     except Exception as e:
-        logger.exception(f"Failed to list contents of bucket '{bucket_name}':", e)
+        logger.exception("Failed to list contents of bucket '%s': %s", bucket_name, e)
 
 
 def key_match(key: str) -> Optional[re.Match]:
@@ -336,7 +336,7 @@ def download_tarball(client, bucket_name: str, obj) -> None:
             logger.warning(f"Incorrect object key {key}, skipping")
             statistic.tarballs_with_incorrect_key += 1
     except Exception as e:
-        logger.exception(f"Unable to download object: {e}")
+        logger.exception("Unable to download object: %s", e)
         statistic.tarballs_not_downloaded += 1
 
 
@@ -357,7 +357,7 @@ def download_tarballs(args: argparse.Namespace) -> None:
         else:
             logger.warning(f"Bucket '{bucket_name}' is empty.")
     except Exception as e:
-        logger.exception(f"Failed to list contents of bucket '{bucket_name}':", e)
+        logger.exception("Failed to list contents of bucket '%s': %s", bucket_name, e)
 
 
 def read_feedbacks_from_tarball(tarball: tarfile.TarFile) -> list[dict[str, Any]]:
@@ -376,7 +376,7 @@ def read_feedbacks_from_tarball(tarball: tarfile.TarFile) -> list[dict[str, Any]
                     logger.error(f"Nothing to extract from {filename}")
                     statistic.tarballs_without_feedback += 1
             except Exception as e:
-                logger.exception(f"Unable to read feedback: {e}")
+                logger.exception("Unable to read feedback: %s", e)
                 statistic.feedback_read_error += 1
     return feedbacks
 


### PR DESCRIPTION
## Description

Refactoring: don't use f-strings to log exceptions

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
