### PR TITLE
OLS-1106: Refactored to create HTTPX client in one centralized place

### DIFF
--- a/ols/src/llms/providers/azure_openai.py
+++ b/ols/src/llms/providers/azure_openai.py
@@ -74,6 +74,7 @@ class AzureOpenAI(LLMProvider):
             "temperature": 0.01,
             "max_tokens": 512,
             "verbose": False,
+            "http_client": self._construct_httpx_client(False),
         }
 
         if self.credentials is not None:

--- a/ols/src/llms/providers/openai.py
+++ b/ols/src/llms/providers/openai.py
@@ -46,6 +46,7 @@ class OpenAI(LLMProvider):
             "temperature": 0.01,
             "max_tokens": 512,
             "verbose": False,
+            "http_client": self._construct_httpx_client(False),
         }
 
     def load(self) -> LLM:

--- a/ols/src/llms/providers/provider.py
+++ b/ols/src/llms/providers/provider.py
@@ -50,6 +50,7 @@ AzureOpenAIParameters = {
     ProviderParameter("temperature", float),
     ProviderParameter("max_tokens", int),
     ProviderParameter("verbose", bool),
+    ProviderParameter("http_client", httpx.Client),
 }
 
 OpenAIParameters = {
@@ -66,6 +67,7 @@ OpenAIParameters = {
     ProviderParameter("temperature", float),
     ProviderParameter("max_tokens", int),
     ProviderParameter("verbose", bool),
+    ProviderParameter("http_client", httpx.Client),
 }
 
 RHOAIVLLMParameters = {
@@ -321,3 +323,12 @@ class LLMProvider(AbstractLLMProvider):
             updated_params = {**updated_params, **config.dev_config.llm_params}
 
         return updated_params
+
+    def _construct_httpx_client(
+        self, use_custom_certificate_store: bool
+    ) -> httpx.Client:
+        """Construct HTTPX client instance to be used to communicate with LLM."""
+        if use_custom_certificate_store:
+            return httpx.Client(verify=self.provider_config.certificates_store)
+        else:
+            return httpx.Client()

--- a/ols/src/llms/providers/rhelai_vllm.py
+++ b/ols/src/llms/providers/rhelai_vllm.py
@@ -3,7 +3,6 @@
 import logging
 from typing import Any, Optional
 
-import httpx
 from langchain.llms.base import LLM
 from langchain_openai import ChatOpenAI
 
@@ -48,7 +47,7 @@ class RHELAIVLLM(LLMProvider):
             "temperature": 0.01,
             "max_tokens": 512,
             "verbose": False,
-            "http_client": httpx.Client(verify=self.provider_config.certificates_store),
+            "http_client": self._construct_httpx_client(True),
         }
 
     def load(self) -> LLM:

--- a/ols/src/llms/providers/rhoai_vllm.py
+++ b/ols/src/llms/providers/rhoai_vllm.py
@@ -3,7 +3,6 @@
 import logging
 from typing import Any, Optional
 
-import httpx
 from langchain.llms.base import LLM
 from langchain_openai import ChatOpenAI
 
@@ -48,7 +47,7 @@ class RHOAIVLLM(LLMProvider):
             "temperature": 0.01,
             "max_tokens": 512,
             "verbose": False,
-            "http_client": httpx.Client(verify=self.provider_config.certificates_store),
+            "http_client": self._construct_httpx_client(True),
         }
 
     def load(self) -> LLM:

--- a/tests/unit/llms/providers/test_azure_openai.py
+++ b/tests/unit/llms/providers/test_azure_openai.py
@@ -3,6 +3,7 @@
 import time
 from unittest.mock import patch
 
+import httpx
 import pytest
 from azure.core.credentials import AccessToken
 from langchain_openai import AzureChatOpenAI
@@ -210,6 +211,13 @@ def test_basic_interface(provider_config):
     assert azure_openai.default_params["api_key"] == "secret_key"
 
     assert azure_openai.default_params["azure_endpoint"] == "test_url"
+
+    # check the HTTP client parameter
+    assert "http_client" in azure_openai.default_params
+    assert azure_openai.default_params["http_client"] is not None
+
+    client = azure_openai.default_params["http_client"]
+    assert isinstance(client, httpx.Client)
 
 
 def test_credentials_in_directory_handling(provider_config_credentials_directory):

--- a/tests/unit/llms/providers/test_openai.py
+++ b/tests/unit/llms/providers/test_openai.py
@@ -1,5 +1,6 @@
 """Unit tests for OpenAI provider."""
 
+import httpx
 import pytest
 from langchain_openai.chat_models.base import ChatOpenAI
 
@@ -80,6 +81,13 @@ def test_basic_interface(provider_config):
     assert "base_url" in openai.default_params
     assert "model" in openai.default_params
     assert "max_tokens" in openai.default_params
+
+    # check the HTTP client parameter
+    assert "http_client" in openai.default_params
+    assert openai.default_params["http_client"] is not None
+
+    client = openai.default_params["http_client"]
+    assert isinstance(client, httpx.Client)
 
 
 def test_params_handling(provider_config):

--- a/tests/unit/llms/providers/test_rhelai_vllm.py
+++ b/tests/unit/llms/providers/test_rhelai_vllm.py
@@ -2,6 +2,7 @@
 
 import os
 
+import httpx
 import pytest
 from langchain_openai.chat_models.base import ChatOpenAI
 
@@ -99,8 +100,13 @@ def test_basic_interface(provider_config, fake_certifi_store):
     assert "base_url" in rhelai_vllm.default_params
     assert "model" in rhelai_vllm.default_params
     assert "max_tokens" in rhelai_vllm.default_params
+
+    # check the HTTP client parameter
     assert "http_client" in rhelai_vllm.default_params
     assert rhelai_vllm.default_params["http_client"] is not None
+
+    client = rhelai_vllm.default_params["http_client"]
+    assert isinstance(client, httpx.Client)
 
 
 def test_params_handling(provider_config, fake_certifi_store):

--- a/tests/unit/llms/providers/test_rhoai_vllm.py
+++ b/tests/unit/llms/providers/test_rhoai_vllm.py
@@ -2,6 +2,7 @@
 
 import os
 
+import httpx
 import pytest
 from langchain_openai.chat_models.base import ChatOpenAI
 
@@ -99,8 +100,13 @@ def test_basic_interface(provider_config, fake_certifi_store):
     assert "base_url" in rhoai_vllm.default_params
     assert "model" in rhoai_vllm.default_params
     assert "max_tokens" in rhoai_vllm.default_params
+
+    # check the HTTP client parameter
     assert "http_client" in rhoai_vllm.default_params
     assert rhoai_vllm.default_params["http_client"] is not None
+
+    client = rhoai_vllm.default_params["http_client"]
+    assert isinstance(client, httpx.Client)
 
 
 def test_params_handling(provider_config, fake_certifi_store):


### PR DESCRIPTION
## Description

Refactored to create HTTPX client in one centralized place
The new method will be used later to specify TLS security profile

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1106](https://issues.redhat.com//browse/OLS-1106)
