### PR TITLE
OLS-1176: add option to configure CA certificate of HTTPS proxy

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -9,6 +9,7 @@ from pydantic import (
     AnyHttpUrl,
     BaseModel,
     DirectoryPath,
+    Field,
     FilePath,
     PositiveInt,
     field_validator,
@@ -118,6 +119,44 @@ class TLSConfig(BaseModel):
                     "Can not enable TLS without ols_config.tls_config.tls_key_path"
                 )
             checks.file_check(self.tls_key_path, "OLS server certificate private key")
+
+
+class ProxyConfig(BaseModel):
+    """HTTPS Proxy configuration."""
+
+    proxy_url: Optional[AnyHttpUrl] = Field(
+        default_factory=lambda: os.getenv("https_proxy") or os.getenv("HTTPS_PROXY")
+    )  # type: ignore
+    proxy_ca_cert_path: Optional[FilePath] = None
+
+    def __init__(self, data: Optional[dict] = None) -> None:
+        """Initialize configuration and perform basic validation."""
+        super().__init__()
+        if not data:
+            return
+        self.proxy_url = data.get("proxy_url")
+        self.proxy_ca_cert_path = data.get("proxy_ca_cert_path")
+
+    def validate_yaml(self) -> None:
+        """Validate proxy config."""
+        if self.proxy_url is None and self.proxy_ca_cert_path:
+            raise checks.InvalidConfigurationError("Proxy URL is missing")
+        if self.proxy_url and not checks.is_valid_http_url(self.proxy_url):
+            raise checks.InvalidConfigurationError(
+                "Proxy URL is invalid, only http:// and https:// URLs are supported"
+            )
+        if self.proxy_ca_cert_path is not None:
+            checks.file_check(self.proxy_ca_cert_path, "Proxy CA certificate")
+
+    @model_validator(mode="before")
+    @classmethod
+    def set_default_proxy_url(cls, values: Any) -> Any:
+        """Set proxy URL from environment variable if not provided."""
+        if "proxy_url" not in values or values["proxy_url"] is None:
+            env_proxy = os.getenv("https_proxy") or os.getenv("HTTPS_PROXY")
+            if env_proxy:
+                values["proxy_url"] = env_proxy
+        return values
 
 
 class AuthenticationConfig(BaseModel):
@@ -1043,6 +1082,8 @@ class OLSConfig(BaseModel):
 
     quota_handlers: Optional[QuotaHandlersConfig] = None
 
+    proxy_config: Optional[ProxyConfig] = None
+
     def __init__(
         self, data: Optional[dict] = None, ignore_missing_certs: bool = False
     ) -> None:
@@ -1095,6 +1136,7 @@ class OLSConfig(BaseModel):
             data.get("tlsSecurityProfile", None)
         )
         self.quota_handlers = QuotaHandlersConfig(data.get("quota_handlers", None))
+        self.proxy_config = ProxyConfig(data.get("proxy_config"))
 
     def __eq__(self, other: object) -> bool:
         """Compare two objects for equality."""
@@ -1118,6 +1160,7 @@ class OLSConfig(BaseModel):
                 and self.expire_llm_is_ready_persistent_state
                 == other.expire_llm_is_ready_persistent_state
                 and self.quota_handlers == other.quota_handlers
+                and self.proxy_config == other.proxy_config
             )
         return False
 
@@ -1136,6 +1179,8 @@ class OLSConfig(BaseModel):
             self.tls_security_profile.validate_yaml()
         if self.authentication_config is not None:
             self.authentication_config.validate_yaml()
+        if self.proxy_config is not None:
+            self.proxy_config.validate_yaml()
 
         valid_query_validation_methods = list(constants.QueryValidationMethod)
         if self.query_validation_method not in valid_query_validation_methods:

--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -122,6 +122,11 @@ class AppConfig:
             self._rag_index_loader = IndexLoader(self.ols_config.reference_content)
         return self._rag_index_loader
 
