### PR TITLE
OLS-1032: Bump-up certify package to 2024.7.30

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:355a16a3176d82fc32d8b270186c10420878b2ad0cafb6fe798f39b08100c60a"
+content_hash = "sha256:48c89e492c4700830bc7f6854972a7b3b4d876110bed7a7515008b1fdac064c8"
 
 [[package]]
 name = "absl-py"
@@ -289,13 +289,13 @@ files = [
 
 [[package]]
 name = "certifi"
-version = "2024.7.4"
+version = "2024.8.30"
 requires_python = ">=3.6"
 summary = "Python package for providing Mozilla's CA Bundle."
 groups = ["default", "dev"]
 files = [
-    {file = "certifi-2024.7.4-py3-none-any.whl", hash = "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"},
-    {file = "certifi-2024.7.4.tar.gz", hash = "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b"},
+    {file = "certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"},
+    {file = "certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ dependencies = [
     "SQLAlchemy==2.0.32",
     "huggingface_hub==0.23.4",
     "ibm-watsonx-ai==1.1.8",
-    "certifi==2024.7.4",
+    "certifi==2024.8.30",
     "cryptography==43.0.1",
     "urllib3==2.2.2",
     "nltk==3.9.1",


### PR DESCRIPTION
## Description

Bump-up certify package to 2024.7.30

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #[OLS-1032](https://issues.redhat.com//browse/OLS-1032)
