### PR TITLE
OLS-1519: no @patch decorator in unit and integration tests

### DIFF
--- a/tests/integration/test_liveness_readiness.py
+++ b/tests/integration/test_liveness_readiness.py
@@ -11,23 +11,23 @@ from ols import config
 from ols.constants import CONFIGURATION_FILE_NAME_ENV_VARIABLE
 
 
-# we need to patch the config file path to point to the test
-# config file before we import anything from main.py
 @pytest.fixture(scope="function", autouse=True)
-@patch.dict(
-    os.environ,
-    {
-        CONFIGURATION_FILE_NAME_ENV_VARIABLE: "tests/config/config_for_integration_tests.yaml"
-    },
-)
 def _setup():
     """Setups the test client."""
     config.reload_from_yaml_file("tests/config/config_for_integration_tests.yaml")
 
-    # app.main need to be imported after the configuration is read
-    from ols.app.main import app  # pylint: disable=C0415
+    # we need to patch the config file path to point to the test
+    # config file before we import anything from main.py
+    with patch.dict(
+        os.environ,
+        {
+            CONFIGURATION_FILE_NAME_ENV_VARIABLE: "tests/config/config_for_integration_tests.yaml"
+        },
+    ):
+        # app.main need to be imported after the configuration is read
+        from ols.app.main import app  # pylint: disable=C0415
 
-    pytest.client = TestClient(app)
+        pytest.client = TestClient(app)
 
 
 def test_liveness():

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -26,21 +26,23 @@ expected_counters = (
 )
 
 
-# we need to patch the config file path to point to the test
-# config file before we import anything from main.py
 @pytest.fixture(scope="function", autouse=True)
-@patch.dict(
-    os.environ,
-    {
-        CONFIGURATION_FILE_NAME_ENV_VARIABLE: "tests/config/config_for_integration_tests.yaml"
-    },
-)
 def _setup():
     """Setups the test client."""
     config.reload_from_yaml_file("tests/config/config_for_integration_tests.yaml")
-    from ols.app.main import app  # pylint: disable=C0415
 
-    pytest.client = TestClient(app)
+    # we need to patch the config file path to point to the test
+    # config file before we import anything from main.py
+    with patch.dict(
+        os.environ,
+        {
+            CONFIGURATION_FILE_NAME_ENV_VARIABLE: "tests/config/config_for_integration_tests.yaml"
+        },
+    ):
+        # app.main need to be imported after the configuration is read
+        from ols.app.main import app  # pylint: disable=C0415
+
+        pytest.client = TestClient(app)
 
 
 def retrieve_metrics(client):

--- a/tests/integration/test_openapi.py
+++ b/tests/integration/test_openapi.py
@@ -12,23 +12,21 @@ from ols import config
 from ols.constants import CONFIGURATION_FILE_NAME_ENV_VARIABLE
 
 
-# we need to patch the config file path to point to the test
-# config file before we import anything from main.py
 @pytest.fixture(scope="function", autouse=True)
-@patch.dict(
-    os.environ,
-    {
-        CONFIGURATION_FILE_NAME_ENV_VARIABLE: "tests/config/config_for_integration_tests.yaml"
-    },
-)
 def _setup():
     """Setups the test client."""
     config.reload_from_yaml_file("tests/config/config_for_integration_tests.yaml")
 
-    # app.main need to be imported after the configuration is read
-    from ols.app.main import app  # pylint: disable=C0415
-
-    pytest.client = TestClient(app)
+    # we need to patch the config file path to point to the test
+    # config file before we import anything from main.py
+    with patch.dict(
+        os.environ,
+        {
+            CONFIGURATION_FILE_NAME_ENV_VARIABLE: "tests/config/config_for_integration_tests.yaml"
+        },
+    ):
+        # app.main need to be imported after the configuration is read
+        from ols.app.main import app  # pylint: disable=C0415
 
 
 def test_openapi_endpoint():

--- a/tests/integration/test_openapi.py
+++ b/tests/integration/test_openapi.py
@@ -28,6 +28,8 @@ def _setup():
         # app.main need to be imported after the configuration is read
         from ols.app.main import app  # pylint: disable=C0415
 
+        pytest.client = TestClient(app)
+
 
 def test_openapi_endpoint():
     """Check if REST API provides endpoint with OpenAPI specification."""

