### PR TITLE
OLS-1519: no @patch decorators in API endpoints unit tests

### DIFF
--- a/tests/unit/app/endpoints/test_health.py
+++ b/tests/unit/app/endpoints/test_health.py
@@ -40,143 +40,161 @@ class MockedLLM:
         return self.invoke_return
 
 
-@patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=False)
-@patch("ols.app.endpoints.health.load_llm")
-def test_readiness_probe_llm_check__str_msg(mocked_load_llm):
+def test_readiness_probe_llm_check__str_msg():
     """Test succesfull scenario - LLM responds as str."""
-    mocked_load_llm.return_value = MockedLLM(invoke_return="message")
-    assert llm_is_ready()
+    with (
+        patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=False),
+        patch("ols.app.endpoints.health.load_llm") as mocked_load_llm,
+    ):
+        mocked_load_llm.return_value = MockedLLM(invoke_return="message")
+        assert llm_is_ready()
 
 
-@patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=False)
-@patch("ols.app.endpoints.health.load_llm")
-def test_readiness_probe_llm_check__ai_msg(mocked_load_llm):
+def test_readiness_probe_llm_check__ai_msg():
     """Test succesfull scenario - LLM responds as AIMessage."""
-    mocked_load_llm.return_value = MockedLLM(invoke_return=AIMessage("message"))
-    assert llm_is_ready()
+    with (
+        patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=False),
+        patch("ols.app.endpoints.health.load_llm") as mocked_load_llm,
+    ):
+        mocked_load_llm.return_value = MockedLLM(invoke_return=AIMessage("message"))
+        assert llm_is_ready()
 
 
-@patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=False)
-@patch("ols.app.endpoints.health.load_llm")
-def test_readiness_probe_llm_check__llm_unexpected_response(mocked_load_llm):
+def test_readiness_probe_llm_check__llm_unexpected_response():
     """Test fail scenario - llm responds in unexpected format."""
-    mocked_load_llm.return_value = MockedLLM(invoke_return={"nobody": "knows"})
-    assert not llm_is_ready()
+    with (
+        patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=False),
+        patch("ols.app.endpoints.health.load_llm") as mocked_load_llm,
+    ):
+        mocked_load_llm.return_value = MockedLLM(invoke_return={"nobody": "knows"})
+        assert not llm_is_ready()
 
 
-@patch("ols.config._conversation_cache", create=True, new=mock_cache())
-@patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=False)
-@patch("ols.app.endpoints.health.load_llm")
-def test_readiness_probe_llm_check__state_cache(mocked_load_llm):
+def test_readiness_probe_llm_check__state_cache():
     """Test succesfull scenario - LLM check is done only once."""
-    mocked_load_llm.return_value = MockedLLM(invoke_return="message")
-    assert llm_is_ready()
-    assert mocked_load_llm.call_count == 1
+    with (
+        patch("ols.config._conversation_cache", create=True, new=mock_cache()),
+        patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=False),
+        patch("ols.app.endpoints.health.load_llm") as mocked_load_llm,
+    ):
+        mocked_load_llm.return_value = MockedLLM(invoke_return="message")
+        assert llm_is_ready()
+        assert mocked_load_llm.call_count == 1
 
-    response = readiness_probe_get_method()
-    assert response == ReadinessResponse(ready=True, reason="service is ready")
+        response = readiness_probe_get_method()
+        assert response == ReadinessResponse(ready=True, reason="service is ready")
 
-    # try again and check if the llm function was invoked again - it shoudn't
-    llm_is_ready()
-    assert mocked_load_llm.call_count == 1
+        # try again and check if the llm function was invoked again - it shoudn't
+        llm_is_ready()
+        assert mocked_load_llm.call_count == 1
 
 
-@patch("ols.config._conversation_cache", create=True, new=mock_cache())
-@patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=False)
-@patch("ols.app.endpoints.health.load_llm")
-def test_readiness_probe_llm_check__state_cache_not_expired(mocked_load_llm):
+def test_readiness_probe_llm_check__state_cache_not_expired():
     """Test the scenario with cache not expired - LLM check is done only once."""
