### PR TITLE
OLS-2258: Fix test failures on the lightspeed-service mainline

### DIFF
--- a/tests/config/operator_install/imagedigestmirrorset.yaml
+++ b/tests/config/operator_install/imagedigestmirrorset.yaml
@@ -17,3 +17,12 @@ spec:
     - source: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9
       mirrors:
         - quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console
+    - source: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9
+      mirrors:
+        - quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-console-pf5
+    - source: registry.redhat.io/openshift-lightspeed/lightspeed-to-dataverse-exporter-rhel9
+      mirrors:
+        - quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-to-dataverse-exporter
+    - source: registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9
+      mirrors:
+        - quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server

--- a/tests/config/operator_install/olsconfig.crd.evaluation.yaml
+++ b/tests/config/operator_install/olsconfig.crd.evaluation.yaml
@@ -37,6 +37,13 @@ spec:
     defaultProvider: openai
     deployment:
       replicas: 1
+      dataCollector:
+        resources:
+          limits:
+            memory: 800Mi
+          requests:
+            cpu: 50m
+            memory: 800Mi
     disableAuth: false
     logLevel: DEBUG
     queryFilters:


### PR DESCRIPTION
## Description

In the ols-evalutate tests, the data collector gets OOMKilled, needs higher memory limit.
In the e2e tests, the app server pod doesn't start because image mirroring for the test cluster needs the data exporter and the mcp server added.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes # https://issues.redhat.com/browse/OLS-2258

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
