### PR TITLE
OLS-1519: no patch decorators in integration tests

### DIFF
--- a/tests/integration/test_authorized.py
+++ b/tests/integration/test_authorized.py
@@ -101,47 +101,51 @@ def test_post_authorized_no_token():
 
 
 @pytest.mark.usefixtures("_enabled_auth")
-@patch("ols.src.auth.k8s.K8sClientSingleton.get_authn_api")
-@patch("ols.src.auth.k8s.K8sClientSingleton.get_authz_api")
-def test_is_user_authorized_valid_token(mock_authz_api, mock_authn_api):
+def test_is_user_authorized_valid_token():
     """Tests the is_user_authorized function with a mocked valid-token."""
-    # Setup mock responses for valid token
-    mock_authn_api.return_value.create_token_review.side_effect = (
-        mock_token_review_response
-    )
-    mock_authz_api.return_value.create_subject_access_review.side_effect = (
-        mock_subject_access_review_response
-    )
-    response = pytest.client.post(
-        "/authorized",
-        headers=[(b"authorization", b"Bearer valid-token")],
-    )
-    assert response.status_code == requests.codes.ok
-    print(response.json())
+    with (
+        patch("ols.src.auth.k8s.K8sClientSingleton.get_authn_api") as mock_authn_api,
+        patch("ols.src.auth.k8s.K8sClientSingleton.get_authz_api") as mock_authz_api,
+    ):
+        # Setup mock responses for valid token
+        mock_authn_api.return_value.create_token_review.side_effect = (
+            mock_token_review_response
+        )
+        mock_authz_api.return_value.create_subject_access_review.side_effect = (
+            mock_subject_access_review_response
+        )
+        response = pytest.client.post(
+            "/authorized",
+            headers=[(b"authorization", b"Bearer valid-token")],
+        )
+        assert response.status_code == requests.codes.ok
+        print(response.json())
 
-    # check the response payload
-    assert response.json() == {
-        "user_id": "valid-uid",
-        "username": "valid-user",
-        "skip_user_id_check": False,
-    }
+        # check the response payload
+        assert response.json() == {
+            "user_id": "valid-uid",
+            "username": "valid-user",
+            "skip_user_id_check": False,
+        }
 
 
 @pytest.mark.usefixtures("_enabled_auth")
-@patch("ols.src.auth.k8s.K8sClientSingleton.get_authn_api")
-@patch("ols.src.auth.k8s.K8sClientSingleton.get_authz_api")
-def test_is_user_authorized_invalid_token(mock_authz_api, mock_authn_api):
+def test_is_user_authorized_invalid_token():
     """Test the is_user_authorized function with a mocked invalid-token."""
-    # Setup mock responses for invalid token
-    mock_authn_api.return_value.create_token_review.side_effect = (
-        mock_token_review_response
-    )
-    mock_authz_api.return_value.create_subject_access_review.side_effect = (
-        mock_subject_access_review_response
-    )
+    with (
+        patch("ols.src.auth.k8s.K8sClientSingleton.get_authn_api") as mock_authn_api,
+        patch("ols.src.auth.k8s.K8sClientSingleton.get_authz_api") as mock_authz_api,
+    ):
+        # Setup mock responses for invalid token
+        mock_authn_api.return_value.create_token_review.side_effect = (
+            mock_token_review_response
+        )
+        mock_authz_api.return_value.create_subject_access_review.side_effect = (
+            mock_subject_access_review_response
+        )
 
