### PR TITLE
Fix GradioUI system prompt

### DIFF
--- a/ols/src/ui/gradio_ui.py
+++ b/ols/src/ui/gradio_ui.py
@@ -34,7 +34,9 @@ class GradioUI:
         additional_inputs = [use_history, provider, model]
         if config.dev_config.enable_system_prompt_override:
             system_prompt = gr.TextArea(
-                value=prompts.QUERY_SYSTEM_INSTRUCTION, label="System prompt"
+                value=config.ols_config.system_prompt
+                or prompts.QUERY_SYSTEM_INSTRUCTION,
+                label="System prompt",
             )
             additional_inputs.append(system_prompt)
         self.ui = gr.ChatInterface(self.chat_ui, additional_inputs=additional_inputs)

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "evaluation"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:ce8969ef24388dae7b8205727984c23b4e3036d514b43c259a0202e20667b436"
+content_hash = "sha256:f52973e650c7b62620102963425c2e51eca278cbb08ac7b396d1ad534db99e3e"
 
 [[metadata.targets]]
 requires_python = ">=3.11.1,<=3.12.10"


### PR DESCRIPTION
## Description

On the GradioUI the system prompt displayed is *always* using the default system prompt, which is problematic when running the service with a custom system prompt (`system_prompt_path`) and allowing overriding it (`enable_system_prompt_override: true`).

With this simple patch we default to the configured system prompt on the GradioUI and only use the default system prompt if we don't have it configured.

## Type of change

- [x] Bug fix

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.