### PR TITLE
parameter adjustment for gpt5 and o-series model

### DIFF
--- a/ols/src/llms/providers/azure_openai.py
+++ b/ols/src/llms/providers/azure_openai.py
@@ -64,21 +64,24 @@ class AzureOpenAI(LLMProvider):
             if azure_config.api_key is not None:
                 self.credentials = azure_config.api_key
 
-        default_parameters = {
+        default_parameters: dict[str, Any] = {
             "azure_endpoint": self.url,
             "api_version": api_version,
             "deployment_name": deployment_name,
             "model": self.model,
-            "top_p": 0.95,
-            "frequency_penalty": 1.03,
             "organization": None,
             "cache": None,
-            "temperature": 0.01,
             "max_tokens": 512,
             "verbose": False,
             "http_client": self._construct_httpx_client(False, False),
             "http_async_client": self._construct_httpx_client(False, True),
         }
+
+        # gpt-5 and o-series models don't support certain parameters
+        if not ("gpt-5" in self.model or self.model.startswith("o")):
+            default_parameters["temperature"] = 0.01
+            default_parameters["top_p"] = 0.95
+            default_parameters["frequency_penalty"] = 1.03
 
         if self.credentials is not None:
             # if credentials with API key is set, use it to call Azure OpenAI endpoints

--- a/ols/src/llms/providers/openai.py
+++ b/ols/src/llms/providers/openai.py
@@ -32,20 +32,24 @@ class OpenAI(LLMProvider):
             if openai_config.api_key is not None:
                 self.credentials = openai_config.api_key
 
-        return {
+        default_parameters: dict[str, Any] = {
             "base_url": self.url,
             "openai_api_key": self.credentials,
             "model": self.model,
-            "top_p": 0.95,
-            "frequency_penalty": 1.03,
             "organization": None,
             "cache": None,
-            "temperature": 0.01,
             "max_tokens": 512,
             "verbose": False,
             "http_client": self._construct_httpx_client(True, False),
             "http_async_client": self._construct_httpx_client(True, True),
         }
+
+        # gpt-5 and o-series models don't support certain parameters
+        if not ("gpt-5" in self.model or self.model.startswith("o")):
+            default_parameters["temperature"] = 0.01
+            default_parameters["top_p"] = 0.95
+            default_parameters["frequency_penalty"] = 1.03
+        return default_parameters
 
     def load(self) -> BaseChatModel:
         """Load LLM."""

--- a/tests/unit/llms/providers/test_openai.py
+++ b/tests/unit/llms/providers/test_openai.py
@@ -236,3 +236,37 @@ def test_params_replace_default_values_with_none(provider_config, fake_certifi_s
     # known parameter(s) should be there, now with None values
     assert "base_url" in openai.params
     assert openai.params["base_url"] is None
+
+
+@pytest.mark.parametrize(
+    "model_name,should_have_params",
+    [
+        ("gpt-4o", True),
+        ("gpt-5-mini", False),
+        ("o1-mini", False),
+    ],
+)
+def test_gpt5_and_o_series_models_parameter_exclusion(
+    provider_config, model_name, should_have_params
+):
+    """Test that some parameters are excluded for gpt-5 and o-series models."""
+    openai = OpenAI(model=model_name, provider_config=provider_config)
+    openai.load()
+
+    if should_have_params:
+        # should have the parameters
+        assert openai.default_params["temperature"] == 0.01
+        assert openai.default_params["top_p"] == 0.95
+        assert openai.default_params["frequency_penalty"] == 1.03
+    else:
+        # gpt-5 and o-series models should not have the parameters
+        assert "temperature" not in openai.default_params
+        assert "top_p" not in openai.default_params
+        assert "frequency_penalty" not in openai.default_params
+
+    # These parameters should always be present
+    assert "base_url" in openai.default_params
+    assert "openai_api_key" in openai.default_params
+    assert "model" in openai.default_params
+    assert "max_tokens" in openai.default_params
+    assert openai.default_params["model"] == model_name


### PR DESCRIPTION
## Description

remove temperature, top_p and frequency_penalty for gpt-5 & o-series models

Note
I have only tested with openai/o3-mini, remaining I am unable to test as those requires deployment (azure), openai/gpt-5 requires org level change (`Your organization must be verified to stream this model. Please go to: https://platform.openai.com/settings/organization/general and click on Verify Organization.`)

[OLS-2041](https://issues.redhat.com/browse/OLS-2041)