### PR TITLE
OLS-2099: Update expected response

### DIFF
--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -464,9 +464,8 @@ def test_azure_entra_id():
     json_response = response.json()
 
     # checking a few major information from response
-    assert "Kubernetes is" in json_response["response"]
     assert re.search(
-        r"orchestration (tool|system|platform|engine)",
+        r"kubernetes|openshift",
         json_response["response"],
         re.IGNORECASE,
     )

--- a/tests/e2e/test_query_endpoint.py
+++ b/tests/e2e/test_query_endpoint.py
@@ -222,9 +222,8 @@ def test_valid_question() -> None:
 
         # checking a few major information from response
         assert json_response["conversation_id"] == cid
-        assert "Kubernetes is" in json_response["response"]
         assert re.search(
-            r"orchestration (tool|system|platform|engine)",
+            r"kubernetes|openshift",
             json_response["response"],
             re.IGNORECASE,
         )

--- a/tests/e2e/test_streaming_query_endpoint.py
+++ b/tests/e2e/test_streaming_query_endpoint.py
@@ -209,9 +209,8 @@ def test_valid_question() -> None:
 
         response_utils.check_content_type(response, constants.MEDIA_TYPE_TEXT)
 
-        assert "Kubernetes is" in response.text
         assert re.search(
-            r"orchestration (tool|system|platform|engine)",
+            r"kubernetes|openshift",
             response.text,
             re.IGNORECASE,
         )


### PR DESCRIPTION
## Description

In 4.20, the responses are like this:
```
In the context of OpenShift, Kubernetes serves as the foundational technology for orchestrating containerized applica... OpenShift, enabling it to provide a powerful and scalable platform for modern application development and deployment.
```
which no longer match `orchestration (tool|system|platform|engine)` pattern.

The reason of test is not to evaluate the response quality, just to ensure we get "something" back.


## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
