### PR TITLE
chore: remove unnecessary exact model name reference during test

### DIFF
--- a/ols/constants.py
+++ b/ols/constants.py
@@ -58,16 +58,6 @@ class ModelFamily(StrEnum):
     GRANITE = "granite"
 
 
-# BAM
-GRANITE_3_8B_INSTRUCT = "ibm/granite-3-8b-instruct"
-
-# OpenAI & Azure OpenAI
-GPT35_TURBO = "gpt-3.5-turbo"
-GPT_4O_MINI = "gpt-4o-mini"
-
-FAKE_MODEL = "fake_model"
-
-
 class GenericLLMParameters:
     """Generic LLM parameters that can be mapped into LLM provider-specific parameters."""
 

--- a/tests/benchmarks/test_prompt_generator.py
+++ b/tests/benchmarks/test_prompt_generator.py
@@ -5,9 +5,6 @@
 import pytest
 
 from ols.constants import (
-    GPT35_TURBO,
-    GPT_4O_MINI,
-    GRANITE_3_8B_INSTRUCT,
     PROVIDER_AZURE_OPENAI,
     PROVIDER_BAM,
     PROVIDER_OPENAI,
@@ -19,12 +16,12 @@ from ols.src.prompts.prompt_generator import GeneratePrompt
 
 # providers and models used by parametrized benchmarks
 provider_and_model = (
-    (PROVIDER_BAM, GRANITE_3_8B_INSTRUCT),
-    (PROVIDER_OPENAI, GPT_4O_MINI),
-    (PROVIDER_WATSONX, GRANITE_3_8B_INSTRUCT),
-    (PROVIDER_AZURE_OPENAI, GPT_4O_MINI),
-    (PROVIDER_RHOAI_VLLM, GPT35_TURBO),
-    (PROVIDER_RHELAI_VLLM, GPT35_TURBO),
+    (PROVIDER_BAM, "some-granite-model"),
+    (PROVIDER_OPENAI, "some-gpt-model"),
+    (PROVIDER_WATSONX, "some-granite-model"),
+    (PROVIDER_AZURE_OPENAI, "some-gpt-model"),
+    (PROVIDER_RHOAI_VLLM, "some-granite-model"),
+    (PROVIDER_RHELAI_VLLM, "some-granite-model"),
 )
 
 

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -177,7 +177,7 @@ def test_post_question_with_model_but_not_provider(_setup):
         json={
             "conversation_id": conversation_id,
             "query": "test query",
-            "model": constants.GRANITE_3_8B_INSTRUCT,
+            "model": "some-model",
         },
     )
     assert response.status_code == requests.codes.unprocessable

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -1026,18 +1026,10 @@ providers = (
     constants.PROVIDER_RHELAI_VLLM,
 )
 
-models = (
-    constants.GRANITE_3_8B_INSTRUCT,
-    constants.GPT35_TURBO,
-    constants.GPT_4O_MINI,
-    "test",
-)
-
 
 @pytest.mark.parametrize("provider_name", providers)
-@pytest.mark.parametrize("model_name", models)
-def test_provider_model_specific_tokens_limit(provider_name, model_name):
-    """Test if the model specific token limits are set as default."""
+def test_provider_model_default_tokens_limit(provider_name):
+    """Test if the token limits are set as default when not set."""
     # provider config with attributes 'blended' for all providers
     provider_config = ProviderConfig(
         {
@@ -1048,7 +1040,7 @@ def test_provider_model_specific_tokens_limit(provider_name, model_name):
             "project_id": 42,
             "models": [
                 {
-                    "name": model_name,
+                    "name": "test_model_name",
                 }
             ],
         }
@@ -1056,16 +1048,12 @@ def test_provider_model_specific_tokens_limit(provider_name, model_name):
     # expected token limit for given model, default is used if not set.
     expected_limit = constants.DEFAULT_CONTEXT_WINDOW_SIZE
 
-    assert provider_config.models[model_name].context_window_size == expected_limit
-    if model_name == "test":
-        assert (
-            provider_config.models[model_name].context_window_size
-            == constants.DEFAULT_CONTEXT_WINDOW_SIZE
-        )
+    assert (
+        provider_config.models["test_model_name"].context_window_size == expected_limit
+    )
 
 
-@pytest.mark.parametrize("model_name", models)
-def test_provider_config_explicit_tokens(model_name):
+def test_provider_config_explicit_tokens():
     """Test the ProviderConfig model when explicit tokens are specified."""
     # Note: context window should be >= 1024 (default) response token limit
     context_window_size = 1025
@@ -1079,7 +1067,7 @@ def test_provider_config_explicit_tokens(model_name):
             "project_id": "test_project_id",
             "models": [
                 {
-                    "name": model_name,
+                    "name": "test_model_name",
                     "url": "http://test.url/",
                     "credentials_path": "tests/config/secret/apitoken",
                     "context_window_size": context_window_size,
@@ -1087,7 +1075,10 @@ def test_provider_config_explicit_tokens(model_name):
             ],
         }
     )
-    assert provider_config.models[model_name].context_window_size == context_window_size
+    assert (
+        provider_config.models["test_model_name"].context_window_size
+        == context_window_size
+    )
 
 
 def test_provider_config_improper_context_window_size_value():

--- a/tests/unit/prompts/test_prompt_generator.py
+++ b/tests/unit/prompts/test_prompt_generator.py
@@ -9,11 +9,7 @@ from langchain.prompts import (
     SystemMessagePromptTemplate,
 )
 
-from ols.constants import (
-    GPT_4O_MINI,
-    GRANITE_3_8B_INSTRUCT,
-    ModelFamily,
-)
+from ols.constants import ModelFamily
 from ols.src.prompts.prompt_generator import (
     GeneratePrompt,
     restructure_history,
@@ -21,7 +17,7 @@ from ols.src.prompts.prompt_generator import (
     restructure_rag_context_pre,
 )
 
-model = [GRANITE_3_8B_INSTRUCT, GPT_4O_MINI]
+model = ["some-granite-model", "some-gpt-model"]
 
 system_instruction = """
 Answer user queries in the context of openshift.


### PR DESCRIPTION
## Description

Removed unnecessary exact model name reference in test modules.

**Background**:
Recently we moved to granite 3 model for CI e2e test. There were several files got modified just to remove any reference to granite 2 in test code. But we don't have any actual logic which checks the exact model name, so having exact name in test cases is not really needed. And this also creates confusion that actual model name is used in app code.

_So removing exact model name reference in unit/integration tests (actual e2e test requires correct/exact model names)_