### PR TITLE
reduce max resp token to 2048

### DIFF
--- a/ols/constants.py
+++ b/ols/constants.py
@@ -76,7 +76,7 @@ DEFAULT_CONTEXT_WINDOW_SIZE = 128000
 # Also response with YAML generally uses more tokens (when large model is used)
 # It should be in reasonable proportion to context window limit; otherwise unnecessary
 # truncation will happen. If not set, default value will be used.
-DEFAULT_MAX_TOKENS_FOR_RESPONSE = 4096
+DEFAULT_MAX_TOKENS_FOR_RESPONSE = 2048
 
 
 # Tokenizer model to generate tokens (for an approximated token calculation)


### PR DESCRIPTION
## Description
4096 is too much, I haven't seen response that big yet.. But it definitely creates problem when people forget to set it properly for smaller model. Reducing it won't resolve the issue completely but error will occur less.
Best solution for this is to make people aware about this through doc.