### PR TITLE
feedback.py: Don't use f-strings in logger

### DIFF
--- a/ols/app/endpoints/feedback.py
+++ b/ols/app/endpoints/feedback.py
@@ -73,7 +73,7 @@ def store_feedback(user_id: str, feedback: dict) -> None:
     with open(feedback_file_path, "w", encoding="utf-8") as feedback_file:
         json.dump(data_to_store, feedback_file)
 
-    logger.debug(f"feedback stored in '{feedback_file_path}'")
+    logger.debug("feedback stored in '%s'", feedback_file_path)
 
 
 @router.get("/status")
@@ -132,7 +132,7 @@ def store_user_feedback(
     try:
         store_feedback(user_id, feedback_request.model_dump(exclude={"model_config"}))
     except Exception as e:
-        logger.error(f"Error storing user feedback: {e}")
+        logger.error("Error storing user feedback: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={


### PR DESCRIPTION
## Description

`feedback.py`: Don't use f-strings in logger

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
