### PR TITLE
OLS-1519: Removed all remained @patch decorators from unit tests

### DIFF
--- a/tests/unit/llms/providers/test_azure_openai.py
+++ b/tests/unit/llms/providers/test_azure_openai.py
@@ -431,33 +431,34 @@ class MockedCredentialThrowingException:
         raise Exception("Error getting token")
 
 
-@patch(
-    "ols.src.llms.providers.azure_openai.ClientSecretCredential", new=MockedCredential
-)
 def test_retrieve_access_token(provider_config_access_token_related_parameters):
     """Test that access token is being retrieved."""
-    azure_openai = AzureOpenAI(
-        model="uber-model",
-        params={},
-        provider_config=provider_config_access_token_related_parameters,
-    )
-    assert "api_key" not in azure_openai.default_params
-    assert (
-        azure_openai.default_params["azure_ad_token"]
-        == "this-is-access-token"  # noqa: S105
-    )
+    with patch(
+        "ols.src.llms.providers.azure_openai.ClientSecretCredential",
+        new=MockedCredential,
+    ):
+        azure_openai = AzureOpenAI(
+            model="uber-model",
+            params={},
+            provider_config=provider_config_access_token_related_parameters,
+        )
+        assert "api_key" not in azure_openai.default_params
+        assert (
+            azure_openai.default_params["azure_ad_token"]
+            == "this-is-access-token"  # noqa: S105
+        )
 
 
-@patch(
-    "ols.src.llms.providers.azure_openai.ClientSecretCredential",
-    new=MockedCredentialThrowingException,
-)
 def test_retrieve_access_token_on_error(
     provider_config_access_token_related_parameters,
 ):
     """Test how error is handled during accessing token."""
-    with patch(
-        "ols.src.llms.providers.azure_openai.TOKEN_CACHE.is_expired", return_value=True
+    with (
+        patch(
+            "ols.src.llms.providers.azure_openai.ClientSecretCredential",
+            new=MockedCredentialThrowingException,
+        ),
+        patch("ols.src.llms.providers.azure_openai.TokenCache.expires_on", new=0),
     ):
         azure_openai = AzureOpenAI(
             model="uber-model",

--- a/tests/unit/llms/providers/test_watsonx.py
+++ b/tests/unit/llms/providers/test_watsonx.py
@@ -99,16 +99,17 @@ def provider_config_with_specific_params():
     )
 
 
-@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_basic_interface(provider_config):
     """Test basic interface."""
-    watsonx = Watsonx(model="uber-model", params={}, provider_config=provider_config)
-    llm = watsonx.load()
-    assert isinstance(llm, ChatWatsonx)
-    assert watsonx.default_params
+    with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
+        watsonx = Watsonx(
+            model="uber-model", params={}, provider_config=provider_config
+        )
+        llm = watsonx.load()
+        assert isinstance(llm, ChatWatsonx)
+        assert watsonx.default_params
 
 
-@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_params_handling(provider_config):
     """Test that not allowed parameters are removed before model init."""
     # first two parameters should be removed before model init
@@ -121,69 +122,69 @@ def test_params_handling(provider_config):
         "temperature": 0.3,
     }
 
-    watsonx = Watsonx(
-        model="uber-model", params=params, provider_config=provider_config
-    )
-    llm = watsonx.load()
-    assert isinstance(llm, ChatWatsonx)
-    assert watsonx.default_params
-    assert watsonx.params
+    with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
+        watsonx = Watsonx(
+            model="uber-model", params=params, provider_config=provider_config
+        )
+        llm = watsonx.load()
+        assert isinstance(llm, ChatWatsonx)
+        assert watsonx.default_params
+        assert watsonx.params
 
-    # taken from configuration
-    assert watsonx.url == "https://us-south.ml.cloud.ibm.com"
-    assert watsonx.credentials == "secret_key"
-    assert watsonx.project_id == "01234567-89ab-cdef-0123-456789abcdef"
+        # taken from configuration
+        assert watsonx.url == "https://us-south.ml.cloud.ibm.com"
+        assert watsonx.credentials == "secret_key"
+        assert watsonx.project_id == "01234567-89ab-cdef-0123-456789abcdef"
 
