### PR TITLE
OLS-1340: use default version of OCP docs RAG if the current version is not available

### DIFF
--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -2949,6 +2949,32 @@ def test_reference_content_yaml_validation():
         reference_content.validate_yaml()
 
 
+def test_reference_content_yaml_validation_fallback_to_default_dir(tmp_path):
+    """Test the ReferenceContent YAML validation method fallback to default dir."""
+    default_dir = tmp_path / "latest"
+    default_dir.mkdir()
+
+    # index path to inexistent dir in the temp dir should fallback to "default" dir
+    inexistent_dir = tmp_path / "non_existing_dir"
+    reference_content = ReferenceContent()
+    reference_content.indexes = [
+        ReferenceContentIndex(
+            {"product_docs_index_id": "foo", "product_docs_index_path": inexistent_dir}
+        )
+    ]
+    reference_content.validate_yaml()
+    assert reference_content.indexes[0].product_docs_index_path == default_dir
+    assert reference_content.indexes[0].product_docs_index_id is None
+
+    # exception should be raised if the default dir does not exist, either
+    default_dir.rmdir()
+    with pytest.raises(
+        InvalidConfigurationError,
+        match="Reference content index path '.+' does not exist",
+    ):
+        reference_content.validate_yaml()
+
+
 def test_config_no_query_filter_node():
     """Test the Config model when query filter is not set at all."""
     config = Config(


### PR DESCRIPTION
## Description

The RAG index loader will use the default version of the RAG index if the assigned version path is not available.
This is a special case for OCP documentation RAGs.
This will work together with this PR on [the RAG content side](https://github.com/openshift/lightspeed-rag-content/pull/346).

## Type of change

- [ ] Refactor
- [x] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # [OLS-1340](https://issues.redhat.com//browse/OLS-1340)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
