### PR TITLE
Pin the openshift-client tar to a specific version (4.17.9)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,10 +19,10 @@ RUN if [ -f /cachi2/output/deps/generic/openshift-clients.tar.gz ]; then \
       echo "Using pre-fetched OpenShift CLI from /cachi2"; \
       tar -xvf /cachi2/output/deps/generic/openshift-clients.tar.gz -C /usr/local/bin; \
     else \
-      echo "Pre-fetched OpenShift CLI not found. Downloading via curl."; \
-      curl -LO "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz" && \
-      tar -xvf openshift-client-linux.tar.gz -C /usr/local/bin && \
-      rm -f openshift-client-linux.tar.gz; \
+      OC_CLIENT_TAR_GZ=openshift-client-linux-amd64-rhel9-4.17.9.tar.gz; \
+      curl -LO "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.17.9/${OC_CLIENT_TAR_GZ}" && \
+      tar xvfz ${OC_CLIENT_TAR_GZ} -C /usr/local/bin && \
+      rm -f ${OC_CLIENT_TAR_GZ}; \
     fi
 
 # finish and verify installation

--- a/artifacts.lock.yaml
+++ b/artifacts.lock.yaml
@@ -1,6 +1,6 @@
 metadata:
   version: "1.0"
 artifacts:
-  - download_url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz"
-    checksum: "sha256:3d696605ef1ef33b49546ed7f6498458ff704935aad4fe9fcc3bab297b9ff80e"
+  - download_url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.17.9/openshift-client-linux-amd64-rhel9-4.17.9.tar.gz"
+    checksum: "sha256:30e663aec2a15a00b6e5eda47bb6ba69d629df915ffc45f49909491a2eb311d7"
     filename: "openshift-clients.tar.gz"


### PR DESCRIPTION
## Description

Pin the openshift-client tar to a specific version (4.17.9) as opposed to 'stable' which can change from under us and invalidate the SHA.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
