### PR TITLE
Refactor mcp server config

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -17,7 +17,6 @@ from pydantic import (
 
 from ols import constants
 from ols.utils import checks, tls
-from ols.utils.checks import InvalidConfigurationError
 
 
 class ModelParameters(BaseModel):
@@ -511,157 +510,65 @@ class LLMProviders(BaseModel):
 class StdioTransportConfig(BaseModel):
     """Stdio transport configuration for MCP server."""
 
-    command: Optional[str] = None
-    args: Optional[str] = None
-    env: Optional[dict[str, str | int]] = None
-    cwd: Optional[str] = None
-    encoding: Optional[str] = None
-
-    def __init__(self, data: Optional[dict] = None) -> None:
-        """Initialize configuration and perform basic validation."""
-        super().__init__()
-        if data is None:
-            raise InvalidConfigurationError("stdio transport configuration is missing")
-        if "command" not in data:
-            raise InvalidConfigurationError(
-                "command needs to be specified for STDIO transport"
-            )
-        self.command = data.get("command", "")
-        self.args = data.get("args", "")
-        self.env = data.get("env", constants.STDIO_TRANSPORT_DEFAULT_ENV)
-        self.cwd = data.get("cwd", constants.STDIO_TRANSPORT_DEFAULT_CWD)
-        self.encoding = data.get("encoding", constants.STDIO_TRANSPORT_DEFAULT_ENCODING)
-
-    def validate_yaml(self) -> None:
-        """Validate STDIO transport config."""
+    command: str
+    args: list[str] = []
+    env: dict[str, str | int] = constants.STDIO_TRANSPORT_DEFAULT_ENV
+    cwd: str = constants.STDIO_TRANSPORT_DEFAULT_CWD
+    encoding: str = constants.STDIO_TRANSPORT_DEFAULT_ENCODING
 
 
 class SseTransportConfig(BaseModel):
     """SSE transport configuration for MCP server."""
 
-    url: Optional[str] = None
-    timeout: Optional[int] = None
-    sse_read_timeout: Optional[int] = None
-
-    def __init__(self, data: Optional[dict] = None) -> None:
-        """Initialize configuration and perform basic validation."""
-        super().__init__()
-        if data is None:
-            raise InvalidConfigurationError("SSE transport configuration is missing")
-        if "url" not in data:
-            raise InvalidConfigurationError(
-                "URL needs to be specified for SSE transport"
-            )
-        self.url = data.get("url", "")
-        self.timeout = data.get("timeout", constants.SSE_TRANSPORT_DEFAULT_TIMEOUT)
-        self.sse_read_timeout = data.get(
-            "sse_read_timeout", constants.SSE_TRANSPORT_DEFAULT_READ_TIMEOUT
-        )
-
-    def validate_yaml(self) -> None:
-        """Validate SSE transport config."""
+    url: str
+    timeout: int = constants.SSE_TRANSPORT_DEFAULT_TIMEOUT
+    sse_read_timeout: int = constants.SSE_TRANSPORT_DEFAULT_READ_TIMEOUT
 
 
 class MCPServerConfig(BaseModel):
     """MCP server configuration."""
 
-    name: Optional[str] = None
-    transport: Optional[str] = None
+    name: str
+    transport: Literal["sse", "stdio"]
     stdio: Optional[StdioTransportConfig] = None
     sse: Optional[SseTransportConfig] = None
 
-    def __init__(self, data: Optional[dict] = None) -> None:
-        """Initialize configuration and perform basic validation."""
-        super().__init__()
-        if data is None:
-            return
-        self.name = data.get("name", None)
-        self.transport = data.get("transport", None)
-        if self.transport is not None:
-            match self.transport:
-                case constants.MCP_TRANSPORT_STDIO:
-                    if constants.MCP_TRANSPORT_STDIO not in data:
-                        raise checks.InvalidConfigurationError(
-                            "STDIO transport type is specified,"
-                            " but STDIO configuration is missing"
-                        )
-                    self.stdio = StdioTransportConfig(
-                        data.get(constants.MCP_TRANSPORT_STDIO)
-                    )
-                case constants.MCP_TRANSPORT_SSE:
-                    if constants.MCP_TRANSPORT_SSE not in data:
-                        raise checks.InvalidConfigurationError(
-                            "SSE transport type is specified,"
-                            " but SSE configuration is missing"
-                        )
-                    self.sse = SseTransportConfig(data.get(constants.MCP_TRANSPORT_SSE))
-                case _:
-                    raise checks.InvalidConfigurationError(
-                        f"unknown MCP transport type specified: {self.transport}"
-                    )
-        else:
-            raise checks.InvalidConfigurationError(
-                "MCP transport type must be specified"
-            )
-
-    def __eq__(self, other: object) -> bool:
-        """Compare two objects for equality."""
-        if isinstance(other, MCPServerConfig):
-            return (
-                self.name == other.name
-                and self.transport == other.transport
-                and self.stdio == other.stdio
-                and self.sse == other.sse
-            )
-        return False
-
-    def validate_yaml(self) -> None:
-        """Validate MCP server config."""
-        if self.name is None:
-            raise checks.InvalidConfigurationError("MCP server name is missing")
-        if self.transport is None:
-            raise checks.InvalidConfigurationError("MCP transport type is missing")
-        # transport type is specified, we can decide which transport configuration to validate
-        match self.transport:
-            case constants.MCP_TRANSPORT_STDIO:
-                self.stdio.validate_yaml()
-            case constants.MCP_TRANSPORT_SSE:
-                self.sse.validate_yaml()
-            case _:
-                raise checks.InvalidConfigurationError(
-                    f"unknown transport type: {self.transport}"
+    @model_validator(mode="after")
+    def stdio_or_sse_specified(self) -> Self:
+        """Check if stdio or sse is specified."""
+        if self.transport == "stdio":
+            if self.stdio is None:
+                raise ValueError(
+                    "Stdio transport selected but 'stdio' config not provided"
                 )
+            if self.sse is not None:
+                raise ValueError(
+                    "Stdio transport selected but 'sse' config should not be provided"
+                )
+        elif self.transport == "sse":
+            if self.sse is None:
+                raise ValueError("SSE transport selected but 'sse' config not provided")
+            if self.stdio is not None:
+                raise ValueError(
+                    "SSE transport selected but 'stdio' config should not be provided"
+                )
+        return self
 
 
 class MCPServers(BaseModel):
     """MCP servers configuration."""
 
-    servers: dict[str, MCPServerConfig] = {}
+    servers: list[MCPServerConfig] = []
 
-    def __init__(
-        self,
-        data: Optional[dict] = None,
-    ) -> None:
-        """Initialize configuration and perform basic validation."""
-        super().__init__()
-        if data is None:
-            return
-        for server_cfg in data:
-            if "name" not in server_cfg:
-                raise checks.InvalidConfigurationError("MCP server name is missing")
-            server = MCPServerConfig(server_cfg)
-            self.servers[server_cfg["name"]] = server
-
-    def __eq__(self, other: object) -> bool:
-        """Compare two objects for equality."""
-        if isinstance(other, MCPServers):
-            return self.servers == other.servers
-        return False
-
-    def validate_yaml(self) -> None:
-        """Validate LLM config."""
-        for v in self.servers.values():
-            v.validate_yaml()
+    @model_validator(mode="after")
+    def check_duplicite_servers(self) -> Self:
+        """Check if there are duplicate servers."""
+        server_names = set()
+        for server in self.servers:
+            if server.name in server_names:
+                raise ValueError(f"Duplicate server name: '{server.name}'")
+            server_names.add(server.name)
+        return self
 
 
 class PostgresConfig(BaseModel):
@@ -1316,9 +1223,7 @@ class Config(BaseModel):
             )
 
         # initialize MCP servers
-        s = data.get("mcp_servers")
-        if s is not None:
-            self.mcp_servers = MCPServers(s)
+        self.mcp_servers = MCPServers(servers=data.get("mcp_servers", []))
 
         # Always initialize dev config, even if there's no config for it.
         self.dev_config = DevConfig(**data.get("dev_config", {}))

--- a/tests/config/config_for_integration_tests.yaml
+++ b/tests/config/config_for_integration_tests.yaml
@@ -123,7 +123,8 @@ mcp_servers:
     transport: stdio
     stdio:
       command: python
-      args: mcp_server_1.py
+      args:
+        - mcp_server_1.py
   - name: bar
     transport: sse
     sse:

--- a/tests/config/valid_config.yaml
+++ b/tests/config/valid_config.yaml
@@ -43,7 +43,8 @@ mcp_servers:
     transport: stdio
     stdio:
       command: python
-      args: mcp_server_1.py
+      args:
+        - mcp_server_1.py
   - name: bar
     transport: sse
     sse:

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -43,7 +43,7 @@ def mcp_server_config_stdio_transport():
     return {
         "name": "foo",
         "transport": "stdio",
-        "stdio": {"command": "python", "args": "server1.py"},
+        "stdio": {"command": "python", "args": ["server1.py"]},
     }
 
 
@@ -61,112 +61,83 @@ def test_mcp_server_config(
     mcp_server_config_stdio_transport, mcp_server_config_sse_transport
 ):
     """Test the MCPServerConfig model."""
-    mcp_server_config = MCPServerConfig(mcp_server_config_stdio_transport)
+    mcp_server_config = MCPServerConfig(**mcp_server_config_stdio_transport)
     assert mcp_server_config.name == "foo"
 
-    mcp_server_config = MCPServerConfig(mcp_server_config_sse_transport)
+    mcp_server_config = MCPServerConfig(**mcp_server_config_sse_transport)
     assert mcp_server_config.name == "bar"
 
 
-def test_mcp_server_config_missing_transport():
+def test_mcp_server_config_required_name():
+    """Test the MCPServerConfig model for missing name."""
+    with pytest.raises(
+        ValidationError,
+        match=r"(?s)name.*Field required",
+    ):
+        MCPServerConfig(
+            transport="stdio", stdio={"command": "python", "args": ["server.py"]}
+        )
+
+
+def test_mcp_server_config_transport():
     """Test the MCPServerConfig model for missing transport option."""
-    configuration_without_transport = {
-        "name": "bar",
-    }
     with pytest.raises(
-        InvalidConfigurationError,
-        match="MCP transport type must be specified",
+        ValidationError,
+        match=r"(?s)transport.*Field required",
     ):
-        MCPServerConfig(configuration_without_transport)
+        MCPServerConfig()
 
-
-def test_mcp_server_config_improper_transport():
-    """Test the MCPServerConfig model for improper transport option."""
-    configuration_with_improper_transport = {
-        "name": "bar",
-        "transport": "foo",
-    }
     with pytest.raises(
-        InvalidConfigurationError,
-        match="unknown MCP transport type specified: foo",
+        ValidationError,
+        match="Input should be",
     ):
-        MCPServerConfig(configuration_with_improper_transport)
+        MCPServerConfig(transport="unknown")
 
 
 def test_mcp_server_config_missing_options():
     """Test the MCPServerConfig model for missing options."""
-    configuration_without_stdio_config = {
-        "name": "bar",
-        "transport": "stdio",
-    }
+    stdio_conf = {"command": "python", "args": ["server.py"]}
+    sse_conf = {"url": "http://server:8080"}
     with pytest.raises(
-        InvalidConfigurationError,
-        match="STDIO transport type is specified, but STDIO configuration is missing",
+        ValidationError,
+        match="Stdio transport selected but 'stdio' config not provided",
     ):
-        MCPServerConfig(configuration_without_stdio_config)
+        MCPServerConfig(
+            name="foo",
+            transport="stdio",
+        )
 
-    configuration_without_sse_config = {
-        "name": "bar",
-        "transport": "sse",
-    }
     with pytest.raises(
-        InvalidConfigurationError,
-        match="SSE transport type is specified, but SSE configuration is missing",
+        ValidationError,
+        match="Stdio transport selected but 'sse' config should not be provided",
     ):
-        MCPServerConfig(configuration_without_sse_config)
+        MCPServerConfig(name="foo", transport="stdio", stdio=stdio_conf, sse=sse_conf)
 
-    configuration_without_stdio_config = {
-        "name": "bar",
-        "transport": "stdio",
-        "stdio": {},
-    }
     with pytest.raises(
-        InvalidConfigurationError,
-        match="command needs to be specified for STDIO transport",
+        ValidationError,
+        match="SSE transport selected but 'sse' config not provided",
     ):
-        MCPServerConfig(configuration_without_stdio_config)
+        MCPServerConfig(
+            name="foo",
+            transport="sse",
+        )
 
-    configuration_without_sse_config = {
-        "name": "bar",
-        "transport": "sse",
-        "sse": {},
-    }
     with pytest.raises(
-        InvalidConfigurationError,
-        match="URL needs to be specified for SSE transport",
+        ValidationError,
+        match="SSE transport selected but 'stdio' config should not be provided",
     ):
-        MCPServerConfig(configuration_without_sse_config)
-
-
-def test_mcp_server_config_validation(mcp_server_config_stdio_transport):
-    """Test the MCPServerConfig model."""
-    mcp_server_config = MCPServerConfig(mcp_server_config_stdio_transport)
-    mcp_server_config.validate_yaml()
-
-    mcp_server_config = MCPServerConfig()
-    with pytest.raises(InvalidConfigurationError, match="MCP server name is missing"):
-        mcp_server_config.validate_yaml()
-
-    mcp_server_config = MCPServerConfig(mcp_server_config_stdio_transport)
-    mcp_server_config.transport = None
-    with pytest.raises(InvalidConfigurationError, match="MCP transport type is missin"):
-        mcp_server_config.validate_yaml()
-
-    mcp_server_config = MCPServerConfig(mcp_server_config_stdio_transport)
-    mcp_server_config.transport = "foo"
-    with pytest.raises(InvalidConfigurationError, match="unknown transport type: foo"):
-        mcp_server_config.validate_yaml()
+        MCPServerConfig(name="foo", transport="sse", stdio=stdio_conf, sse=sse_conf)
 
 
 def test_mcp_server_config_equality(mcp_server_config_stdio_transport):
     """Test the MCPServerConfig model."""
-    mcp_server_config_1 = MCPServerConfig(mcp_server_config_stdio_transport)
-    mcp_server_config_2 = MCPServerConfig(mcp_server_config_stdio_transport)
+    mcp_server_config_1 = MCPServerConfig(**mcp_server_config_stdio_transport)
+    mcp_server_config_2 = MCPServerConfig(**mcp_server_config_stdio_transport)
     mcp_server_config_3 = MCPServerConfig(
-        {
-            "name": "other",
+        **{
+            "name": "some_other_name",
             "transport": "stdio",
-            "stdio": {"command": "python", "args": "server1.py"},
+            "stdio": {"command": "python", "args": ["server2.py"]},
         }
     )
 
@@ -186,27 +157,38 @@ def test_mcp_servers(
 ):
     """Test the MCPServers model."""
     mcp_servers = MCPServers()
-    assert mcp_servers.servers == {}
+    assert mcp_servers.servers == []
 
     mcp_servers = MCPServers(
-        [
+        servers=[
             mcp_server_config_stdio_transport,
             mcp_server_config_sse_transport,
         ]
     )
-    assert "foo" in mcp_servers.servers
-    assert "bar" in mcp_servers.servers
+    assert len(mcp_servers.servers) == 2
+    assert mcp_servers.servers[0].name == "foo"
+    assert mcp_servers.servers[1].name == "bar"
+
+
+def test_mcp_servers_duplicity():
+    """Test the MCPServers model."""
+    mcp_server_config = {
+        "name": "foo",
+        "transport": "stdio",
+        "stdio": {"command": "python", "args": ["server1.py"]},
+    }
+
+    with pytest.raises(ValidationError, match="Duplicate server name: 'foo'"):
+        MCPServers(servers=[mcp_server_config, mcp_server_config])
 
 
 def test_mcp_servers_invalid_input():
     """Test the MCPServers model."""
-    with pytest.raises(InvalidConfigurationError, match="MCP server name is missing"):
-        MCPServers(
-            [
-                {"noname": "foo"},
-                {"name": "bar"},
-            ]
-        )
+    with pytest.raises(ValidationError, match="Input should be a valid list"):
+        MCPServers(servers={"name": "foo"})
+
+    with pytest.raises(ValidationError, match="Input should be a valid list"):
+        MCPServers(servers={})
 
 
 def test_mcp_servers_equality(
@@ -214,20 +196,19 @@ def test_mcp_servers_equality(
 ):
     """Test the MCPServers model."""
     mcp_servers_1 = MCPServers(
-        [
+        servers=[
             mcp_server_config_stdio_transport,
             mcp_server_config_sse_transport,
         ]
     )
     mcp_servers_2 = MCPServers(
-        [
+        servers=[
             mcp_server_config_stdio_transport,
             mcp_server_config_sse_transport,
         ]
     )
     mcp_servers_3 = MCPServers(
-        [
-            mcp_server_config_stdio_transport,
+        servers=[
             mcp_server_config_stdio_transport,
         ]
     )
@@ -243,33 +224,36 @@ def test_mcp_servers_equality(
     assert mcp_servers_1 != other_value
 
 
-def test_mcp_servers_validation(
-    mcp_server_config_stdio_transport, mcp_server_config_sse_transport
-):
-    """Test the MCPServers model."""
-    mcp_servers_1 = MCPServers(
-        [
-            mcp_server_config_stdio_transport,
-            mcp_server_config_sse_transport,
-        ]
-    )
-    mcp_servers_1.validate_yaml()
-
-
 def test_sse_transport_configuration_on_no_data():
     """Test the SSE transport configuration handling when no data are provided."""
-    with pytest.raises(
-        InvalidConfigurationError, match="SSE transport configuration is missing"
-    ):
+    with pytest.raises(ValidationError, match=r"(?s)url.*Field required"):
         SseTransportConfig()
+
+
+def test_sse_transport_defaults():
+    """Test the SSE transport configuration defaults."""
+    sse_transport = SseTransportConfig(url="http://localhost:8080")
+    assert sse_transport.url == "http://localhost:8080"
+    assert sse_transport.timeout == constants.SSE_TRANSPORT_DEFAULT_TIMEOUT
+    assert (
+        sse_transport.sse_read_timeout == constants.SSE_TRANSPORT_DEFAULT_READ_TIMEOUT
+    )
 
 
 def test_stdio_transport_configuration_on_no_data():
     """Test the STDIO transport configuration handling when no data are provided."""
-    with pytest.raises(
-        InvalidConfigurationError, match="stdio transport configuration is missing"
-    ):
+    with pytest.raises(ValidationError, match=r"(?s)command.*Field required"):
         StdioTransportConfig()
+
+
+def test_stdio_transport_defaults():
+    """Test the STDIO transport configuration defaults."""
+    stdio_transport = StdioTransportConfig(command="python")
+    stdio_transport.command == "python"
+    stdio_transport.args == []
+    stdio_transport.env == constants.STDIO_TRANSPORT_DEFAULT_ENV
+    stdio_transport.cwd == constants.STDIO_TRANSPORT_DEFAULT_CWD
+    stdio_transport.encoding == constants.STDIO_TRANSPORT_DEFAULT_ENCODING
 
 
 def test_model_parameters():

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -800,7 +800,8 @@ mcp_servers:
     transport: stdio
     stdio:
       command: python
-      args: mcp_server_1.py
+      args:
+        - mcp_server_1.py
   - name: bar
     transport: sse
     sse:
@@ -889,9 +890,10 @@ def test_valid_config_file():
                         "transport": "stdio",
                         "stdio": {
                             "command": "python",
-                            "args": "mcp_server_1.py",
+                            "args": ["mcp_server_1.py"],
                             "env": {},
                             "cwd": ".",
+                            "encoding": "utf-8",
                         },
                     },
                     {


### PR DESCRIPTION
## Description

Changes:
- use pure pydantic capabilities for config definition
- remove code and methods that were re-implementing what pydantic is already doing
- matching yaml definition - no internal conversions
- type Literal expects the value and not variable (not sure what to do with those constants)

Config changes:
sse - `url` is required, the rest is optional
stdio - `command` and `args` are required, the rest if optional
stdio - `args` are actually a list, not string

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
