### PR TITLE
Make cache content a binary buffer before insertion into a bytea field in Postgres

### DIFF
--- a/ols/src/cache/postgres_cache.py
+++ b/ols/src/cache/postgres_cache.py
@@ -150,14 +150,14 @@ class PostgresCache(Cache):
                         cursor,
                         user_id,
                         conversation_id,
-                        json.dumps(old_value),
+                        json.dumps(old_value).encode("utf-8"),
                     )
                 else:
                     PostgresCache._insert(
                         cursor,
                         user_id,
                         conversation_id,
-                        json.dumps([value]),
+                        json.dumps([value]).encode("utf-8"),
                     )
                     PostgresCache._cleanup(cursor, self.capacity)
                 # commit is implicit at this point

--- a/tests/unit/cache/test_postgres_cache.py
+++ b/tests/unit/cache/test_postgres_cache.py
@@ -14,8 +14,8 @@ from ols.utils import suid
 
 user_id = suid.get_suid()
 conversation_id = suid.get_suid()
-cache_entry_1 = CacheEntry(query="user message1", response="ai message1")
-cache_entry_2 = CacheEntry(query="user message2", response="ai message2")
+cache_entry_1 = CacheEntry(query="用户消息", response="人工智能信息")
+cache_entry_2 = CacheEntry(query="user message", response="ai message")
 
 
 @patch("psycopg2.connect")
@@ -152,7 +152,7 @@ def test_insert_or_append_operation(mock_connect):
         ),
         call(
             PostgresCache.INSERT_CONVERSATION_HISTORY_STATEMENT,
-            (user_id, conversation_id, conversation),
+            (user_id, conversation_id, conversation.encode("utf-8")),
         ),
         call(PostgresCache.QUERY_CACHE_SIZE),
     ]
@@ -194,7 +194,7 @@ def test_insert_or_append_operation_append_item(mock_connect):
         ),
         call(
             PostgresCache.UPDATE_CONVERSATION_HISTORY_STATEMENT,
-            (new_conversation, user_id, conversation_id),
+            (new_conversation.encode("utf-8"), user_id, conversation_id),
         ),
     ]
     mock_cursor.execute.assert_has_calls(calls, any_order=True)


### PR DESCRIPTION
## Description

Fix for the "invalid input syntax for type bytea at character XXX" Postgres error.
Make cache content a binary buffer before insertion into a bytea field in Postgres.
This follows https://www.psycopg.org/docs/usage.html#index-8.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/OLS-438
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
