### PR TITLE
Use provider config type rather than provider when loading vanilla model

### DIFF
--- a/scripts/evaluation/utils/response.py
+++ b/scripts/evaluation/utils/response.py
@@ -32,7 +32,7 @@ def get_model_response(query, provider, model, mode, api_client=None):
     prompt_input = {"query": query}
     provider_config = config.config.llm_providers.providers[provider]
     model_config = provider_config.models[model]
-    llm = VANILLA_MODEL[provider](model, provider_config).load()
+    llm = VANILLA_MODEL[provider_config.type](model, provider_config).load()
 
     if mode == "ols_param":
         max_resp_tokens = model_config.parameters.max_tokens_for_response


### PR DESCRIPTION
## Description

Use provider config type rather than provider when loading vanilla model

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
