### PR TITLE
OLS-1375: Refactoring: conversation-id passing

### DIFF
--- a/tests/unit/app/endpoints/test_ols.py
+++ b/tests/unit/app/endpoints/test_ols.py
@@ -60,7 +60,9 @@ def test_retrieve_conversation_id_existing_id():
 def test_retrieve_previous_input_no_previous_history():
     """Check how function to retrieve previous input handle empty history."""
     llm_request = LLMRequest(query="Tell me about Kubernetes", conversation_id=None)
-    llm_input = ols.retrieve_previous_input(constants.DEFAULT_USER_UID, llm_request)
+    llm_input = ols.retrieve_previous_input(
+        constants.DEFAULT_USER_UID, llm_request.conversation_id
+    )
     assert llm_input == []
 
 
@@ -73,9 +75,9 @@ def test_retrieve_previous_input_empty_user_id():
     )
     # cache must check if user ID is correct
     with pytest.raises(HTTPException, match="Invalid user ID"):
-        ols.retrieve_previous_input("", llm_request)
+        ols.retrieve_previous_input("", llm_request.conversation_id)
     with pytest.raises(HTTPException, match="Invalid user ID"):
-        ols.retrieve_previous_input(None, llm_request)
+        ols.retrieve_previous_input(None, llm_request.conversation_id)
 
 
 @pytest.mark.usefixtures("_load_config")
@@ -87,7 +89,7 @@ def test_retrieve_previous_input_improper_user_id():
     )
     # cache must check if user ID is correct
     with pytest.raises(HTTPException, match="Invalid user ID improper_user_id"):
-        ols.retrieve_previous_input("improper_user_id", llm_request)
+        ols.retrieve_previous_input("improper_user_id", llm_request.conversation_id)
 
 
 @pytest.mark.usefixtures("_load_config")
@@ -100,7 +102,7 @@ def test_retrieve_previous_input_for_previous_history(get):
         query="Tell me about Kubernetes", conversation_id=conversation_id
     )
     previous_input = ols.retrieve_previous_input(
-        constants.DEFAULT_USER_UID, llm_request
+        constants.DEFAULT_USER_UID, llm_request.conversation_id
     )
     assert previous_input == "input"
 


### PR DESCRIPTION
## Description

Refactoring: `conversation-id` passing

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1375](https://issues.redhat.com//browse/OLS-1375)
