### PR TITLE
OLS-855: Bump-up sentence-transformers to 3.0.1

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:fff3891bcedd22c63d70f1d4952eed372d16fdd42b6960bd67cb47b8aca7e421"
+content_hash = "sha256:70d06bc9343189fb73297e6191b0a82051fde0db29573071c850eeb002648903"
 
 [[package]]
 name = "absl-py"
@@ -2996,7 +2996,7 @@ files = [
 
 [[package]]
 name = "sentence-transformers"
-version = "2.7.0"
+version = "3.0.1"
 requires_python = ">=3.8.0"
 summary = "Multilingual text embeddings"
 groups = ["default"]
@@ -3011,8 +3011,8 @@ dependencies = [
     "transformers<5.0.0,>=4.34.0",
 ]
 files = [
-    {file = "sentence_transformers-2.7.0-py3-none-any.whl", hash = "sha256:6a7276b05a95931581bbfa4ba49d780b2cf6904fa4a171ec7fd66c343f761c98"},
-    {file = "sentence_transformers-2.7.0.tar.gz", hash = "sha256:2f7df99d1c021dded471ed2d079e9d1e4fc8e30ecb06f957be060511b36f24ea"},
+    {file = "sentence_transformers-3.0.1-py3-none-any.whl", hash = "sha256:01050cc4053c49b9f5b78f6980b5a72db3fd3a0abb9169b1792ac83875505ee6"},
+    {file = "sentence_transformers-3.0.1.tar.gz", hash = "sha256:8a3d2c537cc4d1014ccc20ac92be3d6135420a3bc60ae29a3a8a9b4bb35fbff6"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dependencies = [
     "uvicorn==0.30.1",
     "redis==5.0.7",
     "faiss-cpu==1.8.0.post1",
-    "sentence-transformers==2.7.0",
+    "sentence-transformers==3.0.1",
     "openai==1.42.0",
     "ibm-generative-ai==3.0.0",
     "ibm-cos-sdk==2.13.6",


### PR DESCRIPTION
## Description

Bump-up sentence-transformers to 3.0.1

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #[OLS-855](https://issues.redhat.com//browse/OLS-855)