-    # known parameters should be there
-    assert GenParams.DECODING_METHOD in watsonx.params
-    assert watsonx.params[GenParams.DECODING_METHOD] == "sample"
+        # known parameters should be there
+        assert GenParams.DECODING_METHOD in watsonx.params
+        assert watsonx.params[GenParams.DECODING_METHOD] == "sample"
 
-    assert GenParams.MAX_NEW_TOKENS in watsonx.params
-    assert watsonx.params[GenParams.MAX_NEW_TOKENS] == 10
+        assert GenParams.MAX_NEW_TOKENS in watsonx.params
+        assert watsonx.params[GenParams.MAX_NEW_TOKENS] == 10
 
-    # unknown parameters should be filtered out
-    assert "unknown_parameter" not in watsonx.params
-    assert "verbose" not in watsonx.params
+        # unknown parameters should be filtered out
+        assert "unknown_parameter" not in watsonx.params
+        assert "verbose" not in watsonx.params
 
 
-@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_credentials_key_in_directory_handling(provider_config_credentials_directory):
     """Test that credentials in directory is handled as expected."""
     params = {}
 
-    watsonx = Watsonx(
-        model="uber-model",
-        params=params,
-        provider_config=provider_config_credentials_directory,
-    )
-    llm = watsonx.load()
-    assert isinstance(llm, ChatWatsonx)
+    with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
+        watsonx = Watsonx(
+            model="uber-model",
+            params=params,
+            provider_config=provider_config_credentials_directory,
+        )
+        llm = watsonx.load()
+        assert isinstance(llm, ChatWatsonx)
 
-    # taken from configuration
-    assert watsonx.credentials == "secret_key"
+        # taken from configuration
+        assert watsonx.credentials == "secret_key"
 
 
-@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_params_handling_specific_params(provider_config_with_specific_params):
     """Test that provider-specific parameters take precedence."""
-    watsonx = Watsonx(
-        model="uber-model",
-        params={},
-        provider_config=provider_config_with_specific_params,
-    )
-    llm = watsonx.load()
-    assert isinstance(llm, ChatWatsonx)
-    assert watsonx.default_params
-    assert watsonx.params
+    with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
+        watsonx = Watsonx(
+            model="uber-model",
+            params={},
+            provider_config=provider_config_with_specific_params,
+        )
+        llm = watsonx.load()
+        assert isinstance(llm, ChatWatsonx)
+        assert watsonx.default_params
+        assert watsonx.params
 
-    # parameters taken from provier-specific configuration
-    # which takes precedence over regular configuration
-    assert watsonx.url == "http://bam.com/"
-    assert watsonx.credentials == "secret_key_2"
-    assert watsonx.project_id == "ffffffff-89ab-cdef-0123-456789abcdef"
+        # parameters taken from provier-specific configuration
+        # which takes precedence over regular configuration
+        assert watsonx.url == "http://bam.com/"
+        assert watsonx.credentials == "secret_key_2"
+        assert watsonx.project_id == "ffffffff-89ab-cdef-0123-456789abcdef"
 
 
-@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_params_handling_none_values(provider_config):
     """Test handling parameters with None values."""
     # first three parameters should be removed before model init
@@ -196,54 +197,56 @@ def test_params_handling_none_values(provider_config):
         "max_new_tokens": None,
     }
 
-    watsonx = Watsonx(
-        model="uber-model", params=params, provider_config=provider_config
-    )
-    llm = watsonx.load()
-    assert isinstance(llm, ChatWatsonx)
-    assert watsonx.default_params
-    assert watsonx.params
+    with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
+        watsonx = Watsonx(
+            model="uber-model", params=params, provider_config=provider_config
+        )
+        llm = watsonx.load()
+        assert isinstance(llm, ChatWatsonx)
+        assert watsonx.default_params
+        assert watsonx.params
 
-    # known parameters should be there
-    assert GenParams.MIN_NEW_TOKENS in watsonx.params
-    assert watsonx.params[GenParams.MIN_NEW_TOKENS] is None
+        # known parameters should be there
+        assert GenParams.MIN_NEW_TOKENS in watsonx.params
+        assert watsonx.params[GenParams.MIN_NEW_TOKENS] is None
 
