### PR TITLE
fix: end of token in granite-13b response

### DIFF
--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -134,6 +134,9 @@ class DocsSummarizer(QueryHelper):
 
         # retrieve text response returned from LLM, strip whitespace characters from beginning/end
         response = summary["text"].strip()
+        # TODO: Better handling of stop token.
+        # Recently watsonx/granite-13b started adding stop token to response.
+        response = response.replace("<|endoftext|>", "")
 
         if len(rag_context) == 0:
             logger.debug("Using llm to answer the query without reference content")

--- a/ols/utils/token_handler.py
+++ b/ols/utils/token_handler.py
@@ -49,7 +49,9 @@ class TokenHandler:
         Returns:
             List of tokens, ex: [1, 2, 3, 4]
         """
-        return self._encoder.encode(text)
+        # return self._encoder.encode(text)
+        # TODO: Better handling of stop token.
+        return self._encoder.encode(text, allowed_special={"<|endoftext|>"})
 
     def tokens_to_text(self, tokens: list) -> str:
         """Convert tokens to text.


### PR DESCRIPTION
## Description
fix: end of token in granite-13b response
[Reference](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_lightspeed-service/1946/pull-ci-openshift-lightspeed-service-main-4.15-e2e-ols-cluster/1860756078703153152)
[OLS-1261](https://issues.redhat.com/browse/OLS-1261)
