### PR TITLE
OLS-1228: TokenCounter as separate dataclass

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -92,10 +92,12 @@ def conversation_request(
     summarizer_response: SummarizerResponse | Generator
 
     if not valid:
+        # response containing info about query that can not be validated
         summarizer_response = SummarizerResponse(
             constants.INVALID_QUERY_RESP,
             [],
             False,
+            None,
         )
     else:
         summarizer_response = generate_response(

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -3,6 +3,7 @@
 from collections import OrderedDict
 from typing import Optional, Self
 
+from langchain.llms.base import LLM
 from pydantic import BaseModel, field_validator, model_validator
 from pydantic.dataclasses import dataclass
 
@@ -526,6 +527,25 @@ class RagChunk:
 
 
 @dataclass
+class TokenCounter:
+    """Model representing token counter.
+
+    Attributes:
+        llm: LLM instance
+        input_tokens: number of tokens sent to LLM
+        output_tokens: number of tokens received from LLM
+        input_tokens_counted: number of input tokens counted by the handler
+        llm_calls: number of LLM calls
+    """
+
+    llm: Optional[LLM] = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    input_tokens_counted: int = 0
+    llm_calls: int = 0
+
+
+@dataclass
 class SummarizerResponse:
     """Model representing a response from the summarizer.
 
@@ -533,11 +553,13 @@ class SummarizerResponse:
         response: The response from the summarizer.
         rag_chunks: The RAG chunks.
         history_truncated: Whether the history was truncated.
+        token_counter: Input and output tokens counters.
     """
 
     response: str
     rag_chunks: list[RagChunk]
     history_truncated: bool
+    token_counter: Optional[TokenCounter]
 
 
 class CacheEntry(BaseModel):

--- a/ols/src/query_helpers/question_validator.py
+++ b/ols/src/query_helpers/question_validator.py
@@ -80,9 +80,9 @@ class QuestionValidator(QueryHelper):
             llm=bare_llm,
             provider=provider_config.type,
             model=self.model,
-        ) as token_counter:
+        ) as generic_token_counter:
             response = llm_chain.invoke(
-                input={"query": query}, config={"callbacks": [token_counter]}
+                input={"query": query}, config={"callbacks": [generic_token_counter]}
             )
         clean_response = str(response["text"]).strip()
 

--- a/tests/unit/app/endpoints/test_ols.py
+++ b/tests/unit/app/endpoints/test_ols.py
@@ -635,6 +635,7 @@ def test_conversation_request(
         response=mock_response,
         rag_chunks=[],
         history_truncated=False,
+        token_counter=None,
     )
     llm_request = LLMRequest(query="Tell me about Kubernetes")
     response = ols.conversation_request(llm_request, auth)
@@ -685,6 +686,7 @@ def test_conversation_request_dedup_ref_docs(
         response="some response",
         rag_chunks=mock_rag_chunk,
         history_truncated=False,
+        token_counter=None,
     )
     llm_request = LLMRequest(query="some query")
     response = ols.conversation_request(llm_request, auth)
@@ -758,6 +760,7 @@ def test_no_question_validation_in_follow_up_conversation(mock_summarize, auth):
         "some elaborate answer",
         [],
         False,
+        token_counter=None,
     )
     conversation_id = suid.get_suid()
     query = "some elaborate question"
@@ -794,6 +797,7 @@ def test_generate_response_valid_subject(mock_summarize):
         mock_response,
         [],
         False,
+        token_counter=None,
     )
 
     # prepare arguments for DocsSummarizer
