### PR TITLE
OLS-1088: More verbose e2e tests setup + increased `oc` command wait time

### DIFF
--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -284,9 +284,13 @@ def install_ols() -> tuple[str, str, str]:
     if not r:
         print("Timed out waiting for new OLS pod to be ready")
         return None
+
+    print("-" * 50)
+    print("OLS pod seems to be ready")
     print(cluster_utils.run_oc(["get", "pods"]).stdout)
     pod_name = cluster_utils.get_pod_by_prefix()[0]
-    print(f"Found new OLS pod {pod_name}")
+    print(f"Found new running OLS pod {pod_name}")
+    print("-" * 50)
 
     # Print the deployment so we can confirm the configuration is what we
     # expect it to be (must-gather will also collect this)
@@ -295,6 +299,7 @@ def install_ols() -> tuple[str, str, str]:
             ["get", "deployment", "lightspeed-app-server", "-o", "yaml"]
         ).stdout
     )
+    print("-" * 50)
 
     # disable collector script by default to avoid running during all
     # tests (collecting/sending data)


### PR DESCRIPTION
- More verbose e2e tests setup for easier debugging
- Increased `oc` command wait time

Fixes issue #[OLS-1088](https://issues.redhat.com//browse/OLS-1088)