### PR TITLE
increase max resp token default to 1024

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ OpenShift LightSpeed (OLS) is an AI powered assistant that runs on OpenShift and
        - `api_key`: path to secret (token) used to call LLM via REST API
        - `models`: list of models configuration (model name + model-specific parameters)
 
+            Notes: 
+            - `Context window size` varies based on provider/model.
+            - `Max response tokens` depends on user need and should be in reasonable proportion to context window size. If value is too less then there is a risk of response truncation. If we set it too high then we will reserve too much for response & truncate history/rag context unneccessarily.
+            - These are optional setting, if not set; then default will be used (which may be incorrect and may cause truncation & potentially error by exceeding context window).
+
    2. Specific configuration options for WatsonX
 
        - `project_id`: as specified on WatsonX AI page

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -77,11 +77,7 @@ class GenericLLMParameters:
 # Token related constants
 DEFAULT_CONTEXT_WINDOW_SIZE = 8192
 DEFAULT_MIN_TOKENS_FOR_RESPONSE = 1
-DEFAULT_MAX_TOKENS_FOR_RESPONSE = 512
-
-# Minimum tokens to have some meaningful RAG context including special tags.
-MINIMUM_CONTEXT_TOKEN_LIMIT = 10
-
+DEFAULT_MAX_TOKENS_FOR_RESPONSE = 1024
 
 # Provider and Model-specific context window size
 # see https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4
@@ -107,6 +103,7 @@ CONTEXT_WINDOW_SIZES = {
     PROVIDER_RHOAI_VLLM: {},
 }
 
+# Tokenizer model to generate tokens (for an approximated token calculation)
 DEFAULT_TOKENIZER_MODEL = "cl100k_base"
 
 # Example: 1.05 means we increase by 5%.
@@ -114,6 +111,9 @@ TOKEN_BUFFER_WEIGHT = 1.1
 
 
 # RAG related constants
+
+# Minimum tokens to have some meaningful RAG context including special tags.
+MINIMUM_CONTEXT_TOKEN_LIMIT = 10
 
 # This is used to decide how many matching chunks we want to retrieve as context.
 # (in descending order of similarity between query & chunk)

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -909,7 +909,8 @@ def test_provider_model_specific_tokens_limit(provider_name, model_name):
 @pytest.mark.parametrize("model_name", models)
 def test_provider_config_explicit_tokens(model_name):
     """Test the ProviderConfig model when explicit tokens are specified."""
-    context_window_size = 550
+    # Note: context window should be >= 1024 (default) response token limit
+    context_window_size = 1025
 
     provider_config = ProviderConfig(
         {


### PR DESCRIPTION
## Description

Increase max resp token default to 1024. YAML in response may take more tokens, so increasing from 512.

This is just a default value; it is recommended to use correct context window and reasonable response token based on model & use.