### PR TITLE
OLS-1808 bugfix: proxy config type error + ignore SSL context for HTTP proxy

### DIFF
--- a/ols/src/llms/providers/provider.py
+++ b/ols/src/llms/providers/provider.py
@@ -346,9 +346,11 @@ class LLMProvider(AbstractLLMProvider):
                 config.ols_config.proxy_config.proxy_url,
                 config.ols_config.proxy_config.proxy_ca_cert_path,
             )
-            proxy_context = ssl.create_default_context(
-                cafile=config.ols_config.proxy_config.proxy_ca_cert_path
-            )
+            proxy_context = None
+            if config.ols_config.proxy_config.is_https():
+                proxy_context = ssl.create_default_context(
+                    cafile=config.ols_config.proxy_config.proxy_ca_cert_path
+                )
             proxy = httpx.Proxy(
                 url=config.ols_config.proxy_config.proxy_url, ssl_context=proxy_context
             )

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -5,7 +5,7 @@ import logging
 import os
 
 import pytest
-from pydantic import AnyHttpUrl, ValidationError
+from pydantic import ValidationError
 
 import ols.utils.tls as tls
 from ols import constants
@@ -4034,9 +4034,18 @@ def test_proxy_config_correct_values_env_var():
         system_proxy = "http://proxy.example.com:1234"
         os.environ["https_proxy"] = "http://proxy.example.com:1234"
     proxy_config = ProxyConfig()
-    assert proxy_config.proxy_url == AnyHttpUrl(system_proxy)
+    assert proxy_config.proxy_url == system_proxy
     assert proxy_config.proxy_ca_cert_path is None
     proxy_config.validate_yaml()
+    # CA alone in config should be valid with URL in env var.
+    proxy_config = ProxyConfig(
+        {
+            "proxy_ca_cert_path": "tests/config/empty_cert.crt",
+        }
+    )
+    proxy_config.validate_yaml()
+    assert str(proxy_config.proxy_ca_cert_path) == "tests/config/empty_cert.crt"
+    assert proxy_config.proxy_url == system_proxy
     if system_proxy == "http://proxy.example.com:1234":
         del os.environ["https_proxy"]
     else:


### PR DESCRIPTION
## Description

fix the proxy config incompatible type problem with httpx client
fix the bug that misuse ssl context for http proxy
based on @onmete 's PR https://github.com/openshift/lightspeed-service/pull/2539

Tested valid for the configs below
1. httpS proxy with CA certificate
```yaml
ols_config:
  proxy_config:
    proxy_url: "https://192.168.2.165:3129"
    proxy_ca_cert_path: rootCA.crt
```
2. http proxy
```yaml
ols_config:
  proxy_config:
    proxy_url: "http://192.168.2.165:3128"
```
3. httpS proxy from env var
```yaml
ols_config:
  proxy_config:
    proxy_ca_cert_path: rootCA.crt

# env var https_proxy="https://192.168.2.165:3129"
```
4. http proxy from env var
```shell
https_proxy="https://192.168.2.165:3129"
```

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes # [OLS-1808](https://issues.redhat.com//browse/OLS-1808)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
