### PR TITLE
OLS-1980: Add autodiscovery for indexID value

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -874,7 +874,6 @@ class ReferenceContentIndex(BaseModel):
         """Validate reference content index config."""
         if self.product_docs_index_path is not None:
             try:
-                fallback_to_default = False
                 checks.dir_check(
                     self.product_docs_index_path, "Reference content index path"
                 )
@@ -887,22 +886,16 @@ class ReferenceContentIndex(BaseModel):
                 try:
                     checks.dir_check(default_path, "Reference content index path")
                     self.product_docs_index_path = FilePath(default_path)
-                    # load all index in the default path
+                    # we don't know the index_id for "latest" so ignore what
+                    # the config says and load whatever index is there
                     self.product_docs_index_id = None
-                    fallback_to_default = True
                 except checks.InvalidConfigurationError:
                     raise e_original
-            if self.product_docs_index_id is None and not fallback_to_default:
+        else:
+            if self.product_docs_index_id is not None:
                 raise checks.InvalidConfigurationError(
-                    "product_docs_index_path is specified but product_docs_index_id is missing"
+                    "product_docs_index_id is specified but product_docs_index_path is missing"
                 )
-        if (
-            self.product_docs_index_id is not None
-            and self.product_docs_index_path is None
-        ):
-            raise checks.InvalidConfigurationError(
-                "product_docs_index_id is specified but product_docs_index_path is missing"
-            )
 
 
 class ReferenceContent(BaseModel):

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -2928,14 +2928,19 @@ def test_reference_content_index_yaml_validation():
     # should not raise an exception
     reference_content_index.validate_yaml()
 
-    # existing docs index path with set up product ID
+    # existing docs index path with set up index ID
     reference_content_index.product_docs_index_path = "."
     reference_content_index.product_docs_index_id = "foo"
     reference_content_index.validate_yaml()
 
-    # existing docs index path, but no product ID
+    # existing docs index path, but no index ID
     reference_content_index.product_docs_index_path = "."
     reference_content_index.product_docs_index_id = None
+    reference_content_index.validate_yaml()
+
+    # no docs index path, but with index id
+    reference_content_index.product_docs_index_path = None
+    reference_content_index.product_docs_index_id = "foo"
     with pytest.raises(InvalidConfigurationError):
         reference_content_index.validate_yaml()
 

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -554,34 +554,6 @@ llm_providers:
 ols_config:
   reference_content:
     indexes:
-    - product_docs_index_path: "/tmp"
-  conversation_cache:
-    type: memory
-    memory:
-      max_entries: 1000
-dev_config:
-  temperature_override: 0.1
-  enable_dev_ui: true
-  disable_auth: false
-
-""",
-        InvalidConfigurationError,
-        "product_docs_index_path is specified but product_docs_index_id is missing",
-    )
-
-    check_expected_exception(
-        """
----
-llm_providers:
-  - name: p1
-    type: bam
-    credentials_path: tests/config/secret/apitoken
-    models:
-      - name: m1
-        credentials_path: tests/config/secret/apitoken
-ols_config:
-  reference_content:
-    indexes:
     - product_docs_index_id: "product"
   conversation_cache:
     type: memory


### PR DESCRIPTION
## Description

Make the Faiss index id for RAG databases optional as there's usually no need to specify it since there's only one index in a database anyway.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/OLS-1980
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
