### PR TITLE
OLS-1318: Bump-up Jinja2 to 3.1.5 to fix vulnerability

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.4.2"
-content_hash = "sha256:52ef85b342690e10e980a3f9f157214bb9cc15c0ed2593fa81e3d484a6f16db7"
+content_hash = "sha256:28552054d2ce8e3cf224e5aaaf12de0b1b6d07a7f30ef1ec52338a33caf11e0b"
 
 [[package]]
 name = "absl-py"

--- a/pdm.lock
+++ b/pdm.lock
@@ -1347,7 +1347,7 @@ files = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.4"
+version = "3.1.5"
 requires_python = ">=3.7"
 summary = "A very fast and expressive template engine."
 groups = ["default", "dev"]
@@ -1355,8 +1355,8 @@ dependencies = [
     "MarkupSafe>=2.0",
 ]
 files = [
-    {file = "jinja2-3.1.4-py3-none-any.whl", hash = "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"},
-    {file = "jinja2-3.1.4.tar.gz", hash = "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369"},
+    {file = "jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"},
+    {file = "jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ dependencies = [
     "nltk==3.9.1",
     "aiohttp==3.10.11",
     "zipp==3.20.1",
-    "jinja2==3.1.4",
+    "jinja2==3.1.5",
     "scikit-learn==1.5.2",
     "starlette==0.41.3",
     "tqdm==4.66.5",


### PR DESCRIPTION
## Description

Bump-up Jinja2 to 3.1.5 to fix vulnerability

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1318](https://issues.redhat.com//browse/OLS-1318), #[OLS-1319](https://issues.redhat.com//browse/OLS-1319)


## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
