### PR TITLE
Remove check if token works for oc tools

### DIFF
--- a/ols/src/tools/oc_cli.py
+++ b/ols/src/tools/oc_cli.py
@@ -66,28 +66,6 @@ def run_oc(args: list[str]) -> subprocess.CompletedProcess:
     return res
 
 
-def token_works_for_oc(token: str) -> bool:
-    """Check if the token can be used with `oc` CLI.
-
-    Args:
-        token: OpenShift user token.
-
-    Returns:
-        True if user token works, False otherwise.
-    """
-    try:
-        run_oc(["version", f"--token={token}"])
-        logger.info("Token is usable for oc CLI")
-        return True
-    except subprocess.CalledProcessError as e:
-        logger.error(
-            "Unable to use the token for oc CLI; stdout: %s, stderr: %s",
-            e.stdout,
-            e.stderr,
-        )
-        return False
-
-
 @tool
 def oc_get(oc_get_args: list[str], token: Annotated[str, InjectedToolArg]) -> str:
     """Display one or many resources from OpenShift cluster.

--- a/ols/src/tools/tools.py
+++ b/ols/src/tools/tools.py
@@ -14,7 +14,6 @@ from ols.src.tools.oc_cli import (
     oc_logs,
     oc_status,
     show_pods,
-    token_works_for_oc,
 )
 
 logger = logging.getLogger(__name__)
@@ -42,12 +41,8 @@ def get_available_tools(
         logger.warning("No user token provided; no oc tools available")
         return {}
 
-    if token_works_for_oc(user_token):
-        logger.info("Authenticated to 'oc' CLI; adding 'oc' tools")
-        return oc_tools
-
-    logger.error("User token not working for 'oc' CLI; no tools available")
-    return {}
+    logger.info("User token provided; adding 'oc' tools")
+    return oc_tools
 
 
 def check_tool_description_length(tool: BaseTool) -> None:

--- a/tests/unit/tools/test_oc_cli.py
+++ b/tests/unit/tools/test_oc_cli.py
@@ -1,11 +1,8 @@
 """Test cases for the oc_cli module."""
 
-import subprocess
-from unittest.mock import patch
-
 import pytest
 
-from ols.src.tools.oc_cli import sanitize_oc_args, token_works_for_oc
+from ols.src.tools.oc_cli import sanitize_oc_args
 
 
 @pytest.mark.parametrize(
@@ -25,21 +22,3 @@ from ols.src.tools.oc_cli import sanitize_oc_args, token_works_for_oc
 def test_sanitize_oc_args(input_args, expected_output):
     """Test that oc args are sanitized."""
     assert sanitize_oc_args(input_args) == expected_output
-
-
-def test_token_works_for_oc_failure():
-    """Test token_works_for_oc failure scenario."""
-    with patch(
-        "ols.src.tools.oc_cli.run_oc",
-        side_effect=subprocess.CalledProcessError(1, "oc"),
-    ):
-        assert not token_works_for_oc("some-token")
-
-
-def test_token_works_for_oc_success():
-    """Test token_works_for_oc success scenario."""
-    with patch(
-        "ols.src.tools.oc_cli.run_oc",
-        returns_value=subprocess.CompletedProcess("oc", 0),
-    ):
-        assert token_works_for_oc("some-token")

--- a/tests/unit/tools/test_tools.py
+++ b/tests/unit/tools/test_tools.py
@@ -1,7 +1,5 @@
 """Unit tests for tools module."""
 
-from unittest.mock import patch
-
 import pytest
 from langchain.tools import tool
 from langchain_core.messages import ToolMessage
@@ -119,20 +117,7 @@ def test_get_available_tools():
     tools = get_available_tools(introspection_enabled=True, user_token="")
     assert tools == {}
 
-    with patch(
-        "ols.src.tools.tools.token_works_for_oc",
-        return_value=False,
-    ):
-        tools = get_available_tools(
-            introspection_enabled=True, user_token="bla"  # noqa: S106
-        )
-        assert tools == {}
-
-    with patch(
-        "ols.src.tools.tools.token_works_for_oc",
-        return_value=True,
-    ):
-        tools = get_available_tools(
-            introspection_enabled=True, user_token="bla"  # noqa: S106
-        )
-        assert tools == oc_tools
+    tools = get_available_tools(
+        introspection_enabled=True, user_token="token-value"  # noqa: S106
+    )
+    assert tools == oc_tools


### PR DESCRIPTION
## Description

Remove check if token works for oc tools. We don't need that. If the token is provided, we add the tools and do not try to check if the token is correct. If the token is invalid, it will fail in tool - that is valid.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
