### PR TITLE
OLS-1352: Suport for user ID in no-op auth module

### DIFF
--- a/tests/integration/test_authorized_noop.py
+++ b/tests/integration/test_authorized_noop.py
@@ -1,0 +1,48 @@
+"""Integration tests for basic OLS REST API endpoints with no-op auth."""
+
+from fastapi import Request
+
+from ols import config, constants
+from ols.src.auth.auth import get_auth_dependency
+
+
+def test_authorized():
+    """Check authorization based on no-op module."""
+    config.reload_from_yaml_file("tests/config/config_for_integration_tests.yaml")
+    config.ols_config.authentication_config.module = "noop"
+    config.dev_config.disable_auth = True
+    from ols.app.endpoints import authorized  # pylint: disable=C0415
+
+    # auth is disabled
+    request = Request(scope={"type": "http", "headers": [], "query_string": ""})
+    response = authorized.is_user_authorized(request)
+    assert response is not None
+    assert response.user_id == constants.DEFAULT_USER_UID
+    assert response.username == constants.DEFAULT_USER_NAME
+
+    config.dev_config.disable_auth = False
+    authorized.auth_dependency = get_auth_dependency(
+        config.ols_config, virtual_path="/ols-access"
+    )
+
+    # auth is enabled
+    request = Request(scope={"type": "http", "headers": [], "query_string": ""})
+    response = authorized.is_user_authorized(request)
+    assert response is not None
+    assert response.user_id == constants.DEFAULT_USER_UID
+    assert response.username == constants.DEFAULT_USER_NAME
+
+    # Simulate a request with user_id specified as optional parameter
+    user_id_in_request = "00000000-1234-1234-1234-000000000000"
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [],
+            "query_string": f"user_id={user_id_in_request}",
+        }
+    )
+
+    response = authorized.is_user_authorized(request)
+    assert response is not None
+    assert response.user_id == user_id_in_request
+    assert response.username == constants.DEFAULT_USER_NAME

--- a/tests/unit/auth/test_noop_auth_dependency.py
+++ b/tests/unit/auth/test_noop_auth_dependency.py
@@ -1,5 +1,7 @@
 """Unit tests for auth/noop module."""
 
+from unittest.mock import patch
+
 import pytest
 from fastapi import Request
 
@@ -19,10 +21,46 @@ async def test_noop_auth_dependency_call():
     """Check that the no-op auth. dependency returns default user ID and name as expected."""
     path = "/ols-access"
     auth_dependency = noop.AuthDependency(virtual_path=path)
-    # Simulate a request without a token
-    request = Request(scope={"type": "http", "headers": []})
+    # Simulate a request without a token nor user_id parameter
+    request = Request(scope={"type": "http", "headers": [], "query_string": ""})
     user_uid, username = await auth_dependency(request)
 
     # Check if the correct user info has been returned
     assert user_uid == DEFAULT_USER_UID
+    assert username == DEFAULT_USER_NAME
+
+
+@pytest.mark.asyncio
+@patch("ols.config.dev_config.disable_auth", True)
+async def test_noop_auth_dependency_call_disable_auth():
+    """Check that the no-op auth. dependency returns default user ID and name as expected."""
+    path = "/ols-access"
+    auth_dependency = noop.AuthDependency(virtual_path=path)
+    # Simulate a request without a token nor user_id parameter
+    request = Request(scope={"type": "http", "headers": [], "query_string": ""})
+    user_uid, username = await auth_dependency(request)
+
+    # Check if the correct user info has been returned
+    assert user_uid == DEFAULT_USER_UID
+    assert username == DEFAULT_USER_NAME
+
+
+@pytest.mark.asyncio
+async def test_noop_auth_dependency_call_with_user_id():
+    """Check that the no-op auth. dependency returns provided user ID."""
+    path = "/ols-access"
+    auth_dependency = noop.AuthDependency(virtual_path=path)
+    # Simulate a request with user_id specified as optional parameter
+    user_id_in_request = "00000000-1234-1234-1234-000000000000"
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [],
+            "query_string": f"user_id={user_id_in_request}",
+        }
+    )
+    user_uid, username = await auth_dependency(request)
+
+    # Check if the correct user info has been returned
+    assert user_uid == user_id_in_request
     assert username == DEFAULT_USER_NAME


### PR DESCRIPTION
## Description

Suport for user ID in no-op auth module

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1352](https://issues.redhat.com//browse/OLS-1352)