--- a/tests/unit/query_helpers/test_docs_summarizer.py
+++ b/tests/unit/query_helpers/test_docs_summarizer.py
@@ -72,71 +72,77 @@ def test_docs_summarizer_streaming_parameter():
     assert summarizer.streaming is True
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
-@patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 1)
 def test_summarize_empty_history():
     """Basic test for DocsSummarizer using mocked index and query engine."""
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    question = "What's the ultimate question with answer 42?"
-    rag_index = MockLlamaIndex()
-    history = []  # empty history
-    summary = summarizer.create_response(question, rag_index, history)
-    check_summary_result(summary, question)
+    with (
+        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
+        patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 1),
+    ):
+        summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+        question = "What's the ultimate question with answer 42?"
+        rag_index = MockLlamaIndex()
+        history = []  # empty history
+        summary = summarizer.create_response(question, rag_index, history)
+        check_summary_result(summary, question)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
-@patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 3)
 def test_summarize_no_history():
     """Basic test for DocsSummarizer using mocked index and query engine, no history is provided."""
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    question = "What's the ultimate question with answer 42?"
-    rag_index = MockLlamaIndex()
-    # no history is passed into summarize() method
-    summary = summarizer.create_response(question, rag_index)
-    check_summary_result(summary, question)
+    with (
+        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
+        patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 3),
+    ):
+        summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+        question = "What's the ultimate question with answer 42?"
+        rag_index = MockLlamaIndex()
+        # no history is passed into summarize() method
+        summary = summarizer.create_response(question, rag_index)
+        check_summary_result(summary, question)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
-@patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 3)
 def test_summarize_history_provided():
     """Basic test for DocsSummarizer using mocked index and query engine, history is provided."""
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    question = "What's the ultimate question with answer 42?"
-    history = ["human: What is Kubernetes?"]
-    rag_index = MockLlamaIndex()
+    with (
+        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
+        patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 3),
+    ):
+        summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+        question = "What's the ultimate question with answer 42?"
+        history = ["human: What is Kubernetes?"]
+        rag_index = MockLlamaIndex()
 
-    # first call with history provided
-    with patch(
-        "ols.src.query_helpers.docs_summarizer.TokenHandler.limit_conversation_history",
-        return_value=([], False),
-    ) as token_handler:
-        summary1 = summarizer.create_response(question, rag_index, history)
-        token_handler.assert_called_once_with(history, ANY, ANY)
-        check_summary_result(summary1, question)
+        # first call with history provided
+        with patch(
+            "ols.src.query_helpers.docs_summarizer.TokenHandler.limit_conversation_history",
+            return_value=([], False),
+        ) as token_handler:
+            summary1 = summarizer.create_response(question, rag_index, history)
+            token_handler.assert_called_once_with(history, ANY, ANY)
+            check_summary_result(summary1, question)
 
-    # second call without history provided
-    with patch(
-        "ols.src.query_helpers.docs_summarizer.TokenHandler.limit_conversation_history",
-        return_value=([], False),
-    ) as token_handler:
-        summary2 = summarizer.create_response(question, rag_index)
-        token_handler.assert_called_once_with([], ANY, ANY)
-        check_summary_result(summary2, question)
+        # second call without history provided
+        with patch(
+            "ols.src.query_helpers.docs_summarizer.TokenHandler.limit_conversation_history",
+            return_value=([], False),
+        ) as token_handler:
+            summary2 = summarizer.create_response(question, rag_index)
+            token_handler.assert_called_once_with([], ANY, ANY)
+            check_summary_result(summary2, question)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
 def test_summarize_truncation():
     """Basic test for DocsSummarizer to check if truncation is done."""
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    question = "What's the ultimate question with answer 42?"
-    rag_index = MockLlamaIndex()
+    with patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4):
+        summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+        question = "What's the ultimate question with answer 42?"
+        rag_index = MockLlamaIndex()
 
-    # too long history
-    history = [HumanMessage("What is Kubernetes?")] * 10000
-    summary = summarizer.create_response(question, rag_index, history)
+        # too long history
+        history = [HumanMessage("What is Kubernetes?")] * 10000
+        summary = summarizer.create_response(question, rag_index, history)
 
-    # truncation should be done
-    assert summary.history_truncated
+        # truncation should be done
+        assert summary.history_truncated
 
 
 def test_summarize_no_reference_content():
