### PR TITLE
build(KONFLUX-5392): Request more memory for build container step as it is actually being used

### DIFF
--- a/.tekton/lightspeed-service-pull-request.yaml
+++ b/.tekton/lightspeed-service-pull-request.yaml
@@ -62,7 +62,7 @@ spec:
     - pipelineTaskName: build-container
       computeResources:
         requests:
-          memory: 1Gi
+          memory: 8Gi
         limits:
           memory: 8Gi
   pipelineSpec:

--- a/.tekton/lightspeed-service-push.yaml
+++ b/.tekton/lightspeed-service-push.yaml
@@ -61,7 +61,7 @@ spec:
     - pipelineTaskName: build-container
       computeResources:
         requests:
-          memory: 1Gi
+          memory: 8Gi
         limits:
           memory: 8Gi
   pipelineSpec:


### PR DESCRIPTION
## Description
Builds are using 8 GiB of memory, so request that memory. See `stone-prd-rh01`:

```
sum by (namespace, pod, container) (
max_over_time(
    container_memory_working_set_bytes{container=~".*step-build.*", pod=~".*-build-container-pod", namespace="crt-nshift-lightspeed-tenant", pod=~"lightspeed-service-.*"}
[1d])
)
```

![image](https://github.com/user-attachments/assets/12851356-336e-4a48-a24c-1690982e34b8)


## Type of change
- Konflux configuration change


## Related Tickets & Documents
- Related Issue https://issues.redhat.com/browse/KONFLUX-5392