### PR TITLE
OLS-1065: fix e2e test to pull unreleased component images

### DIFF
--- a/tests/config/operator_install/imagedigestmirrorset.yaml
+++ b/tests/config/operator_install/imagedigestmirrorset.yaml
@@ -1,0 +1,19 @@
+# The images are pulled from our redhat-user-workloads registry or staging registry while the production image is not yet available.
+kind: ImageDigestMirrorSet
+apiVersion: config.openshift.io/v1
+metadata:
+  name: openshift-lightspeed-prod-to-ci
+spec:
+  imageDigestMirrors:
+    - source: registry.redhat.io/openshift-lightspeed-beta/lightspeed-rhel9-operator
+      mirrors:
+        - quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator
+    - source: registry.redhat.io/openshift-lightspeed-beta/lightspeed-operator-bundle
+      mirrors:
+        - quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/bundle
+    - source: registry.redhat.io/openshift-lightspeed-beta/lightspeed-service-api-rhel9
+      mirrors:
+        - quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service
+    - source: registry.redhat.io/openshift-lightspeed-beta/lightspeed-console-plugin-rhel9
+      mirrors:
+        - quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -84,6 +84,13 @@ def install_ols() -> tuple[str, str, str]:
     token = cluster_utils.get_token_for("test-user")
     metrics_token = cluster_utils.get_token_for("metrics-test-user")
     print("created test service account users")
+    
+    # install the ImageDigestMirrorSet to mirror images from "registry.redhat.io/openshift-lightspeed-beta" 
+    # to "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols"
+    cluster_utils.run_oc(
+        ["create", "-f", "tests/config/operator_install/imagedigestmirrorset.yaml"],
+        ignore_existing_resource=True,
+    )
 
     # install the operator catalog
     cluster_utils.run_oc(

--- a/tests/scripts/utils.sh
+++ b/tests/scripts/utils.sh
@@ -37,6 +37,9 @@ function cleanup_ols_operator() {
 
     # delete the OLS namespace
     oc delete --wait --ignore-not-found ns openshift-lightspeed
+
+    # delete the ImageDigestMirrorSet
+    oc delete --wait --ignore-not-found imagedigestmirrorset/openshift-lightspeed-prod-to-ci
 }
 
 # $1 suite id


### PR DESCRIPTION
add ImageDigestMirrorSet to allow using bundle from unreleased images

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # [OLS-1065](https://issues.redhat.com/browse/OLS-1065)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
