### PR TITLE
OLS-1168: Setting distribution flag

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.4.2"
-content_hash = "sha256:c6b6a71ecda3f38f7902a675a491901f478208b62414c3f11c97314403baa034"
+content_hash = "sha256:a5ee461761b14139a7aedcc05343cb0d9adb0345298d6519273d62f13486fe63"
 
 [[package]]
 name = "absl-py"
@@ -1927,13 +1927,13 @@ files = [
 
 [[package]]
 name = "msgpack"
-version = "1.0.8"
+version = "1.1.0"
 requires_python = ">=3.8"
 summary = "MessagePack serializer"
 groups = ["default"]
 files = [
-    {file = "msgpack-1.0.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b5c044f3eff2a6534768ccfd50425939e7a8b5cf9a7261c385de1e20dcfc85"},
-    {file = "msgpack-1.0.8.tar.gz", hash = "sha256:95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"},
+    {file = "msgpack-1.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e1da8f11a3dd397f0a32c76165cf0c4eb95b31013a94f6ecc0b280c05c91b59"},
+    {file = "msgpack-1.1.0.tar.gz", hash = "sha256:dd432ccc2c72b914e4cb77afce64aab761c1137cc698be3984eee260bcb2896e"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ skips = []
 exclude_dirs = ["tests", "scripts"]
 
 [tool.pdm]
-distribution = false
+distribution = true
 
 [tool.pdm.dev-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ dependencies = [
     "filelock==3.16.1",
     "ffmpy==0.4.0",
     "virtualenv==20.28.0",
+    "msgpack==1.1.0",
 ]
 requires-python = "==3.11.*"
 readme = "README.md"


### PR DESCRIPTION
## Description

Setting distribution flag

It allow us, among other things to run `pdm show --version` to display service version.
`msgpack` has to be updated to pass CI checks (newer version is installed already on CI systems)

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1168](https://issues.redhat.com//browse/OLS-1168)
