### PR TITLE
OLS-2166: even in debug mode, OLS server never indicates BYOK indexes are loaded

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -853,6 +853,7 @@ class ReferenceContentIndex(BaseModel):
 
     product_docs_index_path: Optional[FilePath] = None
     product_docs_index_id: Optional[str] = None
+    product_docs_origin: Optional[str] = None
 
     def __init__(self, data: Optional[dict] = None) -> None:
         """Initialize configuration and perform basic validation."""
@@ -861,6 +862,7 @@ class ReferenceContentIndex(BaseModel):
             return
         self.product_docs_index_path = data.get("product_docs_index_path", None)
         self.product_docs_index_id = data.get("product_docs_index_id", None)
+        self.product_docs_origin = data.get("product_docs_origin", None)
 
     def __eq__(self, other: object) -> bool:
         """Compare two objects for equality."""
@@ -868,6 +870,7 @@ class ReferenceContentIndex(BaseModel):
             return (
                 self.product_docs_index_path == other.product_docs_index_path
                 and self.product_docs_index_id == other.product_docs_index_id
+                and self.product_docs_origin == other.product_docs_origin
             )
         return False
 

--- a/ols/src/rag_index/index_loader.py
+++ b/ols/src/rag_index/index_loader.py
@@ -145,7 +145,15 @@ class IndexLoader:
                     ),
                     persist_dir=index_config.product_docs_index_path,
                 )
-                logger.info("Loading vector index #%d...", i)
+                logger.info(
+                    "Loading vector index #%d%s...",
+                    i,
+                    (
+                        f" from {index_config.product_docs_origin}"
+                        if index_config.product_docs_origin
+                        else ""
+                    ),
+                )
                 index = load_index_from_storage(
                     storage_context=storage_context,
                     index_id=index_config.product_docs_index_id,


### PR DESCRIPTION
## Description

Added a new field to the OLS RAG configuration - product_docs_origin -

```
ols_config:
  reference_content:
    indexes:
      product_docs_origin
```      

that the OLS will use to identify the source of the RAG database. For BYOK RAG sources, product_docs_origin is set to the BYOK image name:tag. For OCP docs, it is set to "Red Hat OpenShift x.y documentation"
The corresponding operator PR: https://github.com/openshift/lightspeed-operator/pull/1049

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/OLS-2166
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