-    assert GenParams.MAX_NEW_TOKENS in watsonx.params
-    assert watsonx.params[GenParams.MAX_NEW_TOKENS] is None
+        assert GenParams.MAX_NEW_TOKENS in watsonx.params
+        assert watsonx.params[GenParams.MAX_NEW_TOKENS] is None
 
-    assert GenParams.TEMPERATURE in watsonx.params
-    assert watsonx.params[GenParams.TEMPERATURE] is None
+        assert GenParams.TEMPERATURE in watsonx.params
+        assert watsonx.params[GenParams.TEMPERATURE] is None
 
-    # unknown parameters should be filtered out
-    assert "unknown_parameter" not in watsonx.params
-    assert "verbose" not in watsonx.params
+        # unknown parameters should be filtered out
+        assert "unknown_parameter" not in watsonx.params
+        assert "verbose" not in watsonx.params
 
 
-@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_params_replace_default_values_with_none(provider_config):
     """Test if default values are replaced by None values."""
-    # provider initialization with empty set of params
-    watsonx = Watsonx(model="uber-model", params={}, provider_config=provider_config)
-    watsonx.load()
+    with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
+        # provider initialization with empty set of params
+        watsonx = Watsonx(
+            model="uber-model", params={}, provider_config=provider_config
+        )
+        watsonx.load()
 
-    # check default value
-    assert GenParams.DECODING_METHOD in watsonx.params
-    assert watsonx.params[GenParams.DECODING_METHOD] == "sample"
+        # check default value
+        assert GenParams.DECODING_METHOD in watsonx.params
+        assert watsonx.params[GenParams.DECODING_METHOD] == "sample"
 
-    # provider initialization where default parameter is overriden
-    params = {"decoding_method": None}
+        # provider initialization where default parameter is overriden
+        params = {"decoding_method": None}
 
-    watsonx = Watsonx(
-        model="uber-model", params=params, provider_config=provider_config
-    )
-    watsonx.load()
+        watsonx = Watsonx(
+            model="uber-model", params=params, provider_config=provider_config
+        )
+        watsonx.load()
 
-    # check default value overrided by None
-    assert GenParams.DECODING_METHOD in watsonx.params
-    assert watsonx.params[GenParams.DECODING_METHOD] is None
+        # check default value overrided by None
+        assert GenParams.DECODING_METHOD in watsonx.params
+        assert watsonx.params[GenParams.DECODING_METHOD] is None
 
 
-@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_generic_parameter_mappings(provider_config):
     """Test generic parameter mapping to provider parameter list."""
     # some non-default values for generic LLM parameters
@@ -255,25 +258,28 @@ def test_generic_parameter_mappings(provider_config):
         GenericLLMParameters.TEMPERATURE: 42.0,
     }
 
-    watsonx = Watsonx(
-        model="uber-model", params=generic_llm_params, provider_config=provider_config
-    )
-    llm = watsonx.load()
-    assert isinstance(llm, ChatWatsonx)
-    assert watsonx.default_params
-    assert watsonx.params
+    with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
+        watsonx = Watsonx(
+            model="uber-model",
+            params=generic_llm_params,
+            provider_config=provider_config,
+        )
+        llm = watsonx.load()
+        assert isinstance(llm, ChatWatsonx)
+        assert watsonx.default_params
+        assert watsonx.params
 
-    # generic parameters should be remapped to Watsonx-specific parameters
-    assert GenParams.MIN_NEW_TOKENS in watsonx.params
-    assert GenParams.MAX_NEW_TOKENS in watsonx.params
-    assert GenParams.TOP_K in watsonx.params
-    assert GenParams.TOP_P in watsonx.params
-    assert GenParams.TEMPERATURE in watsonx.params
-    assert watsonx.params[GenParams.MIN_NEW_TOKENS] == 100
-    assert watsonx.params[GenParams.MAX_NEW_TOKENS] == 200
-    assert watsonx.params[GenParams.TOP_K] == 10
-    assert watsonx.params[GenParams.TOP_P] == 1.5
-    assert watsonx.params[GenParams.TEMPERATURE] == 42.0
+        # generic parameters should be remapped to Watsonx-specific parameters
+        assert GenParams.MIN_NEW_TOKENS in watsonx.params
+        assert GenParams.MAX_NEW_TOKENS in watsonx.params
+        assert GenParams.TOP_K in watsonx.params
+        assert GenParams.TOP_P in watsonx.params
+        assert GenParams.TEMPERATURE in watsonx.params
+        assert watsonx.params[GenParams.MIN_NEW_TOKENS] == 100
+        assert watsonx.params[GenParams.MAX_NEW_TOKENS] == 200
+        assert watsonx.params[GenParams.TOP_K] == 10
+        assert watsonx.params[GenParams.TOP_P] == 1.5
+        assert watsonx.params[GenParams.TEMPERATURE] == 42.0
 
 
 def test_missing_credentials_check(provider_config_without_credentials):

