### PR TITLE
Fix displaying setuptools version in make install-tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,11 @@ install-tools:	install-woke ## Install required utilities/tools
 	# this is quick fix for OLS-758: "Verify" CI job is broken after new Mypy 1.10.1 was released 2 days ago
 	# CI job configuration would need to be updated in follow-up task
 	# pip uninstall -v -y mypy 2> /dev/null || true
-	# display setuptools version
-	pip show setuptools
 	export PIP_DEFAULT_TIMEOUT=100
 	# install all dependencies, including devel ones
 	@for a in 1 2 3 4 5; do pdm install --group default,dev,evaluation --fail-fast -v && break || sleep 15; done
+	# display setuptools version
+	pdm show setuptools
 	# check that correct mypy version is installed
 	# mypy --version
 	pdm run mypy --version
@@ -123,7 +123,7 @@ verify:	install-woke install-deps-test ## Verify the code using various linters
 	pdm run black . --check
 	pdm run ruff check .
 	./woke . --exit-1-on-failure
-	pylint ols scripts tests runner.py
+	pdm run pylint ols scripts tests runner.py
 	pdm run mypy --explicit-package-bases --disallow-untyped-calls --disallow-untyped-defs --disallow-incomplete-defs ols/
 
 schema:	## Generate OpenAPI schema file


### PR DESCRIPTION
## Description

possible this was user error, but previously this target attempted to run setuptools (to check the version) before running the pdm install command that actually installs setuptools, so it was always failing for me.  It might have worked for people who had manually installed setuptools previously.

I'm not entirely sure this output is useful, so an alternative PR would be to just delete the invocation entirely. let me know if you'd prefer that.

here's the output seen with this change:
```
# display setuptools version
pdm show setuptools
Name:                  setuptools                                                         
Latest version:        80.9.0                                                             
Latest stable version: 80.9.0                                                             
Installed version:     80.9.0                                                             
Summary:               Easily download, build, install, upgrade, and uninstall Python     
                       packages                                                           
Requires Python:       >=3.9                                                              
Author:                                                                                   
Author email:          Python Packaging Authority <distutils-sig@python.org>              
License:                                                                                  
Homepage:                                                                                 
Project URLs:          Source: https://github.com/pypa/setuptools                         
                       Documentation: https://setuptools.pypa.io/                         
                       Changelog: https://setuptools.pypa.io/en/stable/history.html       
Platform:                                                                                 
Keywords:              CPAN PyPI distutils eggs package management                        
# check that correct mypy version is installed
# mypy --version
pdm run mypy --version
mypy 1.17.0 (compiled: yes)
# check that correct Black version is installed
pdm run black --version
black, 25.1.0 (compiled: yes)
Python (CPython) 3.12.10
# check that correct Ruff version is installed
pdm run ruff --version
ruff 0.12.1
# check that correct Pydocstyle version is installed
pdm run pydocstyle --version
6.3.0
```

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.