### PR TITLE
OLS-2035: Temporarily change e2e test question about virtualization

### DIFF
--- a/tests/e2e/test_query_endpoint.py
+++ b/tests/e2e/test_query_endpoint.py
@@ -360,7 +360,7 @@ def test_rag_question() -> None:
     with metrics_utils.RestAPICallCounterChecker(pytest.metrics_client, QUERY_ENDPOINT):
         response = pytest.client.post(
             QUERY_ENDPOINT,
-            json={"query": "what is openshift virtualization?"},
+            json={"query": "about openshift virtualization"},
             timeout=test_api.LLM_REST_API_TIMEOUT,
         )
         assert response.status_code == requests.codes.ok
@@ -632,7 +632,7 @@ def test_rag_question_byok1() -> None:
     with metrics_utils.RestAPICallCounterChecker(pytest.metrics_client, QUERY_ENDPOINT):
         response = pytest.client.post(
             QUERY_ENDPOINT,
-            json={"query": "what is openshift virtualization?"},
+            json={"query": "about openshift virtualization"},
             timeout=test_api.LLM_REST_API_TIMEOUT,
         )
         assert response.status_code == requests.codes.ok
@@ -647,7 +647,7 @@ def test_rag_question_byok2() -> None:
     with metrics_utils.RestAPICallCounterChecker(pytest.metrics_client, QUERY_ENDPOINT):
         response = pytest.client.post(
             QUERY_ENDPOINT,
-            json={"query": "what is openshift virtualization?"},
+            json={"query": "about openshift virtualization"},
             timeout=test_api.LLM_REST_API_TIMEOUT,
         )
         assert response.status_code == requests.codes.ok

--- a/tests/e2e/test_streaming_query_endpoint.py
+++ b/tests/e2e/test_streaming_query_endpoint.py
@@ -351,7 +351,7 @@ def test_rag_question() -> None:
         response = post_with_defaults(
             STREAMING_QUERY_ENDPOINT,
             json={
-                "query": "what is openshift virtualization?",
+                "query": "about openshift virtualization",
                 "media_type": constants.MEDIA_TYPE_JSON,
             },
         )


### PR DESCRIPTION
## Description

Temporarily change e2e test question about virtualization. RAG query "what is openshift virtualization?" produces an unexpected top hit with OCP 4.19 docs, which is still very close (10^-3) to the expected top hit. This PR produces the expected top hit and is temporary until a proper investigation is conducted.
This change is needed for https://github.com/openshift/release/pull/68078.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/OLS-2024, https://issues.redhat.com/browse/OLS-2035
- Closes # 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
