### PR TITLE
OLS-1454: Remove streaming parameter from providers

### DIFF
--- a/ols/app/endpoints/health.py
+++ b/ols/app/endpoints/health.py
@@ -47,7 +47,6 @@ def llm_is_ready() -> bool:
         bare_llm = load_llm(
             config.ols_config.default_provider,
             config.ols_config.default_model,
-            streaming=False,
         )
         response = bare_llm.invoke(input="Hello there!")
         # BAM and Watsonx replies as str and not as `AIMessage`

--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -477,7 +477,6 @@ def generate_response(
             provider=llm_request.provider,
             model=llm_request.model,
             system_prompt=llm_request.system_prompt,
-            streaming=streaming,
         )
         history = CacheEntry.cache_entries_to_history(previous_input)
         if streaming:

--- a/ols/src/llms/llm_loader.py
+++ b/ols/src/llms/llm_loader.py
@@ -56,7 +56,6 @@ def load_llm(
     provider: str,
     model: str,
     generic_llm_params: Optional[dict] = None,
-    streaming: Optional[bool] = None,
 ) -> LLM | Any:  # Temporarily using Any, as mypy gives error for missing bind_tools
     """Load LLM according to input provider and model.
 
@@ -64,7 +63,6 @@ def load_llm(
         provider: The provider name.
         model: The model name.
         generic_llm_params: The optional parameters that will be converted into LLM-specific ones.
-        streaming: The optional parameter that enable streaming on LLM side if set to True.
 
     Raises:
         LLMConfigurationError: If the whole provider configuration is missing.
@@ -98,6 +96,4 @@ def load_llm(
     logger.debug("loading LLM model '%s' from provider '%s'", model, provider)
 
     llm_provider = llm_providers_reg.llm_providers[provider_config.type]
-    return llm_provider(
-        model, provider_config, generic_llm_params or {}, streaming
-    ).load()
+    return llm_provider(model, provider_config, generic_llm_params or {}).load()

--- a/ols/src/llms/providers/provider.py
+++ b/ols/src/llms/providers/provider.py
@@ -208,7 +208,6 @@ class LLMProvider(AbstractLLMProvider):
         model: str,
         provider_config: ProviderConfig,
         params: Optional[dict] = None,
-        streaming: bool = False,
     ) -> None:
         """Initialize LLM provider.
 
@@ -216,28 +215,12 @@ class LLMProvider(AbstractLLMProvider):
             model: The model name.
             provider_config: The provider configuration.
             params: The optional parameters that will be converted into LLM specific ones.
