### PR TITLE
Change OCP docs version for tests

### DIFF
--- a/tests/constants.py
+++ b/tests/constants.py
@@ -2,4 +2,4 @@
 
 # embeddings metadata
 OCP_DOCS_ROOT_URL = "https://docs.openshift.com/container-platform"
-OCP_DOCS_VERSION = "4.15"
+OCP_DOCS_VERSION = "4.18"


### PR DESCRIPTION
## Description

Change OCP docs version for tests
We can use **any** version, but people are scared and ask why we use so old OCP docs ;)

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
