### PR TITLE
OLS-1233: Added missing `__init__.py` into all unit tests

### DIFF
--- a/tests/unit/extra_certs/__init__.py
+++ b/tests/unit/extra_certs/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for extra certs handling."""

--- a/tests/unit/runners/__init__.py
+++ b/tests/unit/runners/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for runners."""

--- a/tests/unit/user_data_collection/__init__.py
+++ b/tests/unit/user_data_collection/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the data_collector module."""


### PR DESCRIPTION
## Description

Added missing `__init__.py` into all unit tests

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1233](https://issues.redhat.com//browse/OLS-1233)
