### PR TITLE
tool calling: fixes & improvements

### DIFF
--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -162,8 +162,7 @@ class DocsSummarizer(QueryHelper):
             logger.debug("No MCP servers provided, tool calling is disabled")
             self._tool_calling_enabled = False
 
-        # disabled - leaks token to logs when set to True
-        set_debug(False)
+        set_debug(self.verbose)
 
     def _prepare_llm(self) -> None:
         """Prepare the LLM configuration."""

--- a/tests/e2e/test_query_endpoint.py
+++ b/tests/e2e/test_query_endpoint.py
@@ -621,3 +621,6 @@ def test_tool_calling() -> None:
         )
         assert json_response["input_tokens"] > 0
         assert json_response["output_tokens"] > 0
+
+        # Special check for granite
+        assert not json_response["response"].strip().startswith("<tool_call>")

--- a/tests/e2e/test_streaming_query_endpoint.py
+++ b/tests/e2e/test_streaming_query_endpoint.py
@@ -613,6 +613,8 @@ def test_tool_calling_text() -> None:
             r"(lightspeed-app-server|\[\"pods\", \"-n\", \"openshift-lightspeed\"\])",
             response.text.lower(),
         )
+        # Special check for granite
+        assert not response.text.strip().startswith("<tool_call>")
 
 
 @pytest.mark.tool_calling
@@ -645,3 +647,6 @@ def test_tool_calling_events() -> None:
         )
         assert "tool_call" in unique_events
         assert "tool_result" in unique_events
+
+        # Special check for granite
+        assert not response_text.strip().startswith("<tool_call>")


### PR DESCRIPTION
## Description

- Enable langchain debug (now that we are handling tokens better)
- Create MCP client connection per user request rather than per iteration.
- Raise exception when we skip OC command execution due to some validation. 
- Raise exception when OC command fails, so that status in host can be error.
- handle <tool_call> text (for granite)