### PR TITLE
Refactor: parens not needed after `not` operator - it has low precendence

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -542,7 +542,7 @@ class PostgresConfig(BaseModel):
     @model_validator(mode="after")
     def validate_yaml(self) -> Self:
         """Validate Postgres cache config."""
-        if not (0 < self.port < 65536):
+        if not 0 < self.port < 65536:
             raise ValueError("The port needs to be between 0 and 65536")
         return self
 
@@ -570,7 +570,7 @@ class RedisConfig(BaseModel):
         yaml_port = data.get("port", constants.REDIS_CACHE_PORT)
         try:
             self.port = int(yaml_port)
-            if not (0 < self.port < 65536):
+            if not 0 < self.port < 65536:
                 raise ValueError
         except ValueError:
             raise InvalidConfigurationError(

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -337,7 +337,7 @@ class FeedbackRequest(BaseModel):
     @classmethod
     def check_uuid(cls, value: str) -> str:
         """Check if conversation ID has the proper format."""
-        if not (suid.check_suid(value)):
+        if not suid.check_suid(value):
             raise ValueError(f"Improper conversation ID {value}")
         return value
 

--- a/scripts/upload_artifact_s3.py
+++ b/scripts/upload_artifact_s3.py
@@ -16,8 +16,8 @@ import os
 import boto3
 from botocore.exceptions import ClientError
 
-path = "."
-extension = ".tar.gz"
+PATH = "."
+EXTENSION = ".tar.gz"
 
 
 def upload_artifact_s3(aws_env):
@@ -35,8 +35,8 @@ def upload_artifact_s3(aws_env):
     )
 
     file_name = None
-    for file in os.listdir(path):
-        if file.endswith(extension):
+    for file in os.listdir(PATH):
+        if file.endswith(EXTENSION):
             file_name = file
 
     if file_name is not None:


### PR DESCRIPTION
## Description

Refactor: parens not needed after `not` operator - it has low precendence

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
