### PR TITLE
Keep exception context when raising new one

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -572,10 +572,10 @@ class RedisConfig(BaseModel):
             self.port = int(yaml_port)
             if not 0 < self.port < 65536:
                 raise ValueError
-        except ValueError:
+        except ValueError as e:
             raise InvalidConfigurationError(
                 f"invalid Redis port {yaml_port}, valid ports are integers in the (0, 65536) range"
-            )
+            ) from e
 
         self.max_memory = data.get("max_memory", constants.REDIS_CACHE_MAX_MEMORY)
 
@@ -644,11 +644,11 @@ class InMemoryCacheConfig(BaseModel):
             )
             if self.max_entries < 0:
                 raise ValueError
-        except ValueError:
+        except ValueError as e:
             raise InvalidConfigurationError(
                 "invalid max_entries for memory conversation cache,"
                 " max_entries needs to be a non-negative integer"
-            )
+            ) from e
 
     def __eq__(self, other: object) -> bool:
         """Compare two objects for equality."""
@@ -678,10 +678,10 @@ class QueryFilter(BaseModel):
             self.replace_with = data.get("replace_with")
             if self.name is None or self.pattern is None or self.replace_with is None:
                 raise ValueError
-        except ValueError:
+        except ValueError as e:
             raise InvalidConfigurationError(
                 "name, pattern and replace_with need to be specified"
-            )
+            ) from e
 
     def __eq__(self, other: object) -> bool:
         """Compare two objects for equality."""
@@ -701,8 +701,8 @@ class QueryFilter(BaseModel):
             raise InvalidConfigurationError("pattern is missing")
         try:
             re.compile(self.pattern)
-        except re.error:
-            raise InvalidConfigurationError("pattern is invalid")
+        except re.error as e:
+            raise InvalidConfigurationError("pattern is invalid") from e
         if self.replace_with is None:
             raise InvalidConfigurationError("replace_with is missing")
 


### PR DESCRIPTION
## Description

Keep exception context when raising new one

Why:
Python's exception chaining shows the traceback of the current exception, but also of the original exception. When you raise a new exception after another exception was caught it's likely that the second exception is a friendly re-wrapping of the first exception. In such cases `raise from` provides a better link between the two tracebacks in the final error.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
