### PR TITLE
Remove special formatting of the prompt

### DIFF
--- a/ols/src/prompts/prompts.py
+++ b/ols/src/prompts/prompts.py
@@ -22,15 +22,29 @@ Here are some basic facts about OpenShift:
 - OpenShift is a distribution of Kubernetes. Everything Kubernetes can do, OpenShift can do and more.
 """
 
+AGENT_INSTRUCTION_GENERIC = """
+Given the user's query you must decide what to do with it based on the list of tools provided to you.
+"""
+
+AGENT_INSTRUCTION_GRANITE = """
+You have been also given set of functions/tools.
+Your task is to decide if tool call is needed and produce a list of function calls required to generate response to the user utterance.
+When you request/produce function calls, add `<tool_call>` at the beginning, so that function calls can be identified.
+  Sample tool format: '<tool_call>[{{"arguments": {{"oc_adm_top_args": ["pods", "-A"]}}, "name": "oc_adm_top"}}]'
+Do not use function calls for below kind of queries (These kind of queries do not require real time cluster data):
+  - User is asking about general information about Openshift/Kubernetes.
+  - User is asking "how-to" kind of queries for which you can refer retrieved documents.
+Refer tool response / output before providing your response.
+"""
+
 # Currently only additional instructions are concatenated to original
 # doc summarizer prompt. Depending upon performance dedicated prompt will be used.
 AGENT_SYSTEM_INSTRUCTION = """
-* Given the user's query you must decide what to do with it based on the \
-list of tools provided to you.
 * Think twice before executing a tool, double-check if the tool arguments are \
 really correct for your use case/need.
 * Execute as many tools as possible to gather all information. When you are \
 satisfied with all the details then answer user query.
+* Do not request same tool/function call with same argument.
 
 Style guide:
 * Be extremely concise.

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -98,7 +98,7 @@ class DocsSummarizer(QueryHelper):
         if vector_index:
             retriever = vector_index.as_retriever(similarity_top_k=RAG_CONTENT_LIMIT)
             rag_chunks, available_tokens = token_handler.truncate_rag_context(
-                retriever.retrieve(query), self.model, available_tokens
+                retriever.retrieve(query), available_tokens
             )
         else:
             logger.warning("Proceeding without RAG content. Check start up messages.")
@@ -109,7 +109,7 @@ class DocsSummarizer(QueryHelper):
 
         # Truncate history
         history, truncated = token_handler.limit_conversation_history(
-            history or [], self.model, available_tokens
+            history or [], available_tokens
         )
 
         final_prompt, llm_input_values = GeneratePrompt(
@@ -207,7 +207,6 @@ class DocsSummarizer(QueryHelper):
             )
 
             # Check if model is ready with final response
-            # if (not ai_msg.tool_calls) and (ai_msg.content):
             if is_final_round or out.response_metadata["finish_reason"] == "stop":
                 response = out.content
                 break

--- a/ols/src/tools/oc_cli.py
+++ b/ols/src/tools/oc_cli.py
@@ -1,5 +1,9 @@
 """OpenShift CLI tools."""
 
+# Need this to avoid adding token arg description to tool doc string.
+# inline ignore is getting removed.
+# ruff: noqa: D417
+
 # Debug note: to debug the tools in local service instance, eg. against
 # cluster, use the KUBECONFIG env variable to point to the kubeconfig
 # file with the cluster configuration, as the oc CLI checks this when no
@@ -37,6 +41,15 @@ def sanitize_oc_args(args: list[str]) -> list[str]:
 
         if safe_part:  # only add non-empty results
             sanitized_args.append("".join(safe_part).strip())
+
+    # Temporary workaround for granite.
+    # Sometimes within the list we may get two args combined; ex: [top pod]
+    sanitized_args = " ".join(sanitized_args).split(" ")
+    # Sometimes model gives args which are already added to the tool.
+    remove_arg = ["oc", "get", "describe", "logs", "status", "adm", "top"]
+    for arg in remove_arg:
+        if arg in sanitized_args:
+            sanitized_args.remove(arg)
 
     return sanitized_args
 
@@ -83,10 +96,13 @@ def stdout_or_stderr(result: subprocess.CompletedProcess) -> str:
 
 # NOTE: tools description comes from oc cli --help for each subcommand (shortened)
 @tool
-def oc_get(command_args: list[str], token: Annotated[str, InjectedToolArg]) -> str:
-    """Display one or many resources from OpenShift cluster using `oc get <args>` command.
+def oc_get(oc_get_args: list[str], token: Annotated[str, InjectedToolArg]) -> str:
+    """Display one or many resources from OpenShift cluster.
 
     Standard `oc` flags and options are valid.
+
+    Args:
+        oc_get_args: Arguments for oc get
 
     Examples:
         # List all pods in ps output format.
@@ -104,103 +120,105 @@ def oc_get(command_args: list[str], token: Annotated[str, InjectedToolArg]) -> s
         # List a single replication controller with specified NAME in ps output format.
         oc get replicationcontroller web
 
