### PR TITLE
OLS-1105: Pydocstyle as devel dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ install-tools:	install-woke ## Install required utilities/tools
 	black --version
 	# check that correct Ruff version is installed
 	ruff --version
+	# check that correct Pydocstyle version is installed
+	pydocstyle --version
 
 
 install-woke: ## Install woke, required for Inclusive Naming scan

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:adef69c82a265b051936b668df9da1d97ef7486607a24388ad38e8d33a8b2e53"
+content_hash = "sha256:cf9e46aa119e29d74d1c45b1016000815bc64152ca8927bd07389d0972c12b21"
 
 [[package]]
 name = "absl-py"
@@ -2398,6 +2398,20 @@ files = [
 ]
 
 [[package]]
+name = "pydocstyle"
+version = "6.3.0"
+requires_python = ">=3.6"
+summary = "Python docstring style checker"
+groups = ["dev"]
+dependencies = [
+    "snowballstemmer>=2.2.0",
+]
+files = [
+    {file = "pydocstyle-6.3.0-py3-none-any.whl", hash = "sha256:118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019"},
+    {file = "pydocstyle-6.3.0.tar.gz", hash = "sha256:7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1"},
+]
+
+[[package]]
 name = "pydub"
 version = "0.25.1"
 summary = "Manipulate audio with an simple and easy high level interface"
@@ -2983,6 +2997,16 @@ groups = ["default", "dev"]
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
+name = "snowballstemmer"
+version = "2.2.0"
+summary = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
+groups = ["dev"]
+files = [
+    {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
+    {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ distribution = false
 [tool.pdm.dev-dependencies]
 dev = [
     "black==24.8.0",
+    "pydocstyle==6.3.0",
     "fastparquet==2024.5.0",  # Required for model evaluation (runtime, if parquet qna file is used)
     "httpx==0.27.0",
     "mypy==1.11.2",


### PR DESCRIPTION
## Description

Pydocstyle as devel dependency

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [x] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1105](https://issues.redhat.com//browse/OLS-1105)