@@ -168,93 +174,111 @@ async def test_response_generator():
     assert generated_content == question
 
 
-@patch("ols.src.query_helpers.docs_summarizer.DocsSummarizer._invoke_llm")
-def test_tool_calling_one_iteration(mock_invoke):
+def test_tool_calling_one_iteration():
     """Test tool calling - stops after one iteration."""
     config.ols_config.introspection_enabled = True
     question = "How many namespaces are there in my cluster ?"
 
-    mock_invoke.side_effect = [
-        (
-            AIMessage(content="XYZ", response_metadata={"finish_reason": "stop"}),
-            TokenCounter(),
-        )
-    ]
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    summarizer.create_response(question)
-    assert mock_invoke.call_count == 1
+    with patch(
+        "ols.src.query_helpers.docs_summarizer.DocsSummarizer._invoke_llm"
+    ) as mock_invoke:
+        mock_invoke.side_effect = [
+            (
+                AIMessage(content="XYZ", response_metadata={"finish_reason": "stop"}),
+                TokenCounter(),
+            )
+        ]
+        summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+        summarizer.create_response(question)
+        assert mock_invoke.call_count == 1
 
 
-@patch("ols.src.query_helpers.docs_summarizer.DocsSummarizer._invoke_llm")
-def test_tool_calling_two_iteration(mock_invoke):
+def test_tool_calling_two_iteration():
     """Test tool calling - stops after two iterations."""
     config.ols_config.introspection_enabled = True
     question = "How many namespaces are there in my cluster ?"
 
-    mock_invoke.side_effect = [
-        (
-            AIMessage(content="", response_metadata={"finish_reason": "tool_calls"}),
-            TokenCounter(),
-        ),
-        (
-            AIMessage(content="XYZ", response_metadata={"finish_reason": "stop"}),
-            TokenCounter(),
-        ),
-    ]
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    summarizer.create_response(question)
-    assert mock_invoke.call_count == 2
+    with patch(
+        "ols.src.query_helpers.docs_summarizer.DocsSummarizer._invoke_llm"
+    ) as mock_invoke:
+        mock_invoke.side_effect = [
+            (
+                AIMessage(
+                    content="", response_metadata={"finish_reason": "tool_calls"}
+                ),
+                TokenCounter(),
+            ),
+            (
+                AIMessage(content="XYZ", response_metadata={"finish_reason": "stop"}),
+                TokenCounter(),
+            ),
+        ]
+        summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+        summarizer.create_response(question)
+        assert mock_invoke.call_count == 2
 
 
-@patch("ols.src.query_helpers.docs_summarizer.MAX_ITERATIONS", 3)
-@patch("ols.src.query_helpers.docs_summarizer.DocsSummarizer._invoke_llm")
-def test_tool_calling_force_stop(mock_invoke):
+def test_tool_calling_force_stop():
     """Test tool calling - force stop."""
     config.ols_config.introspection_enabled = True
     question = "How many namespaces are there in my cluster ?"
 
-    mock_invoke.side_effect = [
-        (
-            AIMessage(content="", response_metadata={"finish_reason": "tool_calls"}),
-            TokenCounter(),
-        )
-    ] * 4
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    summarizer.create_response(question)
-    assert mock_invoke.call_count == 3
+    with (
+        patch("ols.src.query_helpers.docs_summarizer.MAX_ITERATIONS", 3),
+        patch(
+            "ols.src.query_helpers.docs_summarizer.DocsSummarizer._invoke_llm"
+        ) as mock_invoke,
+    ):
+        mock_invoke.side_effect = [
+            (
+                AIMessage(
+                    content="", response_metadata={"finish_reason": "tool_calls"}
+                ),
+                TokenCounter(),
+            )
+        ] * 4
+        summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+        summarizer.create_response(question)
+        assert mock_invoke.call_count == 3
 
 
-@patch("ols.src.query_helpers.docs_summarizer.MAX_ITERATIONS", 2)
-@patch("ols.src.query_helpers.docs_summarizer.DocsSummarizer._get_available_tools")
-@patch("ols.src.query_helpers.docs_summarizer.DocsSummarizer._invoke_llm")
-def test_tool_calling_tool_execution(mock_invoke, tools_mock, caplog):
+def test_tool_calling_tool_execution(caplog):
     """Test tool calling - tool execution."""
     caplog.set_level(10)  # Set debug level
     config.ols_config.introspection_enabled = True
 
     question = "How many namespaces are there in my cluster ?"
 
