### PR TITLE
config: base image switch back to ubi9 minimal, FIPS compliant version.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,7 +3,7 @@ ARG LIGHTSPEED_RAG_CONTENT_IMAGE=quay.io/openshift-lightspeed/lightspeed-rag-con
 
 FROM ${LIGHTSPEED_RAG_CONTENT_IMAGE} as lightspeed-rag-content
 
-FROM registry.redhat.io/rhel9-4-els/rhel-minimal@sha256:34ab194b05e765bbbaec550f6158ab907d864fecbb39af04b1e3501d858a5544
+FROM registry.redhat.io/ubi9/ubi-minimal@sha256:8b6978d555746877c73f52375f60fd7b6fd27d6aca000eaed27d0995303c13de
 
 ARG VERSION
 ARG APP_ROOT=/app-root


### PR DESCRIPTION
## Description

Switch back to UBI9 image as base image. The new UBI9 images are already FIPS-140-3 compliant.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # [OLS-1192](https://issues.redhat.com/browse/OLS-1192)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
