### PR TITLE
Add ols config collection

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -8,3 +8,5 @@ exclude:
     - 'scripts/generate_openapi_schema.py'
     - 'scripts/evaluation/**'
     - 'scripts/data_collection/**'
+    # Ignore runner.py due to false positive path traversal alert
+    - 'runner.py'

--- a/examples/olsconfig.yaml
+++ b/examples/olsconfig.yaml
@@ -86,6 +86,8 @@ ols_config:
     feedback_storage: "/tmp/data/feedback"
     transcripts_disabled: false
     transcripts_storage: "/tmp/data/transcripts"
+    config_disabled: false
+    config_storage: "/tmp/data/config"
   tls_config:
     tls_certificate_path: /app-root/certs/certificate.crt
     tls_key_path: /app-root/certs/private.key

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -949,6 +949,8 @@ class UserDataCollection(BaseModel):
     feedback_storage: Optional[str] = None
     transcripts_disabled: bool = True
     transcripts_storage: Optional[str] = None
+    config_disabled: bool = True
+    config_storage: Optional[str] = None
 
     @model_validator(mode="after")
     def check_storage_location_is_set_when_needed(self) -> Self:
@@ -958,6 +960,10 @@ class UserDataCollection(BaseModel):
         if not self.transcripts_disabled and self.transcripts_storage is None:
             raise ValueError(
                 "transcripts_storage is required when transcripts capturing is enabled"
+            )
+        if not self.config_disabled and self.config_storage is None:
+            raise ValueError(
+                "config_storage is required when config collection is enabled"
             )
         return self
 

--- a/ols/user_data_collection/README.md
+++ b/ols/user_data_collection/README.md
@@ -92,9 +92,11 @@ ols_config:
     feedback_storage: "/your-path/user-data/feedback"
     transcripts_disabled: false
     transcripts_storage: "/your-path/user-data/transcripts"
