### PR TITLE
OLS-1835: Service pod fails to connect to the Postgres pod after restart

### DIFF
--- a/ols/src/cache/postgres_cache.py
+++ b/ols/src/cache/postgres_cache.py
@@ -133,7 +133,7 @@ class PostgresCache(Cache):
                 cursor.execute("SELECT 1")
             logger.info("Connection to storage is ok")
             return True
-        except psycopg2.OperationalError as e:
+        except (psycopg2.OperationalError, psycopg2.InterfaceError) as e:
             logger.error("Disconnected from storage: %s", e)
             return False
 

--- a/tests/unit/cache/test_postgres_cache.py
+++ b/tests/unit/cache/test_postgres_cache.py
@@ -641,11 +641,12 @@ def test_ready():
         # cache is not ready
         assert not cache.ready()
 
-        # mock the connection state 0 - open
-        cache.connection.closed = 0
-        # patch the poll function to raise OperationalError
-        cache.connection.poll = MagicMock(
-            side_effect=psycopg2.OperationalError("Connection closed")
-        )
-        # cache is not ready
-        assert not cache.ready()
+        for error_type in (psycopg2.OperationalError, psycopg2.InterfaceError):
+            # mock the connection state 0 - open
+            cache.connection.closed = 0
+            # patch the poll function to raise OperationalError
+            cache.connection.poll = MagicMock(
+                side_effect=error_type("Connection closed")
+            )
+            # cache is not ready
+            assert not cache.ready()


### PR DESCRIPTION
## Description

[OLS-1835](https://issues.redhat.com//browse/OLS-1835): Service pod fails to connect to the Postgres pod after restart
Added psycopg2.InterfaceError as a possible exception seen when a connection to Postgres is lost.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes # https://issues.redhat.com/browse/OLS-1835

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
