### PR TITLE
OLS-1323: Added missing unit test: TLS configuration without TLS key path attribute

### DIFF
--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -1714,6 +1714,21 @@ def test_tls_config_no_data_provided():
         tls_config.validate_yaml(False)
 
 
+def test_tls_config_no_tls_key_path():
+    """Test the TLSConfig model if tls_key_path is not specified."""
+    tls_config = TLSConfig(
+        {
+            "tls_certificate_path": "tests/config/empty_cert.crt",
+            "tls_key_password_path": "tests/config/password",
+        }
+    )
+    with pytest.raises(
+        InvalidConfigurationError,
+        match="Can not enable TLS without ols_config.tls_config.tls_key_path",
+    ):
+        tls_config.validate_yaml(False)
+
+
 def test_postgres_config_default_values():
     """Test the PostgresConfig model."""
     postgres_config = PostgresConfig()


### PR DESCRIPTION
## Description

Added missing unit test: TLS configuration without TLS key path attribute

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests

## Related Tickets & Documents

- Related Issue #[OLS-1323](https://issues.redhat.com//browse/OLS-1323)
