### PR TITLE
add http_async_client for async invocations

### DIFF
--- a/ols/src/llms/providers/azure_openai.py
+++ b/ols/src/llms/providers/azure_openai.py
@@ -76,7 +76,8 @@ class AzureOpenAI(LLMProvider):
             "temperature": 0.01,
             "max_tokens": 512,
             "verbose": False,
-            "http_client": self._construct_httpx_client(False),
+            "http_client": self._construct_httpx_client(False, False),
+            "http_async_client": self._construct_httpx_client(False, True),
         }
 
         if self.credentials is not None:

--- a/ols/src/llms/providers/openai.py
+++ b/ols/src/llms/providers/openai.py
@@ -43,7 +43,8 @@ class OpenAI(LLMProvider):
             "temperature": 0.01,
             "max_tokens": 512,
             "verbose": False,
-            "http_client": self._construct_httpx_client(False),
+            "http_client": self._construct_httpx_client(False, False),
+            "http_async_client": self._construct_httpx_client(False, True),
         }
 
     def load(self) -> LLM:

--- a/ols/src/llms/providers/rhelai_vllm.py
+++ b/ols/src/llms/providers/rhelai_vllm.py
@@ -44,7 +44,8 @@ class RHELAIVLLM(LLMProvider):
             "temperature": 0.01,
             "max_tokens": 512,
             "verbose": False,
-            "http_client": self._construct_httpx_client(True),
+            "http_client": self._construct_httpx_client(True, False),
+            "http_async_client": self._construct_httpx_client(True, True),
         }
 
     def load(self) -> LLM:

--- a/ols/src/llms/providers/rhoai_vllm.py
+++ b/ols/src/llms/providers/rhoai_vllm.py
@@ -44,7 +44,8 @@ class RHOAIVLLM(LLMProvider):
             "temperature": 0.01,
             "max_tokens": 512,
             "verbose": False,
-            "http_client": self._construct_httpx_client(True),
+            "http_client": self._construct_httpx_client(True, False),
+            "http_async_client": self._construct_httpx_client(True, True),
         }
 
     def load(self) -> LLM:

--- a/tests/unit/llms/providers/test_openai.py
+++ b/tests/unit/llms/providers/test_openai.py
@@ -85,6 +85,8 @@ def test_basic_interface(provider_config):
     # check the HTTP client parameter
     assert "http_client" in openai.default_params
     assert openai.default_params["http_client"] is not None
+    assert "http_async_client" in openai.default_params
+    assert openai.default_params["http_async_client"] is not None
 
     client = openai.default_params["http_client"]
     assert isinstance(client, httpx.Client)

--- a/tests/unit/llms/providers/test_providers.py
+++ b/tests/unit/llms/providers/test_providers.py
@@ -147,5 +147,5 @@ def test_construct_httpx_client():
         }
     )
     llm_provider = MyProvider("model", provider_config)
-    client = llm_provider._construct_httpx_client(False)
+    client = llm_provider._construct_httpx_client(False, False)
     assert client is not None

--- a/tests/unit/llms/providers/test_rhelai_vllm.py
+++ b/tests/unit/llms/providers/test_rhelai_vllm.py
@@ -104,9 +104,13 @@ def test_basic_interface(provider_config, fake_certifi_store):
     # check the HTTP client parameter
     assert "http_client" in rhelai_vllm.default_params
     assert rhelai_vllm.default_params["http_client"] is not None
+    assert "http_async_client" in rhelai_vllm.default_params
+    assert rhelai_vllm.default_params["http_async_client"] is not None
 
     client = rhelai_vllm.default_params["http_client"]
     assert isinstance(client, httpx.Client)
+    client = rhelai_vllm.default_params["http_async_client"]
+    assert isinstance(client, httpx.AsyncClient)
 
 
 def test_params_handling(provider_config, fake_certifi_store):
@@ -150,6 +154,8 @@ def test_params_handling(provider_config, fake_certifi_store):
     assert rhelai_vllm.default_params["base_url"] == "test_url"
     assert "http_client" in rhelai_vllm.default_params
     assert rhelai_vllm.default_params["http_client"] is not None
+    assert "http_async_client" in rhelai_vllm.default_params
+    assert rhelai_vllm.default_params["http_async_client"] is not None
 
 
 def test_credentials_key_in_directory_handling(

--- a/tests/unit/llms/providers/test_rhoai_vllm.py
+++ b/tests/unit/llms/providers/test_rhoai_vllm.py
@@ -104,9 +104,13 @@ def test_basic_interface(provider_config, fake_certifi_store):
     # check the HTTP client parameter
     assert "http_client" in rhoai_vllm.default_params
     assert rhoai_vllm.default_params["http_client"] is not None
+    assert "http_async_client" in rhoai_vllm.default_params
+    assert rhoai_vllm.default_params["http_async_client"] is not None
 
     client = rhoai_vllm.default_params["http_client"]
     assert isinstance(client, httpx.Client)
+    client = rhoai_vllm.default_params["http_async_client"]
+    assert isinstance(client, httpx.AsyncClient)
 
 
 def test_params_handling(provider_config, fake_certifi_store):
@@ -150,6 +154,8 @@ def test_params_handling(provider_config, fake_certifi_store):
     assert rhoai_vllm.default_params["base_url"] == "test_url"
     assert "http_client" in rhoai_vllm.default_params
     assert rhoai_vllm.default_params["http_client"] is not None
+    assert "http_async_client" in rhoai_vllm.default_params
+    assert rhoai_vllm.default_params["http_async_client"] is not None
 
 
 def test_credentials_key_in_directory_handling(


### PR DESCRIPTION
## Description

Streaming endpoints use non-blocking astream API to connect to model providers . FIx adds the custom trust store to ssl_context and adds http_async_client parameter per https://python.langchain.com/api_reference/openai/chat_models/langchain_openai.chat_models.base.BaseChatOpenAI.html

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue [#](https://issues.redhat.com/browse/OLS-1527)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
