### PR TITLE
eval: cutoff increase for eval6 - openai

### DIFF
--- a/scripts/evaluation/eval_data/question_answer_pair.json
+++ b/scripts/evaluation/eval_data/question_answer_pair.json
@@ -210,6 +210,7 @@
                     ]
                 },
                 "openai+gpt-3.5-turbo+with_rag": {
+                    "cutoff_score": 0.25,
                     "text": [
                         "The purpose of the Vertical Pod Autoscaler (VPA) Operator in OpenShift is to automatically adjust the resource requests for pods based on their actual usage. By installing the VPA Operator, you enable dynamic resource allocation for pods, ensuring that they have adequate resources to run efficiently without over-provisioning. This helps optimize resource utilization and improve application performance within an OpenShift cluster.",
                         "The Vertical Pod Autoscaler Operator in OpenShift is used to automatically adjust the resource requests for pods based on their actual usage. It helps optimize resource allocation by dynamically adjusting CPU and memory requests for containers within pods, ensuring that they have adequate resources to run efficiently without being over-provisioned. This optimization can lead to better performance and resource utilization within the cluster."


### PR DESCRIPTION
## Description

cutoff increase for eval6 - openai (due to randomness in response)
[Reference](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_lightspeed-service/1572/pull-ci-openshift-lightspeed-service-main-e2e-ols-cluster-4-16/1833511097504632832)

Note:
Now this issue has become more frequent..
Potentially we can move to 4o-mini or have a larger cut-off for openai..
Also there is discussion to remove this check completely.
I will create relevant stories.