### PR TITLE
OLS-1714: reconnect PostgreSQL quota DB when tables are deleted

### DIFF
--- a/ols/src/quota/cluster_quota_limiter.py
+++ b/ols/src/quota/cluster_quota_limiter.py
@@ -22,11 +22,5 @@ class ClusterQuotaLimiter(RevokableQuotaLimiter):
         super().__init__(initial_quota, increase_by, subject, config)
 
         # initialize connection to DB
+        # and initialize tables too
         self.connect()
-
-        try:
-            self._initialize_tables()
-        except Exception as e:
-            self.connection.close()
-            logger.exception("Error initializing Postgres database:\n%s", e)
-            raise

--- a/ols/src/quota/quota_limiter.py
+++ b/ols/src/quota/quota_limiter.py
@@ -42,6 +42,10 @@ class QuotaLimiter(ABC):
         """Initialize connection config."""
         self.connection_config: Optional[PostgresConfig] = None
 
+    @abstractmethod
+    def _initialize_tables(self) -> None:
+        """Initialize tables and indexes."""
+
     # pylint: disable=W0201
     def connect(self) -> None:
         """Initialize connection to database."""
@@ -59,6 +63,14 @@ class QuotaLimiter(ABC):
             # sslrootcert=config.ca_cert_path,
             gssencmode=config.gss_encmode,
         )
+
+        try:
+            self._initialize_tables()
+        except Exception as e:
+            self.connection.close()
+            logger.exception("Error initializing Postgres database:\n%s", e)
+            raise
+
         self.connection.autocommit = True
 
     def connected(self) -> bool:

--- a/ols/src/quota/revokable_quota_limiter.py
+++ b/ols/src/quota/revokable_quota_limiter.py
@@ -150,6 +150,7 @@ class RevokableQuotaLimiter(QuotaLimiter):
 
     def _initialize_tables(self) -> None:
         """Initialize tables used by quota limiter."""
+        logger.info("Initializing tables for quota limiter")
         cursor = self.connection.cursor()
         cursor.execute(RevokableQuotaLimiter.CREATE_QUOTA_TABLE)
         cursor.close()

--- a/ols/src/quota/token_usage_history.py
+++ b/ols/src/quota/token_usage_history.py
@@ -54,13 +54,6 @@ class TokenUsageHistory:
         # initialize connection to DB
         self.connect()
 
-        try:
-            self._initialize_tables()
-        except Exception as e:
-            self.connection.close()
-            logger.exception("Error initializing Postgres database:\n%s", e)
-            raise
-
     @connection
     def consume_tokens(
         self,
@@ -111,6 +104,12 @@ class TokenUsageHistory:
             # sslrootcert=config.ca_cert_path,
             gssencmode=config.gss_encmode,
         )
+        try:
+            self._initialize_tables()
+        except Exception as e:
+            self.connection.close()
+            logger.exception("Error initializing Postgres database:\n%s", e)
+            raise
         self.connection.autocommit = True
 
     def connected(self) -> bool:
@@ -129,6 +128,7 @@ class TokenUsageHistory:
 
     def _initialize_tables(self) -> None:
         """Initialize tables used by quota limiter."""
+        logger.info("Initializing tables for token usage history")
         cursor = self.connection.cursor()
         cursor.execute(TokenUsageHistory.CREATE_TOKEN_USAGE_TABLE)
         cursor.close()

--- a/ols/src/quota/user_quota_limiter.py
+++ b/ols/src/quota/user_quota_limiter.py
@@ -22,11 +22,5 @@ class UserQuotaLimiter(RevokableQuotaLimiter):
         super().__init__(initial_quota, increase_by, subject, config)
 
         # initialize connection to DB
+        # and initialize tables too
         self.connect()
-
-        try:
-            self._initialize_tables()
-        except Exception as e:
-            self.connection.close()
-            logger.exception("Error initializing Postgres database:\n%s", e)
-            raise


### PR DESCRIPTION
## Description

[OLS-1714](https://issues.redhat.com//browse/OLS-1714): reconnect PostgreSQL quota DB when tables are deleted

## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #[OLS-1714](https://issues.redhat.com//browse/OLS-1714)
