### PR TITLE
Use `datetime.now` instead of `utznow`

### DIFF
--- a/ols/app/endpoints/feedback.py
+++ b/ols/app/endpoints/feedback.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -65,7 +65,7 @@ def store_feedback(user_id: str, feedback: dict) -> None:
     storage_path = Path(config.ols_config.user_data_collection.feedback_storage)
     storage_path.mkdir(parents=True, exist_ok=True)
 
-    current_time = str(datetime.utcnow())
+    current_time = str(datetime.now(tz=UTC))
     data_to_store = {"user_id": user_id, "timestamp": current_time, **feedback}
 
     # stores feedback in a file under unique uuid


### PR DESCRIPTION
## Description

Use `datetime.now` instead of `utznow`

Python datetime objects can be naive or timezone-aware. While an aware
object represents a specific moment in time, a naive object does not
contain enough information to unambiguously locate itself relative to other
datetime objects. Since this can lead to errors, it is recommended to
always use timezone-aware objects.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