-    try:
-        # Set cache expiration time to 1 sec.
-        config.ols_config.expire_llm_is_ready_persistent_state = 1
-        mocked_load_llm.return_value = MockedLLM(invoke_return="message")
-        assert llm_is_ready()
-        assert mocked_load_llm.call_count == 1
+    with (
+        patch("ols.config._conversation_cache", create=True, new=mock_cache()),
+        patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=False),
+        patch("ols.app.endpoints.health.load_llm") as mocked_load_llm,
+    ):
+        try:
+            # Set cache expiration time to 1 sec.
+            config.ols_config.expire_llm_is_ready_persistent_state = 1
+            mocked_load_llm.return_value = MockedLLM(invoke_return="message")
+            assert llm_is_ready()
+            assert mocked_load_llm.call_count == 1
 
-        response = readiness_probe_get_method()
-        assert response == ReadinessResponse(ready=True, reason="service is ready")
+            response = readiness_probe_get_method()
+            assert response == ReadinessResponse(ready=True, reason="service is ready")
 
-        # try again and check if the llm function was invoked again - it shouldn't
-        llm_is_ready()
-        assert mocked_load_llm.call_count == 1
-    finally:
-        # Reset the expire_llm_is_ready_persistent_state option.
-        config.ols_config.expire_llm_is_ready_persistent_state = -1
+            # try again and check if the llm function was invoked again - it shouldn't
+            llm_is_ready()
+            assert mocked_load_llm.call_count == 1
+        finally:
+            # Reset the expire_llm_is_ready_persistent_state option.
+            config.ols_config.expire_llm_is_ready_persistent_state = -1
 
 
-@patch("ols.config._conversation_cache", create=True, new=mock_cache())
-@patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=False)
-@patch("ols.app.endpoints.health.load_llm")
-def test_readiness_probe_llm_check__state_cache_expired(mocked_load_llm):
+def test_readiness_probe_llm_check__state_cache_expired():
     """Test the scenario with cache expired - LLM check is done twice."""
-    try:
-        # Set cache expiration time to 1 sec.
-        config.ols_config.expire_llm_is_ready_persistent_state = 1
+    with (
+        patch("ols.config._conversation_cache", create=True, new=mock_cache()),
+        patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=False),
+        patch("ols.app.endpoints.health.load_llm") as mocked_load_llm,
+    ):
+        try:
+            # Set cache expiration time to 1 sec.
+            config.ols_config.expire_llm_is_ready_persistent_state = 1
+            mocked_load_llm.return_value = MockedLLM(invoke_return="message")
+            assert llm_is_ready()
+            assert mocked_load_llm.call_count == 1
+
+            response = readiness_probe_get_method()
+            assert response == ReadinessResponse(ready=True, reason="service is ready")
+            # Wait for 1.5 secs and let the cache get expired.
+            time.sleep(1.5)
+
+            # try again and check if the llm function was invoked again - it should.
+            llm_is_ready()
+            assert mocked_load_llm.call_count == 2
+        finally:
+            # Reset the expire_llm_is_ready_persistent_state option.
+            config.ols_config.expire_llm_is_ready_persistent_state = -1
+
+
+def test_readiness_probe_llm_check__llm_raise():
+    """Test fail scenario - llm raises an exception (eg. invalid credentials)."""
+    with (
+        patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=False),
+        patch("ols.app.endpoints.health.load_llm") as mocked_load_llm,
+    ):
+        mocked_load_llm.side_effect = Exception
+        assert not llm_is_ready()
+
+
+def test_readiness_probe_get_method_service_is_ready():
+    """Test the readiness_probe function when the service is ready."""
+    with (
+        patch("ols.config._conversation_cache", create=True, new=mock_cache()),
+        patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=False),
+        patch("ols.app.endpoints.health.load_llm") as mocked_load_llm,
+    ):
         mocked_load_llm.return_value = MockedLLM(invoke_return="message")
