### PR TITLE
dep: bump up fastapi to 0.115.6

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -4,8 +4,8 @@
 [metadata]
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
-lock_version = "4.4.2"
-content_hash = "sha256:07c6c2311311064cddb0e91424598b73a3839efbd2eb19378ad1633b0b44580c"
+lock_version = "4.4.1"
+content_hash = "sha256:ec767afd11ca8a80fafb781db3877aa68c80f8db6d850e0aae6073954e3d8b1b"
 
 [[package]]
 name = "absl-py"
@@ -632,7 +632,7 @@ files = [
 
 [[package]]
 name = "fastapi"
-version = "0.115.4"
+version = "0.115.6"
 requires_python = ">=3.8"
 summary = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 groups = ["default", "dev"]
@@ -642,8 +642,8 @@ dependencies = [
     "typing-extensions>=4.8.0",
 ]
 files = [
-    {file = "fastapi-0.115.4-py3-none-any.whl", hash = "sha256:0b504a063ffb3cf96a5e27dc1bc32c80ca743a2528574f9cdc77daa2d31b4742"},
-    {file = "fastapi-0.115.4.tar.gz", hash = "sha256:db653475586b091cb8b2fec2ac54a680ac6a158e07406e1abae31679e8826349"},
+    {file = "fastapi-0.115.6-py3-none-any.whl", hash = "sha256:e9240b29e36fa8f4bb7290316988e90c381e5092e0cbe84e7818cc3713bcf305"},
+    {file = "fastapi-0.115.6.tar.gz", hash = "sha256:9ec46f7addc14ea472958a96aae5b5de65f39721a46aaf5705c480d9a8b76654"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dependencies = [
     "torch==2.5.1",
     "pandas==2.1.4",
     "httpx==0.27.2",
-    "fastapi==0.115.4",
+    "fastapi==0.115.6",
     "langchain==0.3.6",
     "langchain-ibm==0.3.2",
     "llama-index==0.12.2",


### PR DESCRIPTION
## Description
bump up fastapi to 0.115.6
[OLS-1278](https://issues.redhat.com//browse/OLS-1278)