### PR TITLE
OLS-2105: Release OpenShift RAG database

### DIFF
--- a/tests/config/operator_install/imagedigestmirrorset.yaml
+++ b/tests/config/operator_install/imagedigestmirrorset.yaml
@@ -26,3 +26,6 @@ spec:
     - source: registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9
       mirrors:
         - quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server
+    - source: registry.redhat.io/openshift-lightspeed/lightspeed-ocp-rag
+      mirrors:
+        - quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-ocp-rag


### PR DESCRIPTION
## Description

Added the lightspeed-ocp-rag component to the image mirroring for the e2e tests.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/OLS-2105
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
