### PR TITLE
Ensuring must gather runs for all e2e test suites.

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -299,8 +299,8 @@ def get_secret_value(env: str) -> str:
 
 def pytest_sessionfinish(session):
     """Create datarouter compatible archive to upload into report portal."""
-    # Gather OLS artifacts only if there were failures
-    if on_cluster and session.testsfailed > 0:
+    # Gather OLS artifacts for all test suites when running on cluster
+    if on_cluster:
         must_gather()
     # Sending reports to report portal
     try:


### PR DESCRIPTION
## Description

Removed condition that will make must gather run only for failing suites.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
