### PR TITLE
OLS-1121: Ability to read system prompt from configuration

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -880,6 +880,8 @@ class OLSConfig(BaseModel):
     reference_content: Optional[ReferenceContent] = None
     authentication_config: AuthenticationConfig = AuthenticationConfig()
     tls_config: TLSConfig = TLSConfig()
+    system_prompt_path: Optional[str] = None
+    system_prompt: Optional[str] = None
 
     default_provider: Optional[str] = None
     default_model: Optional[str] = None
@@ -921,6 +923,10 @@ class OLSConfig(BaseModel):
         self.user_data_collection = UserDataCollection(
             **data.get("user_data_collection", {})
         )
+        # read file containing system prompt
+        # if not specified, the prompt will remain None, which will be handled
+        # by system prompt infrastructure
+        self.system_prompt = _get_attribute_from_file(data, "system_prompt_path")
 
         self.extra_ca = data.get("extra_ca", [])
         self.certificate_directory = data.get(
@@ -940,6 +946,7 @@ class OLSConfig(BaseModel):
                 and self.query_validation_method == other.query_validation_method
                 and self.tls_config == other.tls_config
                 and self.certificate_directory == other.certificate_directory
+                and self.system_prompt == other.system_prompt
             )
         return False
 

--- a/tests/config/system_prompt.txt
+++ b/tests/config/system_prompt.txt
@@ -1,0 +1,1 @@
+This is test system prompt!

--- a/tests/config/valid_config.yaml
+++ b/tests/config/valid_config.yaml
@@ -36,6 +36,7 @@ ols_config:
   user_data_collection:
     transcripts_disabled: true
   certificate_directory: "/foo/bar/baz/xyzzy"
+  system_prompt_path: "tests/config/system_prompt.txt"
 dev_config:
   disable_auth: true
   disable_tls: true

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -758,6 +758,7 @@ ols_config:
   default_provider: p1
   default_model: m1
   certificate_directory: '/foo/bar/baz'
+  system_prompt_path: 'tests/config/system_prompt.txt'
 dev_config:
   enable_dev_ui: true
   disable_auth: false
@@ -832,6 +833,7 @@ def test_valid_config_file():
                     "default_provider": "p1",
                     "default_model": "m1",
                     "certificate_directory": "/foo/bar/baz/xyzzy",
+                    "system_prompt_path": "tests/config/system_prompt.txt",
                 },
             }
         )


### PR DESCRIPTION
## Description

Ability to read system prompt from configuration

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1121](https://issues.redhat.com//browse/OLS-1121)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.
