### PR TITLE
fix: history structure for granite prompt

### DIFF
--- a/ols/utils/token_handler.py
+++ b/ols/utils/token_handler.py
@@ -179,8 +179,9 @@ class TokenHandler:
     ) -> tuple[list[str], bool]:
         """Limit conversation history to specified number of tokens."""
         total_length = 0
+        formatted_history: list[str] = []
 
-        for index, message in enumerate(reversed(history)):
+        for message in reversed(history):
             # Restructure messages as per model
             message = restructure_history(message, model)
 
@@ -192,6 +193,7 @@ class TokenHandler:
                 logger.debug(
                     "History truncated, it exceeds available %d tokens.", limit
                 )
-                return history[len(history) - index :], True
+                return formatted_history[::-1], True
+            formatted_history.append(message)
 
-        return history, False
+        return formatted_history[::-1], False

--- a/tests/unit/utils/test_token_handler.py
+++ b/tests/unit/utils/test_token_handler.py
@@ -6,6 +6,7 @@ from unittest import TestCase, mock
 import pytest
 
 from ols.constants import TOKEN_BUFFER_WEIGHT, ModelFamily
+from ols.src.prompts.prompt_generator import restructure_history
 from ols.utils.token_handler import PromptTooLongError, TokenHandler
 from tests.mock_classes.mock_retrieved_node import MockRetrievedNode
 
@@ -280,4 +281,13 @@ class TestTokenHandler(TestCase):
         )
         # history should truncate to empty list and flag should be True
         assert truncated_history == []
+        assert truncated
+
+        # Test formatted history for granite
+        model = ModelFamily.GRANITE
+        truncated_history, truncated = (
+            self._token_handler_obj.limit_conversation_history(history, model, 22)
+        )
+        assert len(truncated_history) == 2
+        assert truncated_history[-1] == restructure_history(history[-1], model)
         assert truncated


### PR DESCRIPTION
## Description

Fix: Use formatted history/messages for granite prompt.