--- a/tests/unit/llms/test_llm_loader.py
+++ b/tests/unit/llms/test_llm_loader.py
@@ -58,7 +58,6 @@ def test_model_config_missing_error():
         load_llm(provider="bam", model="bla")
 
 
-@patch("ols.src.llms.llm_loader.LLMProvidersRegistry", new=MagicMock())
 def test_unsupported_provider_error():
     """Test raise when provider is not in the registry (not implemented)."""
     providers = LLMProviders(
@@ -66,27 +65,30 @@ def test_unsupported_provider_error():
     )
     config.config.llm_providers = providers
 
-    with pytest.raises(UnsupportedProviderError):
+    with (
+        patch("ols.src.llms.llm_loader.LLMProvidersRegistry", new=MagicMock()),
+        pytest.raises(UnsupportedProviderError),
+    ):
         load_llm(provider="some-provider", model="model")
 
 
 @pytest.mark.usefixtures("_registered_fake_provider")
-@patch("ols.constants.SUPPORTED_PROVIDER_TYPES", new=["fake-provider"])
 def test_load_llm():
     """Test load_llm function."""
-    providers = LLMProviders(
-        [
-            {
-                "name": "fake-provider",
-                "type": "fake-provider",
-                "models": [{"name": "model"}],
-            }
-        ]
-    )
-    config.config.llm_providers = providers
+    with patch("ols.constants.SUPPORTED_PROVIDER_TYPES", new=["fake-provider"]):
+        providers = LLMProviders(
+            [
+                {
+                    "name": "fake-provider",
+                    "type": "fake-provider",
+                    "models": [{"name": "model"}],
+                }
+            ]
+        )
+        config.config.llm_providers = providers
 
-    llm = load_llm(provider="fake-provider", model="model")
-    assert llm == "fake_llm"
+        llm = load_llm(provider="fake-provider", model="model")
+        assert llm == "fake_llm"
 
 
 def test_load_llm_no_provider_config():

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -693,11 +693,11 @@ dev_config:
     )
 
 
-@patch("os.access", return_value=False)
-def test_unreadable_directory(mock_access):
+def test_unreadable_directory():
     """Check if an unredable directory is reported correctly."""
