### PR TITLE
eval: add alternate answers after model transition

### DIFF
--- a/scripts/evaluation/eval_data/question_answer_pair.json
+++ b/scripts/evaluation/eval_data/question_answer_pair.json
@@ -247,8 +247,9 @@
                     ]
                 },
                 "openai+gpt-4o-mini+with_rag": {
-                    "cutoff_score": 0.3,
+                    "cutoff_score": 0.35,
                     "text": [
+                        "Yes, there are detailed sections that describe the update process for Red Hat OpenShift Container Platform (OCP). The primary component that orchestrates and facilitates the update process is the Cluster Version Operator (CVO). It monitors the ClusterVersion resource and ensures that the actual state of resources matches their desired state.\n\nFor specific procedures, you can refer to topics such as performing rolling updates, canary rollouts, and managing machine config pools during updates. It's important to carefully plan your update strategy based on your cluster's characteristics and requirements.",
                         "Yes, the update process for clusters in OpenShift is detailed in various sections. The primary component that orchestrates updates is the Cluster Version Operator (CVO), which monitors the ClusterVersion resource to ensure that the actual state of resources matches their desired state.\nThe update process generally involves selecting a version to update to, monitoring progress through status updates, and confirming that nodes are updated before deploying workloads that rely on new features. It's also important to check for available updates after completing an update.\nIf you have specific questions about any part of the cluster updating process, feel free to ask!"
                     ]
                 },


### PR DESCRIPTION
## Description

Add alternate answer for openai due to randomness.. Adjustment post model change.
[Reference](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_lightspeed-service/1807/pull-ci-openshift-lightspeed-service-main-e2e-ols-cluster-4-17/1849914307219820544)

cut-off increase [[reference](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_lightspeed-service/1829/pull-ci-openshift-lightspeed-service-main-e2e-ols-cluster-4-17/1853356810233188352)]
