### PR TITLE
OLS-1519: no @patch decorators in benchmarks

### DIFF
--- a/tests/benchmarks/test_docs_summarizer.py
+++ b/tests/benchmarks/test_docs_summarizer.py
@@ -46,37 +46,36 @@ def rag_index():
     return MockLlamaIndex()
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
 def test_summarize_empty_history(benchmark, rag_index, summarizer):
     """Benchmark for DocsSummarizer using mocked index and query engine."""
     question = "What's the ultimate question with answer 42?"
     history = []  # empty history
 
-    # run the benchmark
-    benchmark(summarizer.create_response, question, rag_index, history)
+    with patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4):
+        # run the benchmark
+        benchmark(summarizer.create_response, question, rag_index, history)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
 def test_summarize_no_history(benchmark, rag_index, summarizer):
     """Benchmark for DocsSummarizer using mocked index and query engine, no history is provided."""
     question = "What's the ultimate question with answer 42?"
 
-    # no history is passed into summarize() method
-    # run the benchmark
-    benchmark(summarizer.create_response, question, rag_index)
+    with patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4):
+        # no history is passed into summarize() method
+        # run the benchmark
+        benchmark(summarizer.create_response, question, rag_index)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
 def test_summarize_history_provided(benchmark, rag_index, summarizer):
     """Benchmark for DocsSummarizer using mocked index and query engine, history is provided."""
     question = "What's the ultimate question with answer 42?"
     history = [HumanMessage("What is Kubernetes?")]
 
-    # first call with history provided
-    benchmark(summarizer.create_response, question, rag_index, history)
+    with patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4):
+        # first call with history provided
+        benchmark(summarizer.create_response, question, rag_index, history)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
 def test_summarize_history_truncation(benchmark, rag_index, summarizer):
     """Benchmark for DocsSummarizer to check if truncation is done."""
     question = "What's the ultimate question with answer 42?"
@@ -84,8 +83,9 @@ def test_summarize_history_truncation(benchmark, rag_index, summarizer):
     # too long history
     history = [HumanMessage("What is Kubernetes?")] * 10
 
-    # run the benchmark
-    benchmark(summarizer.create_response, question, rag_index, history)
+    with patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4):
+        # run the benchmark
+        benchmark(summarizer.create_response, question, rag_index, history)
 
 
 def try_to_run_summarizer(summarizer, question, rag_index, history):
@@ -94,7 +94,6 @@ def try_to_run_summarizer(summarizer, question, rag_index, history):
         summarizer.summarize(conversation_id, question, rag_index, history)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
 def test_summarize_too_long_question(benchmark, rag_index, summarizer):
     """Benchmark for DocsSummarizer to check if truncation is done."""
     question = "What's the ultimate question with answer 42?" * 10000
@@ -102,11 +101,11 @@ def test_summarize_too_long_question(benchmark, rag_index, summarizer):
     # short history
     history = ["What is Kubernetes?"]
 
-    # run the benchmark
-    benchmark(try_to_run_summarizer, summarizer, question, rag_index, history)
+    with patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4):
+        # run the benchmark
+        benchmark(try_to_run_summarizer, summarizer, question, rag_index, history)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
 def test_summarize_too_long_question_long_history(benchmark, rag_index, summarizer):
     """Benchmark for DocsSummarizer to check if truncation is done."""
     question = "What's the ultimate question with answer 42?" * 10000
@@ -114,8 +113,9 @@ def test_summarize_too_long_question_long_history(benchmark, rag_index, summariz
     # too long history
     history = ["What is Kubernetes?"] * 10000
 
-    # run the benchmark
-    benchmark(try_to_run_summarizer, summarizer, question, rag_index, history)
+    with patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4):
+        # run the benchmark
+        benchmark(try_to_run_summarizer, summarizer, question, rag_index, history)
 
 
 def test_summarize_no_reference_content(benchmark, summarizer_no_reference_content):

--- a/tests/benchmarks/test_question_validator.py
+++ b/tests/benchmarks/test_question_validator.py
@@ -14,36 +14,38 @@ from ols.src.query_helpers.question_validator import QuestionValidator  # noqa: 
 from tests.mock_classes.mock_llm_loader import mock_llm_loader  # noqa: E402
 
 
-@patch("ols.src.query_helpers.question_validator.QuestionValidator._invoke_llm")
-def perform_question_validation_benchmark(benchmark, question, mock_invoke):
+def perform_question_validation_benchmark(benchmark, question):
     """Prepare all mocks and the call the QuestionValidator.validate_question method."""
     # it is needed to initialize configuration in order to be able
     # to construct QuestionValidator instance
     config.reload_from_yaml_file("tests/config/valid_config.yaml")
 
-    # when the LLM will be initialized the check for provided parameters will
-    # be performed
-    llm_loader = mock_llm_loader(
-        None,
-        expected_params=(
-            "p1",
-            "m1",
-            {GenericLLMParameters.MAX_TOKENS_FOR_RESPONSE: 4},
-            False,
-        ),
-    )
-    mock_invoke.return_value = AIMessage(content="ACCEPTED")
+    with patch(
+        "ols.src.query_helpers.question_validator.QuestionValidator._invoke_llm"
+    ) as mock_invoke:
+        # when the LLM will be initialized the check for provided parameters will
+        # be performed
+        llm_loader = mock_llm_loader(
+            None,
+            expected_params=(
+                "p1",
+                "m1",
+                {GenericLLMParameters.MAX_TOKENS_FOR_RESPONSE: 4},
+                False,
+            ),
+        )
+        mock_invoke.return_value = AIMessage(content="ACCEPTED")
 
-    # check that LLM loader was called with expected parameters
-    question_validator = QuestionValidator(llm_loader=llm_loader)
+        # check that LLM loader was called with expected parameters
+        question_validator = QuestionValidator(llm_loader=llm_loader)
 
-    # just run the validation for the provided question, we just need to check
-    # parameters passed to LLM that is performed in mock object
-    benchmark(
-        question_validator.validate_question,
-        "123e4567-e89b-12d3-a456-426614174000",
-        question,
-    )
+        # just run the validation for the provided question, we just need to check
+        # parameters passed to LLM that is performed in mock object
+        benchmark(
+            question_validator.validate_question,
+            "123e4567-e89b-12d3-a456-426614174000",
+            question,
+        )
 
 
 def test_validate_question_short_question(benchmark):


### PR DESCRIPTION
## Description

[OLS-1519](https://issues.redhat.com//browse/OLS-1519): no `@patch` decorators in benchmarks

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Benchmarks

## Related Tickets & Documents

- Related Issue #[OLS-1519](https://issues.redhat.com//browse/OLS-1519)