+    config_disabled: false
+    config_storage: "/your-path/user-data/config"
 ```
 
-> `/feedback` and `/transcripts` needs to be under the same directory - `user-data/` in example above
+> `/feedback`, `/transcripts` and `/config` needs to be under the same directory - `user-data/` in example above
 
 and then just interact with OLS, post feedback or ask a question - it will store the data/JSONs under specified location.
 

--- a/ols/user_data_collection/data_collector.py
+++ b/ols/user_data_collection/data_collector.py
@@ -146,12 +146,13 @@ def collect_ols_data_from(location: str) -> list[pathlib.Path]:
     Returns:
         List of paths to the collected files.
 
-    Only JSON files from the 'feedback' and 'transcripts' directories are collected.
+    Only JSON files from the 'feedback', 'transcripts', and 'config' directories are collected.
     """
     files = []
 
     files += list(pathlib.Path(location).glob("feedback/*.json"))
     files += list(pathlib.Path(location).glob("transcripts/*/*/*.json"))
+    files += list(pathlib.Path(location).glob("config/*.json"))
 
     return files
 

--- a/runner.py
+++ b/runner.py
@@ -1,10 +1,14 @@
 """Main app entrypoint. Starts Uvicorn-based REST API service."""
 
+import json
 import logging
 import os
 import sys
 import threading
+from datetime import datetime
 from pathlib import Path
+
+import pytz
 
 from ols.constants import (
     CONFIGURATION_DUMP_FILE_NAME,
@@ -14,6 +18,7 @@ from ols.constants import (
 from ols.runners.quota_scheduler import start_quota_scheduler
 from ols.runners.uvicorn import start_uvicorn
 from ols.src.auth.auth import use_k8s_auth
+from ols.utils import suid
 from ols.utils.certificates import generate_certificates_file
 from ols.utils.environments import configure_gradio_ui_envs, configure_hugging_face_envs
 from ols.utils.logging_configurator import configure_logging
@@ -26,6 +31,44 @@ def load_index():
     # accessing the config's rag_index property will trigger the loading
     # of the index
     config.rag_index  # pylint: disable=W0104, E0606
+
+
+def store_config(cfg_file: str, logger: logging.Logger, config) -> None:
+    """Store service configuration in the local filesystem.
+
+    This function stores the original configuration file content once at startup.
+    Since the configuration is immutable for a single service deployment,
+    this avoids duplicating the same config data in every transcript/feedback.
+
+    Args:
+        cfg_file: Path to the original configuration file.
+        logger: Logger instance to use for logging.
+        config: The configuration object.
+    """
+    # snyk:ignore:a5ed58a6-47dc-4ff3-a430-5a040df0dc12
+    with open(cfg_file, "r", encoding="utf-8") as f:
+        config_content = f.read()
+
+    data_to_store = {
+        "metadata": {
+            "timestamp": datetime.now(pytz.UTC).isoformat(),
+            "service_version": __version__,
+            "config_file_path": cfg_file,
+            # Identifier for current backend, can be omitted in lcore version
+            "backend": "lightspeed-service",
+        },
+        "configuration": config_content,
+    }
+
+    # Store the data in the local filesystem
+    storage_path = Path(config.ols_config.user_data_collection.config_storage)
+    storage_path.mkdir(parents=True, exist_ok=True)
+    config_file_path = storage_path / f"{suid.get_suid()}.json"
+
+    with open(config_file_path, "w", encoding="utf-8") as config_file:
+        json.dump(data_to_store, config_file, indent=2)
+
+    logger.info("service configuration stored in '%s'", config_file_path)
 
 
 if __name__ == "__main__":
@@ -73,6 +116,12 @@ if __name__ == "__main__":
 
     # init loading of query redactor
     config.query_redactor  # pylint: disable=W0104
+
+    # store service configuration if enabled
+    if not config.ols_config.user_data_collection.config_disabled:
+        store_config(cfg_file, logger, config)
+    else:
+        logger.debug("config collection is disabled in configuration")
 
     if config.dev_config.pyroscope_url:
         start_with_pyroscope_enabled(config, logger)

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1,0 +1,182 @@
+"""Unit tests for runner module - specifically the store_config function."""
+
+import json
+import logging
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from runner import store_config
+
+
+@pytest.fixture
+def config_location(tmpdir):
+    """Fixture provides a temporary config storage location."""
+    return (tmpdir / "config").strpath
+
+
+@pytest.fixture
+def mock_logger():
+    """Fixture provides a mock logger for testing."""
+    return MagicMock(spec=logging.Logger)
+
+
+@pytest.fixture
+def mock_config(config_location):
+    """Fixture provides a mock config object for testing."""
+    mock_config = MagicMock()
+    mock_config.ols_config.user_data_collection.config_storage = config_location
+    return mock_config
+
+
+@pytest.fixture
+def sample_config_file():
+    """Create a temporary config file with sample content."""
+    config_content = """# Sample configuration
+ols_config:
+  default_provider: test_provider
+  default_model: test_model
+  user_data_collection:
+    feedback_disabled: true
+    transcripts_disabled: true
+    config_disabled: false
+    config_storage: "/tmp/config"
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(config_content)
+        f.flush()
+        yield f.name
+    # Cleanup
+    Path(f.name).unlink(missing_ok=True)
+
+
+def test_store_config_enabled(
+    config_location, sample_config_file, mock_logger, mock_config
+):
+    """Test that config is stored when enabled."""
+    store_config(sample_config_file, mock_logger, mock_config)
+
+    # Verify that a config file was created
+    config_files = list(Path(config_location).glob("*.json"))
+    assert len(config_files) == 1, f"Expected 1 config file, found {len(config_files)}"
+
+    # Verify the content
+    with open(config_files[0], "r") as f:
+        stored_data = json.load(f)
+
+    assert "metadata" in stored_data
+    assert "configuration" in stored_data
+    assert "timestamp" in stored_data["metadata"]
+    assert "service_version" in stored_data["metadata"]
+    assert "config_file_path" in stored_data["metadata"]
+    assert "backend" in stored_data["metadata"]
+
+    assert stored_data["metadata"]["config_file_path"] == sample_config_file
+    assert stored_data["metadata"]["backend"] == "lightspeed-service"
+    assert "ols_config:" in stored_data["configuration"]
+    assert "test_provider" in stored_data["configuration"]
+
+
+def test_store_config_creates_directory(tmpdir, sample_config_file, mock_logger):
+    """Test that config storage creates directory if it doesn't exist."""
+    # Use a non-existent nested directory path
+    nested_path = tmpdir / "nested" / "config" / "storage"
+    full_path = nested_path.strpath
+
+    # Create a mock config with the nested path
+    mock_config = MagicMock()
+    mock_config.ols_config.user_data_collection.config_storage = full_path
+
+    # Directory shouldn't exist initially
+    assert not Path(full_path).exists()
+
+    # Call store_config
+    store_config(sample_config_file, mock_logger, mock_config)
+
+    # Directory should be created
+    assert Path(full_path).exists()
+    assert Path(full_path).is_dir()
+
+    # Config file should be stored
+    config_files = list(Path(full_path).glob("*.json"))
+    assert len(config_files) == 1
+
+
+def test_store_config_unique_filenames(
+    config_location, sample_config_file, mock_logger, mock_config
+):
+    """Test that multiple calls create files with unique names."""
+    # Call store_config multiple times
+    store_config(sample_config_file, mock_logger, mock_config)
+    store_config(sample_config_file, mock_logger, mock_config)
+    store_config(sample_config_file, mock_logger, mock_config)
+
+    # Should have 3 unique files
+    config_files = list(Path(config_location).glob("*.json"))
+    assert len(config_files) == 3
+
+    # All filenames should be unique
+    filenames = [f.name for f in config_files]
+    assert len(set(filenames)) == 3
+
+
+@patch("runner.__version__", "1.2.3-test")
+def test_store_config_includes_version(
+    config_location, sample_config_file, mock_logger, mock_config
+):
+    """Test that stored config includes the service version."""
+    store_config(sample_config_file, mock_logger, mock_config)
+
+    config_files = list(Path(config_location).glob("*.json"))
+    with open(config_files[0], "r") as f:
+        stored_data = json.load(f)
+
+    assert stored_data["metadata"]["service_version"] == "1.2.3-test"
+
+
+def test_store_config_preserves_yaml_content(
+    config_location, sample_config_file, mock_logger, mock_config
+):
+    """Test that original YAML content is preserved exactly."""
+    # Read the original content
+    with open(sample_config_file, "r") as f:
+        original_content = f.read()
+
+    store_config(sample_config_file, mock_logger, mock_config)
+
+    config_files = list(Path(config_location).glob("*.json"))
+    with open(config_files[0], "r") as f:
+        stored_data = json.load(f)
+
+    # The stored configuration should match the original exactly
+    assert stored_data["configuration"] == original_content
+
+
+def test_store_config_json_format(
+    config_location, sample_config_file, mock_logger, mock_config
+):
+    """Test that stored file is valid JSON with proper structure."""
+    store_config(sample_config_file, mock_logger, mock_config)
+
+    config_files = list(Path(config_location).glob("*.json"))
+
+    # Should be valid JSON
+    with open(config_files[0], "r") as f:
+        stored_data = json.load(f)  # This will raise if invalid JSON
+
+    # Should have expected structure
+    expected_keys = {"metadata", "configuration"}
+    assert set(stored_data.keys()) == expected_keys
+
+    expected_metadata_keys = {
+        "timestamp",
+        "service_version",
+        "config_file_path",
+        "backend",
+    }
+    assert set(stored_data["metadata"].keys()) == expected_metadata_keys
+
+    # Configuration should be a string (YAML content)
+    assert isinstance(stored_data["configuration"], str)


### PR DESCRIPTION
## Description

This adds the olsconfig.yaml as a new datapoint.
Operator PR: https://github.com/openshift/lightspeed-operator/pull/906


## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
