### PR TITLE
Refactor: disable meaningless warnings

### DIFF
--- a/tests/benchmarks/test_attachment_appender.py
+++ b/tests/benchmarks/test_attachment_appender.py
@@ -1,5 +1,7 @@
 """Bencharks for attachment appender."""
 
+# pylint: disable=W0621
+
 import pytest
 
 from ols.app.models.models import Attachment

--- a/tests/benchmarks/test_docs_summarizer.py
+++ b/tests/benchmarks/test_docs_summarizer.py
@@ -1,5 +1,7 @@
 """Benchmarks for DocsSummarizer class."""
 
+# pylint: disable=W0621
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/benchmarks/test_prompt_generator.py
+++ b/tests/benchmarks/test_prompt_generator.py
@@ -1,5 +1,7 @@
 """Benchmarks for PromptGenerator."""
 
+# pylint: disable=W0621
+
 import pytest
 
 from ols.constants import (

--- a/tests/benchmarks/test_redactor.py
+++ b/tests/benchmarks/test_redactor.py
@@ -1,5 +1,7 @@
 """Benchmarks for the question filter."""
 
+# pylint: disable=W0621
+
 import re
 
 import pytest


### PR DESCRIPTION
## Description

Disable meaningless warnings (linters are too dumb to figure out we pass fixtures)

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
