### PR TITLE
disable openai/watsonx introspection test suites temporarily

### DIFF
--- a/tests/scripts/test-e2e-cluster.sh
+++ b/tests/scripts/test-e2e-cluster.sh
@@ -62,10 +62,11 @@ function run_suites() {
   # Run tool calling - Enable introspection
   run_suite "azure_openai_introspection" "introspection" "azure_openai" "$AZUREOPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE" "y"
   (( rc = rc || $? ))
-  run_suite "openai_introspection" "introspection" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE" "y"
-  (( rc = rc || $? ))
-  run_suite "watsonx_introspection" "introspection" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-3-2-8b-instruct" "$OLS_IMAGE" "y"
-  (( rc = rc || $? ))
+  # Temporarily disabling below test suites until flakiness is resolved.
+  # run_suite "openai_introspection" "introspection" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE" "y"
+  # (( rc = rc || $? ))
+  # run_suite "watsonx_introspection" "introspection" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-3-2-8b-instruct" "$OLS_IMAGE" "y"
+  # (( rc = rc || $? ))
 
   set -e
 


### PR DESCRIPTION
## Description

Disable openai/watsonx introspection test suites temporarily due to some flakiness..
Once the issue is resolved these will be enabled again..

Periodic run still has these.

There are already two PRs for immediate fix.. rerunning test cases for those PRs multiple times to make sure that flakiness has reduced..
https://github.com/openshift/lightspeed-service/pull/2454
https://github.com/openshift/lightspeed-service/pull/2447

[OLS-1657](https://issues.redhat.com//browse/OLS-1657)