### PR TITLE
OLS-1337: Fixed import for generic token counter unit tests

### DIFF
--- a/tests/unit/app/metrics/test_token_counter.py
+++ b/tests/unit/app/metrics/test_token_counter.py
@@ -2,7 +2,13 @@
 
 from langchain_core.outputs.llm_result import LLMResult
 
-from ols.app.metrics import GenericTokenCounter
+from ols import config
+
+# needs to be setup there before is_user_authorized is imported
+config.ols_config.authentication_config.module = "k8s"
+
+
+from ols.app.metrics import GenericTokenCounter  # noqa:E402
 
 
 class MockLLM:


### PR DESCRIPTION
## Description

[OLS-1337](https://issues.redhat.com//browse/OLS-1337): Fixed import for generic token counter unit tests

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1337](https://issues.redhat.com//browse/OLS-1337)
