### PR TITLE
Removing the get from the checks if the resources exist

### DIFF
--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -150,6 +150,16 @@ def install_ols() -> tuple[str, str, str]:
 
     # create the llm api key secret ols will mount
     keypath = os.getenv("PROVIDER_KEY_PATH")
+    try:
+        cluster_utils.run_oc(
+            [
+                "delete",
+                "secret",
+                "llmcreds",
+            ],
+        )
+    except subprocess.CalledProcessError:
+        print("llmcreds secret does not yet exist. Creating it.")
     cluster_utils.run_oc(
         [
             "create",
@@ -177,6 +187,17 @@ def install_ols() -> tuple[str, str, str]:
         )
 
     # create the olsconfig operand
+    try:
+        cluster_utils.run_oc(
+            [
+                "delete",
+                "olsconfig",
+                "cluster",
+            ],
+        )
+    except subprocess.CalledProcessError:
+        print("olsconfig does not yet exist. Creating it.")
+
     cluster_utils.run_oc(
         [
             "create",

--- a/tests/e2e/utils/cluster.py
+++ b/tests/e2e/utils/cluster.py
@@ -79,9 +79,14 @@ def get_cluster_version() -> tuple[str, str]:
 def create_user(name: str, ignore_existing_resource=False) -> None:
     """Create a service account user for testing."""
     try:
-        run_oc(
-            ["create", "sa", name], ignore_existing_resource=ignore_existing_resource
-        )
+        try:
+            run_oc(["get", "sa", name])
+            print("Service account %s already exists", name)
+        except subprocess.CalledProcessError:
+            run_oc(
+                ["create", "sa", name],
+                ignore_existing_resource=ignore_existing_resource,
+            )
     except subprocess.CalledProcessError as e:
         raise Exception("Error creating service account") from e
 


### PR DESCRIPTION
We can just try to delete since we have the error catch underneath.