### PR TITLE
Bump-up pytest-asyncio to 0.24.0

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:5935203d8c725c407270b28287f547560f387c7f954c0060a74dee9f21698b2f"
+content_hash = "sha256:9d0caf41306e742ea7aaac60a2e2233fb40f3ba334c4c2e14cb17bcfbdc7b53c"
 
 [[package]]
 name = "absl-py"
@@ -1165,7 +1165,7 @@ name = "iniconfig"
 version = "2.0.0"
 requires_python = ">=3.7"
 summary = "brain-dead simple config-ini parsing"
-groups = ["default", "dev"]
+groups = ["dev"]
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
@@ -2408,7 +2408,7 @@ name = "pluggy"
 version = "1.5.0"
 requires_python = ">=3.8"
 summary = "plugin and hook calling mechanisms for python"
-groups = ["default", "dev"]
+groups = ["dev"]
 files = [
     {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
     {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
@@ -2673,7 +2673,7 @@ name = "pytest"
 version = "8.3.2"
 requires_python = ">=3.8"
 summary = "pytest: simple powerful testing with Python"
-groups = ["default", "dev"]
+groups = ["dev"]
 dependencies = [
     "iniconfig",
     "packaging",
@@ -2686,16 +2686,16 @@ files = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.23.7"
+version = "0.24.0"
 requires_python = ">=3.8"
 summary = "Pytest support for asyncio"
-groups = ["default", "dev"]
+groups = ["dev"]
 dependencies = [
-    "pytest<9,>=7.0.0",
+    "pytest<9,>=8.2",
 ]
 files = [
-    {file = "pytest_asyncio-0.23.7-py3-none-any.whl", hash = "sha256:009b48127fbe44518a547bddd25611551b0e43ccdbf1e67d12479f569832c20b"},
-    {file = "pytest_asyncio-0.23.7.tar.gz", hash = "sha256:5f5c72948f4c49e7db4f29f2521d4031f1c27f86e57b046126654083d4770268"},
+    {file = "pytest_asyncio-0.24.0-py3-none-any.whl", hash = "sha256:a811296ed596b69bf0b6f3dc40f83bcaf341b155a269052d82efa2b25ac7037b"},
+    {file = "pytest_asyncio-0.24.0.tar.gz", hash = "sha256:d081d828e576d85f875399194281e92bf8a68d60d72d1a2faf2feddb6c46b276"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
     "mypy==1.11.2",
     "pytest==8.3.2",
     "pytest-cov==5.0.0",
-    "pytest-asyncio==0.23.7",
+    "pytest-asyncio==0.24.0",
     "pydantic==2.8.2",
     "rouge-score==0.1.2",  # Required for model evaluation
     "ruff==0.6.2",
@@ -95,7 +95,6 @@ dependencies = [
     "setuptools==72.1.0",
     "prometheus-client==0.20.0",
     "kubernetes==30.1.0",
-    "pytest-asyncio==0.23.7",
     "psycopg2-binary==2.9.9",
     "azure-identity==1.17.1",
     "langchain-community==0.2.10",


### PR DESCRIPTION
## Description

Bump-up pytest-asyncio to 0.24.0

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
- [x] Bump-up library or tool used for development (does not change the final image)
