### PR TITLE
OLS-1168: Ability to print current version to stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ update-deps: ## Check pyproject.toml for changes, update the lock file if needed
 run: ## Run the service locally
 	python runner.py
 
+print-version: ## Print the service version
+	python runner.py --version
+
 test: test-unit test-integration test-e2e ## Run all tests
 
 benchmarks: ## Run benchmarks

--- a/README.md
+++ b/README.md
@@ -803,6 +803,7 @@ The context window size is limited for all supported LLMs which means that token
 │ test-integration                  │ cmd  │ pdm run make test-integration                  │
 │ test-unit                         │ cmd  │ pdm run make test-unit                         │
 │ unit-tests-coverage-report        │ cmd  │ pdm run make unit-tests-coverage-report        │
+│ version                           │ cmd  │ pdm run make print-version                     │
 ╰───────────────────────────────────┴──────┴────────────────────────────────────────────────╯
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ generate-schema = "pdm run make schema"
 security-check = "pdm run make security-check"
 benchmarks = "pdm run make benchmarks"
 requirements = "pdm run make requirements.txt"
+version = "pdm run make print-version"
 
 [tool.setuptools]
 packages = ["ols"]

--- a/runner.py
+++ b/runner.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import sys
 import threading
 from pathlib import Path
 
@@ -10,6 +11,7 @@ from ols.src.auth.auth import use_k8s_auth
 from ols.utils.certificates import generate_certificates_file
 from ols.utils.environments import configure_gradio_ui_envs, configure_hugging_face_envs
 from ols.utils.logging_configurator import configure_logging
+from ols.version import __version__
 
 
 def load_index():
@@ -20,6 +22,10 @@ def load_index():
 
 
 if __name__ == "__main__":
+    if "--version" in sys.argv:
+        print(__version__)
+        sys.exit()
+
     # First of all, configure environment variables for Gradio before
     # import config and initializing config module.
     configure_gradio_ui_envs()


### PR DESCRIPTION
## Description

[OLS-1168](https://issues.redhat.com//browse/OLS-1168): Ability to print current version to stdout

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1168](https://issues.redhat.com//browse/OLS-1168)
