### PR TITLE
 log MCP connection error and go with no tools

### DIFF
--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -262,8 +262,12 @@ class DocsSummarizer(QueryHelper):
             StreamedChunk objects representing parts of the response
         """
         async with asyncio.timeout(constants.TOOL_CALL_ROUND_TIMEOUT * max_rounds):
-            mcp_client = MultiServerMCPClient(self.mcp_servers)
-            all_mcp_tools = await mcp_client.get_tools()
+            try:
+                mcp_client = MultiServerMCPClient(self.mcp_servers)
+                all_mcp_tools = await mcp_client.get_tools()
+            except Exception as e:
+                logger.error("Failed to get MCP tools: %s", e)
+                all_mcp_tools = {}
 
             # Tool calling in a loop
             for i in range(1, max_rounds + 1):


### PR DESCRIPTION
## Description
 When OLS service cannot reach to MCP server , it returns `An error occurred during LLM invocation. Please contact your OpenShift Lightspeed administrator.: unhandled errors in a TaskGroup (1 sub-exception)`
 Log MCP connection error and use no tools if there is no MCP available. 

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
