### PR TITLE
OLS-1460: Allow Python 3.13 to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ configure model, and connect to it.
 
 # Prerequisites
 
-* Python 3.11 or Python 3.12
-    - please note that currently Python 3.13 is not officially supported, because OLS LightSpeed depends on some packages that can not be used in this Python version
+* Python 3.11, Python 3.12 and Python 3.13
+    - please note that currently Python 3.14 is not officially supported, because OLS LightSpeed depends on some packages that can not be used in this Python version
     - all sources are made (backward) compatible with Python 3.11; it is checked on CI
 * Git, pip and [PDM](https://github.com/pdm-project/pdm?tab=readme-ov-file#installation)
 * An LLM API key or API secret (in case of Azure OpenAI)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ dependencies = [
     "virtualenv>=20.28.0",
     "msgpack>=1.1.0",
 ]
-requires-python = ">=3.11.1,<=3.12.8"
+requires-python = ">=3.11.1,<=3.13.2"
 readme = "README.md"
 license = {file = "LICENSE"}
 


### PR DESCRIPTION
## Description

[OLS-1460](https://issues.redhat.com//browse/OLS-1460): Allow Python 3.13 to be used

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1460](https://issues.redhat.com//browse/OLS-1460)
