### PR TITLE
OLS-1204: init k8s module just when configured to

### DIFF
--- a/ols/src/auth/auth.py
+++ b/ols/src/auth/auth.py
@@ -1,0 +1,12 @@
+"""Authentication related utilities."""
+
+from ols.app.models.config import OLSConfig
+
+
+def use_k8s_auth(ols_config: OLSConfig) -> bool:
+    """Return True if k8s authentication should be used in the service."""
+    if ols_config is None or ols_config.authentication_config is None:
+        return False
+
+    auth_module = ols_config.authentication_config.module
+    return auth_module is not None and auth_module == "k8s"

--- a/runner.py
+++ b/runner.py
@@ -13,7 +13,7 @@ from cryptography import x509
 
 import ols.app.models.config as config_model
 from ols import constants
-from ols.src.auth.k8s import K8sClientSingleton
+from ols.src.auth.auth import use_k8s_auth
 from ols.utils import tls
 from ols.utils.logging import configure_logging
 
@@ -199,10 +199,14 @@ if __name__ == "__main__":
     # merged with explicitly specified certificates
     generate_certificates_file(logger, config.ols_config)
 
-    # Initialize the K8sClientSingleton with cluster id during module load.
-    # We want the application to fail early if the cluster ID is not available.
-    cluster_id = K8sClientSingleton.get_cluster_id()
-    logger.info("running on cluster with ID '%s'", cluster_id)
+    if use_k8s_auth(config.ols_config):
+        logger.info("Initializing k8s auth")
+        from ols.src.auth.k8s import K8sClientSingleton
+
+        # Initialize the K8sClientSingleton with cluster id during module load.
+        # We want the application to fail early if the cluster ID is not available.
+        cluster_id = K8sClientSingleton.get_cluster_id()
+        logger.info("running on cluster with ID '%s'", cluster_id)
 
     # init loading of query redactor
     config.query_redactor

--- a/tests/unit/auth/test_auth.py
+++ b/tests/unit/auth/test_auth.py
@@ -1,0 +1,34 @@
+"""Unit tests for auth/auth module."""
+
+from ols.app.models.config import AuthenticationConfig, OLSConfig
+from ols.src.auth.auth import use_k8s_auth
+
+
+def test_use_k8s_auth_no_auth_config():
+    """Test the function use_k8s_auth."""
+    ols_config = OLSConfig()
+    ols_config.authentication_config = None
+    assert use_k8s_auth(ols_config) is False
+
+
+def test_use_k8s_auth_default_auth_config():
+    """Test the function use_k8s_auth."""
+    ols_config = OLSConfig()
+    ols_config.authentication_config = AuthenticationConfig()
+    assert use_k8s_auth(ols_config) is False
+
+
+def test_use_k8s_auth_k8s_module():
+    """Test the function use_k8s_auth when k8s module is selected."""
+    ols_config = OLSConfig()
+    ols_config.authentication_config = AuthenticationConfig()
+    ols_config.authentication_config.module = "k8s"
+    assert use_k8s_auth(ols_config) is True
+
+
+def test_use_k8s_auth_no_k8s_module():
+    """Test the function use_k8s_auth when module different from k8s is selected."""
+    ols_config = OLSConfig()
+    ols_config.authentication_config = AuthenticationConfig()
+    ols_config.authentication_config.module = "foo"
+    assert use_k8s_auth(ols_config) is False

--- a/tests/unit/auth/test_k8s.py
+++ b/tests/unit/auth/test_k8s.py
@@ -1,4 +1,4 @@
-"""Unit tests for auth_dependency module."""
+"""Unit tests for auth/k8s module."""
 
 import os
 from typing import Optional


### PR DESCRIPTION
## Description

[OLS-1204](https://issues.redhat.com//browse/OLS-1204): init k8s module just when configured to
If will allow us to be in-sync with upstream repo (where k8s was commented out on source level)
No changes in operator or in default configuration is needed

## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1204](https://issues.redhat.com//browse/OLS-1204)
