### PR TITLE
OLS-2050: Use new service-id in ingress posts

### DIFF
--- a/ols/user_data_collection/data_collector.py
+++ b/ols/user_data_collection/data_collector.py
@@ -180,11 +180,6 @@ def package_files_into_tarball(
                     file_path, arcname=file_path.as_posix().replace(path_to_strip, "")
                 )
 
-        # add magic file for identification of our archive on the CCX side
-        empty_file = tarfile.TarInfo("openshift_lightspeed.json")
-        empty_file.size = 0
-        tar.addfile(empty_file)
-
     tarball_io.seek(0)
 
     return tarball_io
@@ -233,7 +228,7 @@ def upload_data_to_ingress(tarball: io.BytesIO) -> requests.Response:
         "file": (
             "ols.tgz",
             tarball.read(),
-            "application/vnd.redhat.openshift.periodic+tar",
+            "application/vnd.redhat.ols.periodic+tar",
         ),
     }
 

--- a/tests/unit/user_data_collection/test_data_collector.py
+++ b/tests/unit/user_data_collection/test_data_collector.py
@@ -95,7 +95,7 @@ def test_package_files_into_tarball(tmp_path):
     with tarfile.open(fileobj=tarball, mode="r:gz") as tar:
         files = tar.getnames()
     # asserts that files in tarball are stored without the full path
-    assert files == ["some.json", "extra_dir/extra.json", "openshift_lightspeed.json"]
+    assert files == ["some.json", "extra_dir/extra.json"]
 
 
 def test_delete_data(tmp_path):


### PR DESCRIPTION
## Description

Use new service-id in ingress posts
- Use new 'ols' identifier to trigger new data route and processing behind ingress
- The magic file is no longer required for identification

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
