### PR TITLE
OLS-1004: Use single default value for context window

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -141,15 +141,11 @@ class ModelConfig(BaseModel):
             data, constants.CREDENTIALS_PATH_SELECTOR, constants.API_TOKEN_FILENAME
         )
 
-        # if the context window size is not set explicitly, use value
-        # set for given provider + model, or default value for model without
-        # size setup (note that at this stage, provider is always correct)
-        default = constants.DEFAULT_CONTEXT_WINDOW_SIZE
-        if data.get("provider") in constants.CONTEXT_WINDOW_SIZES:
-            default = constants.CONTEXT_WINDOW_SIZES.get(data["provider"]).get(
-                data["name"] or "", constants.DEFAULT_CONTEXT_WINDOW_SIZE
-            )
-        data["context_window_size"] = data.get("context_window_size", default)
+        # if the context window size is not set explicitly, use default value.
+        # Note that it is important to set a correct value; default may not be accurate.
+        data["context_window_size"] = data.get(
+            "context_window_size", constants.DEFAULT_CONTEXT_WINDOW_SIZE
+        )
         return data
 
     @field_validator("options")

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -77,34 +77,20 @@ class GenericLLMParameters:
 
 
 # Token related constants
+
+# It is important to set correct context window, otherwise there will be potential
+# error due to context window limit or unnecessary truncation may happen.
+# For Provider and Model-specific context window size, Please refer
+# their official documentations. If not set, default value will be used.
 DEFAULT_CONTEXT_WINDOW_SIZE = 8192
-DEFAULT_MIN_TOKENS_FOR_RESPONSE = 1
+
+# Max tokens reserved for response may also vary depending upon provider/model & query.
+# Ex: Larger models tends give more descriptive response,
+# Also response with YAML generally uses more tokens (when large model is used)
+# It should be in reasonable proportion to context window limit; otherwise unnecessary
+# truncation will happen. If not set, default value will be used.
 DEFAULT_MAX_TOKENS_FOR_RESPONSE = 1024
 
-# Provider and Model-specific context window size
-# see https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4
-# and https://www.ibm.com/docs/en/cloud-paks/cp-data/4.8.x?topic=models-supported-foundation
-CONTEXT_WINDOW_SIZES = {
-    PROVIDER_BAM: {
-        GRANITE_13B_CHAT_V2: 8192,
-    },
-    PROVIDER_WATSONX: {
-        GRANITE_13B_CHAT_V2: 8192,
-    },
-    PROVIDER_AZURE_OPENAI: {
-        GPT4_TURBO: 128000,
-        GPT35_TURBO: 16384,
-    },
-    PROVIDER_OPENAI: {
-        GPT4_TURBO: 128000,
-        GPT35_TURBO: 16384,
-    },
-    PROVIDER_FAKE: {
-        FAKE_MODEL: DEFAULT_CONTEXT_WINDOW_SIZE,
-    },
-    PROVIDER_RHOAI_VLLM: {},
-    PROVIDER_RHELAI_VLLM: {},
-}
 
 # Tokenizer model to generate tokens (for an approximated token calculation)
 DEFAULT_TOKENIZER_MODEL = "cl100k_base"

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -963,14 +963,9 @@ def test_provider_model_specific_tokens_limit(provider_name, model_name):
             ],
         }
     )
-    # expected token limit for given model
+    # expected token limit for given model, default is used if not set.
     expected_limit = constants.DEFAULT_CONTEXT_WINDOW_SIZE
 
-    # some provider+model combinations are not specified; in this case
-    # default value is used instead
-    expected_limit = constants.CONTEXT_WINDOW_SIZES.get(provider_name).get(
-        model_name, constants.DEFAULT_CONTEXT_WINDOW_SIZE
-    )
     assert provider_config.models[model_name].context_window_size == expected_limit
     if model_name == "test":
         assert (


### PR DESCRIPTION
## Description

Use single default value for context window; instead of maintaining values for all potential provider/model..

The value keeps on changing with different version (ex: azure/gpt3.5). So It is hard to maintain in-terms of code. Also we may still set an inaccurate value.