@@ -867,7 +871,7 @@ def test_transcripts_are_not_stored_when_disabled(transcripts_location, auth):
         ),
         patch(
             "ols.app.endpoints.ols.generate_response",
-            return_value=SummarizerResponse("something", [], False),
+            return_value=SummarizerResponse("something", [], False, None),
         ),
         patch(
             "ols.app.endpoints.ols.store_conversation_history",

--- a/tests/unit/app/metrics/test_token_counter.py
+++ b/tests/unit/app/metrics/test_token_counter.py
@@ -24,41 +24,41 @@ def test_on_llm_start():
     llm = MockLLM()
 
     # initialize new token counter
-    token_counter = GenericTokenCounter(llm)
+    generic_token_counter = GenericTokenCounter(llm)
 
     # a beginning the counters should be zeroed
-    assert token_counter.llm_calls == 0
-    assert token_counter.input_tokens_counted == 0
+    assert generic_token_counter.token_counter.llm_calls == 0
+    assert generic_token_counter.token_counter.input_tokens_counted == 0
 
     # check the textual representation as well
     expected = (
         "GenericTokenCounter: input_tokens: 0 output_tokens: 0 counted: 0 LLM calls: 0"
     )
-    assert str(token_counter) == expected
+    assert str(generic_token_counter) == expected
 
     # token count for empty input
-    token_counter.on_llm_start({}, [])
+    generic_token_counter.on_llm_start({}, [])
 
     # token counter needs to be zero as mocked LLM does not process anything
-    assert token_counter.llm_calls == 1
-    assert token_counter.input_tokens_counted == 0
+    assert generic_token_counter.token_counter.llm_calls == 1
+    assert generic_token_counter.token_counter.input_tokens_counted == 0
 
     # check the textual representation as well
     expected = (
         "GenericTokenCounter: input_tokens: 0 output_tokens: 0 counted: 0 LLM calls: 1"
     )
-    assert str(token_counter) == expected
+    assert str(generic_token_counter) == expected
 
     # now the prompt will be tokenized into 5 tokens
-    token_counter.on_llm_start({}, ["this is just a test"])
-    assert token_counter.llm_calls == 2
-    assert token_counter.input_tokens_counted == 5
+    generic_token_counter.on_llm_start({}, ["this is just a test"])
+    assert generic_token_counter.token_counter.llm_calls == 2
+    assert generic_token_counter.token_counter.input_tokens_counted == 5
 
     # check the textual representation as well
     expected = (
         "GenericTokenCounter: input_tokens: 0 output_tokens: 0 counted: 5 LLM calls: 2"
     )
-    assert str(token_counter) == expected
+    assert str(generic_token_counter) == expected
 
 
 class MockResult:
@@ -91,39 +91,39 @@ def test_on_llm_end():
     llm = MockLLM()
 
     # initialize new token counter
-    token_counter = GenericTokenCounter(llm)
-    assert token_counter.input_tokens == 0
-    assert token_counter.output_tokens == 0
+    generic_token_counter = GenericTokenCounter(llm)
+    assert generic_token_counter.token_counter.input_tokens == 0
+    assert generic_token_counter.token_counter.output_tokens == 0
 
     # check the textual representation as well
     expected = (
         "GenericTokenCounter: input_tokens: 0 output_tokens: 0 counted: 0 LLM calls: 0"
     )
-    assert str(token_counter) == expected
+    assert str(generic_token_counter) == expected
 
     # empty response
     response = MockLLMResult([])
-    token_counter.on_llm_end(response)
+    generic_token_counter.on_llm_end(response)
 
     # for empty response, counters should not change
-    assert token_counter.input_tokens == 0
-    assert token_counter.output_tokens == 0
+    assert generic_token_counter.token_counter.input_tokens == 0
+    assert generic_token_counter.token_counter.output_tokens == 0
 
     # check the textual representation as well
     expected = (
         "GenericTokenCounter: input_tokens: 0 output_tokens: 0 counted: 0 LLM calls: 0"
     )
-    assert str(token_counter) == expected
+    assert str(generic_token_counter) == expected
 
     # non-empty response
     x = MockResult(10, 20)
     response = MockLLMResult([x])
-    token_counter.on_llm_end(response)
+    generic_token_counter.on_llm_end(response)
 
     # for non-empty response, counters should change
-    assert token_counter.input_tokens == 10
-    assert token_counter.output_tokens == 20
+    assert generic_token_counter.token_counter.input_tokens == 10
+    assert generic_token_counter.token_counter.output_tokens == 20
 
     # check the textual representation as well
     expected = "GenericTokenCounter: input_tokens: 10 output_tokens: 20 counted: 0 LLM calls: 0"
-    assert str(token_counter) == expected
+    assert str(generic_token_counter) == expected


### PR DESCRIPTION
## Description

[OLS-1228](https://issues.redhat.com//browse/OLS-1228): `TokenCounter` as separate dataclass
It allow us to pass it via reference as mutable state (filled by async stream processing etc.)
Basically it is a refactoring, not a new feature

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1228](https://issues.redhat.com//browse/OLS-1228)