-    mock_invoke.return_value = (
-        AIMessage(
-            content="",
-            response_metadata={"finish_reason": "tool_calls"},
-            tool_calls=[
-                {"name": "get_namespaces_mock", "args": {}, "id": "call_id1"},
-                {"name": "invalid_function_name", "args": {}, "id": "call_id2"},
-            ],
-        ),
-        TokenCounter(),
-    )
-    tools_mock.return_value = mock_tools_map
+    with (
+        patch("ols.src.query_helpers.docs_summarizer.MAX_ITERATIONS", 2),
+        patch(
+            "ols.src.query_helpers.docs_summarizer.DocsSummarizer._get_available_tools"
+        ) as mock_tools,
+        patch(
+            "ols.src.query_helpers.docs_summarizer.DocsSummarizer._invoke_llm"
+        ) as mock_invoke,
+    ):
+        mock_invoke.return_value = (
+            AIMessage(
+                content="",
+                response_metadata={"finish_reason": "tool_calls"},
+                tool_calls=[
+                    {"name": "get_namespaces_mock", "args": {}, "id": "call_id1"},
+                    {"name": "invalid_function_name", "args": {}, "id": "call_id2"},
+                ],
+            ),
+            TokenCounter(),
+        )
+        mock_tools.return_value = mock_tools_map
 
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    summarizer.create_response(question)
+        summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+        summarizer.create_response(question)
 
-    assert "Tool: get_namespaces_mock" in caplog.text
-    tool_output = mock_tools_map["get_namespaces_mock"].invoke({})
-    assert f"Output: {tool_output}" in caplog.text
+        assert "Tool: get_namespaces_mock" in caplog.text
+        tool_output = mock_tools_map["get_namespaces_mock"].invoke({})
+        assert f"Output: {tool_output}" in caplog.text
 
-    assert "Tool: invalid_function_name" in caplog.text
-    assert "Error: Tool 'invalid_function_name' not found." in caplog.text
+        assert "Tool: invalid_function_name" in caplog.text
+        assert "Error: Tool 'invalid_function_name' not found." in caplog.text
 
-    assert mock_invoke.call_count == 2
+        assert mock_invoke.call_count == 2

--- a/tests/unit/query_helpers/test_question_validator.py
+++ b/tests/unit/query_helpers/test_question_validator.py
@@ -63,32 +63,34 @@ def test_passing_parameters():
     )
 
 
-@patch("ols.src.query_helpers.question_validator.QuestionValidator._invoke_llm")
-def test_validate_question_llm_loader(mock_invoke):
+def test_validate_question_llm_loader():
     """Test that LLM is loaded within validate_question method with proper parameters."""
     # it is needed to initialize configuration in order to be able
     # to construct QuestionValidator instance
     config.reload_from_yaml_file("tests/config/valid_config.yaml")
 
-    mock_invoke.return_value = AIMessage(content="REJECTED")
+    with patch(
+        "ols.src.query_helpers.question_validator.QuestionValidator._invoke_llm"
+    ) as mock_invoke:
+        mock_invoke.return_value = AIMessage(content="REJECTED")
 
-    # when the LLM will be initialized the check for provided parameters will
-    # be performed
-    llm_loader = mock_llm_loader(
-        None,
-        expected_params=(
-            "p1",
-            "m1",
-            {GenericLLMParameters.MAX_TOKENS_FOR_RESPONSE: 4},
-            False,
-        ),
-    )
+        # when the LLM will be initialized the check for provided parameters will
+        # be performed
+        llm_loader = mock_llm_loader(
+            None,
+            expected_params=(
+                "p1",
+                "m1",
+                {GenericLLMParameters.MAX_TOKENS_FOR_RESPONSE: 4},
+                False,
+            ),
+        )
 
-    # check that LLM loader was called with expected parameters
-    question_validator = QuestionValidator(llm_loader=llm_loader)
+        # check that LLM loader was called with expected parameters
+        question_validator = QuestionValidator(llm_loader=llm_loader)
 
-    # just run the validation, we just need to check parameters passed to LLM
-    # that is performed in mock object
-    question_validator.validate_question(
-        "123e4567-e89b-12d3-a456-426614174000", "query"
-    )
+        # just run the validation, we just need to check parameters passed to LLM
+        # that is performed in mock object
+        question_validator.validate_question(
+            "123e4567-e89b-12d3-a456-426614174000", "query"
+        )