-    check_expected_exception(
-        """
+    with patch("os.access", return_value=False):
+        check_expected_exception(
+            """
 ---
 llm_providers:
   - name: p1
@@ -720,9 +720,9 @@ dev_config:
   disable_tls: true
 
 """,
-        InvalidConfigurationError,
-        "Embeddings model path 'tests/config' is not readable",
-    )
+            InvalidConfigurationError,
+            "Embeddings model path 'tests/config' is not readable",
+        )
 
 
 def test_valid_config_stream():

--- a/tests/unit/utils/test_environments.py
+++ b/tests/unit/utils/test_environments.py
@@ -7,53 +7,53 @@ from ols.app.models.config import OLSConfig, ReferenceContent
 from ols.utils.environments import configure_gradio_ui_envs, configure_hugging_face_envs
 
 
-@patch.dict(os.environ, {"GRADIO_ANALYTICS_ENABLED": "", "MPLCONFIGDIR": ""})
 def test_configure_gradio_ui_envs():
     """Test the function configure_gradio_ui_envs."""
-    # setup before tested function is called
-    assert os.environ.get("GRADIO_ANALYTICS_ENABLED", None) == ""
-    assert os.environ.get("MPLCONFIGDIR", None) == ""
+    with patch.dict(os.environ, {"GRADIO_ANALYTICS_ENABLED": "", "MPLCONFIGDIR": ""}):
+        # setup before tested function is called
+        assert os.environ.get("GRADIO_ANALYTICS_ENABLED", None) == ""
+        assert os.environ.get("MPLCONFIGDIR", None) == ""
 
-    # call the tested function
-    configure_gradio_ui_envs()
+        # call the tested function
+        configure_gradio_ui_envs()
 
-    # expected environment variables
-    assert os.environ.get("GRADIO_ANALYTICS_ENABLED", None) == "false"
-    assert os.environ.get("MPLCONFIGDIR", None) != ""
+        # expected environment variables
+        assert os.environ.get("GRADIO_ANALYTICS_ENABLED", None) == "false"
+        assert os.environ.get("MPLCONFIGDIR", None) != ""
 
 
-@patch.dict(os.environ, {"TRANSFORMERS_CACHE": "", "TRANSFORMERS_OFFLINE": ""})
 def test_configure_hugging_face_env_no_reference_content_set():
     """Test the function configure_hugging_face_envs."""
-    # setup before tested function is called
-    assert os.environ.get("TRANSFORMERS_CACHE", None) == ""
-    assert os.environ.get("TRANSFORMERS_OFFLINE", None) == ""
+    with patch.dict(os.environ, {"TRANSFORMERS_CACHE": "", "TRANSFORMERS_OFFLINE": ""}):
+        # setup before tested function is called
+        assert os.environ.get("TRANSFORMERS_CACHE", None) == ""
+        assert os.environ.get("TRANSFORMERS_OFFLINE", None) == ""
 
-    ols_config = OLSConfig()
-    ols_config.reference_content = None
+        ols_config = OLSConfig()
+        ols_config.reference_content = None
 
-    # call the tested function
-    configure_hugging_face_envs(ols_config)
+        # call the tested function
+        configure_hugging_face_envs(ols_config)
 
-    # expected environment variables
-    assert os.environ.get("TRANSFORMERS_CACHE", None) == ""
-    assert os.environ.get("TRANSFORMERS_OFFLINE", None) == ""
+        # expected environment variables
+        assert os.environ.get("TRANSFORMERS_CACHE", None) == ""
+        assert os.environ.get("TRANSFORMERS_OFFLINE", None) == ""
 
 
-@patch.dict(os.environ, {"TRANSFORMERS_CACHE": "", "TRANSFORMERS_OFFLINE": ""})
 def test_configure_hugging_face_env_reference_content_set():
     """Test the function configure_hugging_face_envs."""
-    # setup before tested function is called
-    assert os.environ.get("TRANSFORMERS_CACHE", None) == ""
-    assert os.environ.get("TRANSFORMERS_OFFLINE", None) == ""
+    with patch.dict(os.environ, {"TRANSFORMERS_CACHE": "", "TRANSFORMERS_OFFLINE": ""}):
+        # setup before tested function is called
+        assert os.environ.get("TRANSFORMERS_CACHE", None) == ""
+        assert os.environ.get("TRANSFORMERS_OFFLINE", None) == ""
 
-    ols_config = OLSConfig()
-    ols_config.reference_content = ReferenceContent()
-    ols_config.reference_content.embeddings_model_path = "foo"
+        ols_config = OLSConfig()
+        ols_config.reference_content = ReferenceContent()
+        ols_config.reference_content.embeddings_model_path = "foo"
 
-    # call the tested function
-    configure_hugging_face_envs(ols_config)
+        # call the tested function
+        configure_hugging_face_envs(ols_config)
 
-    # expected environment variables
-    assert os.environ.get("TRANSFORMERS_CACHE", None) == "foo"
-    assert os.environ.get("TRANSFORMERS_OFFLINE", None) == "1"
+        # expected environment variables
+        assert os.environ.get("TRANSFORMERS_CACHE", None) == "foo"
+        assert os.environ.get("TRANSFORMERS_OFFLINE", None) == "1"


### PR DESCRIPTION
## Description

[OLS-1519](https://issues.redhat.com//browse/OLS-1519): Removed all remained `@patch` decorators from unit tests

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests

## Related Tickets & Documents

- Related Issue #[OLS-1519](https://issues.redhat.com//browse/OLS-1519)