+    @property
+    def proxy_config(self) -> Optional[config_model.ProxyConfig]:
+        """Return the proxy configuration."""
+        return self.config.proxy_config  # type: ignore[attr-defined]
+
     def reload_empty(self) -> None:
         """Reload the configuration with empty values."""
         self.config = config_model.Config()

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -2,9 +2,10 @@
 
 import copy
 import logging
+import os
 
 import pytest
-from pydantic import ValidationError
+from pydantic import AnyHttpUrl, ValidationError
 
 import ols.utils.tls as tls
 from ols import constants
@@ -23,6 +24,7 @@ from ols.app.models.config import (
     OLSConfig,
     PostgresConfig,
     ProviderConfig,
+    ProxyConfig,
     QueryFilter,
     QuotaHandlersConfig,
     RedisConfig,
@@ -4172,3 +4174,70 @@ def test_ols_config_with_quota_handlesr_missing_name():
                 },
             }
         )
+
+
+def test_proxy_config_default_values():
+    """Test the ProxyConfig model default values."""
+    proxy_config = ProxyConfig()
+    os_proxy = os.getenv("https_proxy")
+    if os_proxy is None:
+        os_proxy = os.getenv("HTTPS_PROXY")
+    assert proxy_config.proxy_url == os_proxy
+    assert proxy_config.proxy_ca_cert_path is None
+
+
+def test_proxy_config_correct_values():
+    """Test the ProxyConfig model customized values."""
+    proxy_config = ProxyConfig(
+        {
+            "proxy_url": "http://proxy.example.com:1234",
+            "proxy_ca_cert_path": "tests/config/empty_cert.crt",
+        }
+    )
+    assert str(proxy_config.proxy_ca_cert_path) == "tests/config/empty_cert.crt"
+    assert str(proxy_config.proxy_url) == "http://proxy.example.com:1234"
+    proxy_config.validate_yaml()
+
+
+def test_proxy_config_invalid_url():
+    """Test the ProxyConfig model with invalid URL."""
+    with pytest.raises(
+        InvalidConfigurationError,
+        match="Proxy URL is invalid.+",
+    ):
+        ProxyConfig(
+            {
+                "proxy_url": "invalid-url",
+                "proxy_ca_cert_path": "tests/config/empty_cert.crt",
+            }
+        ).validate_yaml()
+
+
+def test_proxy_config_invalid_ca_cert_path():
+    """Test the ProxyConfig model with invalid CA certificate path."""
+    with pytest.raises(
+        InvalidConfigurationError,
+        match="Proxy CA certificate 'invalid/path/to/cert.crt' is not a file",
+    ):
+        ProxyConfig(
+            {
+                "proxy_url": "http://proxy.example.com:1234",
+                "proxy_ca_cert_path": "invalid/path/to/cert.crt",
+            }
+        ).validate_yaml()
+
+
+def test_proxy_config_correct_values_env_var():
+    """Test the ProxyConfig model customized values."""
+    system_proxy = os.environ.get("https_proxy")
+    if system_proxy is None:
+        system_proxy = "http://proxy.example.com:1234"
+        os.environ["https_proxy"] = "http://proxy.example.com:1234"
+    proxy_config = ProxyConfig()
+    assert proxy_config.proxy_url == AnyHttpUrl(system_proxy)
+    assert proxy_config.proxy_ca_cert_path is None
+    proxy_config.validate_yaml()
+    if system_proxy == "http://proxy.example.com:1234":
+        del os.environ["https_proxy"]
+    else:
+        os.environ["https_proxy"] = system_proxy


### PR DESCRIPTION
## Description

Add a new option to configure CA certificate of HTTPS proxy. This allows the lightspeed backend to connect to external server ,such as LLM provider, through a TLS introspection HTTPS proxy, not only through a transparent proxy. 

This PR does not need synchronize with the operator side.
The operator side PR: https://github.com/openshift/lightspeed-operator/pull/702

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # [OLS-1176](https://issues.redhat.com//browse/OLS-1176)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
