### PR TITLE
OLS-1226: remove warning about outdated import

### DIFF
--- a/ols/src/llms/providers/fake_provider.py
+++ b/ols/src/llms/providers/fake_provider.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any
 
 from langchain.llms.base import LLM
-from langchain.llms.fake import FakeListLLM
+from langchain_community.llms import FakeListLLM
 
 from ols import constants
 from ols.src.llms.providers.provider import LLMProvider


### PR DESCRIPTION
## Description

[OLS-1226](https://issues.redhat.com//browse/OLS-1226): remove warning about outdated import

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1226](https://issues.redhat.com//browse/OLS-1226)
