### PR TITLE
Fix GradioUI system promptShow description for cd38b84

### DIFF
--- a/ols/src/ui/gradio_ui.py
+++ b/ols/src/ui/gradio_ui.py
@@ -34,7 +34,9 @@ class GradioUI:
         additional_inputs = [use_history, provider, model]
         if config.dev_config.enable_system_prompt_override:
             system_prompt = gr.TextArea(
-                value=prompts.QUERY_SYSTEM_INSTRUCTION, label="System prompt"
+                value=config.ols_config.system_prompt
+                or prompts.QUERY_SYSTEM_INSTRUCTION,
+                label="System prompt",
             )
             additional_inputs.append(system_prompt)
         self.ui = gr.ChatInterface(self.chat_ui, additional_inputs=additional_inputs)


### PR DESCRIPTION
On the GradioUI the system prompt displayed is *always* using the default system prompt, which is problematic when running the service with a custom system prompt (`system_prompt_path`) and allowing overriding it (`enable_system_prompt_override: true`).

With this simple patch we default to the configured system prompt on the GradioUI and only use the default system prompt if we don't have it configured.


## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
