### PR TITLE
OLS-1808: Fix proxy_url type

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -124,9 +124,9 @@ class TLSConfig(BaseModel):
 class ProxyConfig(BaseModel):
     """HTTPS Proxy configuration."""
 
-    proxy_url: Optional[AnyHttpUrl] = Field(
+    proxy_url: Optional[str] = Field(
         default_factory=lambda: os.getenv("https_proxy") or os.getenv("HTTPS_PROXY")
-    )  # type: ignore
+    )
     proxy_ca_cert_path: Optional[FilePath] = None
 
     def __init__(self, data: Optional[dict] = None) -> None:

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -5,7 +5,7 @@ import logging
 import os
 
 import pytest
-from pydantic import AnyHttpUrl, ValidationError
+from pydantic import ValidationError
 
 import ols.utils.tls as tls
 from ols import constants
@@ -4034,7 +4034,7 @@ def test_proxy_config_correct_values_env_var():
         system_proxy = "http://proxy.example.com:1234"
         os.environ["https_proxy"] = "http://proxy.example.com:1234"
     proxy_config = ProxyConfig()
-    assert proxy_config.proxy_url == AnyHttpUrl(system_proxy)
+    assert proxy_config.proxy_url == system_proxy
     assert proxy_config.proxy_ca_cert_path is None
     proxy_config.validate_yaml()
     if system_proxy == "http://proxy.example.com:1234":


### PR DESCRIPTION
## Description

This proxy_url is stored as a pydantic.AnyHttpUrl object (which is a subclass of str, but not always treated as a plain str by libraries like httpx or LLM SDKs).

But when passing proxy_url to other libraries (like httpx or an LLM client), they expect a raw string (str) or an httpx.URL object, not AnyHttpUrl.

Even though AnyHttpUrl behaves like a string, it isn't a string type — it's a Pydantic-validated class, and this often causes type mismatches when passed into libraries expecting native types.


## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
