### PR TITLE
OLS-39: Add streaming_query endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,8 @@ To send a request to the server you can use the following curl command:
 curl -X 'POST' 'http://127.0.0.1:8080/v1/query' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{"query": "write a deployment yaml for the mongodb image"}'
 ```
 
+> You can use `/v1/streaming_query` endpoint (with same parameters) to get the streaming response (SSE/HTTP chunking). By default, it streams text, but you can also yield events as JSONs via additionl `"media_type": "text/plain"` parameter in the payload data.
+
 ### Swagger UI
 
 Web page with Swagger UI has the standard `/docs` endpoint. If the service is running on localhost on port 8080, Swagger UI can be accessed on address `http://localhost:8080/docs`.

--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ To send a request to the server you can use the following curl command:
 curl -X 'POST' 'http://127.0.0.1:8080/v1/query' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{"query": "write a deployment yaml for the mongodb image"}'
 ```
 
-> You can use `/v1/streaming_query` endpoint (with same parameters) to get the streaming response (SSE/HTTP chunking). By default, it streams text, but you can also yield events as JSONs via additionl `"media_type": "text/plain"` parameter in the payload data.
+> You can use the `/v1/streaming_query` (with the same parameters) to get the streaming response (SSE/HTTP chunking). By default, it streams text, but you can also yield events as JSONs via additional `"media_type": "text/plain"` parameter in the payload data.
 
 ### Swagger UI
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -88,6 +88,89 @@
                 }
             }
         },
+        "/v1/streaming_query": {
+            "post": {
+                "tags": [
+                    "streaming_query"
+                ],
+                "summary": "Conversation Request",
+                "description": "Handle conversation requests for the OLS endpoint.\n\nArgs:\n    llm_request: The incoming request containing query details.\n    auth: The authentication context, provided by dependency injection.\n\nReturns:\n    StreamingResponse: The streaming response generated for the query.",
+                "operationId": "conversation_request_v1_streaming_query_post",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/LLMRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Query is valid and stream/events from endpoint is returned",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string",
+                                    "title": "Response 200 Conversation Request V1 Streaming Query Post"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Missing or invalid credentials provided by client",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UnauthorizedResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Client does not have permission to access resource",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ForbiddenResponse"
+                                }
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "Prompt is too long",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PromptTooLongResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Query can not be validated, LLM is not accessible or other internal error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v1/feedback/status": {
             "get": {
                 "tags": [
@@ -579,6 +662,18 @@
                             }
                         ],
                         "title": "Attachments"
+                    },
+                    "media_type": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Media Type",
+                        "default": "text/plain"
                     }
                 },
                 "additionalProperties": false,
@@ -587,7 +682,7 @@
                     "query"
                 ],
                 "title": "LLMRequest",
-                "description": "Model representing a request for the LLM (Language Model) send into OLS service.\n\nAttributes:\n    query: The query string.\n    conversation_id: The optional conversation ID (UUID).\n    provider: The optional provider.\n    model: The optional model.\n    attachments: The optional attachments.\n\nExample:\n    ```python\n    llm_request = LLMRequest(query=\"Tell me about Kubernetes\")\n    ```",
+                "description": "Model representing a request for the LLM (Language Model) send into OLS service.\n\nAttributes:\n    query: The query string.\n    conversation_id: The optional conversation ID (UUID).\n    provider: The optional provider.\n    model: The optional model.\n    attachments: The optional attachments.\n    media_type: The optional parameter for streaming response.\n\nExample:\n    ```python\n    llm_request = LLMRequest(query=\"Tell me about Kubernetes\")\n    ```",
                 "examples": [
                     {
                         "attachments": [
@@ -608,6 +703,7 @@
                             }
                         ],
                         "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
+                        "media_type": "text/plain",
                         "model": "gpt-4o-mini",
                         "provider": "openai",
                         "query": "write a deployment yaml for the mongodb image",

--- a/ols/app/endpoints/streaming_ols.py
+++ b/ols/app/endpoints/streaming_ols.py
@@ -1,0 +1,358 @@
+"""FastAPI endpoint for the OLS streaming query.
+
+This module defines the endpoint and supporting functions for handling
+streaming queries.
+"""
+
+import json
+import logging
+import time
+from typing import Any, AsyncGenerator
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
+
+from ols import config, constants
+from ols.app.endpoints.ols import (
+    generate_response,
+    log_processing_durations,
+    process_request,
+    store_conversation_history,
+    store_transcript,
+)
+from ols.app.models.models import (
+    Attachment,
+    ErrorResponse,
+    ForbiddenResponse,
+    LLMRequest,
+    PromptTooLongResponse,
+    RagChunk,
+    ReferencedDocument,
+    SummarizerResponse,
+    UnauthorizedResponse,
+)
+from ols.constants import MEDIA_TYPE_TEXT
+from ols.src.auth.auth import get_auth_dependency
+from ols.utils import errors_parsing
+from ols.utils.token_handler import PromptTooLongError
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["streaming_query"])
+auth_dependency = get_auth_dependency(config.ols_config, virtual_path="/ols-access")
+
+
+query_responses: dict[int | str, dict[str, Any]] = {
+    200: {
+        "description": "Query is valid and stream/events from endpoint is returned",
+        "model": str,
+    },
+    401: {
+        "description": "Missing or invalid credentials provided by client",
+        "model": UnauthorizedResponse,
+    },
+    403: {
+        "description": "Client does not have permission to access resource",
+        "model": ForbiddenResponse,
+    },
+    413: {
+        "description": "Prompt is too long",
+        "model": PromptTooLongResponse,
+    },
+    500: {
+        "description": "Query can not be validated, LLM is not accessible or other internal error",
+        "model": ErrorResponse,
+    },
+}
+
+
+@router.post("/streaming_query", responses=query_responses)
+def conversation_request(
+    llm_request: LLMRequest, auth: Any = Depends(auth_dependency)
+) -> StreamingResponse:
+    """Handle conversation requests for the OLS endpoint.
+
+    Args:
+        llm_request: The incoming request containing query details.
+        auth: The authentication context, provided by dependency injection.
+
+    Returns:
+        StreamingResponse: The streaming response generated for the query.
+    """
+    (
+        user_id,
+        conversation_id,
+        query_without_attachments,
+        previous_input,
+        attachments,
+        valid,
+        timestamps,
+    ) = process_request(auth, llm_request)
+
+    summarizer_response = (
+        invalid_response_generator()
+        if not valid
+        else generate_response(
+            conversation_id, llm_request, previous_input, streaming=True
+        )
+    )
+
+    return StreamingResponse(
+        response_processing_wrapper(
+            summarizer_response,
+            user_id,
+            conversation_id,
+            llm_request,
+            attachments,
+            valid,
+            query_without_attachments,
+            llm_request.media_type,
+            timestamps,
+        ),
+        media_type=llm_request.media_type,
+    )
+
+
+async def invalid_response_generator() -> AsyncGenerator[str, None]:
+    """Yield an invalid query response.
+
+    Yields:
+        str: The response indicating invalid query.
+    """
+    yield constants.INVALID_QUERY_RESP
+
+
+def stream_start_event(conversation_id: str) -> str:
+    """Yield the start of the data stream.
+
+    Args:
+        conversation_id: The conversation ID (UUID).
+    """
+    return json.dumps(
+        {
+            "event": "start",
+            "data": {
+                "conversation_id": conversation_id,
+            },
+        }
+    )
+
+
+def stream_end_event(ref_docs: list[dict], truncated: bool, media_type: str) -> str:
+    """Yield the end of the data stream.
+
+    Args:
+        ref_docs: Referenced documents.
+        truncated: Indicates if the history was truncated.
+        media_type: Media type of the response (e.g. text or JSON).
+    """
+    if media_type == constants.MEDIA_TYPE_JSON:
+        return json.dumps(
+            {
+                "event": "end",
+                "data": {
+                    "referenced_documents": ref_docs,
+                    "truncated": truncated,
+                },
+            }
+        )
+    ref_docs_string = "\n".join(
+        f'{item["doc_title"]}: {item["doc_url"]}' for item in ref_docs
+    )
+    return f"\n\n---\n\n{ref_docs_string}" if ref_docs_string else ""
+
+
+def build_referenced_docs(rag_chunks: list[RagChunk]) -> list[dict]:
+    """Build a list of unique referenced documents."""
+    referenced_documents = ReferencedDocument.from_rag_chunks(rag_chunks)
+    return [
+        {
+            "doc_title": doc.title,
+            "doc_url": doc.docs_url,
+        }
+        for doc in referenced_documents
+    ]
+
+
+def prompt_too_long_error(error: PromptTooLongError, media_type: str) -> str:
+    """Return error representation for long prompts.
+
+    Args:
+        error: The exception raised for long prompts.
+        media_type: Media type of the response (e.g. text or JSON).
+
+    Returns:
+        str: The error message formatted for the media type.
+    """
+    logger.error("Prompt is too long: %s", error)
+    if media_type == MEDIA_TYPE_TEXT:
+        return f"Prompt is too long: {error}"
+    return json.dumps(
+        {
+            "event": "error",
+            "data": {
+                "response": "Prompt is too long",
+                "cause": str(error),
+            },
+        }
+    )
+
+
+def generic_llm_error(error: Exception, media_type: str) -> str:
+    """Return error representation for generic LLM errors.
+
+    Args:
+        error: The exception raised during processing.
+        media_type: Media type of the response (e.g. text or JSON).
+
+    Returns:
+        str: The error message formatted for the media type.
+    """
+    logger.error("Error while obtaining answer for user question")
+    logger.exception(error)
+    _, response, cause = errors_parsing.parse_generic_llm_error(error)
+
+    if media_type == MEDIA_TYPE_TEXT:
+        return f"{response}: {cause}"
+    return json.dumps(
+        {
+            "event": "error",
+            "data": {
+                "response": response,
+                "cause": cause,
+            },
+        }
+    )
+
+
+def build_yield_item(item: str, idx: int, media_type: str) -> str:
+    """Build an item to yield based on media type.
+
+    Args:
+        item: The token or string fragment to yield.
+        idx: Index of the current item in the stream.
+        media_type: Media type of the response (e.g. text or JSON).
+
+    Returns:
+        str: The formatted string or JSON to yield.
+    """
+    if media_type == MEDIA_TYPE_TEXT:
+        return item
+    return json.dumps({"event": "token", "data": {"id": idx, "token": item}})
+
+
+def store_data(
+    user_id: str,
+    conversation_id: str,
+    llm_request: LLMRequest,
+    response: str,
+    attachments: list[Attachment],
+    valid: bool,
+    query_without_attachments: str,
+    rag_chunks: list[RagChunk],
+    history_truncated: bool,
+    timestamps: dict[str, float],
+) -> None:
+    """Store conversation history and transcript if enabled.
+
+    Args:
+        user_id: The user ID (UUID).
+        conversation_id: The conversation ID (UUID).
+        llm_request: The original request.
+        response: The generated response.
+        attachments: list of attachments included in the query.
+        valid: Indicates if the query was valid.
+        query_without_attachments: Query content excluding attachments.
+        rag_chunks: list of RAG (Retrieve-And-Generate) chunks used in the response.
+        history_truncated: Indicates if the conversation history was truncated.
+        timestamps: Dictionary tracking timestamps for various stages.
+    """
+    store_conversation_history(
+        user_id, conversation_id, llm_request, response, attachments
+    )
+
+    if not config.ols_config.user_data_collection.transcripts_disabled:
+        store_transcript(
+            user_id,
+            conversation_id,
+            valid,
+            query_without_attachments,
+            llm_request,
+            response,
+            rag_chunks,
+            history_truncated,
+            attachments,
+        )
+    timestamps["store transcripts"] = time.time()
+
+
+async def response_processing_wrapper(
+    generator: AsyncGenerator[Any, None],
+    user_id: str,
+    conversation_id: str,
+    llm_request: LLMRequest,
+    attachments: list[Attachment],
+    valid: bool,
+    query_without_attachments: str,
+    media_type: str,
+    timestamps: dict[str, float],
+) -> AsyncGenerator[str, None]:
+    """Process the response from the generator and handle metadata and errors.
+
+    Args:
+        generator: The async generator providing summarizer responses.
+        user_id: The user ID (UUID).
+        conversation_id: The conversation ID (UUID).
+        llm_request: The original request.
+        attachments: list of attachments included in the query.
+        valid: Indicates if the query was valid.
+        query_without_attachments: Query content excluding attachments.
+        media_type: Media type of the response (e.g. text or JSON).
+        timestamps: Dictionary tracking timestamps for various stages.
+
+    Yields:
+        str: The response items or error messages.
+    """
+    if media_type == constants.MEDIA_TYPE_JSON:
+        yield stream_start_event(conversation_id)
+
+    response = ""
+    rag_chunks = []
+    history_truncated = False
+    idx = 0
+    try:
+        async for item in generator:
+            if isinstance(item, SummarizerResponse):
+                rag_chunks = item.rag_chunks
+                history_truncated = item.history_truncated
+                break
+
+            response += item
+            yield build_yield_item(item, idx, media_type)
+            idx += 1
+    except PromptTooLongError as summarizer_error:
+        yield prompt_too_long_error(summarizer_error, media_type)
+    except Exception as summarizer_error:
+        yield generic_llm_error(summarizer_error, media_type)
+    timestamps["generate response"] = time.time()
+
+    store_data(
+        user_id,
+        conversation_id,
+        llm_request,
+        response,
+        attachments,
+        valid,
+        query_without_attachments,
+        rag_chunks,
+        history_truncated,
+        timestamps,
+    )
+
+    yield stream_end_event(
+        build_referenced_docs(rag_chunks), history_truncated, media_type
+    )
+
+    timestamps["add references"] = time.time()
+
+    log_processing_durations(timestamps)

--- a/ols/app/endpoints/streaming_ols.py
+++ b/ols/app/endpoints/streaming_ols.py
@@ -332,8 +332,12 @@ async def response_processing_wrapper(
             idx += 1
     except PromptTooLongError as summarizer_error:
         yield prompt_too_long_error(summarizer_error, media_type)
+        return  # stop execution after error
+
     except Exception as summarizer_error:
         yield generic_llm_error(summarizer_error, media_type)
+        return  # stop execution after error
+
     timestamps["generate response"] = time.time()
 
     store_data(

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -6,6 +6,7 @@ from typing import Optional, Self
 from pydantic import BaseModel, field_validator, model_validator
 from pydantic.dataclasses import dataclass
 
+from ols.constants import MEDIA_TYPE_JSON, MEDIA_TYPE_TEXT
 from ols.src.prompts import prompts
 from ols.utils import suid
 
@@ -66,6 +67,7 @@ class LLMRequest(BaseModel):
         provider: The optional provider.
         model: The optional model.
         attachments: The optional attachments.
+        media_type: The optional parameter for streaming response.
 
     Example:
         ```python
@@ -79,6 +81,7 @@ class LLMRequest(BaseModel):
     model: Optional[str] = None
     system_prompt: Optional[str] = None
     attachments: Optional[list[Attachment]] = None
+    media_type: Optional[str] = MEDIA_TYPE_TEXT
 
     # provides examples for /docs endpoint
     model_config = {
@@ -108,6 +111,7 @@ class LLMRequest(BaseModel):
                             "content": "foo: bar",
                         },
                     ],
+                    "media_type": "text/plain",
                 }
             ]
         },
@@ -123,6 +127,11 @@ class LLMRequest(BaseModel):
         if self.provider and not self.model:
             raise ValueError(
                 "LLM model must be specified when the provider is specified."
+            )
+        if self.media_type not in (MEDIA_TYPE_TEXT, MEDIA_TYPE_JSON):
+            raise ValueError(
+                f"Invalid media type: '{self.media_type}', must be "
+                f"{MEDIA_TYPE_TEXT} or {MEDIA_TYPE_JSON}"
             )
         return self
 

--- a/ols/app/routers.py
+++ b/ols/app/routers.py
@@ -2,7 +2,7 @@
 
 from fastapi import FastAPI
 
-from ols.app.endpoints import authorized, feedback, health, ols
+from ols.app.endpoints import authorized, feedback, health, ols, streaming_ols
 from ols.app.metrics import metrics
 
 
@@ -13,6 +13,7 @@ def include_routers(app: FastAPI) -> None:
         app: The `FastAPI` app instance.
     """
     app.include_router(ols.router, prefix="/v1")
+    app.include_router(streaming_ols.router, prefix="/v1")
     app.include_router(feedback.router, prefix="/v1")
     app.include_router(health.router)
     app.include_router(metrics.router)

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -45,12 +45,10 @@ SUPPORTED_PROVIDER_TYPES = frozenset(
         PROVIDER_FAKE,
     }
 )
-
 DEFAULT_AZURE_API_VERSION = "2024-02-15-preview"
 
+
 # models
-
-
 class ModelFamily(StrEnum):
     """Different LLM models family/group."""
 
@@ -219,3 +217,7 @@ DEFAULT_CONFIGURATION_FILE = "olsconfig.yaml"
 # Environment variable containing configuration file name to override default
 # configuration file
 CONFIGURATION_FILE_NAME_ENV_VARIABLE = "OLS_CONFIG_FILE"
+
+# Response streaming media types
+MEDIA_TYPE_TEXT = "text/plain"
+MEDIA_TYPE_JSON = "application/json"

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -1,16 +1,18 @@
 """A class for summarizing documentation context."""
 
 import logging
-from typing import Any, Optional
+from typing import Any, AsyncGenerator, Optional
 
 from langchain.chains import LLMChain
+from langchain_core.prompts import ChatPromptTemplate
 from llama_index.core import VectorStoreIndex
 
 from ols import config
 from ols.app.metrics import TokenMetricUpdater
-from ols.app.models.models import SummarizerResponse
+from ols.app.models.models import RagChunk, SummarizerResponse
 from ols.constants import RAG_CONTENT_LIMIT, GenericLLMParameters
 from ols.src.prompts.prompt_generator import GeneratePrompt
+from ols.src.prompts.prompts import QUERY_SYSTEM_INSTRUCTION
 from ols.src.query_helpers.query_helper import QueryHelper
 from ols.utils.token_handler import TokenHandler
 
@@ -23,62 +25,72 @@ class DocsSummarizer(QueryHelper):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the QuestionValidator."""
         super().__init__(*args, **kwargs)
-        provider_config = config.llm_config.providers.get(self.provider)
-        model_config = provider_config.models.get(self.model)
-        self.generic_llm_params = {
-            GenericLLMParameters.MAX_TOKENS_FOR_RESPONSE: model_config.parameters.max_tokens_for_response  # noqa: E501
-        }
+        self._prepare_llm()
+        self._get_system_prompt()
+        self.verbose = config.ols_config.logging_config.app_log_level == logging.DEBUG
 
-    def summarize(
+    def _prepare_llm(self) -> None:
+        """Prepare the LLM configuration."""
+        self.provider_config = config.llm_config.providers.get(self.provider)
+        self.model_config = self.provider_config.models.get(self.model)
+        self.generic_llm_params = {
+            GenericLLMParameters.MAX_TOKENS_FOR_RESPONSE: self.model_config.parameters.max_tokens_for_response  # noqa: E501
+        }
+        self.bare_llm = self.llm_loader(
+            self.provider, self.model, self.generic_llm_params
+        )
+
+    def _get_system_prompt(self) -> None:
+        """Retrieve the system prompt."""
+        # use system prompt from config if available otherwise use
+        # default system prompt fine-tuned for the service
+        if config.ols_config.system_prompt is not None:
+            self.system_prompt = config.ols_config.system_prompt
+        else:
+            self.system_prompt = QUERY_SYSTEM_INSTRUCTION
+        logger.debug("System prompt: %s", self.system_prompt)
+
+    def _prepare_prompt(
         self,
-        conversation_id: str,
         query: str,
         vector_index: Optional[VectorStoreIndex] = None,
         history: Optional[list[str]] = None,
-    ) -> SummarizerResponse:
+    ) -> tuple[ChatPromptTemplate, dict[str, str], list[RagChunk], bool]:
         """Summarize the given query based on the provided conversation context.
 
         Args:
-            conversation_id: The unique identifier for the conversation.
             query: The query to be summarized.
-            vector_index: Vector index to get rag data/context.
+            vector_index: Vector index to get RAG data/context.
             history: The history of the conversation (if available).
 
         Returns:
-            A `SummarizerResponse` object.
+            A tuple containing the final prompt, input values, RAG chunks,
+            and a flag for truncated history.
         """
-        # if history is not provided, initialize to empty history
-        if history is None:
-            history = []
-
-        verbose = config.ols_config.logging_config.app_log_level == logging.DEBUG
-
         settings_string = (
-            f"conversation_id: {conversation_id}, "
             f"query: {query}, "
             f"provider: {self.provider}, "
             f"model: {self.model}, "
-            f"verbose: {verbose}"
+            f"verbose: {self.verbose}"
         )
-        logger.debug("%s call settings: %s", conversation_id, settings_string)
+        logger.debug("call settings: %s", settings_string)
 
         token_handler = TokenHandler()
-        bare_llm = self.llm_loader(self.provider, self.model, self.generic_llm_params)
-        provider_config = config.llm_config.providers.get(self.provider)
-        model_config = provider_config.models.get(self.model)
 
-        # Use sample text for context/history to get complete prompt instruction.
-        # This is used to calculate available tokens.
+        # Use sample text for context/history to get complete prompt
+        # instruction. This is used to calculate available tokens.
         temp_prompt, temp_prompt_input = GeneratePrompt(
-            query, ["sample"], ["ai: sample"], self._system_prompt
+            query, ["sample"], ["ai: sample"], self.system_prompt
         ).generate_prompt(self.model)
+
         available_tokens = token_handler.calculate_and_check_available_tokens(
             temp_prompt.format(**temp_prompt_input),
-            model_config.context_window_size,
-            model_config.parameters.max_tokens_for_response,
+            self.model_config.context_window_size,
+            self.model_config.parameters.max_tokens_for_response,
         )
 
-        if vector_index is not None:
+        # Retrieve RAG content
+        if vector_index:
             retriever = vector_index.as_retriever(similarity_top_k=RAG_CONTENT_LIMIT)
             rag_chunks, available_tokens = token_handler.truncate_rag_context(
                 retriever.retrieve(query), self.model, available_tokens
@@ -86,16 +98,17 @@ class DocsSummarizer(QueryHelper):
         else:
             logger.warning("Proceeding without RAG content. Check start up messages.")
             rag_chunks = []
-
         rag_context = [rag_chunk.text for rag_chunk in rag_chunks]
+        if len(rag_context) == 0:
+            logger.debug("Using llm to answer the query without reference content")
 
-        # Truncate history, if applicable
+        # Truncate history
         history, truncated = token_handler.limit_conversation_history(
-            history, self.model, available_tokens
+            history or [], self.model, available_tokens
         )
 
         final_prompt, llm_input_values = GeneratePrompt(
-            query, rag_context, history, self._system_prompt
+            query, rag_context, history, self.system_prompt
         ).generate_prompt(self.model)
 
         # Tokens-check: We trigger the computation of the token count
@@ -103,19 +116,32 @@ class DocsSummarizer(QueryHelper):
         # the query is within the token limit.
         token_handler.calculate_and_check_available_tokens(
             final_prompt.format(**llm_input_values),
-            model_config.context_window_size,
-            model_config.parameters.max_tokens_for_response,
+            self.model_config.context_window_size,
+            self.model_config.parameters.max_tokens_for_response,
+        )
+
+        return final_prompt, llm_input_values, rag_chunks, truncated
+
+    def create_response(
+        self,
+        query: str,
+        vector_index: Optional[VectorStoreIndex] = None,
+        history: Optional[list[str]] = None,
+    ) -> SummarizerResponse:
+        """Create a response for the given query based on the provided conversation context."""
+        final_prompt, llm_input_values, rag_chunks, truncated = self._prepare_prompt(
+            query, vector_index, history
         )
 
         chat_engine = LLMChain(
-            llm=bare_llm,
+            llm=self.bare_llm,
             prompt=final_prompt,
-            verbose=verbose,
+            verbose=self.verbose,
         )
 
         with TokenMetricUpdater(
-            llm=bare_llm,
-            provider=provider_config.type,
+            llm=self.bare_llm,
+            provider=self.provider_config.type,
             model=self.model,
         ) as token_counter:
             summary = chat_engine.invoke(
@@ -129,13 +155,37 @@ class DocsSummarizer(QueryHelper):
         # Recently watsonx/granite-13b started adding stop token to response.
         response = response.replace("<|endoftext|>", "")
 
-        if len(rag_context) == 0:
-            logger.debug("Using llm to answer the query without reference content")
-        logger.debug("%s Summary response: %s", conversation_id, response)
-
         return SummarizerResponse(response, rag_chunks, truncated)
 
-    @property
-    def system_prompt(self) -> str:
-        """Return actually used system prompt."""
-        return self._system_prompt
+    async def generate_response(
+        self,
+        query: str,
+        vector_index: Optional[VectorStoreIndex] = None,
+        history: Optional[list[str]] = None,
+    ) -> AsyncGenerator[str, SummarizerResponse]:
+        """Generate a response for the given query based on the provided conversation context."""
+        final_prompt, llm_input_values, rag_chunks, truncated = self._prepare_prompt(
+            query, vector_index, history
+        )
+
+        with TokenMetricUpdater(
+            llm=self.bare_llm,
+            provider=self.provider_config.type,
+            model=self.model,
+        ) as token_counter:
+            async for chunk in self.bare_llm.astream(
+                final_prompt.format_prompt(**llm_input_values).to_messages(),
+                config={"callbacks": [token_counter]},
+            ):
+                # TODO: it is bad to have provider specific code here
+                # the reason we have provider classes is to hide specific
+                # implementation details there. But it requires expanding
+                # the current providers interface, eg. to stream messages
+
+                # openai returns an `AIMessageChunk` while Watsonx plain string
+                chunk_content = chunk.content if hasattr(chunk, "content") else chunk
+                if "<|endoftext|>" in chunk_content:
+                    chunk_content = chunk_content.replace("<|endoftext|>", "")
+                yield chunk_content
+
+        yield SummarizerResponse("", rag_chunks, truncated)  # type: ignore[misc]

--- a/tests/e2e/test_streaming_query_endpoint.py
+++ b/tests/e2e/test_streaming_query_endpoint.py
@@ -1,0 +1,567 @@
+"""End to end tests for the REST API streming query endpoint."""
+
+import json
+import re
+
+import pytest
+import requests
+
+from ols import constants
+from ols.utils import suid
+from tests.e2e.utils import cluster as cluster_utils
+from tests.e2e.utils import metrics as metrics_utils
+from tests.e2e.utils import response as response_utils
+from tests.e2e.utils.decorators import retry
+
+from . import test_api
+
+endpoint = "/v1/streaming_query"
+
+
+def parse_streaming_response_to_events(response: str) -> list[dict]:
+    """Parse streaming response to events."""
+    return json.loads(f'[{response.replace("}{", "},{")}]')
+
+
+def construct_response_from_streamed_events(events: dict) -> str:
+    """Construct response from streamed events."""
+    response = ""
+    for event in events:
+        if event["event"] == "token":
+            response += event["data"]["token"]
+    return response
+
+
+def test_invalid_question():
+    """Check the endpoint POST method for invalid question."""
+    with metrics_utils.RestAPICallCounterChecker(pytest.metrics_client, endpoint):
+        cid = suid.get_suid()
+
+        response = pytest.client.post(
+            endpoint,
+            json={
+                "conversation_id": cid,
+                "query": "how to make burger?",
+                "media_type": constants.MEDIA_TYPE_TEXT,
+            },
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+
+        assert response.status_code == requests.codes.ok
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_TEXT)
+
+        assert re.search(
+            r"(sorry|questions|assist)",
+            response.text,
+            re.IGNORECASE,
+        )
+
+
+def test_invalid_question_without_conversation_id():
+    """Check the endpoint POST method for generating new conversation_id."""
+    with metrics_utils.RestAPICallCounterChecker(pytest.metrics_client, endpoint):
+        response = pytest.client.post(
+            endpoint,
+            json={
+                "query": "how to make burger?",
+                "media_type": constants.MEDIA_TYPE_JSON,
+            },
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+        assert response.status_code == requests.codes.ok
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_JSON)
+        events = parse_streaming_response_to_events(response.text)
+
+        # new conversation ID should be generated
+        assert events[0]["event"] == "start"
+        assert events[0]["data"]
+        assert suid.check_suid(events[0]["data"]["conversation_id"])
+
+
+def test_query_call_without_payload():
+    """Check the endpoint with POST HTTP method when no payload is provided."""
+    with metrics_utils.RestAPICallCounterChecker(
+        pytest.metrics_client,
+        endpoint,
+        status_code=requests.codes.unprocessable_entity,
+    ):
+        response = pytest.client.post(
+            endpoint,
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+        assert response.status_code == requests.codes.unprocessable_entity
+
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_JSON)
+        # the actual response might differ when new Pydantic version
+        # will be used so let's do just primitive check
+        assert "missing" in response.text
+
+
+def test_query_call_with_improper_payload():
+    """Check the endpoint with POST HTTP method when improper payload is provided."""
+    with metrics_utils.RestAPICallCounterChecker(
+        pytest.metrics_client,
+        endpoint,
+        status_code=requests.codes.unprocessable_entity,
+    ):
+        response = pytest.client.post(
+            endpoint,
+            json={"parameter": "this-is-unknown-parameter"},
+            timeout=test_api.NON_LLM_REST_API_TIMEOUT,
+        )
+        assert response.status_code == requests.codes.unprocessable_entity
+
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_JSON)
+        # the actual response might differ when new Pydantic version will be used
+        # so let's do just primitive check
+        assert "missing" in response.text
+
+
+def test_valid_question_improper_conversation_id() -> None:
+    """Check the endpoint with POST HTTP method for improper conversation ID."""
+    with metrics_utils.RestAPICallCounterChecker(
+        pytest.metrics_client,
+        endpoint,
+        status_code=requests.codes.internal_server_error,
+    ):
+        response = pytest.client.post(
+            endpoint,
+            json={"conversation_id": "not-uuid", "query": "what is kubernetes?"},
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+        assert response.status_code == requests.codes.internal_server_error
+
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_JSON)
+        json_response = response.json()
+        expected_response = {
+            "detail": {
+                "response": "Error retrieving conversation history",
+                "cause": "Invalid conversation ID not-uuid",
+            }
+        }
+        assert json_response == expected_response
+
+
+def test_too_long_question() -> None:
+    """Check the endpoint with too long question."""
+    # let's make the query really large, larger that context window size
+    query = "what is kubernetes?" * 10000
+
+    with metrics_utils.RestAPICallCounterChecker(
+        pytest.metrics_client,
+        endpoint,
+        status_code=requests.codes.ok,
+    ):
+        cid = suid.get_suid()
+        response = pytest.client.post(
+            endpoint,
+            json={
+                "conversation_id": cid,
+                "query": query,
+                "media_type": constants.MEDIA_TYPE_JSON,
+            },
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+        assert response.status_code == requests.codes.ok
+
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_JSON)
+
+        events = parse_streaming_response_to_events(response.text)
+
+        assert len(events) == 2
+        assert events[1]["event"] == "error"
+        assert events[1]["data"]["response"] == "Prompt is too long"
+
+
+@pytest.mark.smoketest
+@pytest.mark.rag
+def test_valid_question() -> None:
+    """Check the endpoint with POST HTTP method for valid question and no yaml."""
+    with metrics_utils.RestAPICallCounterChecker(pytest.metrics_client, endpoint):
+        cid = suid.get_suid()
+        response = pytest.client.post(
+            endpoint,
+            json={"conversation_id": cid, "query": "what is kubernetes?"},
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+        assert response.status_code == requests.codes.ok
+
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_TEXT)
+
+        assert "Kubernetes is" in response.text
+        assert re.search(
+            r"orchestration (tool|system|platform|engine)",
+            response.text,
+            re.IGNORECASE,
+        )
+
+
+@pytest.mark.rag
+def test_ocp_docs_version_same_as_cluster_version() -> None:
+    """Check that the version of OCP docs matches the cluster we're on."""
+    with metrics_utils.RestAPICallCounterChecker(pytest.metrics_client, endpoint):
+        cid = suid.get_suid()
+        response = pytest.client.post(
+            endpoint,
+            json={
+                "conversation_id": cid,
+                "query": "welcome openshift container platform documentation",
+                "media_type": constants.MEDIA_TYPE_JSON,
+            },
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+        assert response.status_code == requests.codes.ok
+
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_JSON)
+        major, minor = cluster_utils.get_cluster_version()
+        events = parse_streaming_response_to_events(response.text)
+        assert events[-1]["event"] == "end"
+        assert events[-1]["data"]["referenced_documents"]
+        assert (
+            f"{major}.{minor}"
+            in events[-1]["data"]["referenced_documents"][0]["doc_title"]
+        )
+
+
+def test_valid_question_tokens_counter() -> None:
+    """Check how the tokens counter are updated accordingly."""
+    model, provider = metrics_utils.get_enabled_model_and_provider(
+        pytest.metrics_client
+    )
+
+    with (
+        metrics_utils.RestAPICallCounterChecker(pytest.metrics_client, endpoint),
+        metrics_utils.TokenCounterChecker(pytest.metrics_client, model, provider),
+    ):
+        response = pytest.client.post(
+            endpoint,
+            json={"query": "what is kubernetes?"},
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+        assert response.status_code == requests.codes.ok
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_TEXT)
+
+
+def test_invalid_question_tokens_counter() -> None:
+    """Check how the tokens counter are updated accordingly."""
+    model, provider = metrics_utils.get_enabled_model_and_provider(
+        pytest.metrics_client
+    )
+
+    with (
+        metrics_utils.RestAPICallCounterChecker(pytest.metrics_client, endpoint),
+        metrics_utils.TokenCounterChecker(pytest.metrics_client, model, provider),
+    ):
+        response = pytest.client.post(
+            endpoint,
+            json={"query": "how to make burger?"},
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+        assert response.status_code == requests.codes.ok
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_TEXT)
+
+
+def test_token_counters_for_query_call_without_payload() -> None:
+    """Check how the tokens counter are updated accordingly."""
+    model, provider = metrics_utils.get_enabled_model_and_provider(
+        pytest.metrics_client
+    )
+
+    with (
+        metrics_utils.RestAPICallCounterChecker(
+            pytest.metrics_client,
+            endpoint,
+            status_code=requests.codes.unprocessable_entity,
+        ),
+        metrics_utils.TokenCounterChecker(
+            pytest.metrics_client,
+            model,
+            provider,
+            expect_sent_change=False,
+            expect_received_change=False,
+        ),
+    ):
+        response = pytest.client.post(
+            endpoint,
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+        assert response.status_code == requests.codes.unprocessable_entity
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_JSON)
+
+
+def test_token_counters_for_query_call_with_improper_payload() -> None:
+    """Check how the tokens counter are updated accordingly."""
+    model, provider = metrics_utils.get_enabled_model_and_provider(
+        pytest.metrics_client
+    )
+
+    with (
+        metrics_utils.RestAPICallCounterChecker(
+            pytest.metrics_client,
+            endpoint,
+            status_code=requests.codes.unprocessable_entity,
+        ),
+        metrics_utils.TokenCounterChecker(
+            pytest.metrics_client,
+            model,
+            provider,
+            expect_sent_change=False,
+            expect_received_change=False,
+        ),
+    ):
+        response = pytest.client.post(
+            endpoint,
+            json={"parameter": "this-is-not-proper-question-my-friend"},
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+        assert response.status_code == requests.codes.unprocessable_entity
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_JSON)
+
+
+@pytest.mark.rag
+@retry(max_attempts=3, wait_between_runs=10)
+def test_rag_question() -> None:
+    """Ensure responses include rag references."""
+    with metrics_utils.RestAPICallCounterChecker(pytest.metrics_client, endpoint):
+        response = pytest.client.post(
+            endpoint,
+            json={
+                "query": "what is openshift virtualization?",
+                "media_type": constants.MEDIA_TYPE_JSON,
+            },
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+        assert response.status_code == requests.codes.ok
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_JSON)
+
+        events = parse_streaming_response_to_events(response.text)
+
+        assert events[0]["event"] == "start"
+        assert events[0]["data"]["conversation_id"]
+        assert events[-1]["event"] == "end"
+        ref_docs = events[-1]["data"]["referenced_documents"]
+        assert ref_docs
+        assert "virt" in ref_docs[0]["doc_url"]
+        assert "https://" in ref_docs[0]["doc_url"]
+
+        # ensure no duplicates in docs
+        docs_urls = [doc["doc_url"] for doc in ref_docs]
+        assert len(set(docs_urls)) == len(docs_urls)
+
+
+@pytest.mark.cluster
+def test_query_filter() -> None:
+    """Ensure responses does not include filtered words and redacted words are not logged."""
+    with metrics_utils.RestAPICallCounterChecker(pytest.metrics_client, endpoint):
+        query = "what is foo in bar?"
+        response = pytest.client.post(
+            endpoint,
+            json={"query": query},
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+        assert response.status_code == requests.codes.ok
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_TEXT)
+
+        # values to be filtered and replaced are defined in:
+        # tests/config/singleprovider.e2e.template.config.yaml
+        response_text = response.text.lower()
+        assert "openshift" in response_text
+        assert "deploy" in response_text
+        response_words = response_text.split()
+        assert "foo" not in response_words
+        assert "bar" not in response_words
+
+        # Retrieve the pod name
+        ols_container_name = "lightspeed-service-api"
+        pod_name = cluster_utils.get_pod_by_prefix()[0]
+
+        # Check if filtered words are redacted in the logs
+        container_log = cluster_utils.get_container_log(pod_name, ols_container_name)
+
+        # Ensure redacted patterns do not appear in the logs
+        unwanted_patterns = ["foo ", "what is foo in bar?"]
+        for line in container_log.splitlines():
+            # Only check lines that are not part of a query
+            if re.search(r'Body: \{"query":', line):
+                continue
+            # check that the pattern is indeed not found in logs
+            for pattern in unwanted_patterns:
+                assert pattern not in line.lower()
+
+        # Ensure the intended redaction has occurred
+        assert "what is deployment in openshift?" in container_log
+
+
+@retry(max_attempts=3, wait_between_runs=10)
+def test_conversation_history() -> None:
+    """Ensure conversations include previous query history."""
+    with metrics_utils.RestAPICallCounterChecker(pytest.metrics_client, endpoint):
+        response = pytest.client.post(
+            endpoint,
+            json={
+                "query": "what is ingress in kubernetes?",
+                "media_type": constants.MEDIA_TYPE_JSON,
+            },
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+        scenario_fail_msg = "First call to LLM without conversation history has failed"
+        assert response.status_code == requests.codes.ok, scenario_fail_msg
+        response_utils.check_content_type(
+            response, constants.MEDIA_TYPE_JSON, scenario_fail_msg
+        )
+
+        events = parse_streaming_response_to_events(response.text)
+        response_text = construct_response_from_streamed_events(events).lower()
+
+        assert "ingress" in response_text, scenario_fail_msg
+
+        # get the conversation id so we can reuse it for the follow up question
+        assert events[0]["event"] == "start"
+        cid = events[0]["data"]["conversation_id"]
+        response = pytest.client.post(
+            endpoint,
+            json={
+                "conversation_id": cid,
+                "query": "what?",
+                "media_type": constants.MEDIA_TYPE_JSON,
+            },
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+
+        scenario_fail_msg = "Second call to LLM with conversation history has failed"
+        assert response.status_code == requests.codes.ok
+        response_utils.check_content_type(
+            response, constants.MEDIA_TYPE_JSON, scenario_fail_msg
+        )
+
+        events = parse_streaming_response_to_events(response.text)
+        response_text = construct_response_from_streamed_events(events).lower()
+        assert "ingress" in response_text, scenario_fail_msg
+
+
+def test_query_with_provider_but_not_model() -> None:
+    """Check the endpoint with POST HTTP method for provider specified, but no model."""
+    with metrics_utils.RestAPICallCounterChecker(
+        pytest.metrics_client,
+        endpoint,
+        status_code=requests.codes.unprocessable_entity,
+    ):
+        # just the provider is explicitly specified, but model selection is missing
+        response = pytest.client.post(
+            endpoint,
+            json={
+                "conversation_id": "",
+                "query": "what is kubernetes?",
+                "provider": "bam",
+            },
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+        assert response.status_code == requests.codes.unprocessable_entity
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_JSON)
+
+        json_response = response.json()
+
+        # error thrown on Pydantic level
+        assert (
+            json_response["detail"][0]["msg"]
+            == "Value error, LLM model must be specified when the provider is specified."
+        )
+
+
+def test_query_with_model_but_not_provider() -> None:
+    """Check the endpoint with POST HTTP method for model specified, but no provider."""
+    with metrics_utils.RestAPICallCounterChecker(
+        pytest.metrics_client,
+        endpoint,
+        status_code=requests.codes.unprocessable_entity,
+    ):
+        # just model is explicitly specified, but provider selection is missing
+        response = pytest.client.post(
+            endpoint,
+            json={
+                "conversation_id": "",
+                "query": "what is kubernetes?",
+                "model": "ibm/granite-13b-chat-v2",
+            },
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+        assert response.status_code == requests.codes.unprocessable_entity
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_JSON)
+
+        json_response = response.json()
+
+        assert (
+            json_response["detail"][0]["msg"]
+            == "Value error, LLM provider must be specified when the model is specified."
+        )
+
+
+def test_query_with_unknown_provider() -> None:
+    """Check the endpoint with POST HTTP method for unknown provider specified."""
+    # retrieve currently selected model
+    model, _ = metrics_utils.get_enabled_model_and_provider(pytest.metrics_client)
+
+    with metrics_utils.RestAPICallCounterChecker(
+        pytest.metrics_client,
+        endpoint,
+        status_code=requests.codes.unprocessable_entity,
+    ):
+        # provider is unknown
+        response = pytest.client.post(
+            endpoint,
+            json={
+                "conversation_id": "",
+                "query": "what is kubernetes?",
+                "provider": "foo",
+                "model": model,
+            },
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+        assert response.status_code == requests.codes.unprocessable_entity
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_JSON)
+
+        json_response = response.json()
+
+        # explicit response and cause check
+        assert (
+            "detail" in json_response
+        ), "Improper response format: 'detail' node is missing"
+        assert "Unable to process this request" in json_response["detail"]["response"]
+        assert (
+            "Provider 'foo' is not a valid provider."
+            in json_response["detail"]["cause"]
+        )
+
+
+def test_query_with_unknown_model() -> None:
+    """Check the endpoint with POST HTTP method for unknown model specified."""
+    # retrieve currently selected provider
+    _, provider = metrics_utils.get_enabled_model_and_provider(pytest.metrics_client)
+
+    with metrics_utils.RestAPICallCounterChecker(
+        pytest.metrics_client,
+        endpoint,
+        status_code=requests.codes.unprocessable_entity,
+    ):
+        # model is unknown
+        response = pytest.client.post(
+            endpoint,
+            json={
+                "conversation_id": "",
+                "query": "what is kubernetes?",
+                "provider": provider,
+                "model": "bar",
+            },
+            timeout=test_api.LLM_REST_API_TIMEOUT,
+        )
+        assert response.status_code == requests.codes.unprocessable_entity
+        response_utils.check_content_type(response, constants.MEDIA_TYPE_JSON)
+
+        json_response = response.json()
+
+        # explicit response and cause check
+        assert (
+            "detail" in json_response
+        ), "Improper response format: 'detail' node is missing"
+        assert "Unable to process this request" in json_response["detail"]["response"]
+        assert "Model 'bar' is not a valid model " in json_response["detail"]["cause"]

--- a/tests/mock_classes/mock_llm_loader.py
+++ b/tests/mock_classes/mock_llm_loader.py
@@ -14,6 +14,11 @@ class MockLLMLoader:
             llm.model = "mock_model"
         self.llm = llm
 
+    async def astream(self, llm_input, **kwargs):
+        """Return query result."""
+        # yield input prompt/user query
+        yield llm_input[1].content
+
 
 def mock_llm_loader(llm=None, expected_params=None):
     """Construct mock for load_llm."""

--- a/tests/unit/app/endpoints/test_streaming_ols.py
+++ b/tests/unit/app/endpoints/test_streaming_ols.py
@@ -1,0 +1,131 @@
+"""Unit tests for streaming_ols.py."""
+
+import json
+
+import pytest
+
+from ols import config, constants
+from ols.app.endpoints.streaming_ols import (
+    build_referenced_docs,
+    build_yield_item,
+    generic_llm_error,
+    invalid_response_generator,
+    prompt_too_long_error,
+    stream_end_event,
+    stream_start_event,
+)
+from ols.app.models.models import RagChunk
+from ols.utils import suid
+
+conversation_id = suid.get_suid()
+
+
+async def drain_generator(generator) -> str:
+    """Drain the async generator and return the result."""
+    result = ""
+    async for item in generator:
+        result += item
+    return result
+
+
+@pytest.fixture(scope="function")
+def _load_config():
+    """Load config before unit tests."""
+    config.reload_from_yaml_file("tests/config/test_app_endpoints.yaml")
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_load_config")
+async def test_invalid_response_generator():
+    """Test invalid_response_generator."""
+    generator = invalid_response_generator()
+
+    response = await drain_generator(generator)
+
+    assert response == constants.INVALID_QUERY_RESP
+
+
+def test_build_yield_item():
+    """Test build_yield_item."""
+    assert build_yield_item("bla", 0, constants.MEDIA_TYPE_TEXT) == "bla"
+    assert (
+        build_yield_item("bla", 1, constants.MEDIA_TYPE_JSON)
+        == '{"event": "token", "data": {"id": 1, "token": "bla"}}'
+    )
+
+
+def test_prompt_too_long_error():
+    """Test prompt_too_long_error."""
+    assert (
+        prompt_too_long_error("error", constants.MEDIA_TYPE_TEXT)
+        == "Prompt is too long: error"
+    )
+
+    assert (
+        prompt_too_long_error("error", constants.MEDIA_TYPE_JSON)
+        == '{"event": "error", "data": {"response": "Prompt is too long", "cause": "error"}}'
+    )
+
+
+def test_generic_llm_error():
+    """Test generic_llm_error."""
+    assert (
+        generic_llm_error("error", constants.MEDIA_TYPE_TEXT)
+        == "Oops, something went wrong during LLM invocation: error"
+    )
+
+    assert (
+        generic_llm_error("error", constants.MEDIA_TYPE_JSON)
+        == '{"event": "error", "data": {"response": "Oops, something went wrong during LLM invocation", "cause": "error"}}'  # noqa: E501
+    )
+
+
+def test_stream_start_event():
+    """Test stream_start_event."""
+    assert stream_start_event(conversation_id) == json.dumps(
+        {
+            "event": "start",
+            "data": {
+                "conversation_id": conversation_id,
+            },
+        }
+    )
+
+
+def test_stream_end_event():
+    """Test stream_end_event."""
+    ref_docs = [{"doc_title": "title_1", "doc_url": "doc_url_1"}]
+    truncated = False
+
+    assert (
+        stream_end_event(ref_docs, truncated, constants.MEDIA_TYPE_TEXT)
+        == "\n\n---\n\ntitle_1: doc_url_1"
+    )
+
+    assert stream_end_event(
+        ref_docs, truncated, constants.MEDIA_TYPE_JSON
+    ) == json.dumps(
+        {
+            "event": "end",
+            "data": {
+                "referenced_documents": [
+                    {"doc_title": "title_1", "doc_url": "doc_url_1"}
+                ],
+                "truncated": truncated,
+            },
+        }
+    )
+
+
+def test_build_referenced_docs():
+    """Test build_referenced_docs."""
+    rag_chunks = [
+        RagChunk("bla", "url_1", "title_1"),
+        RagChunk("bla", "url_2", "title_2"),
+        RagChunk("bla", "url_1", "title_1"),  # duplicate
+    ]
+
+    assert build_referenced_docs(rag_chunks) == [
+        {"doc_title": "title_1", "doc_url": "url_1"},
+        {"doc_title": "title_2", "doc_url": "url_2"},
+    ]

--- a/tests/unit/app/models/test_models.py
+++ b/tests/unit/app/models/test_models.py
@@ -16,6 +16,7 @@ from ols.app.models.models import (
     ReferencedDocument,
     StatusResponse,
 )
+from ols.constants import MEDIA_TYPE_JSON, MEDIA_TYPE_TEXT
 from ols.utils import suid
 
 
@@ -33,6 +34,8 @@ class TestLLM:
         assert llm_request.conversation_id is None
         assert llm_request.provider is None
         assert llm_request.model is None
+        assert llm_request.attachments is None
+        assert llm_request.media_type == "text/plain"
 
     @staticmethod
     def test_llm_request_optional_inputs():
@@ -92,6 +95,22 @@ class TestLLM:
         assert llm_response.response == response
         assert llm_response.referenced_documents == referenced_documents
         assert not llm_response.truncated
+
+    @staticmethod
+    def test_media_type():
+        """Test the media_type field of the LLMRequest model."""
+        query = "irrelevant"
+
+        media_type = MEDIA_TYPE_TEXT
+        llm_request = LLMRequest(query=query, media_type=media_type)
+        assert llm_request.media_type == media_type
+
+        media_type = MEDIA_TYPE_JSON
+        llm_request = LLMRequest(query=query, media_type=media_type)
+        assert llm_request.media_type == media_type
+
+        with pytest.raises(ValidationError, match="Invalid media type: 'unknown'"):
+            LLMRequest(query=query, media_type="unknown")
 
 
 class TestStatusResponse:


### PR DESCRIPTION
## Description

Add streaming_query endpoint

## Type of change

- [x] New feature

## TODO
- [ ] decide if this is how we want to implement it
- [ ] additional minor code org
- [ ] docs/schema
- [ ] fix tests

## Preview

### Non-streaming

```sh
curl -X POST http://localhost:8080/v1/query -H "Content-Type: application/json" -d '{"query": "write a short poem about running pods in openshift?"}'

{"conversation_id":"6adc636b-22e3-45cc-8f01-f73fdc2490bc","response":"In OpenShift's realm, where pods take flight,  \nContainers unite, in harmony bright.  \nWith labels and volumes, they dance and they play,  \nOn nodes they reside, come night or come day.  \n\nImmutable spirits, they rise and they fall,  \nManaged by controllers, they heed the call.  \nFrom dev to production, they scale with great ease,  \nIn this orchestration, they flow like the breeze.  \n\nSo here's to the pods, in their vibrant array,  \nIn OpenShift's embrace, they thrive and they sway.  \nWith each deployment, a story unfolds,  \nIn the world of containers, their magic beholds.","referenced_documents":[{"docs_url":"https://docs.openshift.com/container-platform/4.15/nodes/pods/nodes-pods-using.html","title":"Using pods"},{"docs_url":"https://docs.openshift.com/container-platform/4.15/rest_api/workloads_apis/pod-v1.html","title":"Pod [v1]"},{"docs_url":"https://docs.openshift.com/container-platform/4.15/nodes/index.html","title":"Overview of nodes"}],"truncated":false}
```

### Streaming

```sh
curl -X POST http://localhost:8080/v1/streaming_query -H "Content-Type: application/json" -d '{"query": "write a short poem about running pods in openshift?"}'

In OpenShift's realm, where pods take flight,
Containers unite, in the day and the night.
With labels and volumes, they dance in a line,
Scaling up swiftly, like stars that align.

Immutable they stand, in their defined space,
Resilient and strong, they embrace every race.
From nodes they emerge, with IPs to claim,
In the orchestration of Kubernetes, they play the game.

So here's to the pods, in their vibrant array,
In OpenShift's embrace, they thrive every day.
With each deployment, a story unfolds,
In the world of containers, their magic beholds.

---

Using pods: https://docs.openshift.com/container-platform/4.15/nodes/pods/nodes-pods-using.html
Pod [v1]: https://docs.openshift.com/container-platform/4.15/rest_api/workloads_apis/pod-v1.html
Overview of nodes: https://docs.openshift.com/container-platform/4.15/nodes/index.html

```