-        # List deployments in JSON output format, in the "v1" version of the
-        # "apps" API group:
+        # List deployments in JSON output format, in the "v1" version of the "apps" API group:
         oc get deployments.v1.apps -o json
 
-        # List a pod identified by type and name specified in "pod.yaml" in JSON
-        # output format.
+        # List a pod identified by type and name specified in "pod.yaml" in JSON output format.
         oc get -f pod.yaml -o json
 
         # List all replication controllers and services together in ps output format.
         oc get rc,services
     """
-    result = run_oc(["get", *sanitize_oc_args(command_args), "--token", token])
+    result = run_oc(["get", *sanitize_oc_args(oc_get_args), "--token", token])
     return stdout_or_stderr(result)
 
 
 @tool
-def oc_describe(command_args: list[str], token: Annotated[str, InjectedToolArg]) -> str:
+def oc_describe(
+    oc_describe_args: list[str], token: Annotated[str, InjectedToolArg]
+) -> str:
     """Show details of a specific resource or group of resources.
 
-    Print a detailed description of the selected resources, including related
-    resources such as events or controllers. You may select a single object by
-    name, all objects of that type, provide a name prefix, or label selector.
+    Print a detailed description of the selected resources, including related resources such as events or controllers.
+    You may select a single object by name, all objects of that type, provide a name prefix, or label selector.
+
+    Args:
+        oc_describe_args: Arguments for oc describe
 
     Examples:
-    # Describe a node
-    oc describe nodes kubernetes-node-emt8.c.myproject.internal
+        # Describe a node
+        oc describe nodes kubernetes-node-emt8.c.myproject.internal
 
-    # Describe a pod
-    oc describe pods/nginx
+        # Describe a pod
+        oc describe pods/nginx
 
-    # Describe a pod identified by type and name in "pod.json"
-    oc describe -f pod.json
+        # Describe a pod identified by type and name in "pod.json"
+        oc describe -f pod.json
 
-    # Describe all pods
-    oc describe pods
+        # Describe all pods
+        oc describe pods
 
-    # Describe pods by label name=myLabel
-    oc describe po -l name=myLabel
+        # Describe pods by label name=myLabel
+        oc describe po -l name=myLabel
 
-    # Describe all pods managed by the 'frontend' replication controller
-    oc describe pods frontend
-    """
-    result = run_oc(["describe", *sanitize_oc_args(command_args), "--token", token])
+        # Describe all pods managed by the 'frontend' replication controller
+        oc describe pods frontend
+    """  # noqa: E501
+    result = run_oc(["describe", *sanitize_oc_args(oc_describe_args), "--token", token])
     return stdout_or_stderr(result)
 
 
 @tool
-def oc_logs(command_args: list[str], token: Annotated[str, InjectedToolArg]) -> str:
+def oc_logs(oc_logs_args: list[str], token: Annotated[str, InjectedToolArg]) -> str:
     """Print the logs for a resource.
 
-    Supported resources are builds, build configs (bc), deployment configs
-    (dc), and pods. When a pod is specified and has more than one container,
-    the container name should be specified via -c. When a build config or
-    deployment config is specified, you can view the logs for a particular
-    version of it
-    via --version.
+    Supported resources are builds, build configs (bc), deployment configs (dc), and pods.
+    When a pod is specified and has more than one container, the container name should be specified via -c.
+    When a build config or deployment config is specified, you can view the logs for a particular version of it via --version.
+
+    Args:
+        oc_logs_args: Arguments for oc logs
 
     Examples:
-    # Start streaming the logs of the most recent build of the openldap build
-    # config.
-    oc logs -f bc/openldap
+        # Start streaming the logs of the most recent build of the openldap build config.
+        oc logs -f bc/openldap
 
-    # Get the logs of the first deployment for the mysql deployment config.
-    oc logs --version=1 dc/mysql
+        # Get the logs of the first deployment for the mysql deployment config.
+        oc logs --version=1 dc/mysql
 
-    # Return a snapshot of ruby-container logs from pod backend.
-    oc logs backend -c ruby-container
+        # Return a snapshot of ruby-container logs from pod backend.
+        oc logs backend -c ruby-container
 
-    # Start streaming of ruby-container logs from pod backend.
-    oc logs -f pod/backend -c ruby-container
-    """
-    result = run_oc(["logs", *sanitize_oc_args(command_args), "--token", token])
+        # Start streaming of ruby-container logs from pod backend.
+        oc logs -f pod/backend -c ruby-container
+    """  # noqa: E501
+    result = run_oc(["logs", *sanitize_oc_args(oc_logs_args), "--token", token])
     return stdout_or_stderr(result)
 
 
 @tool
-def oc_status(command_args: list[str], token: Annotated[str, InjectedToolArg]) -> str:
+def oc_status(oc_status_args: list[str], token: Annotated[str, InjectedToolArg]) -> str:
     """Show a high level overview of the current project.
 
