### PR TITLE
OLS-1121: Customizable system prompt

### DIFF
--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -31,13 +31,13 @@ class DocsSummarizer(QueryHelper):
             GenericLLMParameters.MAX_TOKENS_FOR_RESPONSE: model_config.parameters.max_tokens_for_response  # noqa: E501
         }
         # default system prompt fine-tuned for the service
-        self.system_prompt = QUERY_SYSTEM_INSTRUCTION
+        self._system_prompt = QUERY_SYSTEM_INSTRUCTION
 
         # allow the system prompt to be customizable
         if config.ols_config.system_prompt is not None:
-            self.system_prompt = config.ols_config.system_prompt
+            self._system_prompt = config.ols_config.system_prompt
 
-        logger.debug("System prompt: %s", self.system_prompt)
+        logger.debug("System prompt: %s", self._system_prompt)
 
     def _get_model_options(
         self, provider_config: ProviderConfig
@@ -88,7 +88,7 @@ class DocsSummarizer(QueryHelper):
         # Use sample text for context/history to get complete prompt instruction.
         # This is used to calculate available tokens.
         temp_prompt, temp_prompt_input = GeneratePrompt(
-            query, ["sample"], ["ai: sample"], self.system_prompt
+            query, ["sample"], ["ai: sample"], self._system_prompt
         ).generate_prompt(self.model)
         available_tokens = token_handler.calculate_and_check_available_tokens(
             temp_prompt.format(**temp_prompt_input),
@@ -113,7 +113,7 @@ class DocsSummarizer(QueryHelper):
         )
 
         final_prompt, llm_input_values = GeneratePrompt(
-            query, rag_context, history, self.system_prompt
+            query, rag_context, history, self._system_prompt
         ).generate_prompt(self.model)
 
         # Tokens-check: We trigger the computation of the token count
@@ -149,3 +149,8 @@ class DocsSummarizer(QueryHelper):
         logger.debug(f"{conversation_id} Summary response: {response}")
 
         return SummarizerResponse(response, rag_chunks, truncated)
+
+    @property
+    def system_prompt(self) -> str:
+        """Return actually used system prompt."""
+        return self._system_prompt

--- a/tests/unit/query_helpers/test_docs_summarizer.py
+++ b/tests/unit/query_helpers/test_docs_summarizer.py
@@ -39,6 +39,14 @@ def _setup():
     config.reload_from_yaml_file("tests/config/valid_config.yaml")
 
 
+def test_if_system_prompt_was_updated():
+    """Test if system prompt was overided from the configuration."""
+    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+    # expected prompt was loaded during configuration phase
+    expected_prompt = config.ols_config.system_prompt
+    assert summarizer.system_prompt == expected_prompt
+
+
 @patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
 @patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 1)
 @patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))


### PR DESCRIPTION
## Description

Customizable system prompt.
It is now possible to use custom system prompt by providing path to the file that contains it. The configuration might look
like:

```yaml
ols_config:
  logging_config:
    app_log_level: info
    lib_log_level: warning
  default_provider: my_bam
  default_model: ibm/granite-13b-chat-v2
  system_prompt_path: "tests/config/system_prompt.txt"
```

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1121](https://issues.redhat.com//browse/OLS-1121)
