### PR TITLE
OLS-1272: don't pass params via kwargs

### DIFF
--- a/ols/src/llms/providers/azure_openai.py
+++ b/ols/src/llms/providers/azure_openai.py
@@ -64,10 +64,8 @@ class AzureOpenAI(LLMProvider):
             "api_version": api_version,
             "deployment_name": deployment_name,
             "model": self.model,
-            "model_kwargs": {
-                "top_p": 0.95,
-                "frequency_penalty": 1.03,
-            },
+            "top_p": 0.95,
+            "frequency_penalty": 1.03,
             "organization": None,
             "cache": None,
             "streaming": True,

--- a/ols/src/llms/providers/openai.py
+++ b/ols/src/llms/providers/openai.py
@@ -36,10 +36,8 @@ class OpenAI(LLMProvider):
             "base_url": self.url,
             "openai_api_key": self.credentials,
             "model": self.model,
-            "model_kwargs": {
-                "top_p": 0.95,
-                "frequency_penalty": 1.03,
-            },
+            "top_p": 0.95,
+            "frequency_penalty": 1.03,
             "organization": None,
             "cache": None,
             "streaming": True,

--- a/ols/src/llms/providers/rhelai_vllm.py
+++ b/ols/src/llms/providers/rhelai_vllm.py
@@ -37,10 +37,8 @@ class RHELAIVLLM(LLMProvider):
             "base_url": self.url,
             "openai_api_key": self.credentials,
             "model": self.model,
-            "model_kwargs": {
-                "top_p": 0.95,
-                "frequency_penalty": 1.03,
-            },
+            "top_p": 0.95,
+            "frequency_penalty": 1.03,
             "organization": None,
             "cache": None,
             "streaming": True,

--- a/ols/src/llms/providers/rhoai_vllm.py
+++ b/ols/src/llms/providers/rhoai_vllm.py
@@ -37,10 +37,8 @@ class RHOAIVLLM(LLMProvider):
             "base_url": self.url,
             "openai_api_key": self.credentials,
             "model": self.model,
-            "model_kwargs": {
-                "top_p": 0.95,
-                "frequency_penalty": 1.03,
-            },
+            "top_p": 0.95,
+            "frequency_penalty": 1.03,
             "organization": None,
             "cache": None,
             "streaming": True,


### PR DESCRIPTION
## Description

[OLS-1272](https://issues.redhat.com//browse/OLS-1272): don't pass params via `kwargs`

## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1272](https://issues.redhat.com//browse/OLS-1272)
