### PR TITLE
eval: add alternative ans for azure-eval9

### DIFF
--- a/scripts/evaluation/eval_data/question_answer_pair.json
+++ b/scripts/evaluation/eval_data/question_answer_pair.json
@@ -321,6 +321,7 @@
                 "azure_openai+gpt-4o-mini+with_rag": {
                     "cutoff_score": 0.35,
                     "text": [
+                        "As of Red Hat OpenShift Container Platform 4.14, DeploymentConfig objects are deprecated and are not recommended for new installations. It is advised to use Deployment objects or other alternatives for declarative updates for pods instead. While DeploymentConfig objects are still supported, only security-related and critical issues will be fixed. Therefore, it is recommended to transition to using Deployment objects for better support and features.",
                         "No, I do not recommend using DeploymentConfig objects. As of OpenShift 4.14, DeploymentConfig objects are deprecated and only security-related and critical issues will be fixed for them. It is advisable to use Deployment objects or other alternatives for declarative updates for pods instead."
                     ]
                 },


### PR DESCRIPTION
## Description
add alternative ans for azure-eval9
[Reference](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_lightspeed-service/2031/pull-ci-openshift-lightspeed-service-main-4.17-e2e-ols-cluster/1866136104692879360)