--- a/tests/unit/rag_index/test_index_loader.py
+++ b/tests/unit/rag_index/test_index_loader.py
@@ -4,7 +4,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 from ols import config
-from ols.app.models.config import ReferenceContent
+from ols.app.models.config import PostgresConfig, ReferenceContent
+from ols.constants import VectorStoreType
 from ols.src.rag_index.index_loader import IndexLoader
 from tests.mock_classes.mock_llama_index import MockLlamaIndex
 
@@ -19,33 +20,84 @@ def test_index_loader_empty_config(caplog):
     assert index is None
 
 
-@patch("llama_index.core.StorageContext.from_defaults")
-def test_index_loader_no_id(storage_context):
+def test_index_loader_no_id():
     """Test index loader without index id."""
     config.ols_config.reference_content = ReferenceContent(None)
     config.ols_config.reference_content.product_docs_index_path = Path("./some_dir")
 
-    index_loader_obj = IndexLoader(config.ols_config.reference_content)
-    index = index_loader_obj.vector_index
+    with patch("llama_index.core.StorageContext.from_defaults"):
+        index_loader_obj = IndexLoader(config.ols_config.reference_content)
+        index = index_loader_obj.vector_index
 
-    assert (
-        index_loader_obj._embed_model == "local:sentence-transformers/all-mpnet-base-v2"
-    )
-    assert index is None
+        assert (
+            index_loader_obj._embed_model
+            == "local:sentence-transformers/all-mpnet-base-v2"
+        )
+        assert index is None
 
 
-@patch("llama_index.core.StorageContext.from_defaults")
-@patch("llama_index.vector_stores.faiss.FaissVectorStore.from_persist_dir")
-@patch("llama_index.core.load_index_from_storage", new=MockLlamaIndex)
-def test_index_loader(storage_context, from_persist_dir):
+def test_index_loader():
     """Test index loader."""
     config.ols_config.reference_content = ReferenceContent(None)
     config.ols_config.reference_content.product_docs_index_path = Path("./some_dir")
     config.ols_config.reference_content.product_docs_index_id = "./some_id"
 
-    from_persist_dir.return_value = None
+    with (
+        patch("llama_index.core.StorageContext.from_defaults"),
+        patch(
+            "llama_index.vector_stores.faiss.FaissVectorStore.from_persist_dir"
+        ) as from_persist_dir,
+        patch("llama_index.core.load_index_from_storage", new=MockLlamaIndex),
+    ):
+        from_persist_dir.return_value = None
 
-    index_loader_obj = IndexLoader(config.ols_config.reference_content)
-    index = index_loader_obj.vector_index
+        index_loader_obj = IndexLoader(config.ols_config.reference_content)
+        index = index_loader_obj.vector_index
 
-    assert isinstance(index, MockLlamaIndex)
+        assert isinstance(index, MockLlamaIndex)
+
+
+def test_index_loader_from_faiss():
+    """Test index loader when 'faiss' is selected for the vector store type."""
+    config.ols_config.reference_content = ReferenceContent(None)
+    config.ols_config.reference_content.vector_store_type = VectorStoreType.FAISS
+    config.ols_config.reference_content.product_docs_index_path = Path("./some_dir")
+    config.ols_config.reference_content.product_docs_index_id = "./some_id"
+
+    with (
+        patch("llama_index.core.StorageContext.from_defaults"),
+        patch(
+            "llama_index.vector_stores.faiss.FaissVectorStore.from_persist_dir"
+        ) as from_persist_dir,
+        patch("llama_index.core.load_index_from_storage", new=MockLlamaIndex),
+    ):
+        from_persist_dir.return_value = None
+
+        index_loader_obj = IndexLoader(config.ols_config.reference_content)
+        index = index_loader_obj.vector_index
+
+        assert isinstance(index, MockLlamaIndex)
+
+
+def test_index_loader_from_postgres():
+    """Test index loader when 'postgres' is selected for the vector store type."""
+    config.ols_config.reference_content = ReferenceContent(None)
+    config.ols_config.reference_content.vector_store_type = VectorStoreType.POSTGRES
+    config.ols_config.reference_content.product_docs_index_id = "some_id"
+    config.ols_config.reference_content.postgres = PostgresConfig()
+
+    with (
+        patch("llama_index.core.StorageContext.from_defaults"),
+        patch(
+            "llama_index.vector_stores.postgres.PGVectorStore.from_params"
+        ) as from_params,
+        patch(
+            "llama_index.core.VectorStoreIndex.from_vector_store", new=MockLlamaIndex
+        ),
+    ):
+        from_params.return_value = None
+
+        index_loader_obj = IndexLoader(config.ols_config.reference_content)
+        index = index_loader_obj.vector_index
+
+        assert isinstance(index, MockLlamaIndex)