-    response = pytest.client.post(
-        "/authorized",
-        headers=[(b"authorization", b"Bearer invalid-token")],
-    )
-    assert response.status_code == 403
+        response = pytest.client.post(
+            "/authorized",
+            headers=[(b"authorization", b"Bearer invalid-token")],
+        )
+        assert response.status_code == 403

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -142,16 +142,18 @@ def test_post_question_on_generic_response_type_summarize_error(_setup, endpoint
 
 
 @pytest.mark.parametrize("endpoint", ("/v1/query", "/v1/streaming_query"))
-@patch(
-    "ols.app.endpoints.ols.config.ols_config.query_validation_method",
-    constants.QueryValidationMethod.LLM,
-)
 def test_post_question_that_is_not_validated(_setup, endpoint):
     """Check the REST API query endpoints for question that is not validated."""
     # let's pretend the question can not be validated
-    with patch(
-        "ols.app.endpoints.ols.QuestionValidator.validate_question",
-        side_effect=Exception("can not validate"),
+    with (
+        patch(
+            "ols.app.endpoints.ols.QuestionValidator.validate_question",
+            side_effect=Exception("can not validate"),
+        ),
+        patch(
+            "ols.app.endpoints.ols.config.ols_config.query_validation_method",
+            constants.QueryValidationMethod.LLM,
+        ),
     ):
         conversation_id = suid.get_suid()
         response = pytest.client.post(
@@ -239,10 +241,6 @@ def test_unknown_provider_in_post(_setup, endpoint):
 
 
 @pytest.mark.parametrize("endpoint", ("/v1/query", "/v1/streaming_query"))
-@patch(
-    "ols.app.endpoints.ols.config.ols_config.query_validation_method",
-    constants.QueryValidationMethod.LLM,
-)
 def test_unsupported_model_in_post(_setup, endpoint):
     """Check the REST API query endpoints with POST method when unsupported model is requested."""
     test_provider = "test-provider"
@@ -250,24 +248,28 @@ def test_unsupported_model_in_post(_setup, endpoint):
     provider_config.models = {}  # no models configured
     config.llm_config.providers = {test_provider: provider_config}
 
-    response = pytest.client.post(
-        endpoint,
-        json={
-            "query": "hello?",
-            "provider": test_provider,
-            "model": "some-model",
-        },
-    )
+    with patch(
+        "ols.app.endpoints.ols.config.ols_config.query_validation_method",
+        constants.QueryValidationMethod.LLM,
+    ):
+        response = pytest.client.post(
+            endpoint,
+            json={
+                "query": "hello?",
+                "provider": test_provider,
+                "model": "some-model",
+            },
+        )
 
-    assert response.status_code == requests.codes.unprocessable
-    expected_json = {
-        "detail": {
-            "cause": "Model 'some-model' is not a valid model for "
-            "provider 'test-provider'. Valid models are: []",
-            "response": "Unable to process this request",
+        assert response.status_code == requests.codes.unprocessable
+        expected_json = {
+            "detail": {
+                "cause": "Model 'some-model' is not a valid model for "
+                "provider 'test-provider'. Valid models are: []",
+                "response": "Unable to process this request",
+            }
         }
-    }
-    assert response.json() == expected_json
+        assert response.json() == expected_json
 
 
 @pytest.mark.parametrize("endpoint", ("/v1/query", "/v1/streaming_query"))
@@ -279,7 +281,6 @@ def test_post_question_improper_conversation_id(_setup, endpoint) -> None:
     with patch(
         "ols.app.endpoints.ols.QuestionValidator.validate_question", return_value=answer
     ):
-
         conversation_id = "not-correct-uuid"
         response = pytest.client.post(
             endpoint,
@@ -322,12 +323,7 @@ def test_post_question_on_noyaml_response_type(_setup, endpoint) -> None:
 
 
 @pytest.mark.parametrize("endpoint", ("/v1/query", "/v1/streaming_query"))
-@patch(
-    "ols.app.endpoints.ols.config.ols_config.query_validation_method",
-    constants.QueryValidationMethod.KEYWORD,
-)
-@patch("ols.app.endpoints.ols.QuestionValidator.validate_question")
-def test_post_question_with_keyword(mock_llm_validation, _setup, endpoint) -> None:
+def test_post_question_with_keyword(_setup, endpoint) -> None:
     """Check the REST API /v1/query with keyword validation."""
     query = "What is Openshift ?"
 
@@ -337,6 +333,13 @@ def test_post_question_with_keyword(mock_llm_validation, _setup, endpoint) -> No
             "ols.src.query_helpers.query_helper.load_llm",
             new=mock_llm_loader(ml()),
         ),
+        patch(
+            "ols.app.endpoints.ols.config.ols_config.query_validation_method",
+            constants.QueryValidationMethod.KEYWORD,
+        ),
+        patch(
+            "ols.app.endpoints.ols.QuestionValidator.validate_question"
+        ) as mock_llm_validation,
     ):
         conversation_id = suid.get_suid()
         response = pytest.client.post(
@@ -473,10 +476,6 @@ def test_post_query_for_conversation_history(_setup, endpoint) -> None:
 
 
 @pytest.mark.parametrize("endpoint", ("/v1/query", "/v1/streaming_query"))
-@patch(
-    "ols.app.endpoints.ols.config.ols_config.query_validation_method",
-    constants.QueryValidationMethod.LLM,
-)
 def test_post_question_without_attachments(_setup, endpoint) -> None:
     """Check the REST API query endpoints without attachments."""
     answer = True
@@ -488,9 +487,15 @@ def test_post_question_without_attachments(_setup, endpoint) -> None:
         query_passed = query
         return answer
 
-    with patch(
-        "ols.app.endpoints.ols.QuestionValidator.validate_question",
-        side_effect=validate_question,
+    with (
+        patch(
+            "ols.app.endpoints.ols.QuestionValidator.validate_question",
+            side_effect=validate_question,
+        ),
+        patch(
+            "ols.app.endpoints.ols.config.ols_config.query_validation_method",
+            constants.QueryValidationMethod.LLM,
+        ),
     ):
         ml = mock_langchain_interface("test response")
         with (
@@ -512,10 +517,6 @@ def test_post_question_without_attachments(_setup, endpoint) -> None:
 
 
 @pytest.mark.parametrize("endpoint", ("/v1/query", "/v1/streaming_query"))
-@patch(
-    "ols.app.endpoints.ols.config.ols_config.query_validation_method",
-    constants.QueryValidationMethod.LLM,
-)
 @pytest.mark.attachment
 def test_post_question_with_empty_list_of_attachments(_setup, endpoint) -> None:
     """Check the REST API query endpoints with empty list of attachments."""
@@ -528,9 +529,15 @@ def test_post_question_with_empty_list_of_attachments(_setup, endpoint) -> None:
         query_passed = query
         return answer
 
-    with patch(
-        "ols.app.endpoints.ols.QuestionValidator.validate_question",
-        side_effect=validate_question,
+    with (
+        patch(
+            "ols.app.endpoints.ols.QuestionValidator.validate_question",
+            side_effect=validate_question,
+        ),
+        patch(
+            "ols.app.endpoints.ols.config.ols_config.query_validation_method",
+            constants.QueryValidationMethod.LLM,
+        ),
     ):
         ml = mock_langchain_interface("test response")
         with (
@@ -554,10 +561,6 @@ def test_post_question_with_empty_list_of_attachments(_setup, endpoint) -> None:
 
 @pytest.mark.parametrize("endpoint", ("/v1/query", "/v1/streaming_query"))
 @pytest.mark.attachment
-@patch(
-    "ols.app.endpoints.ols.config.ols_config.query_validation_method",
-    constants.QueryValidationMethod.LLM,
-)
 def test_post_question_with_one_plaintext_attachment(_setup, endpoint) -> None:
     """Check the REST API query endpoints with one attachment."""
     answer = True
@@ -569,9 +572,15 @@ def test_post_question_with_one_plaintext_attachment(_setup, endpoint) -> None:
         query_passed = query
         return answer
 
-    with patch(
-        "ols.app.endpoints.ols.QuestionValidator.validate_question",
-        side_effect=validate_question,
+    with (
+        patch(
+            "ols.app.endpoints.ols.QuestionValidator.validate_question",
+            side_effect=validate_question,
+        ),
+        patch(
+            "ols.app.endpoints.ols.config.ols_config.query_validation_method",
+            constants.QueryValidationMethod.LLM,
+        ),
     ):
         ml = mock_langchain_interface("test response")
         with (
@@ -608,10 +617,6 @@ this is attachment
 
 @pytest.mark.parametrize("endpoint", ("/v1/query", "/v1/streaming_query"))
 @pytest.mark.attachment
-@patch(
-    "ols.app.endpoints.ols.config.ols_config.query_validation_method",
-    constants.QueryValidationMethod.LLM,
-)
 def test_post_question_with_one_yaml_attachment(_setup, endpoint) -> None:
     """Check the REST API query endpoints with YAML attachment."""
     answer = True
@@ -623,9 +628,15 @@ def test_post_question_with_one_yaml_attachment(_setup, endpoint) -> None:
         query_passed = query
         return answer
 
-    with patch(
-        "ols.app.endpoints.ols.QuestionValidator.validate_question",
-        side_effect=validate_question,
+    with (
+        patch(
+            "ols.app.endpoints.ols.QuestionValidator.validate_question",
+            side_effect=validate_question,
+        ),
+        patch(
+            "ols.app.endpoints.ols.config.ols_config.query_validation_method",
+            constants.QueryValidationMethod.LLM,
+        ),
     ):
         ml = mock_langchain_interface("test response")
         with (
@@ -671,10 +682,6 @@ metadata:
 
 @pytest.mark.parametrize("endpoint", ("/v1/query", "/v1/streaming_query"))
 @pytest.mark.attachment
-@patch(
-    "ols.app.endpoints.ols.config.ols_config.query_validation_method",
-    constants.QueryValidationMethod.LLM,
-)
 def test_post_question_with_two_yaml_attachments(_setup, endpoint) -> None:
     """Check the REST API query endpoints with two YAML attachments."""
     answer = True
@@ -686,9 +693,15 @@ def test_post_question_with_two_yaml_attachments(_setup, endpoint) -> None:
         query_passed = query
         return answer
 
-    with patch(
-        "ols.app.endpoints.ols.QuestionValidator.validate_question",
-        side_effect=validate_question,
+    with (
+        patch(
+            "ols.app.endpoints.ols.QuestionValidator.validate_question",
+            side_effect=validate_question,
+        ),
+        patch(
+            "ols.app.endpoints.ols.config.ols_config.query_validation_method",
+            constants.QueryValidationMethod.LLM,
+        ),
     ):
         ml = mock_langchain_interface("test response")
         with (
@@ -754,10 +767,6 @@ metadata:
 
 @pytest.mark.parametrize("endpoint", ("/v1/query", "/v1/streaming_query"))
 @pytest.mark.attachment
-@patch(
-    "ols.app.endpoints.ols.config.ols_config.query_validation_method",
-    constants.QueryValidationMethod.LLM,
-)
 def test_post_question_with_one_yaml_without_kind_attachment(_setup, endpoint) -> None:
     """Check the REST API query endpoints with one YAML without kind attachment."""
     answer = True
@@ -769,9 +778,15 @@ def test_post_question_with_one_yaml_without_kind_attachment(_setup, endpoint) -
         query_passed = query
         return answer
 
-    with patch(
-        "ols.app.endpoints.ols.QuestionValidator.validate_question",
-        side_effect=validate_question,
+    with (
+        patch(
+            "ols.app.endpoints.ols.QuestionValidator.validate_question",
+            side_effect=validate_question,
+        ),
+        patch(
+            "ols.app.endpoints.ols.config.ols_config.query_validation_method",
+            constants.QueryValidationMethod.LLM,
+        ),
     ):
         ml = mock_langchain_interface("test response")
         with (
@@ -815,10 +830,6 @@ metadata:
 
 @pytest.mark.parametrize("endpoint", ("/v1/query", "/v1/streaming_query"))
 @pytest.mark.attachment
-@patch(
-    "ols.app.endpoints.ols.config.ols_config.query_validation_method",
-    constants.QueryValidationMethod.LLM,
-)
 def test_post_question_with_one_yaml_without_name_attachment(_setup, endpoint) -> None:
     """Check the REST API query endpoints with one YAML without name attachment."""
     answer = True
@@ -830,9 +841,15 @@ def test_post_question_with_one_yaml_without_name_attachment(_setup, endpoint) -
         query_passed = query
         return answer
 
-    with patch(
-        "ols.app.endpoints.ols.QuestionValidator.validate_question",
-        side_effect=validate_question,
+    with (
+        patch(
+            "ols.app.endpoints.ols.QuestionValidator.validate_question",
+            side_effect=validate_question,
+        ),
+        patch(
+            "ols.app.endpoints.ols.config.ols_config.query_validation_method",
+            constants.QueryValidationMethod.LLM,
+        ),
     ):
         ml = mock_langchain_interface("test response")
         with (
@@ -878,10 +895,6 @@ metadata:
 
 @pytest.mark.parametrize("endpoint", ("/v1/query", "/v1/streaming_query"))
 @pytest.mark.attachment
-@patch(
-    "ols.app.endpoints.ols.config.ols_config.query_validation_method",
-    constants.QueryValidationMethod.LLM,
-)
 def test_post_question_with_one_invalid_yaml_attachment(_setup, endpoint) -> None:
     """Check the REST API query endpoints with one invalid YAML attachment."""
     answer = True
@@ -893,9 +906,15 @@ def test_post_question_with_one_invalid_yaml_attachment(_setup, endpoint) -> Non
         query_passed = query
         return answer
 
-    with patch(
-        "ols.app.endpoints.ols.QuestionValidator.validate_question",
-        side_effect=validate_question,
+    with (
+        patch(
+            "ols.app.endpoints.ols.QuestionValidator.validate_question",
+            side_effect=validate_question,
+        ),
+        patch(
+            "ols.app.endpoints.ols.config.ols_config.query_validation_method",
+            constants.QueryValidationMethod.LLM,
+        ),
     ):
         ml = mock_langchain_interface("test response")
         with (
@@ -1054,94 +1073,103 @@ def _post_with_system_prompt_override(_setup, caplog, query, system_prompt):
     assert response.status_code == requests.codes.ok
 
 
-@patch(
-    "ols.app.endpoints.ols.config.dev_config.enable_system_prompt_override",
-    True,
-)
-@patch(
-    "ols.app.endpoints.ols.config.ols_config.query_validation_method",
-    constants.QueryValidationMethod.LLM,
-)
 def test_post_with_system_prompt_override(_setup, caplog):
     """Check the POST /v1/query API with a system prompt."""
     query = "test query"
     system_prompt = "You are an expert in something marvelous."
 
-    _post_with_system_prompt_override(_setup, caplog, query, system_prompt)
+    with (
+        patch(
+            "ols.app.endpoints.ols.config.dev_config.enable_system_prompt_override",
+            True,
+        ),
+        patch(
+            "ols.app.endpoints.ols.config.ols_config.query_validation_method",
+            constants.QueryValidationMethod.LLM,
+        ),
+    ):
+        _post_with_system_prompt_override(_setup, caplog, query, system_prompt)
 
     # Specified system prompt should appear twice in query_helper debug log outputs.
     # One is from question_validator and another is from docs_summarizer.
     assert caplog.text.count("System prompt: " + system_prompt) == 2
 
 
-@patch(
-    "ols.app.endpoints.ols.config.dev_config.enable_system_prompt_override",
-    False,
-)
-@patch(
-    "ols.app.endpoints.ols.config.ols_config.query_validation_method",
-    constants.QueryValidationMethod.LLM,
-)
 def test_post_with_system_prompt_override_disabled(_setup, caplog):
     """Check the POST /v1/query API with a system prompt when overriding is disabled."""
     query = "test query"
     system_prompt = "You are an expert in something marvelous."
-
-    _post_with_system_prompt_override(_setup, caplog, query, system_prompt)
+    with (
+        patch(
+            "ols.app.endpoints.ols.config.dev_config.enable_system_prompt_override",
+            False,
+        ),
+        patch(
+            "ols.app.endpoints.ols.config.ols_config.query_validation_method",
+            constants.QueryValidationMethod.LLM,
+        ),
+    ):
+        _post_with_system_prompt_override(_setup, caplog, query, system_prompt)
 
     # Specified system prompt should NOT appear in query_helper debug log outputs
     # as enable_system_prompt_override is set to False.
     assert caplog.text.count("System prompt: " + system_prompt) == 0
 
 
-@patch("ols.src.query_helpers.docs_summarizer.DocsSummarizer._get_available_tools")
-@patch("ols.src.query_helpers.docs_summarizer.DocsSummarizer._invoke_llm")
-def test_tool_calling(mock_invoke, tools_mock, _setup, caplog) -> None:
+def test_tool_calling(_setup, caplog) -> None:
     """Check the REST API query endpoints when tool calling is enabled."""
     endpoint = "/v1/query"
     caplog.set_level(10)
     config.ols_config.introspection_enabled = True
 
-    mock_invoke.side_effect = [
-        (
-            AIMessage(
-                content="",
-                response_metadata={"finish_reason": "tool_calls"},
-                tool_calls=[
-                    {"name": "get_namespaces_mock", "args": {}, "id": "call_id1"},
-                ],
-            ),
-            TokenCounter(),
-        ),
-        (
-            AIMessage(
-                content="You have 1 namespace.",
-                response_metadata={"finish_reason": "stop"},
-            ),
-            TokenCounter(),
-        ),
-    ]
-    tools_mock.return_value = mock_tools_map
-
     with (
         patch(
-            "ols.src.query_helpers.query_helper.load_llm",
-            new=mock_llm_loader(None),
-        ),
+            "ols.src.query_helpers.docs_summarizer.DocsSummarizer._get_available_tools"
+        ) as tools_mock,
+        patch(
+            "ols.src.query_helpers.docs_summarizer.DocsSummarizer._invoke_llm"
+        ) as mock_invoke,
     ):
-        conversation_id = suid.get_suid()
-        response = pytest.client.post(
-            endpoint,
-            json={
-                "conversation_id": conversation_id,
-                "query": "How many namespaces are there in my cluster ?",
-            },
-        )
-        assert mock_invoke.call_count == 2
+        mock_invoke.side_effect = [
+            (
+                AIMessage(
+                    content="",
+                    response_metadata={"finish_reason": "tool_calls"},
+                    tool_calls=[
+                        {"name": "get_namespaces_mock", "args": {}, "id": "call_id1"},
+                    ],
+                ),
+                TokenCounter(),
+            ),
+            (
+                AIMessage(
+                    content="You have 1 namespace.",
+                    response_metadata={"finish_reason": "stop"},
+                ),
+                TokenCounter(),
+            ),
+        ]
+        tools_mock.return_value = mock_tools_map
 
-        assert "Tool: get_namespaces_mock" in caplog.text
-        tool_output = mock_tools_map["get_namespaces_mock"].invoke({})
-        assert f"Output: {tool_output}" in caplog.text
+        with (
+            patch(
+                "ols.src.query_helpers.query_helper.load_llm",
+                new=mock_llm_loader(None),
+            ),
+        ):
+            conversation_id = suid.get_suid()
+            response = pytest.client.post(
+                endpoint,
+                json={
+                    "conversation_id": conversation_id,
+                    "query": "How many namespaces are there in my cluster ?",
+                },
+            )
+            assert mock_invoke.call_count == 2
 
-        assert response.status_code == requests.codes.ok
-        assert response.json()["response"] == "You have 1 namespace."
+            assert "Tool: get_namespaces_mock" in caplog.text
+            tool_output = mock_tools_map["get_namespaces_mock"].invoke({})
+            assert f"Output: {tool_output}" in caplog.text
+
+            assert response.status_code == requests.codes.ok
+            assert response.json()["response"] == "You have 1 namespace."

--- a/tests/integration/test_runners.py
+++ b/tests/integration/test_runners.py
@@ -16,51 +16,56 @@ QUOTA_LIMITERS_CONFIG_FILE = (
 )
 
 
-@patch("uvicorn.run")
-def test_start_uvicorn_minimal_setup(mocked_runner):
+def test_start_uvicorn_minimal_setup():
     """Test the function to start Uvicorn server."""
     config.reload_from_yaml_file(MINIMAL_CONFIG_FILE)
-    start_uvicorn(config)
-    mocked_runner.assert_called_once_with(
-        "ols.app.main:app",
-        host="0.0.0.0",  # noqa: S104
-        port=8080,
-        workers=1,
-        log_level=30,
-        ssl_keyfile=None,
-        ssl_certfile=None,
-        ssl_keyfile_password=None,
-        ssl_version=ssl.PROTOCOL_TLS_SERVER,
-        ssl_ciphers="TLSv1",
-        access_log=False,
-    )
+
+    # don't start the real Uvicorn server
+    with patch("uvicorn.run") as mocked_runner:
+        start_uvicorn(config)
+        mocked_runner.assert_called_once_with(
+            "ols.app.main:app",
+            host="0.0.0.0",  # noqa: S104
+            port=8080,
+            workers=1,
+            log_level=30,
+            ssl_keyfile=None,
+            ssl_certfile=None,
+            ssl_keyfile_password=None,
+            ssl_version=ssl.PROTOCOL_TLS_SERVER,
+            ssl_ciphers="TLSv1",
+            access_log=False,
+        )
 
 
-@patch("uvicorn.run")
-def test_start_uvicorn_full_setup(mocked_runner):
+def test_start_uvicorn_full_setup():
     """Test the function to start Uvicorn server."""
     config.reload_from_yaml_file(CORRECT_CONFIG_FILE)
-    start_uvicorn(config)
-    mocked_runner.assert_called_once_with(
-        "ols.app.main:app",
-        host="0.0.0.0",  # noqa: S104
-        port=8080,
-        workers=1,
-        log_level=30,
-        ssl_keyfile="tests/config/key",
-        ssl_certfile="tests/config/empty_cert.crt",
-        ssl_keyfile_password="* this is password *",  # noqa: S106
-        ssl_version=ssl.TLSVersion.TLSv1_3,
-        ssl_ciphers="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        access_log=False,
-    )
+    # don't start the real Uvicorn server
+    with patch("uvicorn.run") as mocked_runner:
+        start_uvicorn(config)
+        mocked_runner.assert_called_once_with(
+            "ols.app.main:app",
+            host="0.0.0.0",  # noqa: S104
+            port=8080,
+            workers=1,
+            log_level=30,
+            ssl_keyfile="tests/config/key",
+            ssl_certfile="tests/config/empty_cert.crt",
+            ssl_keyfile_password="* this is password *",  # noqa: S106
+            ssl_version=ssl.TLSVersion.TLSv1_3,
+            ssl_ciphers="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",  # noqa: E501
+            access_log=False,
+        )
 
 
 @pytest.mark.filterwarnings("ignore")
-@patch("psycopg2.connect")
-def test_start_quota_scheduler(mock_connect):
+def test_start_quota_scheduler():
     """Test the function to start Quota scheduler."""
     config.reload_from_yaml_file(QUOTA_LIMITERS_CONFIG_FILE)
-    with patch("ols.runners.quota_scheduler.sleep", side_effect=Exception()):
+    with (
+        patch("ols.runners.quota_scheduler.sleep", side_effect=Exception()),
+        patch("psycopg2.connect"),
+    ):
         # just try to enter the endless loop
         start_quota_scheduler(config)


### PR DESCRIPTION
## Description

[OLS-1519](https://issues.redhat.com//browse/OLS-1519): no `@patch` decorators in integration tests

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Integration tests

## Related Tickets & Documents

- Related Issue #[OLS-1519](https://issues.redhat.com//browse/OLS-1519)