-    This command will show services, deployment configs, build configurations,
-    and active deployments. If you have any misconfigured components
-    information about them will be shown. For more information about individual
-    items, use the describe command (e.g. oc describe buildconfig, oc describe
-    deploymentconfig, oc describe service).
+    This command will show services, deployment configs, build configurations, & active deployments.
+    If you have any misconfigured components information about them will be shown.
+    For more information about individual items, use the describe command \
+    (e.g. oc describe buildconfig, oc describe deploymentconfig, oc describe service).
+
+    Args:
+        oc_status_args: Arguments for oc status
 
     Examples:
-    # See an overview of the current project.
-    oc status
+        # See an overview of the current project.
+        oc status
 
-    # Export the overview of the current project in an svg file.
-    oc status -o dot | dot -T svg -o project.svg
+        # Export the overview of the current project in an svg file.
+        oc status -o dot | dot -T svg -o project.svg
 
-    # See an overview of the current project including details for any
-    # identified issues.
-    oc --suggest
+        # See an overview of the current project including details for any identified issues.
+        oc --suggest
     """
-    result = run_oc(["status", *sanitize_oc_args(command_args), "--token", token])
+    result = run_oc(["status", *sanitize_oc_args(oc_status_args), "--token", token])
     return stdout_or_stderr(result)
 
 
@@ -209,45 +227,47 @@ def show_pods(token: Annotated[str, InjectedToolArg]) -> str:
     """Show resource usage (CPU and memory) for all pods accross all namespaces.
 
     Usecases:
-    - Pods resource usage monitoring.
-    - Resource allocation monitoring.
-    - Average resources consumption.
+        - Pods resource usage monitoring.
+        - Resource allocation monitoring.
+        - Average resources consumption.
 
     The output format is:
-    NAMESPACE    NAME                                              CPU(cores)  MEMORY(bytes)
-    kube-system  konnectivity-agent-qwnsd                          1m          24Mi
-    kube-system  kube-apiserver-proxy-ip-10-0-130-91.ec2.internal  2m          13Mi
+        NAMESPACE    NAME                                              CPU(cores)  MEMORY(bytes)
+        kube-system  konnectivity-agent-qwnsd                          1m          24Mi
+        kube-system  kube-apiserver-proxy-ip-10-0-130-91.ec2.internal  2m          13Mi
     """
-    # the tool is not accepting any options, but we are adding extra arg
-    # with token outside of what llm figures out
     result = run_oc([*["adm", "top", "pods", "-A"], "--token", token])
     return stdout_or_stderr(result)
 
 
 @tool
-def oc_adm_top(command_args: list[str], token: Annotated[str, InjectedToolArg]) -> str:
+def oc_adm_top(
+    oc_adm_top_args: list[str], token: Annotated[str, InjectedToolArg]
+) -> str:
     """Show usage statistics of resources on the server.
 
-    This command analyzes resources managed by the platform and presents
-    current usage statistics.
+    This command analyzes resources managed by the platform and presents current usage statistics.
 
-    When no options are provided, the command will list given resource
-    in default namespace.
-
+    When no options are provided, the command will list given resource in default namespace.
     To get the resources across namespaces, use `-A` flag.
 
+    Args:
+        oc_adm_top_args: Arguments for oc adm top
+
     Usage:
-    oc adm top [commands] [options]
+        oc adm top [commands] [options]
 
     Available Commands:
-    images       Show usage statistics for Images
-    imagestreams Show usage statistics for ImageStreams
-    node         Display Resource (CPU/Memory/Storage) usage of nodes
-    pod          Display Resource (CPU/Memory/Storage) usage of pods
+        images       Show usage statistics for Images
+        imagestreams Show usage statistics for ImageStreams
+        node         Display Resource (CPU/Memory/Storage) usage of nodes
+        pod          Display Resource (CPU/Memory/Storage) usage of pods
 
     Options:
