### PR TITLE
Fix data collector e2e tests

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -1198,6 +1198,7 @@ class UserDataCollectorConfig(BaseModel):
     collection_interval: int = 2 * 60 * 60  # 2 hours
     run_without_initial_wait: bool = False
     ingress_env: Literal["stage", "prod"] = "prod"
+    # this is not offline token, but direct auth token to ingress
     cp_offline_token: Optional[str] = None
     initial_wait: int = 60 * 5  # 5 minutes in seconds
     ingress_timeout: int = 30

--- a/ols/user_data_collection/data_collector.py
+++ b/ols/user_data_collection/data_collector.py
@@ -235,11 +235,19 @@ def upload_data_to_ingress(tarball: io.BytesIO) -> requests.Response:
     headers: dict[str, str | bytes]
 
     if udc_config.cp_offline_token:
-        logger.debug("using CP offline token to generate refresh token")
-        token = access_token_from_offline_token(udc_config.cp_offline_token)
-        # when authenticating with token, user-agent is not accepted
-        # causing "UHC services authentication failed"
-        headers = {"Authorization": f"Bearer {token}"}
+        # logger.debug("using CP offline token to generate refresh token")
+        # token = access_token_from_offline_token(udc_config.cp_offline_token)
+        # # when authenticating with token, user-agent is not accepted
+        # # causing "UHC services authentication failed"
+        # headers = {
+        #     "User-Agent": udc_config.user_agent.format(cluster_id="test"),
+        #     "Authorization": f"Bearer {token}"
+        # }
+        logger.debug("using direct auth token")
+        headers = {
+            "User-Agent": udc_config.user_agent.format(cluster_id="test"),
+            "Authorization": f"Bearer {udc_config.cp_offline_token}",
+        }
     else:
         logger.debug("using cluster pull secret to authenticate")
         cluster_id = K8sClientSingleton.get_cluster_id()


### PR DESCRIPTION
## Description

Instead of providing offline token and using RH endpoint to get the ingress stage auth token, we provide the token directly from our vault.
This affects ONLY how the token is provided to our CI - ingress stage env.
The same token will be expected in the new dataverse exporter.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
