### PR TITLE
OLS-1376: Usage of langchain messages instead of plain strings

### DIFF
--- a/ols/src/cache/postgres_cache.py
+++ b/ols/src/cache/postgres_cache.py
@@ -7,7 +7,7 @@ from typing import Any
 import psycopg2
 
 from ols.app.models.config import PostgresConfig
-from ols.app.models.models import CacheEntry
+from ols.app.models.models import CacheEntry, MessageDecoder, MessageEncoder
 from ols.src.cache.cache import Cache
 from ols.src.cache.cache_error import CacheError
 
@@ -155,14 +155,14 @@ class PostgresCache(Cache):
                         cursor,
                         user_id,
                         conversation_id,
-                        json.dumps(old_value).encode("utf-8"),
+                        json.dumps(old_value, cls=MessageEncoder).encode("utf-8"),
                     )
                 else:
                     PostgresCache._insert(
                         cursor,
                         user_id,
                         conversation_id,
-                        json.dumps([value]).encode("utf-8"),
+                        json.dumps([value], cls=MessageEncoder).encode("utf-8"),
                     )
                     PostgresCache._cleanup(cursor, self.capacity)
                 # commit is implicit at this point
@@ -193,7 +193,7 @@ class PostgresCache(Cache):
             raise ValueError("Invalid value read from cache:", value)
 
         # try to deserialize the value
-        return json.loads(value[0])
+        return json.loads(value[0], cls=MessageDecoder)
 
     @staticmethod
     def _update(

--- a/ols/src/prompts/prompt_generator.py
+++ b/ols/src/prompts/prompt_generator.py
@@ -43,9 +43,9 @@ def restructure_history(message: BaseMessage, model: str) -> BaseMessage:
     new_message = copy(message)
     # Granite specific formatting for history
     if isinstance(message, HumanMessage):
-        new_message.content = "\n<|user|>\n" + message.content
+        new_message.content = "\n<|user|>\n" + str(message.content)
     else:
-        new_message.content = "\n<|assistant|>\n" + message.content
+        new_message.content = "\n<|assistant|>\n" + str(message.content)
     return new_message
 
 
@@ -102,7 +102,9 @@ class GeneratePrompt:
 
         if len(self._history) > 0:
             prompt_message = prompt_message + "\n" + USE_HISTORY_INSTRUCTION.strip()
-            llm_input_values["chat_history"] = "".join(self._history)
+            llm_input_values["chat_history"] = ""
+            for message in self._history:
+                llm_input_values["chat_history"] += str(message.content)
 
         if "context" in llm_input_values:
             prompt_message = prompt_message + "\n{context}"

--- a/ols/src/prompts/prompt_generator.py
+++ b/ols/src/prompts/prompt_generator.py
@@ -1,6 +1,8 @@
 """Prompt generator based on model / context."""
 
-from langchain_core.messages import AIMessage, HumanMessage
+from copy import copy
+
+from langchain_core.messages import BaseMessage, HumanMessage
 from langchain_core.prompts import (
     ChatPromptTemplate,
     HumanMessagePromptTemplate,
@@ -32,16 +34,19 @@ def restructure_rag_context_post(text: str, model: str) -> str:
     return "\n" + text.lstrip("\n") + "\n"
 
 
-def restructure_history(text: str, model: str) -> str:
+def restructure_history(message: BaseMessage, model: str) -> BaseMessage:
     """Restructure history."""
     if ModelFamily.GRANITE not in model:
         # No processing required here for gpt.
-        return text
+        return message
 
+    new_message = copy(message)
     # Granite specific formatting for history
-    if text.startswith("human: "):
-        return "\n<|user|>\n" + text.removeprefix("human: ")
-    return "\n<|assistant|>\n" + text.removeprefix("ai: ")
+    if isinstance(message, HumanMessage):
+        new_message.content = "\n<|user|>\n" + message.content
+    else:
+        new_message.content = "\n<|assistant|>\n" + message.content
+    return new_message
 
 
 class GeneratePrompt:
@@ -51,7 +56,7 @@ class GeneratePrompt:
         self,
         query: str,
         rag_context: list[str] = [],
-        history: list[str] = [],
+        history: list[BaseMessage] = [],
         system_instruction: str = QUERY_SYSTEM_INSTRUCTION,
     ):
         """Initialize prompt generator."""
@@ -71,13 +76,7 @@ class GeneratePrompt:
             sys_intruction = sys_intruction + "\n" + USE_CONTEXT_INSTRUCTION.strip()
 
         if len(self._history) > 0:
-            chat_history = []
-            for h in self._history:
-                if h.startswith("human: "):
-                    chat_history.append(HumanMessage(content=h.removeprefix("human: ")))
-                else:
-                    chat_history.append(AIMessage(content=h.removeprefix("ai: ")))
-            llm_input_values["chat_history"] = chat_history
+            llm_input_values["chat_history"] = self._history
 
             sys_intruction = sys_intruction + "\n" + USE_HISTORY_INSTRUCTION.strip()
 

--- a/ols/utils/token_handler.py
+++ b/ols/utils/token_handler.py
@@ -179,10 +179,10 @@ class TokenHandler:
 
     def limit_conversation_history(
         self, history: list[BaseMessage], model: str, limit: int = 0
-    ) -> tuple[list[str], bool]:
+    ) -> tuple[list[BaseMessage], bool]:
         """Limit conversation history to specified number of tokens."""
         total_length = 0
