### PR TITLE
feat: enable tool calling in a loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ TEST_TAGS := $(if $(TEST_TAGS),$(TEST_TAGS),"")
 SUITE_ID := $(if $(SUITE_ID),$(SUITE_ID),"nosuite")
 PROVIDER := $(if $(PROVIDER),$(PROVIDER),"openai")
 MODEL := $(if $(MODEL),$(MODEL),"gpt-4o-mini")
+INTROSPECTION_ENABLED := $(if $(INTROSPECTION_ENABLED),$(INTROSPECTION_ENABLED),"n")
 
 # Python registry to where the package should be uploaded
 PYTHON_REGISTRY = testpypi

--- a/examples/olsconfig.yaml
+++ b/examples/olsconfig.yaml
@@ -60,6 +60,7 @@ ols_config:
 #    product_docs_index_path: "./vector_db/ocp_product_docs/4.15"
 #    product_docs_index_id: ocp-product-docs-4_15
 #    embeddings_model_path: "./embeddings_model"
+  introspection_enabled: true  # Default is false, OLS tool calling
   conversation_cache:
     type: memory
     memory:

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -850,6 +850,7 @@ class OLSConfig(BaseModel):
     """OLS configuration."""
 
     conversation_cache: Optional[ConversationCacheConfig] = None
+    introspection_enabled: Optional[bool] = False
     logging_config: Optional[LoggingConfig] = None
     reference_content: Optional[ReferenceContent] = None
     authentication_config: AuthenticationConfig = AuthenticationConfig()
@@ -880,6 +881,7 @@ class OLSConfig(BaseModel):
         if data is None:
             return
 
+        self.introspection_enabled = data.get("introspection_enabled", False)
         self.conversation_cache = ConversationCacheConfig(
             data.get("conversation_cache", None)
         )
@@ -929,6 +931,7 @@ class OLSConfig(BaseModel):
         if isinstance(other, OLSConfig):
             return (
                 self.conversation_cache == other.conversation_cache
+                and self.introspection_enabled == other.introspection_enabled
                 and self.logging_config == other.logging_config
                 and self.reference_content == other.reference_content
                 and self.default_provider == other.default_provider

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -66,6 +66,10 @@ class GenericLLMParameters:
     TEMPERATURE = "temperature"
 
 
+# Max Iteration for tool calling
+MAX_ITERATIONS = 5
+
+
 # Token related constants
 
 # It is important to set correct context window, otherwise there will be potential

--- a/ols/src/llms/llm_loader.py
+++ b/ols/src/llms/llm_loader.py
@@ -1,7 +1,7 @@
 """LLM backend libraries loader."""
 
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 from langchain.llms.base import LLM
 
@@ -57,7 +57,7 @@ def load_llm(
     model: str,
     generic_llm_params: Optional[dict] = None,
     streaming: Optional[bool] = None,
-) -> LLM:
+) -> LLM | Any:  # Temporarily using Any, as mypy gives error for missing bind_tools
     """Load LLM according to input provider and model.
 
     Args:
@@ -79,7 +79,6 @@ def load_llm(
 
         bare_llm = load_llm(provider="openai", model="gpt-4o-mini",
                             generic_llm_params=generic_llm_params).llm
-        llm_chain = LLMChain(llm=bare_llm, prompt=prompt)
         ```
     """
     providers_config = config.config.llm_providers

--- a/ols/src/llms/providers/watsonx.py
+++ b/ols/src/llms/providers/watsonx.py
@@ -7,7 +7,7 @@ from ibm_watsonx_ai.metanames import (
     GenTextParamsMetaNames as GenParams,
 )
 from langchain.llms.base import LLM
-from langchain_ibm.llms import WatsonxLLM
+from langchain_ibm import ChatWatsonx
 
 from ols import constants
 from ols.src.llms.providers.provider import LLMProvider
@@ -59,7 +59,7 @@ class Watsonx(LLMProvider):
         if self.project_id is None:
             raise ValueError("Project ID must be specified")
 