-        assert llm_is_ready()
-        assert mocked_load_llm.call_count == 1
 
         response = readiness_probe_get_method()
         assert response == ReadinessResponse(ready=True, reason="service is ready")
-        # Wait for 1.5 secs and let the cache get expired.
-        time.sleep(1.5)
-
-        # try again and check if the llm function was invoked again - it should.
-        llm_is_ready()
-        assert mocked_load_llm.call_count == 2
-    finally:
-        # Reset the expire_llm_is_ready_persistent_state option.
-        config.ols_config.expire_llm_is_ready_persistent_state = -1
 
 
-@patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=False)
-@patch("ols.app.endpoints.health.load_llm")
-def test_readiness_probe_llm_check__llm_raise(mocked_load_llm):
-    """Test fail scenario - llm raises an exception (eg. invalid credentials)."""
-    mocked_load_llm.side_effect = Exception
-    assert not llm_is_ready()
-
-
-@patch("ols.config._conversation_cache", create=True, new=mock_cache())
-@patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=False)
-@patch("ols.app.endpoints.health.load_llm")
-def test_readiness_probe_get_method_service_is_ready(mocked_load_llm):
-    """Test the readiness_probe function when the service is ready."""
-    mocked_load_llm.return_value = MockedLLM(invoke_return="message")
-
-    response = readiness_probe_get_method()
-    assert response == ReadinessResponse(ready=True, reason="service is ready")
-
-
-@patch("ols.config._conversation_cache", create=True, new=mock_cache())
-@patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=True)
 def test_readiness_probe_get_method_index_is_ready():
     """Test the readiness_probe function when index is loaded."""
-    # simulate that the index is loaded
-    config._rag_index = True
-    assert index_is_ready()
-    response = readiness_probe_get_method()
-    assert response == ReadinessResponse(ready=True, reason="service is ready")
+    with (
+        patch("ols.config._conversation_cache", create=True, new=mock_cache()),
+        patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=True),
+    ):
+        # simulate that the index is loaded
+        config._rag_index = True
+        assert index_is_ready()
+        response = readiness_probe_get_method()
+        assert response == ReadinessResponse(ready=True, reason="service is ready")
 
-    # simulate that the index is not loaded, but it shouldn't as there
-    # is no reference content in config
-    config._rag_index = None
-    config.ols_config.reference_content = None
-    assert index_is_ready()
-    response = readiness_probe_get_method()
-    assert response == ReadinessResponse(ready=True, reason="service is ready")
+        # simulate that the index is not loaded, but it shouldn't as there
+        # is no reference content in config
+        config._rag_index = None
+        config.ols_config.reference_content = None
+        assert index_is_ready()
+        response = readiness_probe_get_method()
+        assert response == ReadinessResponse(ready=True, reason="service is ready")
 
 
-@patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=True)
 def test_readiness_probe_get_method_index_not_ready():
     """Test the readiness_probe function when index is not loaded."""
-    # simulate that the index is not loaded
-    config._rag_index = None
-    config.ols_config.reference_content = "something else than None"
+    with patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=True):
+        # simulate that the index is not loaded
+        config._rag_index = None
+        config.ols_config.reference_content = "something else than None"
 
-    assert not index_is_ready()
-    with pytest.raises(HTTPException, match="Service is not ready"):
-        readiness_probe_get_method()
+        assert not index_is_ready()
+        with pytest.raises(HTTPException, match="Service is not ready"):
+            readiness_probe_get_method()
 
 
 def test_readiness_probe_get_method_cache_not_ready():


### PR DESCRIPTION
## Description

OLS-1519: no `@patch` decorators in API endpoints unit tests

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests

## Related Tickets & Documents

- Related Issue #OLS-1519
