### PR TITLE
OLS-1323: Refactoring: f-strings are possible in exception constructors

### DIFF
--- a/tests/e2e/utils/cluster.py
+++ b/tests/e2e/utils/cluster.py
@@ -410,9 +410,7 @@ def delete_resource(resource: str, name: str, namespace: str = "") -> None:
             )
             return
         except subprocess.CalledProcessError as e:
-            raise Exception(
-                "Error deleting the %s instance of %s" % (name, resource)
-            ) from e
+            raise Exception(f"Error deleting the {name} instance of {resource}") from e
     try:
         run_oc(
             [
@@ -423,9 +421,7 @@ def delete_resource(resource: str, name: str, namespace: str = "") -> None:
         )
         return
     except subprocess.CalledProcessError as e:
-        raise Exception(
-            "Error deleting the %s instance of %s" % (name, resource)
-        ) from e
+        raise Exception(f"Error deleting the {name} instance of {resource}") from e
 
 
 def restart_deployment(name: str, namespace: str) -> None:


### PR DESCRIPTION
## Description

Refactoring: f-strings are possible in exception constructors

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1323](https://issues.redhat.com//browse/OLS-1323)
