### PR TITLE
OLS-1715: openai provider allow custom CA

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -306,7 +306,7 @@ class ProviderConfig(BaseModel):
             # deployment_name only required when using Azure OpenAI
             self.deployment_name = data.get("deployment_name", None)
             # note: it can be overwritten in azure_config
-        if self.type in (constants.PROVIDER_RHOAI_VLLM, constants.PROVIDER_RHELAI_VLLM):
+        if self.type in (constants.PROVIDER_RHOAI_VLLM, constants.PROVIDER_RHELAI_VLLM, constants.PROVIDER_OPENAI):
             self.certificates_store = os.path.join(
                 certificate_directory, constants.CERTIFICATE_STORAGE_FILENAME
             )

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -306,7 +306,11 @@ class ProviderConfig(BaseModel):
             # deployment_name only required when using Azure OpenAI
             self.deployment_name = data.get("deployment_name", None)
             # note: it can be overwritten in azure_config
-        if self.type in (constants.PROVIDER_RHOAI_VLLM, constants.PROVIDER_RHELAI_VLLM, constants.PROVIDER_OPENAI):
+        if self.type in (
+            constants.PROVIDER_RHOAI_VLLM,
+            constants.PROVIDER_RHELAI_VLLM,
+            constants.PROVIDER_OPENAI,
+        ):
             self.certificates_store = os.path.join(
                 certificate_directory, constants.CERTIFICATE_STORAGE_FILENAME
             )

--- a/ols/src/llms/providers/openai.py
+++ b/ols/src/llms/providers/openai.py
@@ -43,8 +43,8 @@ class OpenAI(LLMProvider):
             "temperature": 0.01,
             "max_tokens": 512,
             "verbose": False,
-            "http_client": self._construct_httpx_client(False, False),
-            "http_async_client": self._construct_httpx_client(False, True),
+            "http_client": self._construct_httpx_client(True, False),
+            "http_async_client": self._construct_httpx_client(True, True),
         }
 
     def load(self) -> LLM:


### PR DESCRIPTION
An OpenAI provider can be configured with a custom url. If the configured endpoint is secured with a self signed certificate, as in the case of locally hosted OpenAI compatible providers, a trust configuration needs to be applied.

This PR enables the OpenAI provider to use a custom ca the same way as the RHELAI and RHOAI Providers.

## Description

An OpenAI provider can be configured with a custom url. If the configured endpoint is secured with a self signed certificate, as in the case of locally hosted OpenAI compatible providers, a trust configuration needs to be applied.

This PR enables the OpenAI provider to use a custom ca the same way as the RHELAI and RHOAI Providers.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #  [OLS-1715](https://issues.redhat.com//browse/OLS-1715)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
Use LocalAI as OpenAI Compatible server
  * Expose the API as HTTP (InSecure) 
  * Configure ReverseProxy to LocalAI endpoint with LetsEncrypt TLS Certificate Signed with R10 (do not configure customca) 
  * Configure Reverse Proxy to LocalAI endpoint with self-signed TLS certificate, create a configmap with the cert, and set additionalCAConfigMapRef to that configmap
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