-        return WatsonxLLM(
+        return ChatWatsonx(
             model_id=self.model,
             url=self.url,
             apikey=self.credentials,

--- a/ols/src/prompts/prompts.py
+++ b/ols/src/prompts/prompts.py
@@ -22,6 +22,15 @@ Here are some basic facts about OpenShift:
 - OpenShift is a distribution of Kubernetes. Everything Kubernetes can do, OpenShift can do and more.
 """
 
+# Currently only additional instructions are concatenated to original
+# doc summarizer prompt. Depending upon performance dedicated prompt will be used.
+AGENT_SYSTEM_INSTRUCTION = """
+* Given the user's query you must decide what to do with it based on the \
+list of tools provided to you.
+* Execute as many tools as possible to gather all information. When you are \
+satisfied with all the details then answer user query.
+"""
+
 USE_CONTEXT_INSTRUCTION = """
 Use the retrieved document to answer the question.
 """

--- a/ols/src/tools/__init__.py
+++ b/ols/src/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Tools/Functions Definition."""

--- a/ols/src/tools/tools.py
+++ b/ols/src/tools/tools.py
@@ -1,0 +1,19 @@
+"""Functions/Tools definition."""
+
+from langchain.tools import tool
+
+
+# TODO: Sample function to test the flow. Add actual tools/functions here
+@tool
+def get_namespaces() -> str:
+    """Fetch the list of all namespaces in the cluster."""
+    return """
+NAME                                               STATUS   AGE
+default                                            Active   25m
+namespace1                                         Active   25m
+"""
+
+
+tools_map = {
+    "get_namespaces": get_namespaces,
+}

--- a/tests/config/operator_install/olsconfig.crd.azure_openai_introspection.yaml
+++ b/tests/config/operator_install/olsconfig.crd.azure_openai_introspection.yaml
@@ -1,0 +1,36 @@
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+  labels:
+    app.kubernetes.io/created-by: lightspeed-operator
+    app.kubernetes.io/instance: olsconfig-sample
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: olsconfig
+    app.kubernetes.io/part-of: lightspeed-operator
+spec:
+  llm:
+    providers:
+      - name: azure_openai
+        type: azure_openai
+        credentialsSecretRef:
+          name: llmcreds
+        deploymentName: gpt-4o-mini
+        models:
+          - name: gpt-4o-mini
+        url: 'https://ols-test.openai.azure.com/'
+  ols:
+    defaultModel: gpt-4o-mini
+    defaultProvider: azure_openai
+    introspectionEnabled: true
+    deployment:
+      replicas: 1
+    disableAuth: false
+    logLevel: DEBUG
+    queryFilters:
+      - name: foo_filter
+        pattern: '\b(?:foo)\b'
+        replaceWith: "deployment"
+      - name: bar_filter
+        pattern: '\b(?:bar)\b'
+        replaceWith: "openshift"

--- a/tests/config/operator_install/olsconfig.crd.openai_introspection.yaml
+++ b/tests/config/operator_install/olsconfig.crd.openai_introspection.yaml
@@ -1,0 +1,34 @@
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+  labels:
+    app.kubernetes.io/created-by: lightspeed-operator
+    app.kubernetes.io/instance: olsconfig-sample
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: olsconfig
+    app.kubernetes.io/part-of: lightspeed-operator
+spec:
+  llm:
+    providers:
+      - credentialsSecretRef:
+          name: llmcreds
+        models:
+          - name: gpt-4o-mini
+        name: openai
+        type: openai
+  ols:
+    defaultModel: gpt-4o-mini
+    defaultProvider: openai
+    introspectionEnabled: true
+    deployment:
+      replicas: 1
+    disableAuth: false
+    logLevel: DEBUG
+    queryFilters:
+      - name: foo_filter
+        pattern: '\b(?:foo)\b'
+        replaceWith: "deployment"
+      - name: bar_filter
+        pattern: '\b(?:bar)\b'
+        replaceWith: "openshift"

--- a/tests/config/operator_install/olsconfig.crd.watsonx_introspection.yaml
+++ b/tests/config/operator_install/olsconfig.crd.watsonx_introspection.yaml
@@ -1,0 +1,35 @@
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+  labels:
+    app.kubernetes.io/created-by: lightspeed-operator
+    app.kubernetes.io/instance: olsconfig-sample
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: olsconfig
+    app.kubernetes.io/part-of: lightspeed-operator
+spec:
+  llm:
+    providers:
+      - credentialsSecretRef:
+          name: llmcreds
+        projectID: ad629765-c373-4731-9d69-dc701724c081
+        models:
+          - name: ibm/granite-3-8b-instruct
+        name: watsonx
+        type: watsonx
+  ols:
+    defaultModel: ibm/granite-3-8b-instruct
+    defaultProvider: watsonx
+    introspectionEnabled: true
+    deployment:
+      replicas: 1
+    disableAuth: false
+    logLevel: DEBUG
+    queryFilters:
+      - name: foo_filter
+        pattern: '\b(?:foo)\b'
+        replaceWith: "deployment"
+      - name: bar_filter
+        pattern: '\b(?:bar)\b'
+        replaceWith: "openshift"

--- a/tests/e2e/pytest.ini
+++ b/tests/e2e/pytest.ini
@@ -13,3 +13,4 @@ markers =
 	azure_entra_id
 	smoketest
 	not_konflux
+	introspection

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -98,6 +98,7 @@ def fixture_postgres_connection():
 
 
 @pytest.mark.smoketest
+@pytest.mark.introspection
 @retry(max_attempts=3, wait_between_runs=10)
 def test_readiness():
     """Test handler for /readiness REST API endpoint."""
@@ -110,6 +111,7 @@ def test_readiness():
 
 
 @pytest.mark.smoketest
+@pytest.mark.introspection
 def test_liveness():
     """Test handler for /liveness REST API endpoint."""
     endpoint = "/liveness"

--- a/tests/e2e/utils/ols_installer.py
+++ b/tests/e2e/utils/ols_installer.py
@@ -119,7 +119,7 @@ def replace_ols_image(ols_image: str) -> None:
     )
 
 
-def install_ols() -> tuple[str, str, str]:  # pylint: disable=R0915
+def install_ols() -> tuple[str, str, str]:  # pylint: disable=R0915  # noqa: C901
     """Install OLS onto an OCP cluster using the OLS operator."""
     print("Setting up for on cluster test execution")
     is_konflux = os.getenv("KONFLUX_BOOL")
@@ -248,11 +248,16 @@ def install_ols() -> tuple[str, str, str]:  # pylint: disable=R0915
     except subprocess.CalledProcessError:
         print("olsconfig does not yet exist. Creating it.")
 
+    crd_yml_name = f"olsconfig.crd.{provider}"
+    if os.getenv("INTROSPECTION_ENABLED", "n") == "y":
+        print("Cluster introspection is enabled.")
+        crd_yml_name += "_introspection"
+
     cluster_utils.run_oc(
         [
             "create",
             "-f",
-            f"tests/config/operator_install/olsconfig.crd.{provider}.yaml",
+            f"tests/config/operator_install/{crd_yml_name}.yaml",
         ],
         ignore_existing_resource=True,
     )

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -14,12 +14,13 @@ from ols.app.models.config import (
     ProviderConfig,
     QueryFilter,
 )
+from ols.app.models.models import TokenCounter
 from ols.utils import suid
 from ols.utils.errors_parsing import DEFAULT_ERROR_MESSAGE, DEFAULT_STATUS_CODE
 from ols.utils.logging_configurator import configure_logging
 from tests.mock_classes.mock_langchain_interface import mock_langchain_interface
-from tests.mock_classes.mock_llm_chain import mock_llm_chain
 from tests.mock_classes.mock_llm_loader import mock_llm_loader
+from tests.mock_classes.mock_tools import mock_tools_map
 
 
 @pytest.fixture(scope="function")
@@ -303,10 +304,6 @@ def test_post_question_on_noyaml_response_type(_setup, endpoint) -> None:
     ml = mock_langchain_interface("test response")
     with (
         patch(
-            "ols.src.query_helpers.docs_summarizer.LLMChain",
-            new=mock_llm_chain(None),
-        ),
-        patch(
             "ols.src.query_helpers.query_helper.load_llm",
             new=mock_llm_loader(ml()),
         ),
@@ -335,10 +332,6 @@ def test_post_question_with_keyword(mock_llm_validation, _setup, endpoint) -> No
 
     ml = mock_langchain_interface(None)
     with (
-        patch(
-            "ols.src.query_helpers.docs_summarizer.LLMChain",
-            new=mock_llm_chain(None),
-        ),
         patch(
             "ols.src.query_helpers.query_helper.load_llm",
             new=mock_llm_loader(ml()),
@@ -386,10 +379,6 @@ def test_post_query_with_query_filters_response_type(_setup, endpoint) -> None:
         ml = mock_langchain_interface("test response")
         with (
             patch(
-                "ols.src.query_helpers.docs_summarizer.LLMChain",
-                new=mock_llm_chain(None),
-            ),
-            patch(
                 "ols.src.query_helpers.query_helper.load_llm",
                 new=mock_llm_loader(ml()),
             ),
@@ -436,10 +425,6 @@ def test_post_query_for_conversation_history(_setup, endpoint) -> None:
 
     ml = mock_langchain_interface("test response")
     with (
-        patch(
-            "ols.src.query_helpers.docs_summarizer.LLMChain",
-            new=mock_llm_chain(None),
-        ),
         patch(
             "ols.src.query_helpers.query_helper.load_llm",
             new=mock_llm_loader(ml()),
@@ -509,10 +494,6 @@ def test_post_question_without_attachments(_setup, endpoint) -> None:
         ml = mock_langchain_interface("test response")
         with (
             patch(
-                "ols.src.query_helpers.docs_summarizer.LLMChain",
-                new=mock_llm_chain(None),
-            ),
-            patch(
                 "ols.src.query_helpers.query_helper.load_llm",
                 new=mock_llm_loader(ml()),
             ),
@@ -552,10 +533,6 @@ def test_post_question_with_empty_list_of_attachments(_setup, endpoint) -> None:
     ):
         ml = mock_langchain_interface("test response")
         with (
-            patch(
-                "ols.src.query_helpers.docs_summarizer.LLMChain",
-                new=mock_llm_chain(None),
-            ),
             patch(
                 "ols.src.query_helpers.query_helper.load_llm",
                 new=mock_llm_loader(ml()),
@@ -597,10 +574,6 @@ def test_post_question_with_one_plaintext_attachment(_setup, endpoint) -> None:
     ):
         ml = mock_langchain_interface("test response")
         with (
-            patch(
-                "ols.src.query_helpers.docs_summarizer.LLMChain",
-                new=mock_llm_chain(None),
-            ),
             patch(
                 "ols.src.query_helpers.query_helper.load_llm",
                 new=mock_llm_loader(ml()),
@@ -655,10 +628,6 @@ def test_post_question_with_one_yaml_attachment(_setup, endpoint) -> None:
     ):
         ml = mock_langchain_interface("test response")
         with (
-            patch(
-                "ols.src.query_helpers.docs_summarizer.LLMChain",
-                new=mock_llm_chain(None),
-            ),
             patch(
                 "ols.src.query_helpers.query_helper.load_llm",
                 new=mock_llm_loader(ml()),
@@ -722,10 +691,6 @@ def test_post_question_with_two_yaml_attachments(_setup, endpoint) -> None:
     ):
         ml = mock_langchain_interface("test response")
         with (
-            patch(
-                "ols.src.query_helpers.docs_summarizer.LLMChain",
-                new=mock_llm_chain(None),
-            ),
             patch(
                 "ols.src.query_helpers.query_helper.load_llm",
                 new=mock_llm_loader(ml()),
@@ -810,10 +775,6 @@ def test_post_question_with_one_yaml_without_kind_attachment(_setup, endpoint) -
         ml = mock_langchain_interface("test response")
         with (
             patch(
-                "ols.src.query_helpers.docs_summarizer.LLMChain",
-                new=mock_llm_chain(None),
-            ),
-            patch(
                 "ols.src.query_helpers.query_helper.load_llm",
                 new=mock_llm_loader(ml()),
             ),
@@ -874,10 +835,6 @@ def test_post_question_with_one_yaml_without_name_attachment(_setup, endpoint) -
     ):
         ml = mock_langchain_interface("test response")
         with (
-            patch(
-                "ols.src.query_helpers.docs_summarizer.LLMChain",
-                new=mock_llm_chain(None),
-            ),
             patch(
                 "ols.src.query_helpers.query_helper.load_llm",
                 new=mock_llm_loader(ml()),
@@ -941,10 +898,6 @@ def test_post_question_with_one_invalid_yaml_attachment(_setup, endpoint) -> Non
     ):
         ml = mock_langchain_interface("test response")
         with (
-            patch(
-                "ols.src.query_helpers.docs_summarizer.LLMChain",
-                new=mock_llm_chain(None),
-            ),
             patch(
                 "ols.src.query_helpers.query_helper.load_llm",
                 new=mock_llm_loader(ml()),
@@ -1011,10 +964,6 @@ logs:
     ):
         ml = mock_langchain_interface("test response")
         with (
-            patch(
-                "ols.src.query_helpers.docs_summarizer.LLMChain",
-                new=mock_llm_chain(None),
-            ),
             patch(
                 "ols.src.query_helpers.query_helper.load_llm",
                 new=mock_llm_loader(ml()),
@@ -1084,10 +1033,6 @@ def _post_with_system_prompt_override(_setup, caplog, query, system_prompt):
         ml = mock_langchain_interface("test response")
         with (
             patch(
-                "ols.src.query_helpers.docs_summarizer.LLMChain",
-                new=mock_llm_chain(None),
-            ),
-            patch(
                 "ols.src.query_helpers.query_helper.load_llm",
                 new=mock_llm_loader(ml()),
             ),
@@ -1146,3 +1091,55 @@ def test_post_with_system_prompt_override_disabled(_setup, caplog):
     # Specified system prompt should NOT appear in query_helper debug log outputs
     # as enable_system_prompt_override is set to False.
     assert caplog.text.count("System prompt: " + system_prompt) == 0
+
+
+@patch("ols.src.query_helpers.docs_summarizer.tools_map", mock_tools_map)
+@patch("ols.src.query_helpers.docs_summarizer.DocsSummarizer._invoke_llm")
+def test_tool_calling(mock_invoke, _setup, caplog) -> None:
+    """Check the REST API query endpoints when tool calling is enabled."""
+    endpoint = "/v1/query"
+    caplog.set_level(10)
+    config.ols_config.introspection_enabled = True
+
+    mock_invoke.side_effect = [
+        (
+            AIMessage(
+                content="",
+                response_metadata={"finish_reason": "tool_calls"},
+                tool_calls=[
+                    {"name": "get_namespaces_mock", "args": {}, "id": "call_id1"},
+                ],
+            ),
+            TokenCounter(),
+        ),
+        (
+            AIMessage(
+                content="You have 1 namespace.",
+                response_metadata={"finish_reason": "stop"},
+            ),
+            TokenCounter(),
+        ),
+    ]
+
+    with (
+        patch(
+            "ols.src.query_helpers.query_helper.load_llm",
+            new=mock_llm_loader(None),
+        ),
+    ):
+        conversation_id = suid.get_suid()
+        response = pytest.client.post(
+            endpoint,
+            json={
+                "conversation_id": conversation_id,
+                "query": "How many namespaces are there in my cluster ?",
+            },
+        )
+        assert mock_invoke.call_count == 2
+
+        assert "tool name: get_namespaces_mock" in caplog.text
+        tool_output = mock_tools_map["get_namespaces_mock"].invoke({})
+        assert f"tool_output: {tool_output}" in caplog.text
+
+        assert response.status_code == requests.codes.ok
+        assert response.json()["response"] == "You have 1 namespace."

--- a/tests/mock_classes/mock_llm_loader.py
+++ b/tests/mock_classes/mock_llm_loader.py
@@ -2,8 +2,10 @@
 
 from types import SimpleNamespace
 
+from langchain_core.runnables import Runnable
 
-class MockLLMLoader:
+
+class MockLLMLoader(Runnable):
     """Mock for LLMLoader."""
 
     def __init__(self, llm=None):
@@ -14,10 +16,19 @@ class MockLLMLoader:
             llm.model = "mock_model"
         self.llm = llm
 
-    async def astream(self, llm_input, **kwargs):
+    def invoke(self, *args, **kwargs):
+        """Mock model invoke."""
+        return args[0].messages[1]
+
+    @classmethod
+    def bind_tools(cls, *args, **kwargs):
+        """Mock bind tools."""
+        return cls()
+
+    async def astream(self, *args, **kwargs):
         """Return query result."""
         # yield input prompt/user query
-        yield llm_input[1].content
+        yield args[0][1].content
 
 
 def mock_llm_loader(llm=None, expected_params=None):

--- a/tests/mock_classes/mock_tools.py
+++ b/tests/mock_classes/mock_tools.py
@@ -1,0 +1,16 @@
+"""Mocked tools for tool calling."""
+
+from langchain.tools import tool
+
+
+# Define Mock/Sample tools
+@tool
+def get_namespaces_mock() -> str:
+    """Fetch the list of all namespaces in the cluster."""
+    return """
+NAME                                               STATUS   AGE
+default                                            Active   25m
+"""
+
+
+mock_tools_map = {"get_namespaces_mock": get_namespaces_mock}

--- a/tests/mock_classes/mock_watsonxllm.py
+++ b/tests/mock_classes/mock_watsonxllm.py
@@ -1,13 +1,13 @@
-"""Mocked WatsonxLLM class to avoid accessing real Watsonx API."""
+"""Mocked ChatWatsonx class to avoid accessing real Watsonx API."""
 
 from langchain.llms.base import LLM
 
 
-class WatsonxLLM(LLM):
-    """Mocked WatsonxLLM class to avoid accessing real Watsonx API."""
+class ChatWatsonx(LLM):
+    """Mocked ChatWatsonx class to avoid accessing real Watsonx API."""
 
     def __init__(self):
-        """Initialize mocked WatsonxLLM."""
+        """Initialize mocked ChatWatsonx."""
 
     def _call(self, prompt, stop=None, run_manager=None, **kwargs):
         """Override abstract method from LLM abstract class."""

--- a/tests/scripts/test-e2e-cluster.sh
+++ b/tests/scripts/test-e2e-cluster.sh
@@ -35,26 +35,36 @@ function run_suites() {
   # runsuite arguments:
   # suiteid test_tags provider provider_keypath model ols_image
   # empty test_tags means run all tests
-  run_suite "azure_openai" "not model_evaluation and not certificates" "azure_openai" "$AZUREOPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE"
+  run_suite "azure_openai" "not model_evaluation and not certificates and not (introspection and not smoketest and not rag)" "azure_openai" "$AZUREOPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE" "n"
   (( rc = rc || $? ))
 
-  # BAM is currently not working, commenting for now
-  # run_suite "bam" "not model_evaluation" "bam" "$BAM_PROVIDER_KEY_PATH" "ibm/granite-3-8b-instruct" "$OLS_IMAGE"
+  # # BAM is currently not working, commenting for now
+  # run_suite "bam" "not model_evaluation and not azure_entra_id and not certificates and not (introspection and not smoketest and not rag)" "bam" "$BAM_PROVIDER_KEY_PATH" "ibm/granite-3-8b-instruct" "$OLS_IMAGE" "n"
   # (( rc = rc || $? ))
 
-  run_suite "openai" "not model_evaluation and not azure_entra_id and not certificates" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE"
+  run_suite "openai" "not model_evaluation and not azure_entra_id and not certificates and not (introspection and not smoketest and not rag)" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE" "n"
   (( rc = rc || $? ))
 
-  run_suite "watsonx" "not model_evaluation and not azure_entra_id and not certificates" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-3-8b-instruct" "$OLS_IMAGE"
+  run_suite "watsonx" "not model_evaluation and not azure_entra_id and not certificates and not (introspection and not smoketest and not rag)" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-3-8b-instruct" "$OLS_IMAGE" "n"
   (( rc = rc || $? ))
 
   # smoke tests for RHOAI VLLM-compatible provider
-  run_suite "rhoai_vllm" "smoketest" "rhoai_vllm" "$OPENAI_PROVIDER_KEY_PATH" "gpt-3.5-turbo" "$OLS_IMAGE"
+  run_suite "rhoai_vllm" "smoketest" "rhoai_vllm" "$OPENAI_PROVIDER_KEY_PATH" "gpt-3.5-turbo" "$OLS_IMAGE" "n"
   (( rc = rc || $? ))
 
   # smoke tests for RHELAI VLLM-compatible provider
-  run_suite "rhelai_vllm" "smoketest" "rhelai_vllm" "$OPENAI_PROVIDER_KEY_PATH" "gpt-3.5-turbo" "$OLS_IMAGE"
+  run_suite "rhelai_vllm" "smoketest" "rhelai_vllm" "$OPENAI_PROVIDER_KEY_PATH" "gpt-3.5-turbo" "$OLS_IMAGE" "n"
   (( rc = rc || $? ))
+
+  # TODO: Enable below test cases once flag is added to operator CRD. Update flag name in CRD yaml (if different name is used)
+  # TODO: Reduce execution time. Sequential execution will take more time. Parallel execution will have cluster claim issue.
+  # Run tool calling - Enable introspection
+  # run_suite "azure_openai_introspection" "introspection" "azure_openai" "$AZUREOPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE" "y"
+  # (( rc = rc || $? ))
+  # run_suite "openai_introspection" "introspection" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE" "y"
+  # (( rc = rc || $? ))
+  # run_suite "watsonx_introspection" "introspection" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-3-8b-instruct" "$OLS_IMAGE" "y"
+  # (( rc = rc || $? ))
 
   set -e
 

--- a/tests/scripts/utils.sh
+++ b/tests/scripts/utils.sh
@@ -44,13 +44,14 @@ function cleanup_ols_operator() {
 # $4 PROVIDER_KEY_PATH
 # $5 MODEL
 # $6 OLS_IMAGE
+# $7 INTROSPECTION_ENABLED
 function run_suite() {
   echo "Preparing to run suite $1"
 
   cleanup_ols_operator
   
   # Run e2e tests with response evaluation.
-  SUITE_ID=$1 TEST_TAGS=$2 PROVIDER=$3 PROVIDER_KEY_PATH=$4 MODEL=$5 OLS_IMAGE=$6 ARTIFACT_DIR=$ARTIFACT_DIR make test-e2e
+  SUITE_ID=$1 TEST_TAGS=$2 PROVIDER=$3 PROVIDER_KEY_PATH=$4 MODEL=$5 OLS_IMAGE=$6 INTROSPECTION_ENABLED=$7 ARTIFACT_DIR=$ARTIFACT_DIR make test-e2e
 
   local rc=$?
   return $rc

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -2153,6 +2153,7 @@ def test_ols_config(tmpdir):
         {
             "default_provider": "test_default_provider",
             "default_model": "test_default_model",
+            "introspection_enabled": True,
             "conversation_cache": {
                 "type": "memory",
                 "memory": {
@@ -2169,6 +2170,7 @@ def test_ols_config(tmpdir):
     assert ols_config.conversation_cache.type == "memory"
     assert ols_config.conversation_cache.memory.max_entries == 100
     assert ols_config.logging_config.app_log_level == logging.INFO
+    assert ols_config.introspection_enabled
     assert (
         ols_config.query_validation_method == constants.QueryValidationMethod.DISABLED
     )
@@ -2206,6 +2208,7 @@ def test_ols_config_with_auth_config(tmpdir):
     assert ols_config.default_model == "test_default_model"
     assert ols_config.conversation_cache.type == "memory"
     assert ols_config.conversation_cache.memory.max_entries == 100
+    assert not ols_config.introspection_enabled
     assert ols_config.logging_config.app_log_level == logging.INFO
     assert (
         ols_config.query_validation_method == constants.QueryValidationMethod.DISABLED

--- a/tests/unit/llms/providers/test_watsonx.py
+++ b/tests/unit/llms/providers/test_watsonx.py
@@ -10,7 +10,7 @@ from ibm_watsonx_ai.metanames import (
 from ols.app.models.config import ProviderConfig
 from ols.constants import GenericLLMParameters
 from ols.src.llms.providers.watsonx import Watsonx
-from tests.mock_classes.mock_watsonxllm import WatsonxLLM
+from tests.mock_classes.mock_watsonxllm import ChatWatsonx
 
 
 @pytest.fixture
@@ -101,16 +101,16 @@ def provider_config_with_specific_params():
     )
 
 
-@patch("ols.src.llms.providers.watsonx.WatsonxLLM", new=WatsonxLLM())
+@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_basic_interface(provider_config):
     """Test basic interface."""
     watsonx = Watsonx(model="uber-model", params={}, provider_config=provider_config)
     llm = watsonx.load()
-    assert isinstance(llm, WatsonxLLM)
+    assert isinstance(llm, ChatWatsonx)
     assert watsonx.default_params
 
 
-@patch("ols.src.llms.providers.watsonx.WatsonxLLM", new=WatsonxLLM())
+@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_params_handling(provider_config):
     """Test that not allowed parameters are removed before model init."""
     # first two parameters should be removed before model init
@@ -127,7 +127,7 @@ def test_params_handling(provider_config):
         model="uber-model", params=params, provider_config=provider_config
     )
     llm = watsonx.load()
-    assert isinstance(llm, WatsonxLLM)
+    assert isinstance(llm, ChatWatsonx)
     assert watsonx.default_params
     assert watsonx.params
 
@@ -148,7 +148,7 @@ def test_params_handling(provider_config):
     assert "verbose" not in watsonx.params
 
 
-@patch("ols.src.llms.providers.watsonx.WatsonxLLM", new=WatsonxLLM())
+@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_credentials_key_in_directory_handling(provider_config_credentials_directory):
     """Test that credentials in directory is handled as expected."""
     params = {}
@@ -159,13 +159,13 @@ def test_credentials_key_in_directory_handling(provider_config_credentials_direc
         provider_config=provider_config_credentials_directory,
     )
     llm = watsonx.load()
-    assert isinstance(llm, WatsonxLLM)
+    assert isinstance(llm, ChatWatsonx)
 
     # taken from configuration
     assert watsonx.credentials == "secret_key"
 
 
-@patch("ols.src.llms.providers.watsonx.WatsonxLLM", new=WatsonxLLM())
+@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_params_handling_specific_params(provider_config_with_specific_params):
     """Test that provider-specific parameters take precedence."""
     watsonx = Watsonx(
@@ -174,7 +174,7 @@ def test_params_handling_specific_params(provider_config_with_specific_params):
         provider_config=provider_config_with_specific_params,
     )
     llm = watsonx.load()
-    assert isinstance(llm, WatsonxLLM)
+    assert isinstance(llm, ChatWatsonx)
     assert watsonx.default_params
     assert watsonx.params
 
@@ -185,7 +185,7 @@ def test_params_handling_specific_params(provider_config_with_specific_params):
     assert watsonx.project_id == "ffffffff-89ab-cdef-0123-456789abcdef"
 
 
-@patch("ols.src.llms.providers.watsonx.WatsonxLLM", new=WatsonxLLM())
+@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_params_handling_none_values(provider_config):
     """Test handling parameters with None values."""
     # first three parameters should be removed before model init
@@ -202,7 +202,7 @@ def test_params_handling_none_values(provider_config):
         model="uber-model", params=params, provider_config=provider_config
     )
     llm = watsonx.load()
-    assert isinstance(llm, WatsonxLLM)
+    assert isinstance(llm, ChatWatsonx)
     assert watsonx.default_params
     assert watsonx.params
 
@@ -221,7 +221,7 @@ def test_params_handling_none_values(provider_config):
     assert "verbose" not in watsonx.params
 
 
-@patch("ols.src.llms.providers.watsonx.WatsonxLLM", new=WatsonxLLM())
+@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_params_replace_default_values_with_none(provider_config):
     """Test if default values are replaced by None values."""
     # provider initialization with empty set of params
@@ -245,7 +245,7 @@ def test_params_replace_default_values_with_none(provider_config):
     assert watsonx.params[GenParams.DECODING_METHOD] is None
 
 
-@patch("ols.src.llms.providers.watsonx.WatsonxLLM", new=WatsonxLLM())
+@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_generic_parameter_mappings(provider_config):
     """Test generic parameter mapping to provider parameter list."""
     # some non-default values for generic LLM parameters
@@ -261,7 +261,7 @@ def test_generic_parameter_mappings(provider_config):
         model="uber-model", params=generic_llm_params, provider_config=provider_config
     )
     llm = watsonx.load()
-    assert isinstance(llm, WatsonxLLM)
+    assert isinstance(llm, ChatWatsonx)
     assert watsonx.default_params
     assert watsonx.params
 


### PR DESCRIPTION
## Description
Change Summary
* [OLS-1383](https://issues.redhat.com/browse/OLS-1383)
   * Add a flag to the config to enable introspection
* [OLS-1373](https://issues.redhat.com//browse/OLS-1373)
   * Add sample tool with mock output
   * Tool calling in a loop when introspection flag is enabled
   * Stop the loop when max iteration is reached or model gives final response.
   * Existing flow when flag is False.
   * Minor modification to prompt when tool calling is enabled
   * Modify watsonx model class to handle bind_tools
   * some refactoring
* [OLS-1288](https://issues.redhat.com/browse/OLS-1288)
   * Use langchain runnable instead of LLMChain (Didn't change query validator, as we need to remove the logic)
* e2e test case
   * Added different suite with different marker for tool calling e2e test case. Currently commented (till we have property in operator crd)

Note
* Goal is to have the flow (tool calling in a loop) ready, so that we can iterate. Optimization is not in scope.
* Prompt optimization is not in scope
* Actual tools are not in scope
* Optimizing for granite not in scope
* There are several other enhancement, will create follow up stories.