### PR TITLE
OLS-757: Use buildah-8g task with higher memory limits

### DIFF
--- a/.tekton/lightspeed-service-pull-request.yaml
+++ b/.tekton/lightspeed-service-pull-request.yaml
@@ -232,9 +232,9 @@ spec:
         taskRef:
           params:
             - name: name
-              value: buildah-6gb
+              value: buildah-8gb
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb:0.2@sha256:1577d17d35acf1dfef8b29f59994c3cc2ca38d807e1464abe627081f7eb3d38b
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-8gb:0.2@sha256:6b727ecc0401f641175f60f141cc6841fe0764a321d187a61652332c2cc5823b
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/lightspeed-service-push.yaml
+++ b/.tekton/lightspeed-service-push.yaml
@@ -231,9 +231,9 @@ spec:
         taskRef:
           params:
             - name: name
-              value: buildah-6gb
+              value: buildah-8gb
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-6gb:0.2@sha256:1577d17d35acf1dfef8b29f59994c3cc2ca38d807e1464abe627081f7eb3d38b
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-8gb:0.2@sha256:6b727ecc0401f641175f60f141cc6841fe0764a321d187a61652332c2cc5823b
             - name: kind
               value: task
           resolver: bundles


### PR DESCRIPTION
## Description

Use buildah-8g task with higher memory limits

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #[OLS-757](https://issues.redhat.com//browse/OLS-757)