-    --namespace <namespace>
-        Lists resources for specified namespace.
+        --namespace <namespace>
+            Lists resources for specified namespace.
     """
-    result = run_oc(["adm", "top", *sanitize_oc_args(command_args), "--token", token])
+    result = run_oc(
+        ["adm", "top", *sanitize_oc_args(oc_adm_top_args), "--token", token]
+    )
     return stdout_or_stderr(result)

--- a/scripts/evaluation/eval_data/question_answer_pair.json
+++ b/scripts/evaluation/eval_data/question_answer_pair.json
@@ -79,7 +79,7 @@
                     ]
                 },
                 "watsonx+ibm/granite-3-8b-instruct+with_rag": {
-                    "cutoff_score": 0.3,
+                    "cutoff_score": 0.35,
                     "text": [
                         "OpenShift Virtualization is an add-on to Red Hat OpenShift Container Platform that allows you to run and manage virtual machine workloads alongside container workloads. It adds new objects into your Red Hat OpenShift Container Platform cluster by using Kubernetes custom resources to enable virtualization tasks such as creating and managing Linux and Windows virtual machines, running pod and VM workloads alongside each other in a cluster, connecting to virtual machines through various consoles and CLI tools, importing and cloning existing virtual machines, managing network interface controllers and storage disks attached to virtual machines, and live migrating virtual machines between nodes. An enhanced web console provides a graphical portal to manage these virtualized resources alongside the Red Hat OpenShift Container Platform cluster containers and infrastructure."
                     ]

--- a/scripts/evaluation/utils/rag.py
+++ b/scripts/evaluation/utils/rag.py
@@ -22,6 +22,6 @@ def retrieve_rag_chunks(query, model, model_config):
 
     retriever = config.rag_index.as_retriever(similarity_top_k=RAG_CONTENT_LIMIT)
     rag_chunks, _ = token_handler.truncate_rag_context(
-        retriever.retrieve(query), model, available_tokens
+        retriever.retrieve(query), available_tokens
     )
     return [rag_chunk.text for rag_chunk in rag_chunks]

--- a/tests/benchmarks/test_token_handler.py
+++ b/tests/benchmarks/test_token_handler.py
@@ -2,7 +2,6 @@
 
 from langchain_core.messages import AIMessage, HumanMessage
 
-from ols.constants import ModelFamily
 from ols.utils.token_handler import TokenHandler
 
 
@@ -50,7 +49,7 @@ def benchmark_limit_conversation_history(benchmark, history, limit=1000):
     """Benchmark the method to calculate available tokens."""
     token_handler = TokenHandler()
 
-    benchmark(token_handler.limit_conversation_history, history, ModelFamily.GPT, limit)
+    benchmark(token_handler.limit_conversation_history, history, limit)
 
 
 def test_limit_conversation_history_no_history(benchmark):

--- a/tests/config/operator_install/olsconfig.crd.watsonx_introspection.yaml
+++ b/tests/config/operator_install/olsconfig.crd.watsonx_introspection.yaml
@@ -15,11 +15,11 @@ spec:
           name: llmcreds
         projectID: ad629765-c373-4731-9d69-dc701724c081
         models:
-          - name: ibm/granite-3-8b-instruct
+          - name: ibm/granite-3-2-8b-instruct
         name: watsonx
         type: watsonx
   ols:
-    defaultModel: ibm/granite-3-8b-instruct
+    defaultModel: ibm/granite-3-2-8b-instruct
     defaultProvider: watsonx
     introspectionEnabled: true
     deployment:

--- a/tests/e2e/test_query_endpoint.py
+++ b/tests/e2e/test_query_endpoint.py
@@ -593,11 +593,7 @@ def test_tool_calling() -> None:
             QUERY_ENDPOINT,
             json={
                 "conversation_id": cid,
-                "query": (
-                    "In my cluster, is there a 'lightspeed-app-server' pod in "
-                    "'openshift-lightspeed' namespace? Please, explicitely "
-                    "say 'yes' or 'no'."
-                ),
+                "query": "Show me pods in openshift-lightspeed namespace?",
             },
             timeout=test_api.LLM_REST_API_TIMEOUT,
         )
@@ -610,6 +606,6 @@ def test_tool_calling() -> None:
         # checking a few major information from response
         assert json_response["conversation_id"] == cid
 
-        assert "yes" in json_response["response"].lower()
+        assert "lightspeed-app-server" in json_response["response"].lower()
         assert json_response["input_tokens"] > 0
         assert json_response["output_tokens"] > 0

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -1123,6 +1123,7 @@ def test_tool_calling(_setup, caplog) -> None:
     config.ols_config.introspection_enabled = True
 
     with (
+        patch("ols.src.prompts.prompts.QUERY_SYSTEM_INSTRUCTION", "System Instruction"),
         patch(
             "ols.src.query_helpers.docs_summarizer.DocsSummarizer._get_available_tools"
         ) as tools_mock,

--- a/tests/scripts/test-e2e-cluster.sh
+++ b/tests/scripts/test-e2e-cluster.sh
@@ -56,14 +56,13 @@ function run_suites() {
   run_suite "rhelai_vllm" "smoketest" "rhelai_vllm" "$OPENAI_PROVIDER_KEY_PATH" "gpt-3.5-turbo" "$OLS_IMAGE" "n"
   (( rc = rc || $? ))
 
-  # TODO: Enable below test cases once flag is added to operator CRD. Update flag name in CRD yaml (if different name is used)
   # TODO: Reduce execution time. Sequential execution will take more time. Parallel execution will have cluster claim issue.
   # Run tool calling - Enable introspection
   run_suite "azure_openai_introspection" "introspection" "azure_openai" "$AZUREOPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE" "y"
   (( rc = rc || $? ))
   run_suite "openai_introspection" "introspection" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE" "y"
   (( rc = rc || $? ))
-  run_suite "watsonx_introspection" "introspection" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-3-8b-instruct" "$OLS_IMAGE" "y"
+  run_suite "watsonx_introspection" "introspection" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-3-2-8b-instruct" "$OLS_IMAGE" "y"
   (( rc = rc || $? ))
 
   set -e

--- a/tests/unit/prompts/test_prompt_generator.py
+++ b/tests/unit/prompts/test_prompt_generator.py
@@ -1,27 +1,32 @@
 """Unit tests for PromptGenerator."""
 
+from unittest.mock import patch
+
 import pytest
 from langchain.prompts import (
     ChatPromptTemplate,
     HumanMessagePromptTemplate,
     MessagesPlaceholder,
-    PromptTemplate,
     SystemMessagePromptTemplate,
 )
 from langchain_core.messages import AIMessage, HumanMessage
 
 from ols.constants import ModelFamily
-from ols.src.prompts.prompt_generator import (
-    GeneratePrompt,
-    restructure_history,
-    restructure_rag_context_post,
-    restructure_rag_context_pre,
-)
+from ols.src.prompts.prompt_generator import GeneratePrompt, format_retrieved_chunk
 
 model = ["some-granite-model", "some-gpt-model"]
 
 system_instruction = """
 Answer user queries in the context of openshift.
