### PR TITLE
OLS-1408: Enable introspection e2e

### DIFF
--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -31,7 +31,9 @@ class DocsSummarizer(QueryHelper):
         self._prepare_llm()
         self.verbose = config.ols_config.logging_config.app_log_level == logging.DEBUG
         self._introspection_enabled = config.ols_config.introspection_enabled
-        set_debug(self.verbose)
+
+        # disabled - leaks token to logs when set to True
+        set_debug(False)
 
     def _prepare_llm(self) -> None:
         """Prepare the LLM configuration."""

--- a/tests/e2e/test_query_endpoint.py
+++ b/tests/e2e/test_query_endpoint.py
@@ -591,7 +591,11 @@ def test_tool_calling() -> None:
             QUERY_ENDPOINT,
             json={
                 "conversation_id": cid,
-                "query": "Is there openshift-lightspeed namespace in the cluster?",
+                "query": (
+                    "In my cluster, is there a 'lightspeed-app-server' pod in "
+                    "'openshift-lightspeed' namespace? Please, explicitely "
+                    "say 'yes' or 'no'."
+                ),
             },
             timeout=test_api.LLM_REST_API_TIMEOUT,
         )
@@ -604,6 +608,6 @@ def test_tool_calling() -> None:
         # checking a few major information from response
         assert json_response["conversation_id"] == cid
 
-        assert "yes" in json_response["response"]
+        assert "yes" in json_response["response"].lower()
         assert json_response["input_tokens"] > 0
         assert json_response["output_tokens"] > 0

--- a/tests/e2e/utils/ols_installer.py
+++ b/tests/e2e/utils/ols_installer.py
@@ -35,6 +35,36 @@ def create_and_config_sas() -> tuple[str, str]:
         "metrics-test-user", "lightspeed-operator-ols-metrics-reader"
     )
     print("test service account permissions granted")
+
+    # grant pod listing permission to test-user - to test the tools,
+    # more specifically the we need the test-user be able to see pods
+    # in the namespace
+    cluster_utils.run_oc(
+        [
+            "create",
+            "role",
+            "pod-reader",
+            "--verb=get,list",
+            "--resource=pods",
+            "--namespace=openshift-lightspeed",
+        ],
+        ignore_existing_resource=True,
+    )
+
+    cluster_utils.run_oc(
+        [
+            "create",
+            "rolebinding",
+            "test-user-pod-reader",
+            "--role=pod-reader",
+            "--serviceaccount=openshift-lightspeed:test-user",
+            "--namespace=openshift-lightspeed",
+        ],
+        ignore_existing_resource=True,
+    )
+
+    print("Granted test-user permission to list pods.")
+
     return token, metrics_token
 
 

--- a/tests/scripts/test-e2e-cluster.sh
+++ b/tests/scripts/test-e2e-cluster.sh
@@ -59,12 +59,12 @@ function run_suites() {
   # TODO: Enable below test cases once flag is added to operator CRD. Update flag name in CRD yaml (if different name is used)
   # TODO: Reduce execution time. Sequential execution will take more time. Parallel execution will have cluster claim issue.
   # Run tool calling - Enable introspection
-  # run_suite "azure_openai_introspection" "introspection" "azure_openai" "$AZUREOPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE" "y"
-  # (( rc = rc || $? ))
-  # run_suite "openai_introspection" "introspection" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE" "y"
-  # (( rc = rc || $? ))
-  # run_suite "watsonx_introspection" "introspection" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-3-8b-instruct" "$OLS_IMAGE" "y"
-  # (( rc = rc || $? ))
+  run_suite "azure_openai_introspection" "introspection" "azure_openai" "$AZUREOPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE" "y"
+  (( rc = rc || $? ))
+  run_suite "openai_introspection" "introspection" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE" "y"
+  (( rc = rc || $? ))
+  run_suite "watsonx_introspection" "introspection" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-3-8b-instruct" "$OLS_IMAGE" "y"
+  (( rc = rc || $? ))
 
   set -e
 

--- a/tests/unit/tools/test_oc_cli.py
+++ b/tests/unit/tools/test_oc_cli.py
@@ -1,6 +1,5 @@
 """Test cases for the oc_cli module."""
 
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -26,28 +25,13 @@ def test_sanitize_oc_args(input_args, expected_output):
     assert sanitize_oc_args(input_args) == expected_output
 
 
-def test_token_works_for_oc_missing_server():
-    """Test token_works_for_oc with missing server."""
-    # env is not set and empty string is provided as server
-    with patch.dict(os.environ, {}):
-        assert not token_works_for_oc("some-token", "")
-
-    # env is empty string and server is not provided
-    with patch.dict(os.environ, {"KUBERNETES_SERVICE_HOST": ""}):
-        assert not token_works_for_oc("some-token")
-
-    # env is not set and server is not provided
-    with patch.dict(os.environ, {}, clear=True):
-        assert not token_works_for_oc("some-token")
-
-
 def test_token_works_for_oc_failure():
     """Test token_works_for_oc failure scenario."""
     with patch("ols.src.tools.oc_cli.run_oc") as mock_run_oc:
         mock_process = MagicMock()
         mock_process.returncode = 1  # simulate failure
         mock_run_oc.return_value = mock_process
-        assert not token_works_for_oc("some-token", "http://bad-server")
+        assert not token_works_for_oc("some-token")
 
 
 def test_token_works_for_oc_success():
@@ -56,7 +40,7 @@ def test_token_works_for_oc_success():
         mock_process = MagicMock()
         mock_process.returncode = 0  # simulate success
         mock_run_oc.return_value = mock_process
-        assert token_works_for_oc("some-token", "some-server")
+        assert token_works_for_oc("some-token")
 
 
 def test_stdout_or_stderr():


### PR DESCRIPTION
## Description

Enable introspection E2E test
- Remove oc server arg.
- Use InjectedToolArg for token arg (nothing for LLM to figure out).
- Remove langchain's debug (leaks token).

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
