### PR TITLE
Move model evaluation tests

### DIFF
--- a/tests/scripts/test-e2e-cluster-periodics.sh
+++ b/tests/scripts/test-e2e-cluster-periodics.sh
@@ -45,7 +45,7 @@ function run_suites() {
   run_suite "openai" "not model_evaluation and not azure_entra_id and not certificates" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE"
   (( rc = rc || $? ))
 
-  run_suite "watsonx" " not azure_entra_id and not certificates" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-3-8b-instruct" "$OLS_IMAGE"
+  run_suite "watsonx" "not model_evaluation and not azure_entra_id and not certificates" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-3-8b-instruct" "$OLS_IMAGE"
   (( rc = rc || $? ))
 
   # smoke tests for RHOAI VLLM-compatible provider
@@ -56,7 +56,10 @@ function run_suites() {
   run_suite "rhelai_vllm" "smoketest" "rhelai_vllm" "$OPENAI_PROVIDER_KEY_PATH" "gpt-3.5-turbo" "$OLS_IMAGE"
   (( rc = rc || $? ))
   
-  run_suite "openai" "certificates" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE"
+  run_suite "certificates" "certificates" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE"
+  (( rc = rc || $? ))
+
+  run_suite "model_eval" "model_evaluation" "wasonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-3-8b-instruct" "$OLS_IMAGE"
   (( rc = rc || $? ))
 
   set -e

--- a/tests/scripts/test-e2e-cluster-periodics.sh
+++ b/tests/scripts/test-e2e-cluster-periodics.sh
@@ -59,7 +59,7 @@ function run_suites() {
   run_suite "certificates" "certificates" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE"
   (( rc = rc || $? ))
 
-  run_suite "model_eval" "model_evaluation" "wasonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-3-8b-instruct" "$OLS_IMAGE"
+  run_suite "model_eval" "model_evaluation" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-3-8b-instruct" "$OLS_IMAGE"
   (( rc = rc || $? ))
 
   set -e


### PR DESCRIPTION
## Description
Moving model evaluation tests outside watsonx tests in periodic pipelines so that it doesn't affect standard tests statistics and we can work on creating more model evaluation tests.
Also renaming suite id for certificates to not override the openai suite summary.

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
