### PR TITLE
Refactor `start_uvicorn` to be less verbose with conditionals

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -113,30 +113,25 @@ def start_uvicorn():
         if config.dev_config.run_on_localhost
         else "0.0.0.0"  # noqa: S104 # nosec: B104
     )
+    port = 8080 if config.dev_config.disable_tls else 8443
     log_level = config.ols_config.logging_config.uvicorn_log_level
 
-    if config.dev_config.disable_tls:
-        # TLS is disabled, run without SSL configuration
-        uvicorn.run(
-            "ols.app.main:app",
-            host=host,
-            port=8080,
-            log_level=log_level,
-            workers=1,
-            access_log=log_level < logging.INFO,
-        )
-    else:
-        uvicorn.run(
-            "ols.app.main:app",
-            host=host,
-            port=8443,
-            workers=1,
-            log_level=log_level,
-            ssl_keyfile=config.ols_config.tls_config.tls_key_path,
-            ssl_certfile=config.ols_config.tls_config.tls_certificate_path,
-            ssl_keyfile_password=config.ols_config.tls_config.tls_key_password,
-            access_log=log_level < logging.INFO,
-        )
+    # The tls fields can be None, which means we will pass those values as None to uvicorn.run
+    ssl_keyfile = config.ols_config.tls_config.tls_key_path
+    ssl_certfile = config.ols_config.tls_config.tls_certificate_path
+    ssl_keyfile_password = config.ols_config.tls_config.tls_key_password
+
+    uvicorn.run(
+        "ols.app.main:app",
+        host=host,
+        port=port,
+        workers=1,
+        log_level=log_level,
+        ssl_keyfile=ssl_keyfile,
+        ssl_certfile=ssl_certfile,
+        ssl_keyfile_password=ssl_keyfile_password,
+        access_log=log_level < logging.INFO,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

<Patch from upstream>

Simplified the condition to start uvicorn. The TLS flags will be None in case they are not being used, so there is no need for branching that. The condition was moved to determinate the port of the running service.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
