### PR TITLE
OLS-1032: Bump-up FastAPI to 0.114.2

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:9b0cb3b97e92dd2fbdcdc532ba3ea691e676a3f92747d2b9b51a02558ae3d930"
+content_hash = "sha256:167963f42324e5489d4d682453cbdc6bda6f685ce73ec6ac78f2b34f5e48f741"
 
 [[package]]
 name = "absl-py"
@@ -602,7 +602,7 @@ files = [
 
 [[package]]
 name = "fastapi"
-version = "0.112.2"
+version = "0.114.2"
 requires_python = ">=3.8"
 summary = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 groups = ["default", "dev"]
@@ -612,8 +612,8 @@ dependencies = [
     "typing-extensions>=4.8.0",
 ]
 files = [
-    {file = "fastapi-0.112.2-py3-none-any.whl", hash = "sha256:db84b470bd0e2b1075942231e90e3577e12a903c4dc8696f0d206a7904a7af1c"},
-    {file = "fastapi-0.112.2.tar.gz", hash = "sha256:3d4729c038414d5193840706907a41839d839523da6ed0c2811f1168cac1798c"},
+    {file = "fastapi-0.114.2-py3-none-any.whl", hash = "sha256:44474a22913057b1acb973ab90f4b671ba5200482e7622816d79105dcece1ac5"},
+    {file = "fastapi-0.114.2.tar.gz", hash = "sha256:0adb148b62edb09e8c6eeefa3ea934e8f276dabc038c5a82989ea6346050c3da"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
     "pdm==2.18.1",
     "torch==2.4.1",
     "pandas==2.1.4",
-    "fastapi==0.112.2",
+    "fastapi==0.114.2",
     "langchain==0.2.16",
     "langchain-ibm==0.1.12",
     "llama-index==0.10.62",


### PR DESCRIPTION
## Description

Bump-up FastAPI to 0.114.2

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #[OLS-1032](https://issues.redhat.com//browse/OLS-1032)
