### PR TITLE
OLS-1800: Add auth header for sse mcp config

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -574,6 +574,7 @@ class SseTransportConfig(BaseModel):
     url: str
     timeout: int = constants.SSE_TRANSPORT_DEFAULT_TIMEOUT
     sse_read_timeout: int = constants.SSE_TRANSPORT_DEFAULT_READ_TIMEOUT
+    headers: dict[str, str] = Field(default_factory=dict)
 
 
 class MCPServerConfig(BaseModel):

--- a/ols/src/tools/mcp_config_builder.py
+++ b/ols/src/tools/mcp_config_builder.py
@@ -1,0 +1,85 @@
+"""MCPConfigBuilder for building MultiServerMCPClient configuration."""
+
+import logging
+import os
+from typing import Any
+
+from ols.app.models.config import MCPServerConfig
+
+logger = logging.getLogger(__name__)
+
+
+# Additional header containing user token for k8s/ocp authentication
+# for SSE MCP servers.
+K8S_AUTH_HEADER = "kubernetes-authorization-bearer-token"
+
+
+class MCPConfigBuilder:
+    """Builds MCP config for MultiServerMCPClient."""
+
+    def __init__(
+        self, user_token: str, mcp_server_configs: list[MCPServerConfig]
+    ) -> None:
+        """Initialize the MCPConfigBuilder with user token and server config list."""
+        self.user_token = user_token
+        self.mcp_server_configs = mcp_server_configs
+
+    @staticmethod
+    def include_auth_header(user_token: str, config: dict[str, Any]) -> dict[str, Any]:
+        """Include user token in the config headers."""
+        if "headers" not in config:
+            config["headers"] = {}
+        if K8S_AUTH_HEADER in config["headers"]:
+            logger.warning(
+                "Kubernetes auth header is already set, overriding with actual user token."
+            )
+        config["headers"][K8S_AUTH_HEADER] = user_token
+        return config
+
+    def include_auth_to_stdio(self, server_envs: dict[str, str]) -> dict[str, str]:
+        """Resolve OpenShift stdio env config."""
+        logger.debug("Updating env configuration of openshift stdio mcp server")
+        env = {**server_envs}
+
+        if "OC_USER_TOKEN" in env:
+            logger.warning("OC_USER_TOKEN is set, overriding with actual user token.")
+        env["OC_USER_TOKEN"] = self.user_token
+
+        if "KUBECONFIG" not in env:
+            if "KUBECONFIG" in os.environ:
+                logger.info("Using KUBECONFIG from environment.")
+                env["KUBECONFIG"] = os.environ["KUBECONFIG"]
+            elif (
+                "KUBERNETES_SERVICE_HOST" in os.environ
+                and "KUBERNETES_SERVICE_PORT" in os.environ
+            ):
+                logger.info("Using KUBERNETES_SERVICE_* from environment.")
+                env["KUBERNETES_SERVICE_HOST"] = os.environ["KUBERNETES_SERVICE_HOST"]
+                env["KUBERNETES_SERVICE_PORT"] = os.environ["KUBERNETES_SERVICE_PORT"]
+            else:
+                logger.error("Missing necessary KUBECONFIG/KUBERNETES_SERVICE_* envs.")
+        return env
+
+    def dump_client_config(self) -> dict[str, Any]:
+        """Convert server configs to MultiServerMCPClient config format."""
+        servers_conf: dict[str, Any] = {}
+
+        for server_conf in self.mcp_server_configs:
+            servers_conf[server_conf.name] = {
+                "transport": server_conf.transport,
+            }
+
+            if server_conf.stdio:
+                stdio_conf = server_conf.stdio.model_dump()
+                if server_conf.name == "openshift":
+                    stdio_conf["env"] = self.include_auth_to_stdio(
+                        server_conf.stdio.env
+                    )
+                servers_conf[server_conf.name].update(stdio_conf)
+
+            if server_conf.sse:
+                sse_conf = server_conf.sse.model_dump()
+                self.include_auth_header(self.user_token, sse_conf)
+                servers_conf[server_conf.name].update(sse_conf)
+
+        return servers_conf

--- a/ols/src/tools/mcp_config_builder.py
+++ b/ols/src/tools/mcp_config_builder.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 # Additional header containing user token for k8s/ocp authentication
 # for SSE MCP servers.
-K8S_AUTH_HEADER = "kubernetes-authorization-bearer-token"
+K8S_AUTH_HEADER = "kubernetes-authorization"
 
 
 class MCPConfigBuilder:
