### PR TITLE
change tool calling query

### DIFF
--- a/tests/e2e/test_query_endpoint.py
+++ b/tests/e2e/test_query_endpoint.py
@@ -593,7 +593,7 @@ def test_tool_calling() -> None:
             QUERY_ENDPOINT,
             json={
                 "conversation_id": cid,
-                "query": "Show me pods in openshift-lightspeed namespace?",
+                "query": "show me pods in openshift-lightspeed namespace",
             },
             timeout=test_api.LLM_REST_API_TIMEOUT,
         )


### PR DESCRIPTION
## Description
OpenAI tool calling test case started failing.
Surprisingly it works if we remove the `?` in query. GPT is not supposed to be so fragile though.
Perhaps there is a better solution, but for time being it fixes the issue.