### PR TITLE
eval: increase default cut-off

### DIFF
--- a/scripts/evaluation/utils/constants.py
+++ b/scripts/evaluation/utils/constants.py
@@ -47,4 +47,4 @@ REST_API_TIMEOUT = 120
 TIME_TO_BREATH = 10
 
 # Cut-off similarity score used for response evaluation.
-EVAL_THRESHOLD = 0.2  # low score is better
+EVAL_THRESHOLD = 0.3  # low score is better


### PR DESCRIPTION
## Description

eval default cut-off increase.

[Reference](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_lightspeed-service/1736/pull-ci-openshift-lightspeed-service-main-e2e-ols-cluster-4-17/1844367918855360512)