### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for lightspeed-service

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -71,7 +71,8 @@ LABEL io.k8s.display-name="OpenShift LightSpeed Service" \
       description="Red Hat OpenShift Lightspeed Service" \
       summary="Red Hat OpenShift Lightspeed Service" \
       com.redhat.component=openshift-lightspeed-service \
-      name=openshift-lightspeed-service \
+      name="openshift-lightspeed/lightspeed-service-api-rhel9" \
+      cpe="cpe:/a:redhat:openshift_lightspeed:1::el9" \
       vendor="Red Hat, Inc."
 
 


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
