### PR TITLE
Ability to use token in noop auth (if needed)

### DIFF
--- a/ols/src/auth/auth_dependency_interface.py
+++ b/ols/src/auth/auth_dependency_interface.py
@@ -2,7 +2,33 @@
 
 from abc import ABC, abstractmethod
 
-from fastapi import Request
+from fastapi import HTTPException, Request
+
+
+def extract_bearer_token(header: str) -> str:
+    """Extract the bearer token from an HTTP authorization header.
+
+    Args:
+        header: The authorization header containing the token.
+
+    Returns:
+        The extracted token if present, else an empty string.
+    """
+    try:
+        scheme, token = header.split(" ", 1)
+        return token if scheme.lower() == "bearer" else ""
+    except ValueError:
+        return ""
+
+
+def extract_token_from_request(request: Request) -> str:
+    """Extract the bearer token from a FastAPI request."""
+    authorization_header = request.headers.get("Authorization")
+    if not authorization_header:
+        raise HTTPException(
+            status_code=401, detail="Unauthorized: No auth header found"
+        )
+    return extract_bearer_token(authorization_header)
 
 
 class AuthDependencyInterface(ABC):

--- a/ols/src/auth/noop.py
+++ b/ols/src/auth/noop.py
@@ -2,10 +2,11 @@
 
 import logging
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 
 from ols import config
 from ols.constants import DEFAULT_USER_NAME, DEFAULT_USER_UID, NO_USER_TOKEN
+from ols.src.auth.auth_dependency_interface import extract_token_from_request
 
 from .auth_dependency_interface import AuthDependencyInterface
 
@@ -33,7 +34,12 @@ class AuthDependency(AuthDependencyInterface):
             If user_id check should be skipped
             User's token
         """
-        user_token = NO_USER_TOKEN  # no-op auth yield no token
+        # the user token is optional in the noop auth, if there is no token we
+        # use our default value for this scenario
+        try:
+            user_token = extract_token_from_request(request)
+        except HTTPException:
+            user_token = NO_USER_TOKEN
         if config.dev_config.disable_auth:
             if (
                 config.ols_config.logging_config is None
@@ -58,4 +64,9 @@ class AuthDependency(AuthDependencyInterface):
         # try to read user ID from request
         user_id = request.query_params.get("user_id", DEFAULT_USER_UID)
         logger.info("User ID: %s", user_id)
-        return user_id, DEFAULT_USER_NAME, self.skip_userid_check, user_token
+        return (
+            user_id,
+            DEFAULT_USER_NAME,
+            self.skip_userid_check,
+            user_token,
+        )

--- a/tests/unit/auth/test_noop_auth_dependency.py
+++ b/tests/unit/auth/test_noop_auth_dependency.py
@@ -70,3 +70,26 @@ async def test_noop_auth_dependency_call_with_user_id():
     assert username == DEFAULT_USER_NAME
     assert skip_user_id_check is True
     assert token == NO_USER_TOKEN
+
+
+@pytest.mark.asyncio
+async def test_noop_auth_dependency_provided_token():
+    """Check that the no-op auth. dependency returns provided token."""
+    path = "/ols-access"
+    auth_dependency = noop.AuthDependency(virtual_path=path)
+    # Simulate a request with user_id specified as optional parameter
+    user_id_in_request = "00000000-1234-1234-1234-000000000000"
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [(b"authorization", b"Bearer user-token")],
+            "query_string": f"user_id={user_id_in_request}",
+        }
+    )
+    user_uid, username, skip_user_id_check, token = await auth_dependency(request)
+
+    # Check if the correct user info has been returned
+    assert user_uid == user_id_in_request
+    assert username == DEFAULT_USER_NAME
+    assert skip_user_id_check is True
+    assert token == "user-token"  # noqa: S105


### PR DESCRIPTION
## Description

Ability to use token in noop auth (if needed). When this auth is set in config and user posts a query with token, noop is forwarding this token then instead of default value.