### PR TITLE
OLS-1311: Bump-up tqdm to 4.67.1

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.4.2"
-content_hash = "sha256:28552054d2ce8e3cf224e5aaaf12de0b1b6d07a7f30ef1ec52338a33caf11e0b"
+content_hash = "sha256:9d2e9b4b1860365c37577db6e377c9847e178fb3f981664de7f58fb3fe75ee79"
 
 [[package]]
 name = "absl-py"
@@ -4104,13 +4104,13 @@ files = [
 
 [[package]]
 name = "tqdm"
-version = "4.66.5"
+version = "4.67.1"
 requires_python = ">=3.7"
 summary = "Fast, Extensible Progress Meter"
 groups = ["default", "dev"]
 files = [
-    {file = "tqdm-4.66.5-py3-none-any.whl", hash = "sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd"},
-    {file = "tqdm-4.66.5.tar.gz", hash = "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad"},
+    {file = "tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2"},
+    {file = "tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ dependencies = [
     "jinja2==3.1.5",
     "scikit-learn==1.5.2",
     "starlette==0.41.3",
-    "tqdm==4.66.5",
+    "tqdm==4.67.1",
     "findpython==0.6.2",
     "filelock==3.16.1",
     "ffmpy==0.4.0",


### PR DESCRIPTION
## Description

Bump-up `tqdm` to 4.67.1

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library
- [x] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1311](https://issues.redhat.com//browse/OLS-1311)