--- a/tests/unit/rag_index/test_index_loader.py
+++ b/tests/unit/rag_index/test_index_loader.py
@@ -4,8 +4,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from ols import config
-from ols.app.models.config import PostgresConfig, ReferenceContent
-from ols.constants import VectorStoreType
+from ols.app.models.config import ReferenceContent
 from ols.src.rag_index.index_loader import IndexLoader
 from tests.mock_classes.mock_llama_index import MockLlamaIndex
 
@@ -50,52 +49,6 @@ def test_index_loader():
         patch("llama_index.core.load_index_from_storage", new=MockLlamaIndex),
     ):
         from_persist_dir.return_value = None
-
-        index_loader_obj = IndexLoader(config.ols_config.reference_content)
-        index = index_loader_obj.vector_index
-
-        assert isinstance(index, MockLlamaIndex)
-
-
-def test_index_loader_from_faiss():
-    """Test index loader when 'faiss' is selected for the vector store type."""
-    config.ols_config.reference_content = ReferenceContent(None)
-    config.ols_config.reference_content.vector_store_type = VectorStoreType.FAISS
-    config.ols_config.reference_content.product_docs_index_path = Path("./some_dir")
-    config.ols_config.reference_content.product_docs_index_id = "./some_id"
-
-    with (
-        patch("llama_index.core.StorageContext.from_defaults"),
-        patch(
-            "llama_index.vector_stores.faiss.FaissVectorStore.from_persist_dir"
-        ) as from_persist_dir,
-        patch("llama_index.core.load_index_from_storage", new=MockLlamaIndex),
-    ):
-        from_persist_dir.return_value = None
-
-        index_loader_obj = IndexLoader(config.ols_config.reference_content)
-        index = index_loader_obj.vector_index
-
-        assert isinstance(index, MockLlamaIndex)
-
-
-def test_index_loader_from_postgres():
-    """Test index loader when 'postgres' is selected for the vector store type."""
-    config.ols_config.reference_content = ReferenceContent(None)
-    config.ols_config.reference_content.vector_store_type = VectorStoreType.POSTGRES
-    config.ols_config.reference_content.product_docs_index_id = "some_id"
-    config.ols_config.reference_content.postgres = PostgresConfig()
-
-    with (
-        patch("llama_index.core.StorageContext.from_defaults"),
-        patch(
-            "llama_index.vector_stores.postgres.PGVectorStore.from_params"
-        ) as from_params,
-        patch(
-            "llama_index.core.VectorStoreIndex.from_vector_store", new=MockLlamaIndex
-        ),
-    ):
-        from_params.return_value = None
 
         index_loader_obj = IndexLoader(config.ols_config.reference_content)
         index = index_loader_obj.vector_index

--- a/tests/unit/runners/test_uvicorn_runner.py
+++ b/tests/unit/runners/test_uvicorn_runner.py
@@ -35,80 +35,84 @@ def default_config():
     )
 
 
-@patch("uvicorn.run")
-def test_start_uvicorn(mocked_run, default_config):
+def test_start_uvicorn(default_config):
     """Test the function to start Uvicorn server."""
-    start_uvicorn(default_config)
-    mocked_run.assert_called_once_with(
-        "ols.app.main:app",
-        host="0.0.0.0",  # noqa: S104
-        port=8080,
-        workers=1,
-        log_level=30,
-        ssl_keyfile=None,
-        ssl_certfile=None,
-        ssl_keyfile_password=None,
-        ssl_version=17,
-        ssl_ciphers="TLSv1",
-        access_log=False,
-    )
+    # don't start real Uvicorn server
+    with patch("uvicorn.run") as mocked_run:
+        start_uvicorn(default_config)
+        mocked_run.assert_called_once_with(
+            "ols.app.main:app",
+            host="0.0.0.0",  # noqa: S104
+            port=8080,
+            workers=1,
+            log_level=30,
+            ssl_keyfile=None,
+            ssl_certfile=None,
+            ssl_keyfile_password=None,
+            ssl_version=17,
+            ssl_ciphers="TLSv1",
+            access_log=False,
+        )
 
 
-@patch("uvicorn.run")
-def test_start_uvicorn_with_tls(mocked_run, default_config):
+def test_start_uvicorn_with_tls(default_config):
     """Test the function to start Uvicorn server."""
     default_config.dev_config.disable_tls = False
