### PR TITLE
conf: konflux nudge ignore FBC

### DIFF
--- a/.tekton/lightspeed-service-push.yaml
+++ b/.tekton/lightspeed-service-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: |
-      .*Dockerfile.*, bundle/manifests/lightspeed-operator.clusterserviceversion.yaml, config/default/kustomization.yaml, lightspeed-catalog-4.15/index.yaml, lightspeed-catalog-4.16/index.yaml, lightspeed-catalog-4.17/index.yaml, related_images.json
+      .*Dockerfile.*, bundle/manifests/lightspeed-operator.clusterserviceversion.yaml, config/default/kustomization.yaml, related_images.json
     build.appstudio.openshift.io/repo: https://github.com/openshift/lightspeed-service?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'


### PR DESCRIPTION
## Description

stop nudging catalog files, because catalog should be updated from bundle not only image references.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [x] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
