### PR TITLE
fix: introspection e2e flakiness

### DIFF
--- a/tests/e2e/test_query_endpoint.py
+++ b/tests/e2e/test_query_endpoint.py
@@ -611,6 +611,11 @@ def test_tool_calling() -> None:
         # checking a few major information from response
         assert json_response["conversation_id"] == cid
 
-        assert "lightspeed-app-server" in json_response["response"].lower()
+        # Sometime granite doesn't summarize well,
+        # response may contain actual tool commands.
+        assert re.search(
+            r"(lightspeed-app-server|\[\"pods\", \"-n\", \"openshift-lightspeed\"\])",
+            json_response["response"],
+        )
         assert json_response["input_tokens"] > 0
         assert json_response["output_tokens"] > 0

--- a/tests/e2e/test_query_endpoint.py
+++ b/tests/e2e/test_query_endpoint.py
@@ -206,7 +206,10 @@ def test_valid_question() -> None:
         cid = suid.get_suid()
         response = pytest.client.post(
             QUERY_ENDPOINT,
-            json={"conversation_id": cid, "query": "what is kubernetes?"},
+            json={
+                "conversation_id": cid,
+                "query": "what is kubernetes in the context of OpenShift?",
+            },
             timeout=test_api.LLM_REST_API_TIMEOUT,
         )
         assert response.status_code == requests.codes.ok
@@ -595,7 +598,7 @@ def test_tool_calling() -> None:
             QUERY_ENDPOINT,
             json={
                 "conversation_id": cid,
-                "query": "show me pods in openshift-lightspeed namespace",
+                "query": "Get me current running pods in openshift-lightspeed namespace",
             },
             timeout=test_api.LLM_REST_API_TIMEOUT,
         )

--- a/tests/e2e/test_streaming_query_endpoint.py
+++ b/tests/e2e/test_streaming_query_endpoint.py
@@ -602,7 +602,12 @@ def test_tool_calling_text() -> None:
 
         response_utils.check_content_type(response, constants.MEDIA_TYPE_TEXT)
 
-        assert "lightspeed-app-server" in response.text.lower()
+        # Sometime granite doesn't summarize well,
+        # response may contain actual tool commands.
+        assert re.search(
+            r"(lightspeed-app-server|\[\"pods\", \"-n\", \"openshift-lightspeed\"\])",
+            response.text.lower(),
+        )
 
 
 @pytest.mark.introspection
@@ -627,6 +632,11 @@ def test_tool_calling_events() -> None:
         unique_events = {e["event"] for e in events}
         response_text = construct_response_from_streamed_events(events).lower()
 
-        assert "lightspeed-app-server" in response_text
+        # Sometime granite doesn't summarize well,
+        # response may contain actual tool commands.
+        assert re.search(
+            r"(lightspeed-app-server|\[\"pods\", \"-n\", \"openshift-lightspeed\"\])",
+            response_text,
+        )
         assert "tool_call" in unique_events
         assert "tool_result" in unique_events

--- a/tests/e2e/test_streaming_query_endpoint.py
+++ b/tests/e2e/test_streaming_query_endpoint.py
@@ -594,7 +594,7 @@ def test_tool_calling_text() -> None:
             STREAMING_QUERY_ENDPOINT,
             json={
                 "conversation_id": cid,
-                "query": "show me pods in openshift-lightspeed namespace",
+                "query": "Get me current running pods in openshift-lightspeed namespace",
                 "media_type": constants.MEDIA_TYPE_TEXT,
             },
         )
@@ -616,7 +616,7 @@ def test_tool_calling_events() -> None:
             STREAMING_QUERY_ENDPOINT,
             json={
                 "conversation_id": cid,
-                "query": "show me pods in openshift-lightspeed namespace",
+                "query": "Get me current running pods in openshift-lightspeed namespace",
                 "media_type": constants.MEDIA_TYPE_JSON,
             },
         )

--- a/tests/e2e/test_streaming_query_endpoint.py
+++ b/tests/e2e/test_streaming_query_endpoint.py
@@ -627,6 +627,6 @@ def test_tool_calling_events() -> None:
         unique_events = {e["event"] for e in events}
         response_text = construct_response_from_streamed_events(events).lower()
 
+        assert "lightspeed-app-server" in response_text
         assert "tool_call" in unique_events
         assert "tool_result" in unique_events
-        assert "lightspeed-app-server" in response_text

--- a/tests/scripts/test-e2e-cluster.sh
+++ b/tests/scripts/test-e2e-cluster.sh
@@ -62,11 +62,10 @@ function run_suites() {
   # Run tool calling - Enable introspection
   run_suite "azure_openai_introspection" "introspection" "azure_openai" "$AZUREOPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE" "y"
   (( rc = rc || $? ))
-  # Temporarily disabling below test suites until flakiness is resolved.
-  # run_suite "openai_introspection" "introspection" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE" "y"
-  # (( rc = rc || $? ))
-  # run_suite "watsonx_introspection" "introspection" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-3-2-8b-instruct" "$OLS_IMAGE" "y"
-  # (( rc = rc || $? ))
+  run_suite "openai_introspection" "introspection" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE" "y"
+  (( rc = rc || $? ))
+  run_suite "watsonx_introspection" "introspection" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-3-2-8b-instruct" "$OLS_IMAGE" "y"
+  (( rc = rc || $? ))
 
   set -e
 


### PR DESCRIPTION
## Description
openai/gpt-4o-mini currently rejects tool calling e2e query as non-ocp.
Prompt modification can be done, but it seems like model quality is the issue as same query is successful with azure/gpt-4o-mini.
So far the actual reason seems to be model is getting confused with the given context.
Modify e2e query to make it more obvious for openai/gpt to do a tool call.

Granite also fails to summarize sometime. This is more related to model flakiness as most of the time it is successful. So adding alternate assert statement.

Enable previously commented test suites.
[OLS-1657](https://issues.redhat.com//browse/OLS-1657)