+"""
+agent_instruction_granite = """
+Agent Instruction Granite.
+"""
+agent_instruction_generic = """
+Agent Instruction generic.
+"""
+agent_system_instruction = """
+Agent Instruction default.
 """
 query = "What is Kubernetes?"
 rag_context = ["context 1", "context 2"]
@@ -31,291 +36,193 @@ conversation_history = [
 ]
 
 
-def _restructure_prompt_input(rag_context, conversation_history, model):
-    """Restructure prompt input."""
-    rag_formatted = [
-        restructure_rag_context_post(restructure_rag_context_pre(text, model), model)
-        for text in rag_context
-    ]
-    history_formatted = [
-        restructure_history(history, model) for history in conversation_history
-    ]
-    return rag_formatted, history_formatted
-
-
 @pytest.mark.parametrize("model", model)
 def test_generate_prompt_default_prompt(model):
     """Test if prompt generator returns default prompt for given input."""
-    rag_formatted, history_formatted = _restructure_prompt_input(
-        rag_context, conversation_history, model
-    )
+    rag_formatted = [format_retrieved_chunk(text) for text in rag_context]
 
     prompt, llm_input_values = GeneratePrompt(
         query,
         rag_formatted,
-        history_formatted,
+        conversation_history,
         system_instruction,
     ).generate_prompt(model)
 
     assert set(prompt.input_variables) == {"chat_history", "context", "query"}
     assert set(llm_input_values.keys()) == set(prompt.input_variables)
 
-    if ModelFamily.GRANITE in model:
-        assert type(prompt) is PromptTemplate
-        assert prompt.template == (
-            "<|system|>\n"
-            "Answer user queries in the context of openshift.\n"
-            "\n"
-            "Use the retrieved document to answer the question.\n"
-            "Use the previous chat history to interact and help the user.\n"
-            "{context}\n"
-            "{chat_history}\n"
-            "<|user|>\n"
-            "{query}\n"
-            "<|assistant|>"
-            "\n"
-        )
-        assert prompt.format(**llm_input_values) == (
-            "<|system|>\n"
-            "Answer user queries in the context of openshift.\n"
-            "\n"
-            "Use the retrieved document to answer the question.\n"
-            "Use the previous chat history to interact and help the user.\n"
-            "\n"
-            "[Document]\n"
-            "context 1\n"
-            "[End]\n"
-            "[Document]\n"
-            "context 2\n"
-            "[End]\n"
-            "\n"
-            "<|user|>\n"
-            "First human message\n"
-            "<|assistant|>\n"
-            "First AI message\n"
-            "<|user|>\n"
-            "What is Kubernetes?\n"
-            "<|assistant|>"
-            "\n"
-        )
-    else:
-        assert type(prompt) is ChatPromptTemplate
-        assert len(prompt.messages) == 3
-        assert type(prompt.messages[0]) is SystemMessagePromptTemplate
-        assert type(prompt.messages[1]) is MessagesPlaceholder
-        assert type(prompt.messages[2]) is HumanMessagePromptTemplate
-        assert prompt.messages[0].prompt.template == (
-            "Answer user queries in the context of openshift.\n"
-            "\n"
-            "Use the retrieved document to answer the question.\n"
-            "Use the previous chat history to interact and help the user.\n"
-            "{context}"
-        )
-        assert prompt.format(**llm_input_values) == (
-            "System: Answer user queries in the context of openshift.\n"
-            "\n"
-            "Use the retrieved document to answer the question.\n"
-            "Use the previous chat history to interact and help the user.\n"
-            "\n"
-            "Document:\n"
-            "context 1\n"
-            "\n"
-            "Document:\n"
-            "context 2\n"
-            "\n"
-            "Human: First human message\n"
-            "AI: First AI message\n"
-            f"Human: {query}"
-        )
+    assert type(prompt) is ChatPromptTemplate
+    assert len(prompt.messages) == 3
+    assert type(prompt.messages[0]) is SystemMessagePromptTemplate
+    assert type(prompt.messages[1]) is MessagesPlaceholder
+    assert type(prompt.messages[2]) is HumanMessagePromptTemplate
+
+    assert prompt.messages[0].prompt.template == (
+        "Answer user queries in the context of openshift.\n"
+        "Use the retrieved document to answer the question.\n"
+        "Use the previous chat history to interact and help the user.\n"
+        "{context}"
+    )
+    assert prompt.format(**llm_input_values) == (
+        "System: Answer user queries in the context of openshift.\n"
+        "Use the retrieved document to answer the question.\n"
+        "Use the previous chat history to interact and help the user.\n"
+        "Document:\n"
+        "context 1\n"
+        "Document:\n"
+        "context 2\n"
+        "Human: First human message\n"
+        "AI: First AI message\n"
+        f"Human: {query}"
+    )
 
 
 @pytest.mark.parametrize("model", model)
 def test_generate_prompt_without_rag_context(model):
     """Test what prompt will be returned for non-existent RAG context."""
-    rag_context = []
-    rag_formatted, history_formatted = _restructure_prompt_input(
-        rag_context, conversation_history, model
-    )
-
     prompt, llm_input_values = GeneratePrompt(
         query,
-        rag_formatted,
-        history_formatted,
+        [],
+        conversation_history,
         system_instruction,
     ).generate_prompt(model)
 
     assert set(prompt.input_variables) == {"chat_history", "query"}
     assert set(llm_input_values.keys()) == set(prompt.input_variables)
 
-    if ModelFamily.GRANITE in model:
-        assert type(prompt) is PromptTemplate
-        assert prompt.template == (
-            "<|system|>\n"
-            "Answer user queries in the context of openshift.\n"
-            "\n"
-            "Use the previous chat history to interact and help the user.\n"
-            "{chat_history}\n"
-            "<|user|>\n"
-            "{query}\n"
-            "<|assistant|>"
-            "\n"
-        )
-        assert prompt.format(**llm_input_values) == (
-            "<|system|>\n"
-            "Answer user queries in the context of openshift.\n"
-            "\n"
-            "Use the previous chat history to interact and help the user.\n"
-            "\n"
-            "<|user|>\n"
-            "First human message\n"
-            "<|assistant|>\n"
-            "First AI message\n"
-            "<|user|>\n"
-            "What is Kubernetes?\n"
-            "<|assistant|>"
-            "\n"
-        )
-    else:
-        assert type(prompt) is ChatPromptTemplate
-        assert len(prompt.messages) == 3
-        assert type(prompt.messages[0]) is SystemMessagePromptTemplate
-        assert type(prompt.messages[1]) is MessagesPlaceholder
-        assert type(prompt.messages[2]) is HumanMessagePromptTemplate
-        assert prompt.messages[0].prompt.template == (
-            "Answer user queries in the context of openshift.\n"
-            "\n"
-            "Use the previous chat history to interact and help the user."
-        )
-        assert prompt.format(**llm_input_values) == (
-            "System: Answer user queries in the context of openshift.\n"
-            "\n"
-            "Use the previous chat history to interact and help the user.\n"
-            "Human: First human message\n"
-            "AI: First AI message\n"
-            f"Human: {query}"
-        )
+    assert type(prompt) is ChatPromptTemplate
+    assert len(prompt.messages) == 3
+    assert type(prompt.messages[0]) is SystemMessagePromptTemplate
+    assert type(prompt.messages[1]) is MessagesPlaceholder
+    assert type(prompt.messages[2]) is HumanMessagePromptTemplate
+
+    assert prompt.messages[0].prompt.template == (
+        "Answer user queries in the context of openshift.\n"
+        "Use the previous chat history to interact and help the user."
+    )
+    assert prompt.format(**llm_input_values) == (
+        "System: Answer user queries in the context of openshift.\n"
+        "Use the previous chat history to interact and help the user.\n"
+        "Human: First human message\n"
+        "AI: First AI message\n"
+        f"Human: {query}"
+    )
 
 
 @pytest.mark.parametrize("model", model)
 def test_generate_prompt_without_history(model):
     """Test if prompt generator returns prompt without history."""
-    conversation_history = []
     rag_context = ["context 1"]
-
-    rag_formatted, history_formatted = _restructure_prompt_input(
-        rag_context, conversation_history, model
-    )
+    rag_formatted = [format_retrieved_chunk(text) for text in rag_context]
 
     prompt, llm_input_values = GeneratePrompt(
         query,
         rag_formatted,
-        history_formatted,
+        [],
         system_instruction,
     ).generate_prompt(model)
 
     assert set(prompt.input_variables) == {"context", "query"}
     assert set(llm_input_values.keys()) == set(prompt.input_variables)
 
-    if ModelFamily.GRANITE in model:
-        assert type(prompt) is PromptTemplate
-        assert prompt.template == (
-            "<|system|>\n"
-            "Answer user queries in the context of openshift.\n"
-            "\n"
-            "Use the retrieved document to answer the question.\n"
-            "{context}\n"
-            "<|user|>\n"
-            "{query}\n"
-            "<|assistant|>"
-            "\n"
-        )
-        assert prompt.format(**llm_input_values) == (
-            "<|system|>\n"
-            "Answer user queries in the context of openshift.\n"
-            "\n"
-            "Use the retrieved document to answer the question.\n"
-            "\n"
-            "[Document]\n"
-            "context 1\n"
-            "[End]\n"
-            "<|user|>\n"
-            "What is Kubernetes?\n"
-            "<|assistant|>"
-            "\n"
-        )
-    else:
-        assert type(prompt) is ChatPromptTemplate
-        assert len(prompt.messages) == 2
-        assert type(prompt.messages[0]) is SystemMessagePromptTemplate
-        assert type(prompt.messages[1]) is HumanMessagePromptTemplate
-        assert prompt.messages[0].prompt.template == (
-            "Answer user queries in the context of openshift.\n"
-            "\n"
-            "Use the retrieved document to answer the question.\n"
-            "{context}"
-        )
-        assert prompt.format(**llm_input_values) == (
-            "System: Answer user queries in the context of openshift.\n"
-            "\n"
-            "Use the retrieved document to answer the question.\n"
-            "\n"
-            "Document:\n"
-            "context 1\n"
-            "\n"
-            f"Human: {query}"
-        )
+    assert type(prompt) is ChatPromptTemplate
+    assert len(prompt.messages) == 2
+    assert type(prompt.messages[0]) is SystemMessagePromptTemplate
+    assert type(prompt.messages[1]) is HumanMessagePromptTemplate
+
+    assert prompt.messages[0].prompt.template == (
+        "Answer user queries in the context of openshift.\n"
+        "Use the retrieved document to answer the question.\n"
+        "{context}"
+    )
+    assert prompt.format(**llm_input_values) == (
+        "System: Answer user queries in the context of openshift.\n"
+        "Use the retrieved document to answer the question.\n"
+        "Document:\n"
+        "context 1\n"
+        f"Human: {query}"
+    )
 
 
 @pytest.mark.parametrize("model", model)
 def test_generate_prompt_without_rag_without_history(model):
     """Test if prompt generator returns prompt without RAG and without history."""
-    conversation_history = []
-    rag_context = []
-
-    rag_formatted, history_formatted = _restructure_prompt_input(
-        rag_context, conversation_history, model
-    )
-
     prompt, llm_input_values = GeneratePrompt(
         query,
-        rag_formatted,
-        history_formatted,
+        [],
+        [],
         system_instruction,
     ).generate_prompt(model)
 
     assert prompt.input_variables == ["query"]
     assert set(llm_input_values.keys()) == set(prompt.input_variables)
 
+    assert type(prompt) is ChatPromptTemplate
+    assert len(prompt.messages) == 2
+    assert type(prompt.messages[0]) is SystemMessagePromptTemplate
+    assert type(prompt.messages[1]) is HumanMessagePromptTemplate
+    assert prompt.messages[0].prompt.template == (
+        "Answer user queries in the context of openshift."
+    )
+    assert prompt.format(**llm_input_values) == (
+        "System: Answer user queries in the context of openshift.\n" f"Human: {query}"
+    )
+
+
+@pytest.mark.parametrize("model", model)
+def test_generate_prompt_with_tool_call(model):
+    """Test prompt when tool call is enabled."""
+    rag_formatted = [format_retrieved_chunk(text) for text in rag_context]
+
+    with (
+        patch(
+            "ols.src.prompts.prompt_generator.AGENT_INSTRUCTION_GRANITE",
+            agent_instruction_granite,
+        ),
+        patch(
+            "ols.src.prompts.prompt_generator.AGENT_INSTRUCTION_GENERIC",
+            agent_instruction_generic,
+        ),
+        patch(
+            "ols.src.prompts.prompt_generator.AGENT_SYSTEM_INSTRUCTION",
+            agent_system_instruction,
+        ),
+    ):
+        prompt, llm_input_values = GeneratePrompt(
+            query, rag_formatted, conversation_history, system_instruction, True
+        ).generate_prompt(model)
+
+    assert set(prompt.input_variables) == {"chat_history", "context", "query"}
+    assert set(llm_input_values.keys()) == set(prompt.input_variables)
+
+    assert type(prompt) is ChatPromptTemplate
+    assert len(prompt.messages) == 3
+    assert type(prompt.messages[0]) is SystemMessagePromptTemplate
+    assert type(prompt.messages[1]) is MessagesPlaceholder
+    assert type(prompt.messages[2]) is HumanMessagePromptTemplate
+
+    agent_instruction = agent_instruction_generic.strip()
     if ModelFamily.GRANITE in model:
-        assert type(prompt) is PromptTemplate
-        assert prompt.template == (
-            "<|system|>\n"
-            "Answer user queries in the context of openshift.\n"
-            "\n"
-            "<|user|>\n"
-            "{query}\n"
-            "<|assistant|>"
-            "\n"
-        )
-        assert prompt.format(**llm_input_values) == (
-            "<|system|>\n"
-            "Answer user queries in the context of openshift.\n"
-            "\n"
-            "<|user|>\n"
-            "What is Kubernetes?\n"
-            "<|assistant|>"
-            "\n"
-        )
-    else:
-        assert type(prompt) is ChatPromptTemplate
-        assert len(prompt.messages) == 2
-        assert type(prompt.messages[0]) is SystemMessagePromptTemplate
-        assert type(prompt.messages[1]) is HumanMessagePromptTemplate
-        assert prompt.messages[0].prompt.template == (
-            "Answer user queries in the context of openshift.\n"
-        )
-        assert prompt.format(**llm_input_values) == (
-            "System: Answer user queries in the context of openshift.\n"
-            "\n"
-            f"Human: {query}"
-        )
+        agent_instruction = agent_instruction_granite.strip()
+    agent_instruction = agent_instruction + "\n" + agent_system_instruction.strip()
+
+    assert prompt.messages[0].prompt.template == (
+        "Answer user queries in the context of openshift.\n"
+        f"{agent_instruction}\n"
+        "Use the retrieved document to answer the question.\n"
+        "Use the previous chat history to interact and help the user.\n"
+        "{context}"
+    )
+    assert prompt.format(**llm_input_values) == (
+        "System: Answer user queries in the context of openshift.\n"
+        f"{agent_instruction}\n"
+        "Use the retrieved document to answer the question.\n"
+        "Use the previous chat history to interact and help the user.\n"
+        "Document:\n"
+        "context 1\n"
+        "Document:\n"
+        "context 2\n"
+        "Human: First human message\n"
+        "AI: First AI message\n"
+        f"Human: {query}"
+    )

--- a/tests/unit/query_helpers/test_docs_summarizer.py
+++ b/tests/unit/query_helpers/test_docs_summarizer.py
@@ -105,7 +105,7 @@ def test_summarize_history_provided():
             return_value=([], False),
         ) as token_handler:
             summary1 = summarizer.create_response(question, rag_index, history)
-            token_handler.assert_called_once_with(history, ANY, ANY)
+            token_handler.assert_called_once_with(history, ANY)
             check_summary_result(summary1, question)
 
         # second call without history provided
@@ -114,7 +114,7 @@ def test_summarize_history_provided():
             return_value=([], False),
         ) as token_handler:
             summary2 = summarizer.create_response(question, rag_index)
-            token_handler.assert_called_once_with([], ANY, ANY)
+            token_handler.assert_called_once_with([], ANY)
             check_summary_result(summary2, question)
 
 

--- a/tests/unit/tools/test_oc_cli.py
+++ b/tests/unit/tools/test_oc_cli.py
@@ -10,14 +10,15 @@ from ols.src.tools.oc_cli import sanitize_oc_args, stdout_or_stderr, token_works
 @pytest.mark.parametrize(
     "input_args, expected_output",
     [
-        (["get", "pods"], ["get", "pods"]),
-        (["get", "pods; rm -rf /"], ["get", "pods"]),
-        (["get", "pods & rm -rf /"], ["get", "pods"]),
-        (["get", "pods | cat /etc/passwd"], ["get", "pods"]),
-        (["get", "pods `ls`"], ["get", "pods"]),
-        (["get", "pods $(rm -rf /)"], ["get", "pods"]),
-        (["get", "pods \\& whoami"], ["get", "pods"]),
-        (["get", "pods; rm -rf / & echo hacked | cat /etc/passwd"], ["get", "pods"]),
+        (["get", "pods"], ["pods"]),
+        (["oc", "adm", "top", "pods", "-A"], ["pods", "-A"]),
+        (["get", "pods; rm -rf /"], ["pods"]),
+        (["get", "pods & rm -rf /"], ["pods"]),
+        (["get", "pods | cat /etc/passwd"], ["pods"]),
+        (["get", "pods `ls`"], ["pods"]),
+        (["get", "pods $(rm -rf /)"], ["pods"]),
+        (["get", "pods \\& whoami"], ["pods"]),
+        (["get", "pods; rm -rf / & echo hacked | cat /etc/passwd"], ["pods"]),
     ],
 )
 def test_sanitize_oc_args(input_args, expected_output):


### PR DESCRIPTION
## Description

- Different prompt for Granite tool call.
- Removed unnecessary new-lines during prompt generation
- Removed special tag (granite-2 specific) addition to the prompt. (This will be taken care by the packages)
- Tool doc string modification to make it easier for granite.
- Temporarily added processing of tool arguments to handle scenarios where granite gives additional args.
- Use latest granite model for tool calling
- Simplified token calculation.

Note: Initially the plan was to add special tags/processing for granite. But it is not required now.
[OLS-1497](https://issues.redhat.com//browse/OLS-1497)