-    start_uvicorn(default_config)
-    mocked_run.assert_called_once_with(
-        "ols.app.main:app",
-        host="0.0.0.0",  # noqa: S104
-        port=8443,
-        workers=1,
-        log_level=30,
-        ssl_keyfile=None,
-        ssl_certfile=None,
-        ssl_keyfile_password=None,
-        ssl_version=17,
-        ssl_ciphers="TLSv1",
-        access_log=False,
-    )
+    # don't start real Uvicorn server
+    with patch("uvicorn.run") as mocked_run:
+        start_uvicorn(default_config)
+        mocked_run.assert_called_once_with(
+            "ols.app.main:app",
+            host="0.0.0.0",  # noqa: S104
+            port=8443,
+            workers=1,
+            log_level=30,
+            ssl_keyfile=None,
+            ssl_certfile=None,
+            ssl_keyfile_password=None,
+            ssl_version=17,
+            ssl_ciphers="TLSv1",
+            access_log=False,
+        )
 
 
-@patch("uvicorn.run")
-def test_start_uvicorn_on_localhost(mocked_run, default_config):
+def test_start_uvicorn_on_localhost(default_config):
     """Test the function to start Uvicorn server."""
     default_config.dev_config.run_on_localhost = True
-    start_uvicorn(default_config)
-    mocked_run.assert_called_once_with(
-        "ols.app.main:app",
-        host="localhost",
-        port=8080,
-        workers=1,
-        log_level=30,
-        ssl_keyfile=None,
-        ssl_certfile=None,
-        ssl_keyfile_password=None,
-        ssl_version=17,
-        ssl_ciphers="TLSv1",
-        access_log=False,
-    )
+    # don't start real Uvicorn server
+    with patch("uvicorn.run") as mocked_run:
+        start_uvicorn(default_config)
+        mocked_run.assert_called_once_with(
+            "ols.app.main:app",
+            host="localhost",
+            port=8080,
+            workers=1,
+            log_level=30,
+            ssl_keyfile=None,
+            ssl_certfile=None,
+            ssl_keyfile_password=None,
+            ssl_version=17,
+            ssl_ciphers="TLSv1",
+            access_log=False,
+        )
 
 
-@patch("uvicorn.run")
-def test_start_uvicorn_on_non_default_port(mocked_run, default_config):
+def test_start_uvicorn_on_non_default_port(default_config):
     """Test the function to start Uvicorn server on a non-default port."""
     default_config.dev_config.uvicorn_port_number = 8081
-    start_uvicorn(default_config)
-    mocked_run.assert_called_once_with(
-        "ols.app.main:app",
-        host="0.0.0.0",  # noqa: S104
-        port=8081,
-        workers=1,
-        log_level=30,
-        ssl_keyfile=None,
-        ssl_certfile=None,
-        ssl_keyfile_password=None,
-        ssl_version=17,
-        ssl_ciphers="TLSv1",
-        access_log=False,
-    )
+    # don't start real Uvicorn server
+    with patch("uvicorn.run") as mocked_run:
+        start_uvicorn(default_config)
+        mocked_run.assert_called_once_with(
+            "ols.app.main:app",
+            host="0.0.0.0",  # noqa: S104
+            port=8081,
+            workers=1,
+            log_level=30,
+            ssl_keyfile=None,
+            ssl_certfile=None,
+            ssl_keyfile_password=None,
+            ssl_version=17,
+            ssl_ciphers="TLSv1",
+            access_log=False,
+        )


### PR DESCRIPTION
## Description

[OLS-1519](https://issues.redhat.com//browse/OLS-1519): no `@patch` decorator in unit and integration tests

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests

## Related Tickets & Documents

- Related Issue #[OLS-1519](https://issues.redhat.com//browse/OLS-1519)
