### PR TITLE
OLS-1311: Bump-up Redis to version 5.2.0

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.4.2"
-content_hash = "sha256:951269abbfbe659bb6d2534b6015020e88edc35e722b3a9b63345cb87b37e6a4"
+content_hash = "sha256:e81334d3b255ce18016079e96d0ed3198402bca44521b5ee5d23528124795e37"
 
 [[package]]
 name = "absl-py"
@@ -3412,13 +3412,13 @@ files = [
 
 [[package]]
 name = "redis"
-version = "5.0.8"
-requires_python = ">=3.7"
+version = "5.2.0"
+requires_python = ">=3.8"
 summary = "Python client for Redis database and key-value store"
 groups = ["default"]
 files = [
-    {file = "redis-5.0.8-py3-none-any.whl", hash = "sha256:56134ee08ea909106090934adc36f65c9bcbbaecea5b21ba704ba6fb561f8eb4"},
-    {file = "redis-5.0.8.tar.gz", hash = "sha256:0c5b10d387568dfe0698c6fad6615750c24170e548ca2deac10c649d463e9870"},
+    {file = "redis-5.2.0-py3-none-any.whl", hash = "sha256:ae174f2bb3b1bf2b09d54bf3e51fbc1469cf6c10aa03e21141f51969801a7897"},
+    {file = "redis-5.2.0.tar.gz", hash = "sha256:0b1087665a771b1ff2e003aa5bdd354f15a70c9e25d5a7dbf9c722c16528a7b0"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ dependencies = [
     "llama-index-vector-stores-faiss==0.3.0",
     "llama-index-embeddings-huggingface==0.4.0",
     "uvicorn==0.32.1",
-    "redis==5.0.8",
+    "redis==5.2.0",
     "faiss-cpu==1.8.0.post1",
     "sentence-transformers==3.1.1",
     "openai==1.54.3",


### PR DESCRIPTION
## Description

Bump-up Redis to version 5.2.0

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1311](https://issues.redhat.com//browse/OLS-1311)
