### PR TITLE
Bump-up Redis to 5.0.8

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:659093f44714c1d3100d2aa332375b56a0fa5663cba5f4424b2cff49e162707c"
+content_hash = "sha256:9d9090d2099cfa1f006e56500817d74bac2f1a9cdbcb196d40131e4df29b6cdd"
 
 [[package]]
 name = "absl-py"
@@ -2671,13 +2671,13 @@ files = [
 
 [[package]]
 name = "redis"
-version = "5.0.7"
+version = "5.0.8"
 requires_python = ">=3.7"
 summary = "Python client for Redis database and key-value store"
 groups = ["default"]
 files = [
-    {file = "redis-5.0.7-py3-none-any.whl", hash = "sha256:0e479e24da960c690be5d9b96d21f7b918a98c0cf49af3b6fafaa0753f93a0db"},
-    {file = "redis-5.0.7.tar.gz", hash = "sha256:8f611490b93c8109b50adc317b31bfd84fff31def3475b92e7e80bf39f48175b"},
+    {file = "redis-5.0.8-py3-none-any.whl", hash = "sha256:56134ee08ea909106090934adc36f65c9bcbbaecea5b21ba704ba6fb561f8eb4"},
+    {file = "redis-5.0.8.tar.gz", hash = "sha256:0c5b10d387568dfe0698c6fad6615750c24170e548ca2deac10c649d463e9870"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ dependencies = [
     "llama-index-vector-stores-faiss==0.1.2",
     "llama-index-embeddings-huggingface==0.2.2",
     "uvicorn==0.30.1",
-    "redis==5.0.7",
+    "redis==5.0.8",
     "faiss-cpu==1.8.0.post1",
     "sentence-transformers==3.0.1",
     "openai==1.42.0",


### PR DESCRIPTION
## Description

Bump-up Redis to 5.0.8

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
