### PR TITLE
OLS-1085: Show PDM version on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ install-tools:	install-woke ## Install required utilities/tools
 	# OLS 1085: Service build failure issue caused by newest PDM version
 	# (right now we need to stick to PDM specified in pyproject.toml file)
 	@command -v pdm > /dev/null || { echo >&2 "pdm is not installed. Installing..."; pip install pdm==2.18.1; }
+	# make sure the installed PDM is also the one to be called
+	pdm --version
 	# this is quick fix for OLS-758: "Verify" CI job is broken after new Mypy 1.10.1 was released 2 days ago
 	# CI job configuration would need to be updated in follow-up task
 	# pip uninstall -y mypy 2> /dev/null || true


### PR DESCRIPTION
## Description

Show PDM version on CI

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1085](https://issues.redhat.com//browse/OLS-1085)
