### PR TITLE
OLS-1067 config: add api_version required for azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Depends on configuration, but usually it is not needed to generate or use API ke
 
    3. Specific configuration options for Azure OpenAI
 
+       - `api_version`: as specified in official documentation, if not set; by default `2024-02-15-preview` is used.
        - `deployment_name`: as specified in AzureAI project settings
 
    4. Default provider and default model

--- a/examples/olsconfig.yaml
+++ b/examples/olsconfig.yaml
@@ -19,6 +19,7 @@ llm_providers:
     type: azure_openai
     url: "https://myendpoint.openai.azure.com/"
     credentials_path: azure_openai_api_key.txt
+    api_version: "2024-02-15-preview"
     deployment_name: my_azure_openai_deployment_name
     models:
       - name: gpt-3.5-turbo

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -276,6 +276,7 @@ class ProviderConfig(BaseModel):
     credentials: Optional[str] = None
     project_id: Optional[str] = None
     models: dict[str, ModelConfig] = {}
+    api_version: Optional[str] = None
     deployment_name: Optional[str] = None
     openai_config: Optional[OpenAIConfig] = None
     azure_config: Optional[AzureOpenAIConfig] = None
@@ -321,6 +322,9 @@ class ProviderConfig(BaseModel):
         self.setup_models_config(data)
 
         if self.type == constants.PROVIDER_AZURE_OPENAI:
+            self.api_version = data.get(
+                "api_version", constants.DEFAULT_AZURE_API_VERSION
+            )
             # deployment_name only required when using Azure OpenAI
             self.deployment_name = data.get("deployment_name", None)
             # note: it can be overwritten in azure_config

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -45,6 +45,8 @@ SUPPORTED_PROVIDER_TYPES = frozenset(
     }
 )
 
+DEFAULT_AZURE_API_VERSION = "2024-02-15-preview"
+
 # models
 
 

--- a/ols/src/llms/providers/azure_openai.py
+++ b/ols/src/llms/providers/azure_openai.py
@@ -48,6 +48,7 @@ class AzureOpenAI(LLMProvider):
         """Default LLM params."""
         self.url = str(self.provider_config.url or self.url)
         self.credentials = self.provider_config.credentials
+        api_version = self.provider_config.api_version
         deployment_name = self.provider_config.deployment_name
         azure_config = self.provider_config.azure_config
 
@@ -60,7 +61,7 @@ class AzureOpenAI(LLMProvider):
 
         default_parameters = {
             "azure_endpoint": self.url,
-            "api_version": "2024-02-15-preview",
+            "api_version": api_version,
             "deployment_name": deployment_name,
             "model": self.model,
             "model_kwargs": {

--- a/tests/config/valid_config_with_azure_openai_api_version.yaml
+++ b/tests/config/valid_config_with_azure_openai_api_version.yaml
@@ -5,7 +5,7 @@ llm_providers:
     url: "https://url1"
     deployment_name: "test"
     credentials_path": tests/config/secret/apitoken
-    api_version: 2024-12-31
+    api_version: "2024-12-31"
     azure_openai_config:
       url: "http://localhost:1234"
       deployment_name: "*deployment name*"

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -448,6 +448,9 @@ def test_provider_config_azure_openai_specific():
             ],
         }
     )
+    # Default azure api version
+    assert provider_config.api_version == constants.DEFAULT_AZURE_API_VERSION
+
     # Azure OpenAI-specific configuration must be present
     assert provider_config.azure_config is not None
     assert str(provider_config.azure_config.url) == "http://localhost/"
@@ -477,6 +480,7 @@ def test_provider_config_apitoken_only():
             "name": "test_name",
             "type": "azure_openai",
             "url": "test_url",
+            "api_version": "2024-02-15",
             "azure_openai_config": {
                 "url": "http://localhost",
                 "credentials_path": "tests/config/secret/apitoken",
@@ -490,6 +494,9 @@ def test_provider_config_apitoken_only():
             ],
         }
     )
+    # Azure version is set from config
+    assert provider_config.api_version == "2024-02-15"
+
     # Azure OpenAI-specific configuration must be present
     assert provider_config.azure_config is not None
     assert str(provider_config.azure_config.url) == "http://localhost/"
@@ -777,6 +784,8 @@ def test_provider_config_watsonx_specific():
     assert provider_config.azure_config is None
     assert provider_config.openai_config is None
     assert provider_config.bam_config is None
+
+    assert provider_config.api_version is None
 
 
 def test_provider_config_watsonx_unknown_parameters():

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -1103,6 +1103,10 @@ def test_valid_config_with_azure_openai():
             }
         )
         assert config.config == expected_config
+        assert (
+            config.config.llm_providers.providers.get("p1").api_version
+            == constants.DEFAULT_AZURE_API_VERSION
+        )
     except Exception as e:
         print(traceback.format_exc())
         pytest.fail(f"loading valid configuration failed: {e}")
@@ -1210,6 +1214,9 @@ def test_valid_config_with_azure_openai_api_version():
             }
         )
         assert config.config == expected_config
+        assert (
+            config.config.llm_providers.providers.get("p1").api_version == "2024-12-31"
+        )
     except Exception as e:
         print(traceback.format_exc())
         pytest.fail(f"loading valid configuration failed: {e}")
@@ -1260,6 +1267,7 @@ def test_valid_config_with_bam():
             }
         )
         assert config.config == expected_config
+        assert config.config.llm_providers.providers.get("p1").api_version is None
     except Exception as e:
         print(traceback.format_exc())
         pytest.fail(f"loading valid configuration failed: {e}")


### PR DESCRIPTION
## Description

Add api_version to be configurable [Optional]. This is currently required for azure. Default version is used when it is not set for azure.