-            streaming: Enables streaming response.
         """
         self.model = model
         self.provider_config = provider_config
         params = self._override_params(params or {})
         params = self._remap_to_llm_params(params)
         self.params = self._validate_parameters(params)
-
-        # "streaming" is a special parameter that should be set only when sending
-        # data via special streaming REST API endpoint
-        # It is valid just for OpenAI-compatible LLM providers
-        if self.provider_config is None or (
-            self.provider_config is not None
-            and self.provider_config.type
-            in {
-                PROVIDER_AZURE_OPENAI,
-                PROVIDER_OPENAI,
-                PROVIDER_RHELAI_VLLM,
-                PROVIDER_RHOAI_VLLM,
-            }
-        ):
-            self.params["streaming"] = streaming
 
     def _remap_to_llm_params(
         self, generic_llm_params: dict[str, Any]

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -43,7 +43,7 @@ class DocsSummarizer(QueryHelper):
             GenericLLMParameters.MAX_TOKENS_FOR_RESPONSE: self.model_config.parameters.max_tokens_for_response  # noqa: E501
         }
         self.bare_llm = self.llm_loader(
-            self.provider, self.model, self.generic_llm_params, self.streaming
+            self.provider, self.model, self.generic_llm_params
         )
 
     def _prepare_prompt(

--- a/ols/src/query_helpers/query_helper.py
+++ b/ols/src/query_helpers/query_helper.py
@@ -21,9 +21,8 @@ class QueryHelper:
         provider: Optional[str] = None,
         model: Optional[str] = None,
         generic_llm_params: Optional[dict] = None,
-        llm_loader: Optional[Callable[[str, str, dict, bool], LLM]] = None,
+        llm_loader: Optional[Callable[[str, str, dict], LLM]] = None,
         system_prompt: Optional[str] = None,
-        streaming: Optional[bool] = None,
     ) -> None:
         """Initialize query helper."""
         # NOTE: As signature of this method is evaluated before the config,
@@ -33,7 +32,6 @@ class QueryHelper:
         self.model = model or config.ols_config.default_model
         self.generic_llm_params = generic_llm_params or {}
         self.llm_loader = llm_loader or load_llm
-        self.streaming = streaming or False
 
         self._system_prompt = (
             (config.dev_config.enable_system_prompt_override and system_prompt)

--- a/ols/src/query_helpers/question_validator.py
+++ b/ols/src/query_helpers/question_validator.py
@@ -34,7 +34,7 @@ class QuestionValidator(QueryHelper):
         super().__init__(*args, **dict(kwargs, generic_llm_params=generic_llm_params))
 
         self.bare_llm = self.llm_loader(
-            self.provider, self.model, self.generic_llm_params, self.streaming
+            self.provider, self.model, self.generic_llm_params
         )
         self.provider_config = config.llm_config.providers.get(self.provider)
         self.model_config = self.provider_config.models.get(self.model)

--- a/tests/unit/llms/providers/test_providers.py
+++ b/tests/unit/llms/providers/test_providers.py
@@ -81,32 +81,6 @@ def test_llm_provider_params_order__inputs_overrides_defaults():
 
     assert my_provider.params["provider-param"] == 2
     assert my_provider.params["not-to-be-overwritten-param"] == "foo"
-    assert my_provider.params["streaming"] is False
-
-    my_provider_with_streaming_disabled = MyProvider(
-        model="bla",
-        params={"provider-param": 2},
-        provider_config=None,
-        streaming=False,
-    )
-
-    assert my_provider_with_streaming_disabled.params["provider-param"] == 2
-    assert (
-        my_provider_with_streaming_disabled.params["not-to-be-overwritten-param"]
-        == "foo"
-    )
-    assert my_provider_with_streaming_disabled.params["streaming"] is False
-
-    my_provider_with_streaming_enabled = MyProvider(
-        model="bla", params={"provider-param": 2}, provider_config=None, streaming=True
-    )
-
-    assert my_provider_with_streaming_enabled.params["provider-param"] == 2
-    assert (
-        my_provider_with_streaming_enabled.params["not-to-be-overwritten-param"]
-        == "foo"
-    )
-    assert my_provider_with_streaming_enabled.params["streaming"] is True
 
 
 def test_llm_provider_params_order__config_overrides_everything():
@@ -127,28 +101,6 @@ def test_llm_provider_params_order__config_overrides_everything():
 
     assert my_provider.params["provider-param"] == 3
     assert my_provider.params["not-to-be-overwritten-param"] == "foo"
-
-    my_provider_with_streaming_disabled = MyProvider(
-        model="bla", params={"provider-param": 2}, provider_config=None, streaming=False
-    )
-
-    assert my_provider_with_streaming_disabled.params["provider-param"] == 3
-    assert (
-        my_provider_with_streaming_disabled.params["not-to-be-overwritten-param"]
-        == "foo"
-    )
-    assert my_provider_with_streaming_disabled.params["streaming"] is False
-
-    my_provider_with_streaming_enabled = MyProvider(
-        model="bla", params={"provider-param": 2}, provider_config=None, streaming=True
-    )
-
-    assert my_provider_with_streaming_enabled.params["provider-param"] == 3
-    assert (
-        my_provider_with_streaming_enabled.params["not-to-be-overwritten-param"]
-        == "foo"
-    )
-    assert my_provider_with_streaming_enabled.params["streaming"] is True
 
 
 def test_llm_provider_params_order__no_provider_type():
@@ -171,28 +123,6 @@ def test_llm_provider_params_order__no_provider_type():
 
     assert my_provider.params["provider-param"] == 3
     assert my_provider.params["not-to-be-overwritten-param"] == "foo"
-
-    my_provider_with_streaming_disabled = MyProvider(
-        model="bla", params={"provider-param": 2}, provider_config=None, streaming=False
-    )
-
-    assert my_provider_with_streaming_disabled.params["provider-param"] == 3
-    assert (
-        my_provider_with_streaming_disabled.params["not-to-be-overwritten-param"]
-        == "foo"
-    )
-    assert my_provider_with_streaming_disabled.params["streaming"] is False
-
-    my_provider_with_streaming_enabled = MyProvider(
-        model="bla", params={"provider-param": 2}, provider_config=None, streaming=True
-    )
-
-    assert my_provider_with_streaming_enabled.params["provider-param"] == 3
-    assert (
-        my_provider_with_streaming_enabled.params["not-to-be-overwritten-param"]
-        == "foo"
-    )
-    assert my_provider_with_streaming_enabled.params["streaming"] is True
 
 
 def test_construct_httpx_client():

--- a/tests/unit/query_helpers/test_docs_summarizer.py
+++ b/tests/unit/query_helpers/test_docs_summarizer.py
@@ -60,18 +60,6 @@ def test_if_system_prompt_was_updated():
     assert summarizer._system_prompt == expected_prompt
 
 
-def test_docs_summarizer_streaming_parameter():
-    """Test if optional streaming parameter is stored."""
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    assert summarizer.streaming is False
-
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None), streaming=False)
-    assert summarizer.streaming is False
-
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None), streaming=True)
-    assert summarizer.streaming is True
-
-
 def test_summarize_empty_history():
     """Basic test for DocsSummarizer using mocked index and query engine."""
     with (

--- a/tests/unit/query_helpers/test_query_helper.py
+++ b/tests/unit/query_helpers/test_query_helper.py
@@ -15,7 +15,6 @@ def test_defaults_used():
     assert qh.model == config.ols_config.default_model
     assert qh.llm_loader is load_llm
     assert qh.generic_llm_params == {}
-    assert qh.streaming is False
 
 
 def test_inputs_are_used():
@@ -26,12 +25,3 @@ def test_inputs_are_used():
 
     assert qh.provider == test_provider
     assert qh.model == test_model
-
-
-def test_streaming_parameter():
-    """Test that the optional streaming parameter is stored."""
-    qh = QueryHelper(streaming=False)
-    assert qh.streaming is False
-
-    qh = QueryHelper(streaming=True)
-    assert qh.streaming is True

--- a/tests/unit/query_helpers/test_question_validator.py
+++ b/tests/unit/query_helpers/test_question_validator.py
@@ -82,7 +82,6 @@ def test_validate_question_llm_loader():
                 "p1",
                 "m1",
                 {GenericLLMParameters.MAX_TOKENS_FOR_RESPONSE: 4},
-                False,
             ),
         )
 


### PR DESCRIPTION
## Description

We don't need this option. It have no effect as the non-streaming/streaming depends on `docs_summarizer` method selected - create_response (non-streaming) or generate_response (streaming).

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
