### PR TITLE
[Upstream][Feature] Event stream format support

### DIFF
--- a/examples/olsconfig.yaml
+++ b/examples/olsconfig.yaml
@@ -73,6 +73,7 @@ ols_config:
   default_provider: my_bam
   default_model: ibm/granite-3-8b-instruct
   expire_llm_is_ready_persistent_state: -1
+  enable_event_stream_format: true
   # query_filters:
   #   - name: foo_filter
   #     pattern: '\b(?:foo)\b'

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -870,6 +870,8 @@ class OLSConfig(BaseModel):
     extra_ca: list[FilePath] = []
     certificate_directory: Optional[str] = None
 
+    enable_event_stream_format: bool = False
+
     def __init__(
         self, data: Optional[dict] = None, ignore_missing_certs: bool = False
     ) -> None:
@@ -920,6 +922,7 @@ class OLSConfig(BaseModel):
         self.tls_security_profile = TLSSecurityProfile(
             data.get("tlsSecurityProfile", None)
         )
+        self.enable_event_stream_format = data.get("enable_event_stream_format", False)
 
     def __eq__(self, other: object) -> bool:
         """Compare two objects for equality."""


### PR DESCRIPTION
## Description

[Upstream][Feature] Event stream format support

Implements changes for #299.  This will add a new option `enable_event_stream_format` to `ols_config`.
When `enable_event_stream_format` is set to `true` (default is `false`), it will add `data: ` to the beginning and 
`\n\n` at the end of stringfied JSON data. This option works only when `media-type` is set to `application/json`. 

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change