@@ -33,7 +33,7 @@ class MCPConfigBuilder:
             logger.warning(
                 "Kubernetes auth header is already set, overriding with actual user token."
             )
-        config["headers"][K8S_AUTH_HEADER] = user_token
+        config["headers"][K8S_AUTH_HEADER] = f"Bearer {user_token}"
         return config
 
     def include_auth_to_stdio(self, server_envs: dict[str, str]) -> dict[str, str]:

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -1168,7 +1168,7 @@ def test_tool_calling(_setup, caplog) -> None:
     with (
         patch("ols.customize.prompts.QUERY_SYSTEM_INSTRUCTION", "System Instruction"),
         patch(
-            "ols.src.query_helpers.docs_summarizer.MCPConfigBuilder.mcp_config_to_client_dump",
+            "ols.src.query_helpers.docs_summarizer.MCPConfigBuilder.dump_client_config",
             return_value=mcp_servers,
         ),
         patch(

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -240,6 +240,7 @@ def test_sse_transport_defaults():
     assert (
         sse_transport.sse_read_timeout == constants.SSE_TRANSPORT_DEFAULT_READ_TIMEOUT
     )
+    assert sse_transport.headers == {}
 
 
 def test_stdio_transport_configuration_on_no_data():

--- a/tests/unit/tools/test_mcp_config_builder.py
+++ b/tests/unit/tools/test_mcp_config_builder.py
@@ -152,7 +152,7 @@ class TestMCPConfigBuilder:
         result = MCPConfigBuilder.include_auth_header(user_token, config)
 
         assert "headers" in result
-        assert result["headers"][K8S_AUTH_HEADER] == user_token
+        assert result["headers"][K8S_AUTH_HEADER] == f"Bearer {user_token}"
 
     @staticmethod
     def test_include_auth_header_existing_headers():
@@ -163,7 +163,7 @@ class TestMCPConfigBuilder:
         result = MCPConfigBuilder.include_auth_header(user_token, config)
 
         assert result["headers"]["Content-Type"] == "application/json"
-        assert result["headers"][K8S_AUTH_HEADER] == user_token
+        assert result["headers"][K8S_AUTH_HEADER] == f"Bearer {user_token}"
 
     @staticmethod
     def test_include_auth_header_existing_auth(caplog):
@@ -173,7 +173,7 @@ class TestMCPConfigBuilder:
 
         result = MCPConfigBuilder.include_auth_header(user_token, config)
 
-        assert result["headers"][K8S_AUTH_HEADER] == user_token
+        assert result["headers"][K8S_AUTH_HEADER] == f"Bearer {user_token}"
         assert (
             "Kubernetes auth header is already set, overriding with actual user token"
             in caplog.text
@@ -200,7 +200,9 @@ class TestMCPConfigBuilder:
         assert result["sse-server"]["transport"] == "sse"
         assert result["sse-server"]["url"] == "https://example.com/events"
         assert result["sse-server"]["headers"]["X-Custom-Header"] == "value"
-        assert result["sse-server"]["headers"][K8S_AUTH_HEADER] == user_token
+        assert (
+            result["sse-server"]["headers"][K8S_AUTH_HEADER] == f"Bearer {user_token}"
+        )
 
     @staticmethod
     def test_dump_client_config_with_mixed_transports():
@@ -233,4 +235,6 @@ class TestMCPConfigBuilder:
         assert result["openshift"]["transport"] == "stdio"
         assert result["sse-server"]["transport"] == "sse"
         assert result["openshift"]["env"]["OC_USER_TOKEN"] == user_token
-        assert result["sse-server"]["headers"][K8S_AUTH_HEADER] == user_token
+        assert (
+            result["sse-server"]["headers"][K8S_AUTH_HEADER] == f"Bearer {user_token}"
+        )

--- a/tests/unit/tools/test_mcp_config_builder.py
+++ b/tests/unit/tools/test_mcp_config_builder.py
@@ -1,0 +1,236 @@
+"""Tests for MCPConfigBuilder."""
+
+import os
+from unittest.mock import patch
+
+from ols.app.models.config import (
+    MCPServerConfig,
+    SseTransportConfig,
+    StdioTransportConfig,
+)
+from ols.src.tools.mcp_config_builder import K8S_AUTH_HEADER, MCPConfigBuilder
+
+
+def test_mcp_config_builder_dump_client_config():
+    """Test MCPConfigBuilder.dump_client_config method."""
+    mcp_server_configs = [
+        MCPServerConfig(
+            name="openshift",
+            transport="stdio",
+            stdio=StdioTransportConfig(
+                command="hello",
+                env={"X": "Y"},
+            ),
+        ),
+        MCPServerConfig(
+            name="not-openshift",
+            transport="stdio",
+            stdio=StdioTransportConfig(
+                command="hello",
+                env={"X": "Y"},
+            ),
+        ),
+    ]
+    user_token = "fake-token"  # noqa: S105
+
+    # patch the environment variable to avoid using values from the system
+    with patch.dict(os.environ, {}, clear=True):
+        builder = MCPConfigBuilder(user_token, mcp_server_configs)
+        mcp_config = builder.dump_client_config()
+
+    assert mcp_config == {
+        "openshift": {
+            "transport": "stdio",
+            "command": "hello",
+            "args": [],
+            "env": {"X": "Y", "OC_USER_TOKEN": "fake-token"},
+            "cwd": ".",
+            "encoding": "utf-8",
+        },
+        "not-openshift": {
+            "transport": "stdio",
+            "command": "hello",
+            "args": [],
+            "env": {"X": "Y"},
+            "cwd": ".",
+            "encoding": "utf-8",
+        },
+    }
+
+
+class TestMCPConfigBuilder:
+    """Test MCPConfigBuilder class."""
+
+    @staticmethod
+    def test_include_auth_to_stdio():
+        """Test include_auth_to_stdio method."""
+        user_token = "fake-token"  # noqa: S105
+        envs = {"A": 42, "KUBECONFIG": "bla"}
+
+        builder = MCPConfigBuilder(user_token, [])
+        mcp_config = builder.include_auth_to_stdio(envs)
+
+        expected = {**envs, "OC_USER_TOKEN": user_token}
+        assert mcp_config == expected
+
+    @staticmethod
+    def test_token_set_in_env(caplog):
+        """Test include_auth_to_stdio with token set in env."""
+        # OC_USER_TOKEN set in env - is logged and overriden
+        user_token = "fake-token"  # noqa: S105
+        envs = {"OC_USER_TOKEN": "different-value"}
+
+        builder = MCPConfigBuilder(user_token, [])
+        with patch.dict(os.environ, {}, clear=True):
+            mcp_config = builder.include_auth_to_stdio(envs)
+
+        expected = {"OC_USER_TOKEN": user_token}
+        assert mcp_config == expected
+        assert "overriding with actual user token" in caplog.text
+
+    @staticmethod
+    def test_kubeconfig_from_environ(caplog):
+        """Test include_auth_to_stdio with KUBECONFIG from environment."""
+        # KUBECONFIG is not set in env - value from os.environ is used
+        caplog.set_level(20)  # info
+        envs = {"A": 42}
+        user_token = "fake-token"  # noqa: S105
+
+        builder = MCPConfigBuilder(user_token, [])
+        with patch.dict(os.environ, {"KUBECONFIG": "os value"}):
+            mcp_config = builder.include_auth_to_stdio(envs)
+
+        expected = {**envs, "OC_USER_TOKEN": user_token, "KUBECONFIG": "os value"}
+        assert mcp_config == expected
+        assert "Using KUBECONFIG from environment" in caplog.text
+
+    @staticmethod
+    def test_kubernetes_service_from_environ(caplog):
+        """Test include_auth_to_stdio with KUBERNETES_SERVICE_* from environment."""
+        # KUBECONFIG is not set, but KUBERNETES_SERVICE_* is available
+        caplog.set_level(20)  # info
+        envs = {"A": 42}
+        user_token = "fake-token"  # noqa: S105
+
+        builder = MCPConfigBuilder(user_token, [])
+        with patch.dict(
+            os.environ,
+            {"KUBERNETES_SERVICE_HOST": "k8s-host", "KUBERNETES_SERVICE_PORT": "8443"},
+        ):
+            mcp_config = builder.include_auth_to_stdio(envs)
+
+        expected = {
+            **envs,
+            "OC_USER_TOKEN": user_token,
+            "KUBERNETES_SERVICE_HOST": "k8s-host",
+            "KUBERNETES_SERVICE_PORT": "8443",
+        }
+        assert mcp_config == expected
+        assert "Using KUBERNETES_SERVICE_* from environment" in caplog.text
+
+    @staticmethod
+    def test_missing_kubeconfig_and_kubernetes_service(caplog):
+        """Test include_auth_to_stdio with missing KUBECONFIG and KUBERNETES_SERVICE_*."""
+        # Both KUBECONFIG and KUBERNETES_SERVICE_* are missing
+        envs = {}
+        user_token = "fake-token"  # noqa: S105
+
+        builder = MCPConfigBuilder(user_token, [])
+        with patch.dict(os.environ, {}, clear=True):
+            mcp_config = builder.include_auth_to_stdio(envs)
+
+        expected = {"OC_USER_TOKEN": user_token}
+        assert mcp_config == expected
+        assert "Missing necessary KUBECONFIG/KUBERNETES_SERVICE_* envs" in caplog.text
+
+    @staticmethod
+    def test_include_auth_header():
+        """Test include_auth_header method."""
+        user_token = "fake-token"  # noqa: S105
+        config = {}
+
+        result = MCPConfigBuilder.include_auth_header(user_token, config)
+
+        assert "headers" in result
+        assert result["headers"][K8S_AUTH_HEADER] == user_token
+
+    @staticmethod
+    def test_include_auth_header_existing_headers():
+        """Test include_auth_header with existing headers."""
+        user_token = "fake-token"  # noqa: S105
+        config = {"headers": {"Content-Type": "application/json"}}
+
+        result = MCPConfigBuilder.include_auth_header(user_token, config)
+
+        assert result["headers"]["Content-Type"] == "application/json"
+        assert result["headers"][K8S_AUTH_HEADER] == user_token
+
+    @staticmethod
+    def test_include_auth_header_existing_auth(caplog):
+        """Test include_auth_header with existing auth header."""
+        user_token = "fake-token"  # noqa: S105
+        config = {"headers": {K8S_AUTH_HEADER: "old-token"}}
+
+        result = MCPConfigBuilder.include_auth_header(user_token, config)
+
+        assert result["headers"][K8S_AUTH_HEADER] == user_token
+        assert (
+            "Kubernetes auth header is already set, overriding with actual user token"
+            in caplog.text
+        )
+
+    @staticmethod
+    def test_dump_client_config_with_sse():
+        """Test dump_client_config with SSE configuration."""
+        mcp_server_configs = [
+            MCPServerConfig(
+                name="sse-server",
+                transport="sse",
+                sse=SseTransportConfig(
+                    url="https://example.com/events",
+                    headers={"X-Custom-Header": "value"},
+                ),
+            ),
+        ]
+        user_token = "fake-token"  # noqa: S105
+
+        builder = MCPConfigBuilder(user_token, mcp_server_configs)
+        result = builder.dump_client_config()
+
+        assert result["sse-server"]["transport"] == "sse"
+        assert result["sse-server"]["url"] == "https://example.com/events"
+        assert result["sse-server"]["headers"]["X-Custom-Header"] == "value"
+        assert result["sse-server"]["headers"][K8S_AUTH_HEADER] == user_token
+
+    @staticmethod
+    def test_dump_client_config_with_mixed_transports():
+        """Test dump_client_config with both SSE and stdio configurations."""
+        mcp_server_configs = [
+            MCPServerConfig(
+                name="openshift",
+                transport="stdio",
+                stdio=StdioTransportConfig(
+                    command="hello",
+                    env={"X": "Y"},
+                ),
+            ),
+            MCPServerConfig(
+                name="sse-server",
+                transport="sse",
+                sse=SseTransportConfig(
+                    url="https://example.com/events",
+                ),
+            ),
+        ]
+        user_token = "fake-token"  # noqa: S105
+
+        with patch.dict(os.environ, {}, clear=True):
+            builder = MCPConfigBuilder(user_token, mcp_server_configs)
+            result = builder.dump_client_config()
+
+        assert "openshift" in result
+        assert "sse-server" in result
+        assert result["openshift"]["transport"] == "stdio"
+        assert result["sse-server"]["transport"] == "sse"
+        assert result["openshift"]["env"]["OC_USER_TOKEN"] == user_token
+        assert result["sse-server"]["headers"][K8S_AUTH_HEADER] == user_token


### PR DESCRIPTION
## Description

Implements user-token auth through header.

**How to test locally**
0. get the cluster, do `oc login` and store the kubeconfig `oc config view --raw > <kubeconfig_path>`
1. start the mcp server via `npx kubernetes-mcp-server@latest --sse-port 8090 --kubeconfig <kubeconfig_path>`
2. start ols service with this config
```yaml
ols_config:
       authentication_config:
    module: "noop-with-token"
    ...
mcp_servers:
  - name: k8s-mcp
    transport: sse
    sse:
      url: "http://localhost:8090/sse"
```
3. prompt through
```bash
curl -X POST http://localhost:8080/v1/query -H "Content-Type: application/json" -H "Authorization: Bearer sha256~blabla" -d '{"query": "Is there openshift-lightspeed namespace in my openshift 4 cluster?"}'
```
