### PR TITLE
fix: create link /bin/python

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@ ARG BUILDARCH
 
 RUN microdnf install -y --nodocs --setopt=keepcache=0 --setopt=tsflags=nodocs \
     python3.11 python3.11-devel python3.11-pip
-
+RUN cd /bin && ln -s python3.11 python
 # conditional installation of OpenShift CLI
 
 ENV BUILDARCH=${BUILDARCH}


### PR DESCRIPTION
## Description

fix the bug that cannot start MCP server because `python` is not available in $PATH

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