-        formatted_history: list[str] = []
+        formatted_history: list[BaseMessage] = []
 
         for original_message in reversed(history):
             # Restructure messages as per model

--- a/ols/utils/token_handler.py
+++ b/ols/utils/token_handler.py
@@ -3,6 +3,7 @@
 import logging
 from math import ceil
 
+from langchain_core.messages import BaseMessage
 from llama_index.core.schema import NodeWithScore
 from tiktoken import get_encoding
 
@@ -177,7 +178,7 @@ class TokenHandler:
         return rag_chunks, max_tokens
 
     def limit_conversation_history(
-        self, history: list[str], model: str, limit: int = 0
+        self, history: list[BaseMessage], model: str, limit: int = 0
     ) -> tuple[list[str], bool]:
         """Limit conversation history to specified number of tokens."""
         total_length = 0
@@ -186,8 +187,9 @@ class TokenHandler:
         for original_message in reversed(history):
             # Restructure messages as per model
             message = restructure_history(original_message, model)
-
-            message_length = TokenHandler._get_token_count(self.text_to_tokens(message))
+            message_length = TokenHandler._get_token_count(
+                self.text_to_tokens(f"{message.type}: {message.content}")
+            )
             total_length += message_length
             # if total length of already checked messages is higher than limit
             # then skip all remaining messages (we need to skip from top)

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 import requests
 from fastapi.testclient import TestClient
+from langchain_core.messages import AIMessage, HumanMessage
 
 from ols import config, constants
 from ols.app.models.config import (
@@ -426,7 +427,7 @@ def test_post_query_for_conversation_history(_setup, endpoint) -> None:
     from ols.app.endpoints.ols import retrieve_previous_input  # pylint: disable=C0415
     from ols.app.models.models import CacheEntry  # pylint: disable=C0415
 
-    actual_returned_history = None
+    actual_returned_history = []
 
     def capture_return_value(*args, **kwargs):
         nonlocal actual_returned_history
@@ -468,9 +469,21 @@ def test_post_query_for_conversation_history(_setup, endpoint) -> None:
         )
         assert response.status_code == requests.codes.ok
         chat_history_expected = [
-            CacheEntry(query="Query1", response="Query1", attachments=[])
+            CacheEntry(
+                query=HumanMessage("Query1"),
+                response=AIMessage("Query1"),
+                attachments=[],
+            )
         ]
-        assert actual_returned_history == chat_history_expected
+        # cannot test exact timestamp, test the existence
+        assert (
+            actual_returned_history[0].query.content
+            == chat_history_expected[0].query.content
+        )
+        assert (
+            actual_returned_history[0].response.content
+            == chat_history_expected[0].response.content
+        )
 
 
 @pytest.mark.parametrize("endpoint", ("/v1/query", "/v1/streaming_query"))

--- a/tests/integration/test_redis.py
+++ b/tests/integration/test_redis.py
@@ -1,6 +1,7 @@
 """Integration tests for real Redis behaviour."""
 
 import pytest
+from langchain_core.messages import AIMessage, HumanMessage
 
 from ols.app.models.config import RedisConfig
 from ols.app.models.models import CacheEntry
