### PR TITLE
fix: set top-k chunks correctly

### DIFF
--- a/ols/src/rag_index/index_loader.py
+++ b/ols/src/rag_index/index_loader.py
@@ -147,7 +147,10 @@ class IndexLoader:
         ):
             return self._retriever
         retriever = QueryFusionRetriever(
-            [index.as_retriever() for index in self._indexes],
+            [
+                index.as_retriever(similarity_top_k=similarity_top_k)
+                for index in self._indexes
+            ],
             similarity_top_k=similarity_top_k,
             num_queries=1,  # set this to 1 to disable query generation
             use_async=False,

--- a/tests/e2e/test_query_endpoint.py
+++ b/tests/e2e/test_query_endpoint.py
@@ -5,6 +5,7 @@ import re
 import pytest
 import requests
 
+from ols.constants import RAG_CONTENT_LIMIT
 from ols.utils import suid
 from tests.e2e.utils import cluster as cluster_utils
 from tests.e2e.utils import metrics as metrics_utils
@@ -363,7 +364,7 @@ def test_rag_question() -> None:
         print(vars(response))
         json_response = response.json()
         assert "conversation_id" in json_response
-        assert len(json_response["referenced_documents"]) > 1
+        assert len(json_response["referenced_documents"]) == RAG_CONTENT_LIMIT
         assert "virt" in json_response["referenced_documents"][0]["doc_url"]
         assert "https://" in json_response["referenced_documents"][0]["doc_url"]
         assert json_response["referenced_documents"][0]["doc_title"]


### PR DESCRIPTION
## Description

We need to set top-k chunks in both the places, otherwise default of 2 is considered.
Without this we will retrieve only 2 chunks, even if we have set to 5 in the 2nd part.
So the flow is like 
- use top k for individual retrieval (this will pick k chunks from each index)
- Use same/or different top k for final query fusion retrieval (this will give us final set of chunks from `n index * k chunks`)..

While using 1 index, first index only retrieves default 2 chunks and that's the reason we don't get 5 chunks in final retrieval 