### PR TITLE
chore(KONFLUX-5392): check-container step in ecosystem-cert-preflight-checks routinely goes above 7 GiB

### DIFF
--- a/.tekton/lightspeed-service-pull-request.yaml
+++ b/.tekton/lightspeed-service-pull-request.yaml
@@ -49,7 +49,7 @@ spec:
       computeResources:
         requests:
           cpu: '1'
-          memory: 1Gi
+          memory: 8Gi
         limits:
           memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks

--- a/.tekton/lightspeed-service-pull-request.yaml
+++ b/.tekton/lightspeed-service-pull-request.yaml
@@ -56,7 +56,7 @@ spec:
       computeResources:
         requests:
           cpu: '1'
-          memory: 1Gi
+          memory: 8Gi
         limits:
           memory: 8Gi
     - pipelineTaskName: build-container

--- a/.tekton/lightspeed-service-push.yaml
+++ b/.tekton/lightspeed-service-push.yaml
@@ -55,7 +55,7 @@ spec:
       computeResources:
         requests:
           cpu: '1'
-          memory: 1Gi
+          memory: 8Gi
         limits:
           memory: 8Gi
     - pipelineTaskName: build-container

--- a/.tekton/lightspeed-service-push.yaml
+++ b/.tekton/lightspeed-service-push.yaml
@@ -48,7 +48,7 @@ spec:
       computeResources:
         requests:
           cpu: '1'
-          memory: 1Gi
+          memory: 8Gi
         limits:
           memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks


### PR DESCRIPTION
## Description

Looking at this query:
```
(
    avg by (namespace, pod) (
        container_memory_working_set_bytes{container=~".*check-container.*"}
    )
    -
    avg by (namespace,  pod) (
        kube_pod_container_resource_requests{container=~".*check-container.*"}
    )
) > 0
```

![image](https://github.com/user-attachments/assets/0c47df2c-31d2-4c6b-a97c-8e88e8b734f6)

It is safer to request as much memory as required.

## Type of change

- Konflux configuration change


## Related Tickets & Documents

- Related Issue: https://issues.redhat.com/browse/KONFLUX-5392