@@ -39,7 +40,10 @@ def test_conversation_in_redis():
     assert retrieved is None
 
     # insert some conversation
-    cache_entry = CacheEntry(query="First human message", response="First AI response")
+    cache_entry = CacheEntry(
+        query=HumanMessage("First human message"),
+        response=AIMessage("First AI response"),
+    )
     pytest.redis_cache.insert_or_append(USER_ID, CONVERSATION_ID, cache_entry)
 
     # check what is stored in conversation cache

--- a/tests/unit/app/endpoints/test_ols.py
+++ b/tests/unit/app/endpoints/test_ols.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from fastapi import HTTPException
+from langchain_core.messages import AIMessage, HumanMessage
 
 from ols import config, constants
 from ols.app.endpoints import ols
@@ -217,7 +218,7 @@ def test_store_conversation_history(insert_or_append):
         constants.DEFAULT_USER_UID, conversation_id, llm_request, response, []
     )
 
-    expected_history = CacheEntry(query="Tell me about Kubernetes")
+    expected_history = CacheEntry(query=HumanMessage(query))
     insert_or_append.assert_called_with(
         constants.DEFAULT_USER_UID,
         conversation_id,
@@ -242,7 +243,7 @@ def test_store_conversation_history_some_response(insert_or_append):
     )
 
     expected_history = CacheEntry(
-        query="Tell me about Kubernetes", response="*response*"
+        query=HumanMessage(query), response=AIMessage(response)
     )
     insert_or_append.assert_called_with(
         user_id, conversation_id, expected_history, skip_user_id_check
@@ -762,7 +763,7 @@ def test_question_validation_in_conversation_start(auth):
 @pytest.mark.usefixtures("_load_config")
 @patch(
     "ols.app.endpoints.ols.retrieve_previous_input",
-    new=Mock(return_value=[CacheEntry(query="some question")]),
+    new=Mock(return_value=[CacheEntry(query=HumanMessage("some question"))]),
 )
 @patch(
     "ols.app.endpoints.ols.validate_question",

--- a/tests/unit/app/models/test_models.py
+++ b/tests/unit/app/models/test_models.py
@@ -349,25 +349,29 @@ class TestCacheEntry:
     @staticmethod
     def test_basic_interface():
         """Test the CacheEntry model."""
-        cache_entry = CacheEntry(query="query")
-        assert cache_entry.query == "query"
-        assert cache_entry.response == ""
+        cache_entry = CacheEntry(query=HumanMessage("query"))
+        assert cache_entry.query == HumanMessage("query")
+        assert cache_entry.response == AIMessage("")
 
-        cache_entry = CacheEntry(query="query", response=None)
-        assert cache_entry.query == "query"
-        assert cache_entry.response == ""
+        cache_entry = CacheEntry(query=HumanMessage("query"), response=None)
+        assert cache_entry.query == HumanMessage("query")
+        assert cache_entry.response == AIMessage("")
 
-        cache_entry = CacheEntry(query="query", response="response")
-        assert cache_entry.query == "query"
-        assert cache_entry.response == "response"
+        cache_entry = CacheEntry(
+            query=HumanMessage("query"), response=AIMessage("response")
+        )
+        assert cache_entry.query == HumanMessage("query")
+        assert cache_entry.response == AIMessage("response")
 
     @staticmethod
     def test_to_dict():
         """Test the to_dict method of the CacheEntry model."""
-        cache_entry = CacheEntry(query="query", response="response")
+        cache_entry = CacheEntry(
+            query=HumanMessage("query"), response=AIMessage("response")
+        )
         assert cache_entry.to_dict() == {
-            "human_query": "query",
-            "ai_response": "response",
+            "human_query": HumanMessage("query"),
+            "ai_response": AIMessage("response"),
             "attachments": [],
         }
 
@@ -381,64 +385,67 @@ class TestCacheEntry:
         )
         cache_entry = CacheEntry.from_dict(
             {
-                "human_query": "query",
-                "ai_response": "response",
+                "human_query": HumanMessage("query"),
+                "ai_response": AIMessage("response"),
                 "attachments": [attachment.model_dump()],
             }
         )
-        assert cache_entry.query == "query"
-        assert cache_entry.response == "response"
+        assert cache_entry.query == HumanMessage("query")
+        assert cache_entry.response == AIMessage("response")
         assert cache_entry.attachments == [attachment]
 
     @staticmethod
     def test_cache_entries_to_history():
         """Test the cache_entries_to_history method of the CacheEntry model."""
         cache_entries = [
-            CacheEntry(query="query1", response="response1"),
-            CacheEntry(query="query2", response="response2"),
+            CacheEntry(query=HumanMessage("query1"), response=AIMessage("response1")),
+            CacheEntry(query=HumanMessage("query2"), response=AIMessage("response2")),
         ]
         history = CacheEntry.cache_entries_to_history(cache_entries)
         assert history == [
-            "human: query1",
-            "ai: response1",
-            "human: query2",
-            "ai: response2",
+            HumanMessage("query1"),
+            AIMessage("response1"),
+            HumanMessage("query2"),
+            AIMessage("response2"),
         ]
 
     @staticmethod
     def test_cache_entries_to_history_no_whitespace():
         """Test content is stripped."""
         cache_entries = [
-            CacheEntry(query="\ngood\nmorning\n", response="\ngood\nnight\n"),
+            CacheEntry(
+                query=HumanMessage("\ngood\nmorning\n"),
+                response=AIMessage("\ngood\nnight\n"),
+            ),
         ]
         history = CacheEntry.cache_entries_to_history(cache_entries)
         assert history == [
-            "human: good\nmorning",
-            "ai: good\nnight",
+            HumanMessage("good\nmorning"),
+            AIMessage("good\nnight"),
         ]
 
     @staticmethod
     def test_cache_entries_to_history_no_content():
         """Test empty AI response is handled."""
         cache_entries = [
-            CacheEntry(query="what?", response=""),
+            CacheEntry(query=HumanMessage("what?"), response=AIMessage("")),
         ]
         history = CacheEntry.cache_entries_to_history(cache_entries)
         assert history == [
-            "human: what?",
-            "ai: ",
+            HumanMessage("what?"),
+            AIMessage(""),
         ]
 
     @staticmethod
     def test_cache_entries_to_history_no_response():
         """Test no AI response is handled."""
         cache_entries = [
-            CacheEntry(query="what?", response=None),
+            CacheEntry(query=HumanMessage("what?"), response=None),
         ]
         history = CacheEntry.cache_entries_to_history(cache_entries)
         assert history == [
-            "human: what?",
-            "ai: ",
+            HumanMessage("what?"),
+            AIMessage(""),
         ]
 
 

--- a/tests/unit/cache/test_in_memory_cache.py
+++ b/tests/unit/cache/test_in_memory_cache.py
@@ -1,6 +1,7 @@
 """Unit tests for InMemoryCache class."""
 
 import pytest
+from langchain_core.messages import AIMessage, HumanMessage
 
 from ols import constants
 from ols.app.models.config import InMemoryCacheConfig
@@ -10,8 +11,12 @@ from ols.utils import suid
 
 conversation_id = suid.get_suid()
 user_provided_user_id = "test-user1"
-cache_entry_1 = CacheEntry(query="user message1", response="ai message1")
-cache_entry_2 = CacheEntry(query="user message2", response="ai message2")
+cache_entry_1 = CacheEntry(
+    query=HumanMessage("user message1"), response=AIMessage("ai message1")
+)
+cache_entry_2 = CacheEntry(
+    query=HumanMessage("user message2"), response=AIMessage("ai message2")
+)
 
 
 @pytest.fixture
@@ -75,7 +80,7 @@ def test_insert_or_append_overflow(cache):
     cache.capacity = capacity
     for i in range(capacity + 1):
         user = f"{user_name_prefix}{i}"
-        value = CacheEntry(query=f"user query {i}")
+        value = CacheEntry(query=HumanMessage(f"user query {i}"))
         cache.insert_or_append(
             user,
             conversation_id,
@@ -85,7 +90,7 @@ def test_insert_or_append_overflow(cache):
     # Ensure the oldest entry is evicted
     assert cache.get(f"{user_name_prefix}0", conversation_id) is None
     # Ensure the newest entry is still present
-    expected_result = [CacheEntry(query=f"user query {i}")]
+    expected_result = [CacheEntry(query=HumanMessage(f"user query {i}"))]
     assert (
         cache.get(f"{user_name_prefix}{capacity}", conversation_id) == expected_result
     )

--- a/tests/unit/cache/test_redis_cache.py
+++ b/tests/unit/cache/test_redis_cache.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import pytest
+from langchain_core.messages import AIMessage, HumanMessage
 
 from ols import constants
 from ols.app.models.config import RedisConfig
@@ -12,8 +13,12 @@ from ols.utils import suid
 from tests.mock_classes.mock_redis_client import MockRedisClient
 
 conversation_id = suid.get_suid()
-cache_entry_1 = CacheEntry(query="user message1", response="ai message1")
-cache_entry_2 = CacheEntry(query="user message2", response="ai message2")
+cache_entry_1 = CacheEntry(
+    query=HumanMessage("user message1"), response=AIMessage("ai message1")
+)
+cache_entry_2 = CacheEntry(
+    query=HumanMessage("user message2"), response=AIMessage("ai message2")
+)
 user_provided_user_id = "test-user1"
 
 

--- a/tests/unit/prompts/test_prompt_generator.py
+++ b/tests/unit/prompts/test_prompt_generator.py
@@ -8,6 +8,7 @@ from langchain.prompts import (
     PromptTemplate,
     SystemMessagePromptTemplate,
 )
+from langchain_core.messages import AIMessage, HumanMessage
 
 from ols.constants import ModelFamily
 from ols.src.prompts.prompt_generator import (
@@ -24,7 +25,10 @@ Answer user queries in the context of openshift.
 """
 query = "What is Kubernetes?"
 rag_context = ["context 1", "context 2"]
-conversation_history = ["human: First human message", "ai: First AI message"]
+conversation_history = [
+    HumanMessage("First human message"),
+    AIMessage("First AI message"),
+]
 
 
 def _restructure_prompt_input(rag_context, conversation_history, model):

--- a/tests/unit/query_helpers/test_docs_summarizer.py
+++ b/tests/unit/query_helpers/test_docs_summarizer.py
@@ -3,6 +3,7 @@
 from unittest.mock import ANY, patch
 
 import pytest
+from langchain_core.messages import HumanMessage
 
 from ols import config
 
@@ -133,7 +134,7 @@ def test_summarize_truncation():
     rag_index = MockLlamaIndex()
 
     # too long history
-    history = ["human: What is Kubernetes?"] * 10000
+    history = [HumanMessage("What is Kubernetes?")] * 10000
     summary = summarizer.create_response(question, rag_index, history)
 
     # truncation should be done

--- a/tests/unit/utils/test_token_handler.py
+++ b/tests/unit/utils/test_token_handler.py
@@ -4,6 +4,7 @@ from math import ceil
 from unittest import TestCase, mock
 
 import pytest
+from langchain_core.messages import AIMessage, HumanMessage
 
 from ols.constants import TOKEN_BUFFER_WEIGHT, ModelFamily
 from ols.src.prompts.prompt_generator import restructure_history
@@ -199,12 +200,12 @@ class TestTokenHandler(TestCase):
     def test_limit_conversation_history(self):
         """Check the behaviour of limiting long conversation history."""
         history = [
-            "human: first message from human",
-            "ai: first answer from AI",
-            "human: second message from human",
-            "ai: second answer from AI",
-            "human: third message from human",
-            "ai: third answer from AI",
+            HumanMessage("first message from human"),
+            AIMessage("first answer from AI"),
+            HumanMessage("second message from human"),
+            AIMessage("second answer from AI"),
+            HumanMessage("third message from human"),
+            AIMessage("third answer from AI"),
         ]
         # for each of the above actual messages the tokens count is 4.
         # then 2 tokens for the tags. Total tokens are 6.
@@ -288,6 +289,6 @@ class TestTokenHandler(TestCase):
         truncated_history, truncated = (
             self._token_handler_obj.limit_conversation_history(history, model, 22)
         )
-        assert len(truncated_history) == 2
+        assert len(truncated_history) == 1
         assert truncated_history[-1] == restructure_history(history[-1], model)
         assert truncated


### PR DESCRIPTION
## Description

[OLS-1376](https://issues.redhat.com//browse/OLS-1376): Usage of langchain messages instead of plain strings

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
