### PR TITLE
OLS-1174: bump-up OpenAI to version 1.53.3

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.4.2"
-content_hash = "sha256:63c5c84503055a63986da4672fbc135ecbc728d368b0217d40983206bf111b26"
+content_hash = "sha256:bc965303371d1ca84683ded7ebe56ddd55225f1c5e26dc2523aa572ceec8aca4"
 
 [[package]]
 name = "absl-py"
@@ -2065,8 +2065,8 @@ files = [
 
 [[package]]
 name = "openai"
-version = "1.53.1"
-requires_python = ">=3.7.1"
+version = "1.54.3"
+requires_python = ">=3.8"
 summary = "The official Python library for the openai API"
 groups = ["default"]
 dependencies = [
@@ -2080,8 +2080,8 @@ dependencies = [
     "typing-extensions<5,>=4.11",
 ]
 files = [
-    {file = "openai-1.53.1-py3-none-any.whl", hash = "sha256:b26bc2d91eda8a9317ebecddfbd388b3698f89fa56d78672dd115a1ccc175722"},
-    {file = "openai-1.53.1.tar.gz", hash = "sha256:04b8df362e7e2af75c8a3bcd105a5abb3837ce883e2fa3cb8d922cb8ee3515ac"},
+    {file = "openai-1.54.3-py3-none-any.whl", hash = "sha256:f18dbaf09c50d70c4185b892a2a553f80681d1d866323a2da7f7be2f688615d5"},
+    {file = "openai-1.54.3.tar.gz", hash = "sha256:7511b74eeb894ac0b0253dc71f087a15d2e4d71d22d0088767205143d880cca6"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ dependencies = [
     "redis==5.0.8",
     "faiss-cpu==1.8.0.post1",
     "sentence-transformers==3.1.1",
-    "openai==1.53.1",
+    "openai==1.54.3",
     "pyarrow==18.0.0",
     "ibm-generative-ai==3.0.0",
     "ibm-cos-sdk==2.13.6",


### PR DESCRIPTION
## Description

[OLS-1174](https://issues.redhat.com//browse/OLS-1174): bump-up OpenAI to version 1.53.3

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1174](https://issues.redhat.com//browse/OLS-1174)
