### PR TITLE
eval: add alternate eval3 ans for openai

### DIFF
--- a/scripts/evaluation/eval_data/question_answer_pair.json
+++ b/scripts/evaluation/eval_data/question_answer_pair.json
@@ -116,7 +116,9 @@
                     ]
                 },
                 "openai+gpt-3.5-turbo+with_rag": {
+                    "cutoff_score": 0.25,
                     "text": [
+                        "In Red Hat OpenShift Container Platform, the imagePullPolicy is used to determine if the container image should be pulled prior to starting the container. This policy helps control when and how images are fetched for containers within a pod. The purpose of the imagePullPolicy is to ensure that containers have access to the correct version of an image when they start running.",
                         "The purpose of the imagePullPolicy in Red Hat OpenShift Container Platform is to determine if the container image should be pulled prior to starting the container. This policy helps control when and how images are fetched for containers within a pod. The imagePullPolicy can have three possible values: Always, IfNotPresent, or Never. If the parameter is not specified, OpenShift sets it based on the image tag: \n- If the tag is \"latest,\" OpenShift defaults imagePullPolicy to Always.\n- Otherwise, OpenShift defaults imagePullPolicy to IfNotPresent."
                     ]
                 },


### PR DESCRIPTION
## Description

add alternate eval3 ans for openai (4.15)

[Reference](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_lightspeed-service/1512/pull-ci-openshift-lightspeed-service-main-e2e-ols-cluster-4-15/1830855746502266880)
[Reference](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_lightspeed-service/1534/pull-ci-openshift-lightspeed-service-main-e2e-ols-cluster-4-15/1831224066074218496)