### PR TITLE
OLS-1229: Refactor GradioUI environment variables handling from runner.py

### DIFF
--- a/ols/utils/environments.py
+++ b/ols/utils/environments.py
@@ -1,0 +1,17 @@
+"""Environment variables handling."""
+
+import os
+import tempfile
+
+
+def configure_gradio_ui_envs() -> None:
+    """Configure GradioUI framework environment variables."""
+    # disable Gradio analytics, which calls home to https://api.gradio.app
+    os.environ["GRADIO_ANALYTICS_ENABLED"] = "false"
+
+    # Setup config directory for Matplotlib. It will be used to store info
+    # about fonts (usually one JSON file) and it really is just temporary
+    # storage that can be deleted at any time and recreated later.
+    # Fixes: https://issues.redhat.com/browse/OLS-301
+    tempdir = os.path.join(tempfile.gettempdir(), "matplotlib")
+    os.environ["MPLCONFIGDIR"] = tempdir

--- a/runner.py
+++ b/runner.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import tempfile
 import threading
 from pathlib import Path
 
@@ -12,6 +11,7 @@ import ols.app.models.config as config_model
 from ols.src.auth.auth import use_k8s_auth
 from ols.utils import ssl
 from ols.utils.certificates import generate_certificates_file
+from ols.utils.environments import configure_gradio_ui_envs
 from ols.utils.logging_configurator import configure_logging
 
 
@@ -27,19 +27,6 @@ def configure_hugging_face_envs(ols_config: config_model.OLSConfig) -> None:
             ols_config.reference_content.embeddings_model_path
         )
         os.environ["TRANSFORMERS_OFFLINE"] = "1"
-
-
-def configure_gradio_ui_envs() -> None:
-    """Configure GradioUI framework environment variables."""
-    # disable Gradio analytics, which calls home to https://api.gradio.app
-    os.environ["GRADIO_ANALYTICS_ENABLED"] = "false"
-
-    # Setup config directory for Matplotlib. It will be used to store info
-    # about fonts (usually one JSON file) and it really is just temporary
-    # storage that can be deleted at any time and recreated later.
-    # Fixes: https://issues.redhat.com/browse/OLS-301
-    tempdir = os.path.join(tempfile.gettempdir(), "matplotlib")
-    os.environ["MPLCONFIGDIR"] = tempdir
 
 
 def load_index():

--- a/tests/unit/utils/test_environments.py
+++ b/tests/unit/utils/test_environments.py
@@ -1,0 +1,21 @@
+"""Unit tests for functions defined in environments.py."""
+
+import os
+from unittest.mock import patch
+
+from ols.utils.environments import configure_gradio_ui_envs
+
+
+@patch.dict(os.environ, {"GRADIO_ANALYTICS_ENABLED": "", "MPLCONFIGDIR": ""})
+def test_configure_gradio_ui_envs():
+    """Test the function configure_gradio_ui_envs."""
+    # setup before tested function is called
+    assert os.environ.get("GRADIO_ANALYTICS_ENABLED", None) == ""
+    assert os.environ.get("MPLCONFIGDIR", None) == ""
+
+    # call the tested function
+    configure_gradio_ui_envs()
+
+    # expected environment variables
+    assert os.environ.get("GRADIO_ANALYTICS_ENABLED", None) == "false"
+    assert os.environ.get("MPLCONFIGDIR", None) != ""


### PR DESCRIPTION
## Description

OLS-1229: Refactor GradioUI environment variables from `runner.py`
Added unit tests as expected

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #OLS-1229
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
