### PR TITLE
OLS-2030: wrap the auth headers in a strip() to remove extra space

### DIFF
--- a/ols/src/tools/mcp_config_builder.py
+++ b/ols/src/tools/mcp_config_builder.py
@@ -28,13 +28,15 @@ class MCPConfigBuilder:
     @staticmethod
     def include_auth_header(user_token: str, config: dict[str, Any]) -> dict[str, Any]:
         """Include user token in the config headers."""
-        if "headers" not in config:
-            config["headers"] = {}
-        if K8S_AUTH_HEADER in config["headers"]:
-            logger.warning(
-                "Kubernetes auth header is already set, overriding with actual user token."
-            )
-        config["headers"][K8S_AUTH_HEADER] = f"Bearer {user_token}"
+        # Only add Authorization header if we have a valid token
+        if user_token and user_token.strip():
+            if "headers" not in config:
+                config["headers"] = {}
+            if K8S_AUTH_HEADER in config["headers"]:
+                logger.warning(
+                    "Kubernetes auth header is already set, overriding with actual user token."
+                )
+            config["headers"][K8S_AUTH_HEADER] = f"Bearer {user_token}"
         return config
 
     def include_auth_to_stdio(self, server_envs: dict[str, str]) -> dict[str, str]:


### PR DESCRIPTION
Fix bug with new MCP Server config that adds a space space after Bearer.
Wrap the auth headers in a strip() to remove extra space after Bearer when token token is present.

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
