### PR TITLE
MG-138: Add datamasking service adapted from codeready-toolchain/tarsy-bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+config/
 # ignore python and editors cache
 __pycache__
 __pypackages__

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -17,6 +17,7 @@ from pydantic import (
 )
 
 from ols import constants
+from ols.app.models.masking_config import MaskingConfig
 from ols.utils import checks, tls
 
 
@@ -605,6 +606,7 @@ class MCPServerConfig(BaseModel):
     stdio: Optional[StdioTransportConfig] = None
     sse: Optional[SseTransportConfig] = None
     streamable_http: Optional[StreamableHttpTransportConfig] = None
+    data_masking: Optional[MaskingConfig] = None
 
     @model_validator(mode="after")
     def correct_transport_specified(self) -> Self:

--- a/ols/app/models/masking_config.py
+++ b/ols/app/models/masking_config.py
@@ -1,0 +1,124 @@
+"""Masking configuration data models.
+
+This module defines Pydantic models for validating data masking configurations
+that are applied to MCP server request/response flows to protect sensitive data.
+"""
+
+import re
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class MaskingPattern(BaseModel):
+    """A single masking pattern configuration.
+
+    Defines a regex pattern to match sensitive data and the replacement
+    text to use when masking.
+    """
+
+    name: str = Field(..., description="Pattern identifier (e.g., 'security_token')")
+    pattern: str = Field(..., description="Regex pattern for matching sensitive data")
+    replacement: str = Field(..., description="Replacement text for matches")
+    description: str = Field(..., description="Human-readable description of the pattern")
+    enabled: bool = Field(True, description="Whether pattern is active")
+
+    @field_validator("pattern")
+    @classmethod
+    def validate_regex_pattern(cls, v: str) -> str:
+        """Validate that the pattern is a valid regex.
+
+        Args:
+            v: The regex pattern string
+
+        Returns:
+            The validated pattern string
+
+        Raises:
+            ValueError: If the pattern is not a valid regex
+        """
+        try:
+            re.compile(v)
+        except re.error as e:
+            raise ValueError(f"Invalid regex pattern: {e}") from e
+        return v
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        """Validate that the pattern name is not empty.
+
+        Args:
+            v: The pattern name
+
+        Returns:
+            The validated pattern name
+
+        Raises:
+            ValueError: If the name is empty or only whitespace
+        """
+        if not v or not v.strip():
+            raise ValueError("Pattern name cannot be empty")
+        return v.strip()
+
+
+class MaskingConfig(BaseModel):
+    """Configuration for data masking on a specific MCP server.
+
+    Defines which patterns and pattern groups to apply when masking
+    sensitive data from MCP server responses.
+    """
+
+    enabled: bool = Field(True, description="Whether masking is enabled for this server")
+    pattern_groups: List[str] = Field(
+        default_factory=list, description="List of built-in pattern group names to apply"
+    )
+    patterns: List[str] = Field(
+        default_factory=list, description="List of built-in pattern names to apply"
+    )
+    custom_patterns: Optional[List[MaskingPattern]] = Field(
+        None, description="Server-specific custom patterns"
+    )
+
+    @field_validator("pattern_groups")
+    @classmethod
+    def validate_pattern_groups(cls, v: List[str]) -> List[str]:
+        """Validate pattern group names are not empty.
+
+        Args:
+            v: List of pattern group names
+
+        Returns:
+            The validated list of pattern group names
+
+        Raises:
+            ValueError: If any group name is empty
+        """
+        validated_groups = []
+        for group in v:
+            if not group or not group.strip():
+                raise ValueError("Pattern group name cannot be empty")
+            validated_groups.append(group.strip())
+        return validated_groups
+
+    @field_validator("patterns")
+    @classmethod
+    def validate_patterns(cls, v: List[str]) -> List[str]:
+        """Validate pattern names are not empty.
+
+        Args:
+            v: List of pattern names
+
+        Returns:
+            The validated list of pattern names
+
+        Raises:
+            ValueError: If any pattern name is empty
+        """
+        validated_patterns = []
+        for pattern in v:
+            if not pattern or not pattern.strip():
+                raise ValueError("Pattern name cannot be empty")
+            validated_patterns.append(pattern.strip())
+        return validated_patterns
+

--- a/ols/src/maskers/__init__.py
+++ b/ols/src/maskers/__init__.py
@@ -1,0 +1,12 @@
+"""Code-based data maskers for complex masking scenarios.
+
+This package provides code-based maskers that complement regex patterns
+with structural awareness and context-sensitive masking logic.
+"""
+
+from ols.src.maskers.base_masker import BaseMasker
+from ols.src.maskers.data_masking_service import DataMaskingService
+from ols.src.maskers.kubernetes_secret_masker import KubernetesSecretMasker
+
+__all__ = ["BaseMasker", "DataMaskingService", "KubernetesSecretMasker"]
+

--- a/ols/src/maskers/base_masker.py
+++ b/ols/src/maskers/base_masker.py
@@ -1,0 +1,91 @@
+"""Base masker interface for code-based data masking.
+
+This module defines the abstract interface that all code-based maskers must implement.
+Code-based maskers complement regex patterns by providing structural awareness and
+context-sensitive masking logic for complex data formats.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class BaseMasker(ABC):
+    """Abstract base class for code-based data maskers.
+
+    Code-based maskers provide sophisticated masking logic that goes beyond
+    simple regex pattern matching. They can parse structured data (YAML, JSON),
+    understand context, and apply intelligent masking rules.
+
+    Example:
+        class MyMasker(BaseMasker):
+            def name(self) -> str:
+                return "my_masker"
+
+            def applies_to(self, data: str) -> bool:
+                return "custom_marker" in data
+
+            def mask(self, data: str) -> str:
+                # Apply custom masking logic
+                return masked_data
+
+    Note:
+        Maskers should be defensive and fail gracefully. If parsing or masking
+        fails, return the original data rather than raising an exception.
+    """
+
+    @abstractmethod
+    def name(self) -> str:
+        """Return the unique identifier for this masker.
+
+        The name is used to reference this masker in configuration files
+        and pattern groups. It should be descriptive and unique across
+        all maskers.
+
+        Returns:
+            A unique string identifier (e.g., "kubernetes_secret")
+        """
+        pass
+
+    @abstractmethod
+    def applies_to(self, data: str) -> bool:
+        """Check if this masker should process the given data.
+
+        This method performs a lightweight check to determine if the masker
+        is applicable to the provided data. It should be fast and avoid
+        expensive parsing operations when possible.
+
+        Args:
+            data: The input data to check for applicability
+
+        Returns:
+            True if this masker should process the data, False otherwise
+
+        Note:
+            This method should never raise exceptions. If uncertain,
+            return False to skip masking.
+        """
+        pass
+
+    @abstractmethod
+    def mask(self, data: str) -> str:
+        """Apply masking logic to the data and return the masked result.
+
+        This method performs the actual masking operation. It should:
+        - Parse the data structure if needed
+        - Identify sensitive fields or patterns
+        - Replace sensitive content with masked values
+        - Preserve structure and formatting where possible
+        - Handle errors gracefully (return original data on failure)
+
+        Args:
+            data: The input data to mask
+
+        Returns:
+            The masked data with sensitive information replaced
+
+        Note:
+            This method should be defensive and handle malformed input.
+            If masking fails, return the original data rather than
+            raising an exception to maintain system reliability.
+        """
+        pass
+

--- a/ols/src/maskers/builtin_config.py
+++ b/ols/src/maskers/builtin_config.py
@@ -1,0 +1,137 @@
+"""Built-in masking patterns, pattern groups, and code-based maskers.
+
+This module contains all built-in masking patterns and configuration
+for the DataMaskingService. It serves as the single source of truth for:
+- Built-in regex masking patterns
+- Pattern groups for convenient configuration
+- Code-based masker import paths
+"""
+
+from typing import Dict, List
+
+# ==============================================================================
+# BUILT-IN MASKING PATTERNS
+# ==============================================================================
+
+# Central registry of all built-in masking patterns for MCP server responses
+# Format: "pattern_name" -> {"pattern": regex, "replacement": text, "description": text}
+# Note: Kubernetes Secret masking is handled by code-based masker (see BUILTIN_CODE_MASKERS)
+BUILTIN_MASKING_PATTERNS: Dict[str, Dict[str, str]] = {
+    "base64_secret": {
+        "pattern": r"\b([A-Za-z0-9+/]{20,}={0,2})\b",
+        "replacement": "__MASKED_BASE64_VALUE__",
+        "description": "Base64-encoded values in secret contexts (20+ chars)",
+    },
+    "base64_short": {
+        "pattern": r"(?<=:\s)([A-Za-z0-9+/]{4,19}={0,2})(?=\s|$)",
+        "replacement": "__MASKED_SHORT_BASE64__",
+        "description": "Short base64-encoded values (4-19 chars) after colons in Kubernetes contexts",
+    },
+    "api_key": {
+        "pattern": r'(?i)(?:api[_-]?key|apikey|key)["\']?\s*[:=]\s*["\']?([A-Za-z0-9_\-]{20,})["\']?',
+        "replacement": r'"api_key": "__MASKED_API_KEY__"',
+        "description": "API keys in various formats",
+    },
+    "password": {
+        "pattern": r'(?i)(?:password|pwd|pass)["\']?\s*[:=]\s*["\']?([^"\'\s\n]{6,})["\']?',
+        "replacement": r'"password": "__MASKED_PASSWORD__"',
+        "description": "Password fields",
+    },
+    "certificate": {
+        "pattern": r"-----BEGIN [A-Z ]+-----.*?-----END [A-Z ]+-----",
+        "replacement": "__MASKED_CERTIFICATE__",
+        "description": "SSL/TLS certificates and private keys",
+    },
+    "certificate_authority_data": {
+        "pattern": r"(?i)certificate-authority-data:\s*([A-Za-z0-9+/]{20,}={0,2})",
+        "replacement": r"certificate-authority-data: __MASKED_CA_CERTIFICATE__",
+        "description": "Certificate authority data in Kubernetes configs and YAML files",
+    },
+    "email": {
+        "pattern": r"(?<!\\)\b[A-Za-z0-9._%+-]+@[A-Za-z0-9]+(?:[.-][A-Za-z0-9]+)*\.[A-Za-z]{2,63}\b(?!\()",
+        "replacement": "__MASKED_EMAIL__",
+        "description": "Email addresses",
+    },
+    "token": {
+        "pattern": r'(?i)(?:token|bearer|jwt)["\']?\s*[:=]\s*["\']?([A-Za-z0-9_\-\.]{20,})["\']?',
+        "replacement": r'"token": "__MASKED_TOKEN__"',
+        "description": "Access tokens, bearer tokens, and JWTs",
+    },
+    "ssh_key": {
+        "pattern": r"ssh-(?:rsa|dss|ed25519|ecdsa)\s+[A-Za-z0-9+/=]+",
+        "replacement": "__MASKED_SSH_KEY__",
+        "description": "SSH public keys (all common algorithms)",
+    },
+}
+
+# ==============================================================================
+# BUILT-IN PATTERN GROUPS
+# ==============================================================================
+
+# Central registry of built-in pattern groups for convenient configuration
+# Format: "group_name" -> [list_of_pattern_names]
+# Groups can reference both regex patterns and code-based maskers
+BUILTIN_PATTERN_GROUPS: Dict[str, List[str]] = {
+    "basic": ["api_key", "password"],  # Most common secrets
+    "secrets": ["api_key", "password", "token"],  # Basic + tokens
+    "security": [
+        "api_key",
+        "password",
+        "token",
+        "certificate",
+        "certificate_authority_data",
+        "email",
+        "ssh_key",
+    ],  # Full security focus
+    "kubernetes": [
+        "kubernetes_secret",
+        "api_key",
+        "password",
+        "certificate_authority_data",
+    ],  # Kubernetes-specific - uses code-based masker for Secrets (not ConfigMaps)
+    "all": [
+        "base64_secret",
+        "base64_short",
+        "api_key",
+        "password",
+        "certificate",
+        "certificate_authority_data",
+        "email",
+        "token",
+        "ssh_key",
+    ],  # All patterns
+}
+
+# ==============================================================================
+# BUILT-IN CODE-BASED MASKERS
+# ==============================================================================
+
+# Central registry of built-in code-based maskers
+# Format: "masker_name" -> "import.path.ClassName"
+# Code-based maskers provide structural awareness for complex masking scenarios
+# where simple regex patterns are insufficient (e.g., parsing YAML/JSON structures)
+BUILTIN_CODE_MASKERS: Dict[str, str] = {
+    "kubernetes_secret": "ols.src.maskers.kubernetes_secret_masker.KubernetesSecretMasker",
+    # Future maskers will be added here as needed
+}
+
+
+# ==============================================================================
+# CONVENIENCE ACCESSORS
+# ==============================================================================
+
+
+def get_builtin_masking_patterns() -> Dict[str, Dict[str, str]]:
+    """Get all built-in masking patterns."""
+    return BUILTIN_MASKING_PATTERNS.copy()
+
+
+def get_builtin_pattern_groups() -> Dict[str, List[str]]:
+    """Get all built-in pattern groups."""
+    return {k: v.copy() for k, v in BUILTIN_PATTERN_GROUPS.items()}
+
+
+def get_builtin_code_maskers() -> Dict[str, str]:
+    """Get all built-in code-based masker import paths."""
+    return BUILTIN_CODE_MASKERS.copy()
+

--- a/ols/src/maskers/data_masking_service.py
+++ b/ols/src/maskers/data_masking_service.py
@@ -1,0 +1,539 @@
+"""Data masking service for sensitive MCP server data.
+
+This module provides the core data masking functionality to prevent
+sensitive data from reaching the LLM, logging, and storage systems.
+"""
+
+import importlib
+import json
+import logging
+import re
+from typing import Any, Callable, Dict, List, Optional, Pattern
+
+from ols.app.models.masking_config import MaskingConfig, MaskingPattern
+from ols.src.maskers.base_masker import BaseMasker
+from ols.src.maskers.builtin_config import (
+    BUILTIN_CODE_MASKERS,
+    BUILTIN_MASKING_PATTERNS,
+    BUILTIN_PATTERN_GROUPS,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DataMaskingService:
+    """Service for masking sensitive data in MCP server responses.
+
+    This service applies both regex patterns and code-based maskers to mask
+    sensitive information before it reaches the LLM, logging, or storage systems.
+
+    Code-based maskers are applied first (more specific), followed by regex
+    patterns (more general).
+    """
+
+    def __init__(
+        self,
+        get_server_masking_config: Optional[Callable[[str], Optional[MaskingConfig]]] = None,
+    ):
+        """Initialize the data masking service.
+
+        Args:
+            get_server_masking_config: Callback function to retrieve masking config
+                for a given server name. If None, masking will be disabled for all servers.
+        """
+        self._get_server_masking_config = get_server_masking_config
+        self.compiled_patterns: Dict[str, Pattern[str]] = {}
+        self.custom_pattern_metadata: Dict[str, Dict[str, str]] = {}
+        self.code_based_maskers: Dict[str, BaseMasker] = {}
+        self._load_builtin_patterns()
+        self._load_builtin_maskers()
+
+        logger.info("DataMaskingService initialized")
+
+    def _load_builtin_patterns(self) -> None:
+        """Load and compile built-in regex patterns.
+
+        This method compiles all built-in patterns for performance.
+        Patterns that fail to compile will be logged and skipped.
+        """
+        logger.debug("Loading built-in masking patterns")
+
+        for pattern_name, pattern_config in BUILTIN_MASKING_PATTERNS.items():
+            try:
+                compiled_pattern = re.compile(
+                    pattern_config["pattern"], re.DOTALL | re.MULTILINE
+                )
+                self.compiled_patterns[pattern_name] = compiled_pattern
+                logger.debug(f"Compiled pattern: {pattern_name}")
+            except re.error as e:
+                logger.error(f"Failed to compile built-in pattern '{pattern_name}': {e}")
+
+        logger.info(f"Loaded {len(self.compiled_patterns)} built-in patterns")
+
+    def _load_builtin_maskers(self) -> None:
+        """Load and instantiate built-in code-based maskers.
+
+        This method dynamically imports and instantiates code-based maskers
+        registered in BUILTIN_CODE_MASKERS. Maskers that fail to load will
+        be logged and skipped.
+        """
+        logger.debug("Loading built-in code-based maskers")
+
+        for masker_name, import_path in BUILTIN_CODE_MASKERS.items():
+            try:
+                # Parse import path: "module.path.ClassName"
+                module_path, class_name = import_path.rsplit(".", 1)
+
+                # Dynamically import the module
+                module = importlib.import_module(module_path)
+
+                # Get the class
+                masker_class = getattr(module, class_name)
+
+                # Verify it's a BaseMasker subclass before instantiation
+                if not issubclass(masker_class, BaseMasker):
+                    logger.error(
+                        f"Masker '{masker_name}' from '{import_path}' is not a BaseMasker subclass"
+                    )
+                    continue
+
+                # Instantiate the masker
+                masker_instance = masker_class()
+
+                # Validate that the masker's name() matches the registry key
+                actual_name = masker_instance.name()
+                if actual_name != masker_name:
+                    logger.warning(
+                        f"Masker name mismatch: registry key is '{masker_name}' but "
+                        f"masker.name() returns '{actual_name}'. This could indicate "
+                        f"configuration drift. Skipping this masker."
+                    )
+                    continue
+
+                # Register the masker
+                self.code_based_maskers[masker_name] = masker_instance
+                logger.debug(f"Loaded code-based masker: {masker_name}")
+
+            except (ImportError, AttributeError, Exception) as e:
+                logger.error(
+                    f"Failed to load built-in masker '{masker_name}' from '{import_path}': "
+                    f"{type(e).__name__}: {e}"
+                )
+
+        logger.info(f"Loaded {len(self.code_based_maskers)} built-in code-based maskers")
+
+    def _compile_and_add_custom_patterns(
+        self, custom_patterns: List[MaskingPattern]
+    ) -> List[str]:
+        """Compile custom patterns and add them to the compiled patterns dictionary.
+
+        Args:
+            custom_patterns: List of MaskingPattern objects to compile and add
+
+        Returns:
+            List of pattern names that were successfully compiled and added
+        """
+        compiled_pattern_names = []
+
+        for custom_pattern in custom_patterns:
+            if not custom_pattern.enabled:
+                logger.debug(f"Skipping disabled custom pattern: {custom_pattern.name}")
+                continue
+
+            try:
+                compiled_pattern = re.compile(
+                    custom_pattern.pattern, re.DOTALL | re.MULTILINE
+                )
+
+                # Store both compiled pattern and replacement text
+                # Use a unique key to avoid conflicts with built-in patterns
+                pattern_key = f"custom_{custom_pattern.name}"
+                self.compiled_patterns[pattern_key] = compiled_pattern
+
+                # Store custom pattern metadata for replacement lookup
+                self.custom_pattern_metadata[pattern_key] = {
+                    "replacement": custom_pattern.replacement,
+                    "description": custom_pattern.description,
+                }
+
+                compiled_pattern_names.append(pattern_key)
+                logger.debug(
+                    f"Compiled custom pattern: {custom_pattern.name} -> {pattern_key}"
+                )
+
+            except re.error as e:
+                logger.error(
+                    f"Failed to compile custom pattern '{custom_pattern.name}': {e}"
+                )
+                continue
+
+        logger.debug(f"Successfully compiled {len(compiled_pattern_names)} custom patterns")
+        return compiled_pattern_names
+
+    def mask_data(self, data: Dict[str, Any], pattern_group: str = "security") -> Dict[str, Any]:
+        """Mask sensitive data in data payloads using specified pattern group.
+
+        This method provides standalone data masking without requiring
+        MCP server configuration. It's used for masking data
+        at the API entry point.
+
+        Uses the same core masking mechanism as mask_response() to apply
+        both code-based maskers and regex patterns to data structures.
+
+        Args:
+            data: The data dictionary to mask
+            pattern_group: Pattern group name (default: "security")
+                          Available groups: basic, secrets, security, kubernetes, all
+
+        Returns:
+            Masked data dictionary with sensitive information replaced
+
+        Raises:
+            ValueError: If pattern_group is not recognized
+        """
+        logger.debug(f"mask_data called with pattern_group: {pattern_group}")
+
+        try:
+            # Validate pattern group exists
+            if pattern_group not in BUILTIN_PATTERN_GROUPS:
+                available_groups = list(BUILTIN_PATTERN_GROUPS.keys())
+                error_msg = (
+                    f"Unknown pattern group '{pattern_group}'. Available: {available_groups}"
+                )
+                logger.error(error_msg)
+                raise ValueError(error_msg)
+
+            # Expand pattern group to individual patterns
+            patterns = self._expand_pattern_groups([pattern_group])
+
+            if not patterns:
+                logger.warning(
+                    f"Pattern group '{pattern_group}' expanded to no patterns - returning data unchanged"
+                )
+                return data
+
+            logger.debug(
+                f"Applying {len(patterns)} patterns from group '{pattern_group}' to data"
+            )
+
+            # Use the same core masking mechanism as mask_response()
+            masked_data = self._mask_data_structure(data, patterns)
+
+            logger.debug(f"Data masking completed for pattern group '{pattern_group}'")
+            return masked_data
+
+        except ValueError:
+            # Re-raise validation errors
+            raise
+        except Exception as e:
+            # Log error but don't fail - return original data for reliability
+            logger.error(
+                f"Error during data masking with pattern group '{pattern_group}': {e}",
+                exc_info=True,
+            )
+            logger.warning(
+                "Returning original data due to masking error (fail-open for reliability)"
+            )
+            return data
+
+    def mask_response(self, response: Dict[str, Any], server_name: str) -> Dict[str, Any]:
+        """Apply server-specific masking patterns to response data.
+
+        This method looks up the masking configuration for the specified server
+        and applies all configured patterns to the response data.
+
+        Args:
+            response: The response data from the MCP server
+            server_name: Name of the MCP server that generated the response
+
+        Returns:
+            The response data with sensitive information masked
+        """
+        logger.debug(f"mask_response called for server: {server_name}")
+
+        try:
+            # Step 1: Get masking configuration for the server
+            masking_config = self._get_masking_config_for_server(server_name)
+            if not masking_config or not masking_config.enabled:
+                logger.debug(f"Masking disabled for server: {server_name}")
+                return response
+
+            # Step 2: Expand pattern groups to individual patterns
+            all_patterns: List[str] = []
+            if masking_config.pattern_groups:
+                expanded_patterns = self._expand_pattern_groups(
+                    masking_config.pattern_groups
+                )
+                all_patterns.extend(expanded_patterns)
+
+            # Step 3: Add individual patterns
+            if masking_config.patterns:
+                all_patterns.extend(masking_config.patterns)
+
+            # Step 4: Add custom patterns
+            custom_pattern_names: List[str] = []
+            if masking_config.custom_patterns:
+                custom_pattern_names = self._compile_and_add_custom_patterns(
+                    masking_config.custom_patterns
+                )
+                logger.debug(
+                    f"Compiled and added {len(custom_pattern_names)} custom patterns: "
+                    f"{custom_pattern_names}"
+                )
+
+            # Combine all patterns (built-in + custom)
+            all_patterns.extend(custom_pattern_names)
+
+            if not all_patterns:
+                logger.debug(f"No patterns configured for server: {server_name}")
+                return response
+
+            # Remove duplicates while preserving order
+            unique_patterns: List[str] = []
+            seen: set[str] = set()
+            for pattern in all_patterns:
+                if pattern not in seen:
+                    unique_patterns.append(pattern)
+                    seen.add(pattern)
+
+            logger.debug(
+                f"Applying {len(unique_patterns)} patterns to response for server: {server_name}"
+            )
+
+            # Step 5: Apply masking to the response data
+            masked_response = self._mask_data_structure(response, unique_patterns)
+
+            logger.debug(f"Masking completed for server: {server_name}")
+            return masked_response
+
+        except Exception as e:
+            logger.error(f"Error during masking for server '{server_name}': {e}")
+            # Fail-safe behavior: mask the entire response content
+            logger.warning(f"Applying fail-safe masking for server: {server_name}")
+            return self._apply_failsafe_masking(response)
+
+    def _mask_data_structure(self, data: Any, patterns: List[str]) -> Any:
+        """Recursively traverse and mask data structures.
+
+        Args:
+            data: The data structure to mask (can be dict, list, str, or other types)
+            patterns: List of pattern names to apply
+
+        Returns:
+            The data structure with sensitive information masked
+        """
+        if isinstance(data, dict):
+            # Recursively mask dictionary values
+            masked_dict = {}
+            for key, value in data.items():
+                masked_dict[key] = self._mask_data_structure(value, patterns)
+            return masked_dict
+
+        elif isinstance(data, list):
+            # Recursively mask list elements
+            return [self._mask_data_structure(item, patterns) for item in data]
+
+        elif isinstance(data, str):
+            # Apply patterns to string content
+            return self._apply_patterns(data, patterns)
+
+        else:
+            # For other types (int, float, bool, None), return unchanged
+            return data
+
+    def _apply_failsafe_masking(self, response: Dict[str, Any]) -> Dict[str, Any]:
+        """Apply fail-safe masking when normal masking fails.
+
+        Args:
+            response: The original response data
+
+        Returns:
+            A response with all string content masked
+        """
+        logger.debug("Applying fail-safe masking")
+
+        try:
+            # Convert response to string and mask it entirely
+            json.dumps(response, default=str)
+            masked_content = "__MASKED_ERROR__"
+
+            # Try to preserve the basic response structure
+            if "result" in response:
+                return {"result": masked_content}
+            else:
+                return {"masked_response": masked_content}
+
+        except Exception as e:
+            logger.error(f"Error in fail-safe masking: {e}")
+            # Ultimate fail-safe
+            return {"result": "__MASKED_ERROR__"}
+
+    def _apply_patterns(self, text: str, patterns: List[str]) -> str:
+        """Apply code-based maskers and regex patterns to mask text content.
+
+        This method applies masking in two phases:
+        1. Code-based maskers (more specific, structural awareness)
+        2. Regex patterns (more general, pattern matching)
+
+        Args:
+            text: The text content to mask
+            patterns: List of pattern names to apply
+
+        Returns:
+            The text with sensitive information masked
+        """
+        logger.debug(
+            f"_apply_patterns called with {len(patterns)} patterns on text length {len(text)}"
+        )
+
+        if not text or not patterns:
+            return text
+
+        masked_text = text
+        patterns_applied = 0
+
+        # Phase 1: Apply code-based maskers (more specific)
+        for pattern_name in patterns:
+            if pattern_name in self.code_based_maskers:
+                masker = self.code_based_maskers[pattern_name]
+                try:
+                    if masker.applies_to(masked_text):
+                        previous_text = masked_text
+                        masked_text = masker.mask(masked_text)
+
+                        if masked_text != previous_text:
+                            patterns_applied += 1
+                            logger.debug(
+                                f"Code-based masker '{pattern_name}' applied - masking performed"
+                            )
+                        else:
+                            logger.debug(
+                                f"Code-based masker '{pattern_name}' applied - no changes made"
+                            )
+                except Exception as e:
+                    logger.error(
+                        f"Error in code-based masker '{pattern_name}': {e}", exc_info=True
+                    )
+                    # Continue with other patterns rather than failing completely
+                    continue
+
+        # Phase 2: Apply regex patterns (more general)
+        for pattern_name in patterns:
+            # Skip patterns that are code-based only (not regex patterns)
+            if (
+                pattern_name in self.code_based_maskers
+                and pattern_name not in self.compiled_patterns
+            ):
+                continue
+
+            if pattern_name not in self.compiled_patterns:
+                logger.warning(
+                    f"Pattern '{pattern_name}' not found in compiled patterns - skipping"
+                )
+                continue
+
+            # Get replacement text (built-in vs custom patterns)
+            if pattern_name.startswith("custom_"):
+                # Custom pattern - get replacement from metadata
+                if pattern_name not in self.custom_pattern_metadata:
+                    logger.warning(
+                        f"Custom pattern '{pattern_name}' metadata not found - skipping"
+                    )
+                    continue
+                replacement = self.custom_pattern_metadata[pattern_name]["replacement"]
+            else:
+                # Built-in pattern - get replacement from builtin patterns
+                if pattern_name not in BUILTIN_MASKING_PATTERNS:
+                    logger.warning(
+                        f"Built-in pattern '{pattern_name}' not found in builtin patterns - skipping"
+                    )
+                    continue
+                replacement = BUILTIN_MASKING_PATTERNS[pattern_name]["replacement"]
+
+            try:
+                compiled_pattern = self.compiled_patterns[pattern_name]
+
+                # Apply the pattern with error handling
+                previous_text = masked_text
+                masked_text = compiled_pattern.sub(replacement, masked_text)
+
+                if masked_text != previous_text:
+                    patterns_applied += 1
+                    logger.debug(f"Pattern '{pattern_name}' applied - masking performed")
+                else:
+                    logger.debug(f"Pattern '{pattern_name}' applied - no matches found")
+
+            except Exception as e:
+                logger.error(f"Error applying pattern '{pattern_name}': {e}")
+                # Continue with other patterns rather than failing completely
+                continue
+
+        logger.debug(
+            f"Pattern application complete - {patterns_applied}/{len(patterns)} patterns had matches"
+        )
+        return masked_text
+
+    def _expand_pattern_groups(self, pattern_groups: List[str]) -> List[str]:
+        """Expand pattern group names to individual pattern names.
+
+        Args:
+            pattern_groups: List of pattern group names to expand
+
+        Returns:
+            List of individual pattern names from all specified groups
+        """
+        logger.debug(f"_expand_pattern_groups called with groups: {pattern_groups}")
+
+        expanded_patterns: List[str] = []
+        for group_name in pattern_groups:
+            if group_name in BUILTIN_PATTERN_GROUPS:
+                group_patterns = BUILTIN_PATTERN_GROUPS[group_name]
+                expanded_patterns.extend(group_patterns)
+                logger.debug(f"Expanded group '{group_name}' to patterns: {group_patterns}")
+            else:
+                logger.warning(f"Unknown pattern group '{group_name}' - skipping")
+
+        # Remove duplicates while preserving order
+        unique_patterns: List[str] = []
+        seen: set[str] = set()
+        for pattern in expanded_patterns:
+            if pattern not in seen:
+                unique_patterns.append(pattern)
+                seen.add(pattern)
+
+        logger.debug(f"Final expanded patterns: {unique_patterns}")
+        return unique_patterns
+
+    def _get_masking_config_for_server(self, server_name: str) -> Optional[MaskingConfig]:
+        """Get masking configuration for a specific server.
+
+        Args:
+            server_name: Name of the MCP server
+
+        Returns:
+            The masking configuration for the server, or None if not configured
+        """
+        logger.debug(f"_get_masking_config_for_server called for server: {server_name}")
+
+        if not self._get_server_masking_config:
+            logger.debug("No config callback available - masking disabled")
+            return None
+
+        try:
+            masking_config = self._get_server_masking_config(server_name)
+            if not masking_config:
+                logger.debug(f"No masking configuration found for server: {server_name}")
+                return None
+
+            logger.debug(
+                f"Found masking configuration for server '{server_name}': "
+                f"enabled={masking_config.enabled}"
+            )
+            return masking_config
+
+        except Exception as e:
+            logger.error(
+                f"Error retrieving masking config for server '{server_name}': {e}"
+            )
+            return None
+

--- a/ols/src/maskers/kubernetes_secret_masker.py
+++ b/ols/src/maskers/kubernetes_secret_masker.py
@@ -1,0 +1,373 @@
+"""Kubernetes Secret masker for comprehensive secret data masking.
+
+This module provides code-based masking for Kubernetes Secret resources,
+handling both YAML and JSON formats, including complex nested structures
+like last-applied-configuration annotations.
+"""
+
+import json
+import logging
+import re
+from typing import Any, Dict, Optional
+
+import yaml
+
+from ols.src.maskers.base_masker import BaseMasker
+
+logger = logging.getLogger(__name__)
+
+
+class KubernetesSecretMasker(BaseMasker):
+    """Code-based masker for Kubernetes Secret resources.
+
+    This masker handles Kubernetes Secrets in multiple formats:
+    - YAML format with data: sections
+    - JSON format with "data" objects
+    - Nested JSON in annotations (e.g., last-applied-configuration)
+    - Both data and stringData fields
+
+    It intelligently distinguishes between Secrets (which should be masked)
+    and ConfigMaps (which should not be masked), even when they appear in
+    the same document or nested structures.
+    """
+
+    MASKED_VALUE = "__MASKED_SECRET_DATA__"
+
+    def name(self) -> str:
+        """Return the unique identifier for this masker."""
+        return "kubernetes_secret"
+
+    def applies_to(self, data: str) -> bool:
+        """Check if this masker should process the given data.
+
+        Returns True only if the data appears to contain Kubernetes Secret resources.
+        ConfigMaps are completely ignored.
+        """
+        if not data:
+            return False
+
+        # Check for Kubernetes Secret patterns:
+        # YAML: kind: Secret
+        # JSON: "kind": "Secret" or "kind":"Secret"
+        yaml_pattern = r"\bkind:\s*Secret\b"
+        json_pattern = r'"kind"\s*:\s*"Secret"'
+
+        return bool(re.search(yaml_pattern, data) or re.search(json_pattern, data))
+
+    def mask(self, data: str) -> str:
+        """Apply masking logic to Kubernetes Secret resources.
+
+        This method:
+        1. Detects the format (YAML or JSON)
+        2. Parses the content
+        3. Identifies Secret resources (not ConfigMaps)
+        4. Masks data and stringData fields
+        5. Recursively processes nested structures (annotations)
+        """
+        if not data:
+            return data
+
+        try:
+            # Try YAML format first (most common for kubectl output)
+            masked = self._mask_yaml_format(data)
+            if masked != data:
+                return masked
+
+            # Try pure JSON format
+            masked = self._mask_json_format(data)
+            if masked != data:
+                return masked
+
+            # If neither worked, return original
+            logger.debug("KubernetesSecretMasker: No masking applied (not a recognized format)")
+            return data
+
+        except Exception as e:
+            logger.error(f"Error in KubernetesSecretMasker.mask: {e}", exc_info=True)
+            # Fail-safe: return original data
+            return data
+
+    def _mask_yaml_format(self, data: str) -> str:
+        """Mask Kubernetes Secrets in YAML format.
+
+        Handles both simple YAML and YAML containing JSON in annotations.
+        """
+        try:
+            # Parse YAML to check what we have and identify Secret resources
+            docs = list(yaml.safe_load_all(data))
+            if not docs:
+                return data
+
+            # Check if we have any Secrets to mask
+            secret_indices = [
+                i
+                for i, doc in enumerate(docs)
+                if isinstance(doc, dict) and doc.get("kind") == "Secret"
+            ]
+
+            if not secret_indices:
+                # No secrets to mask, but might have JSON in annotations
+                # Try to mask JSON within the YAML text
+                return self._mask_json_in_text(data)
+
+            # We have secrets - use regex to find and mask data: sections in Secrets only
+            # Split by document separator to process each YAML doc
+            doc_texts = data.split("\n---\n")
+
+            # Safety check: ensure parsed docs count matches split docs count
+            if len(doc_texts) != len(docs):
+                logger.warning(
+                    f"KubernetesSecretMasker: Document count mismatch - "
+                    f"parsed {len(docs)} YAML docs but split into {len(doc_texts)} text segments. "
+                    f"Applying conservative fallback masking to avoid silent skips."
+                )
+                # Conservative fallback: mask all splits at secret indices
+                masked_docs = []
+                for i, doc_text in enumerate(doc_texts):
+                    if i in secret_indices:
+                        # This index corresponds to a Secret, mask it
+                        doc_text = self._mask_yaml_secret_data_sections(doc_text)
+                    masked_docs.append(doc_text)
+
+                masked_data = "\n---\n".join(masked_docs)
+                masked_data = self._mask_json_in_text(masked_data)
+                return masked_data
+
+            masked_docs = []
+            for i, doc_text in enumerate(doc_texts):
+                # Check if this document index corresponds to a Secret
+                if i in secret_indices:
+                    # This is a Secret, mask its data: and stringData: sections
+                    doc_text = self._mask_yaml_secret_data_sections(doc_text)
+
+                masked_docs.append(doc_text)
+
+            masked_data = "\n---\n".join(masked_docs)
+
+            # Also mask any JSON in annotations (like last-applied-configuration)
+            masked_data = self._mask_json_in_text(masked_data)
+
+            return masked_data
+
+        except yaml.YAMLError:
+            # Not valid YAML, try other formats
+            return data
+        except Exception as e:
+            logger.error(f"Error in _mask_yaml_format: {e}", exc_info=True)
+            return data
+
+    def _mask_yaml_secret_data_sections(self, yaml_text: str) -> str:
+        """Mask data: and stringData: sections in a YAML Secret.
+
+        Args:
+            yaml_text: YAML text of a single Secret resource
+
+        Returns:
+            YAML text with data sections masked
+        """
+        lines = yaml_text.split("\n")
+        result_lines = []
+        i = 0
+
+        while i < len(lines):
+            line = lines[i]
+
+            # Check for data: or stringData: at the start of a line (field name)
+            data_match = re.match(r"^(data|stringData):\s*$", line)
+            if data_match:
+                # Found data section, mask it
+                result_lines.append(line.rstrip())
+                i += 1
+
+                # Determine indent level from first non-blank line in the data section
+                indent = " "  # Default to single space (standard kubectl output)
+                start_i = i
+                while i < len(lines):
+                    next_line = lines[i]
+                    # Look for first indented line to capture indent
+                    if next_line and next_line[:1] in (" ", "\t"):
+                        # Calculate indent from this line
+                        indent_len = len(next_line) - len(next_line.lstrip())
+                        indent = next_line[:indent_len]
+                        break
+                    elif not next_line.strip():
+                        # Blank line, continue searching
+                        i += 1
+                    else:
+                        # Non-indented line, data section ended (empty data section)
+                        break
+
+                # Reset to start and skip all indented or blank lines
+                i = start_i
+                while i < len(lines):
+                    next_line = lines[i]
+                    # Indented or blank line → still part of the data section
+                    if (next_line and next_line[:1] in (" ", "\t")) or not next_line.strip():
+                        i += 1
+                    else:
+                        # Non-indented line, data section ended
+                        break
+
+                # Add masked value with preserved indentation
+                result_lines.append(f"{indent}{self.MASKED_VALUE}")
+            else:
+                result_lines.append(line)
+                i += 1
+
+        return "\n".join(result_lines)
+
+    def _mask_json_format(self, data: str) -> str:
+        """Mask Kubernetes Secrets in pure JSON format."""
+        try:
+            # Try to parse as JSON
+            obj = json.loads(data)
+
+            # Mask if it's a Secret
+            if isinstance(obj, dict):
+                masked_obj = self._mask_secret_object(obj)
+                return json.dumps(masked_obj, separators=(",", ":"))
+
+            return data
+
+        except json.JSONDecodeError:
+            # Not valid JSON
+            return data
+        except Exception as e:
+            logger.error(f"Error in _mask_json_format: {e}", exc_info=True)
+            return data
+
+    def _mask_secret_object(self, obj: Dict[str, Any]) -> Dict[str, Any]:
+        """Recursively mask Secret objects in dictionaries.
+
+        This handles nested structures like annotations containing JSON.
+        """
+        if not isinstance(obj, dict):
+            return obj
+
+        # Check if this is a Secret resource
+        is_secret = obj.get("kind") == "Secret"
+
+        result = {}
+        for key, value in obj.items():
+            if is_secret and key in ("data", "stringData"):
+                # Mask the entire data or stringData object
+                result[key] = self.MASKED_VALUE
+            elif isinstance(value, dict):
+                # Recursively process nested dictionaries
+                result[key] = self._mask_secret_object(value)
+            elif isinstance(value, str):
+                # Check if this string contains JSON with Secrets
+                result[key] = self._mask_json_in_text(value)
+            elif isinstance(value, list):
+                # Process lists
+                result[key] = [
+                    self._mask_secret_object(item) if isinstance(item, dict) else item
+                    for item in value
+                ]
+            else:
+                result[key] = value
+
+        return result
+
+    def _mask_json_in_text(self, text: str) -> str:
+        """Find and mask JSON objects containing Secrets within text.
+
+        This handles cases like JSON in YAML annotations.
+        """
+        if not text or "Secret" not in text:
+            return text
+
+        # Pattern to find JSON objects (simplified)
+        # Look for {"...kind":"Secret"...}
+        json_pattern = r'\{[^{}]*"kind"\s*:\s*"Secret"[^{}]*\}'
+
+        def mask_json_match(match: re.Match) -> str:
+            """Mask a JSON Secret object found in text."""
+            json_str = match.group(0)
+            try:
+                obj = json.loads(json_str)
+                masked_obj = self._mask_secret_object(obj)
+                return json.dumps(masked_obj, separators=(",", ":"))
+            except (json.JSONDecodeError, Exception) as e:
+                logger.debug(f"Failed to parse JSON in text: {e}")
+                return json_str
+
+        # Try simple pattern first
+        masked = re.sub(json_pattern, mask_json_match, text)
+
+        # Handle more complex nested JSON (with nested braces)
+        # This is a more sophisticated approach for deeply nested structures
+        if "data" in masked and "Secret" in masked:
+            masked = self._mask_nested_json_in_text(masked)
+
+        return masked
+
+    def _mask_nested_json_in_text(self, text: str) -> str:
+        """Handle complex nested JSON objects in text using bracket counting."""
+        if "Secret" not in text:
+            return text
+
+        result = []
+        i = 0
+        while i < len(text):
+            if text[i] == "{":
+                # Found potential JSON start
+                # Extract the JSON object by counting braces
+                json_str, end_idx = self._extract_json_object(text, i)
+                if json_str:
+                    try:
+                        obj = json.loads(json_str)
+                        if isinstance(obj, dict) and obj.get("kind") == "Secret":
+                            # This is a Secret, mask it
+                            masked_obj = self._mask_secret_object(obj)
+                            result.append(json.dumps(masked_obj, separators=(",", ":")))
+                            i = end_idx + 1
+                            continue
+                    except (json.JSONDecodeError, Exception):
+                        pass
+
+            result.append(text[i])
+            i += 1
+
+        return "".join(result)
+
+    def _extract_json_object(self, text: str, start: int) -> tuple[Optional[str], int]:
+        """Extract a complete JSON object from text starting at given position.
+
+        Returns:
+            Tuple of (json_string, end_index) or (None, start) if not valid JSON
+        """
+        if start >= len(text) or text[start] != "{":
+            return None, start
+
+        brace_count = 0
+        in_string = False
+        escape_next = False
+
+        for i in range(start, len(text)):
+            char = text[i]
+
+            if escape_next:
+                escape_next = False
+                continue
+
+            if char == "\\":
+                escape_next = True
+                continue
+
+            if char == '"':
+                in_string = not in_string
+                continue
+
+            if not in_string:
+                if char == "{":
+                    brace_count += 1
+                elif char == "}":
+                    brace_count -= 1
+                    if brace_count == 0:
+                        # Found complete JSON object
+                        return text[start : i + 1], i
+
+        # Incomplete JSON object
+        return None, start
+

--- a/ols/src/tools/tools.py
+++ b/ols/src/tools/tools.py
@@ -3,14 +3,108 @@
 import asyncio
 import json
 import logging
+from typing import Optional
 
 from langchain_core.messages import ToolMessage
 from langchain_core.tools.structured import StructuredTool
+
+from ols.app.models.config import MCPServerConfig
+from ols.app.models.masking_config import MaskingConfig
+from ols.src.maskers.data_masking_service import DataMaskingService
 
 logger = logging.getLogger(__name__)
 
 
 SENSITIVE_KEYWORDS = ["secret"]
+
+# Global data masking service instance
+_data_masking_service: Optional[DataMaskingService] = None
+_mcp_server_configs: dict[str, MCPServerConfig] = {}
+
+
+def initialize_data_masking(mcp_servers: list[MCPServerConfig]) -> None:
+    """Initialize the data masking service with MCP server configurations.
+
+    This should be called during application startup to set up server-specific
+    masking configurations.
+
+    Args:
+        mcp_servers: List of MCP server configurations
+    """
+    global _mcp_server_configs, _data_masking_service
+
+    # Build server config lookup
+    _mcp_server_configs = {server.name: server for server in mcp_servers}
+
+    # Create masking service with config callback
+    _data_masking_service = DataMaskingService(_get_server_masking_config)
+
+    logger.info(
+        "DataMaskingService initialized with %d server configurations",
+        len(_mcp_server_configs),
+    )
+
+
+def _get_server_masking_config(server_name: str) -> Optional[MaskingConfig]:
+    """Get masking configuration for a specific server.
+
+    Args:
+        server_name: Name of the MCP server
+
+    Returns:
+        The MaskingConfig for the server, or None if not configured
+    """
+    server_config = _mcp_server_configs.get(server_name)
+    if server_config and server_config.data_masking:
+        return server_config.data_masking
+    return None
+
+
+def get_data_masking_service(
+    config_callback: Optional[callable] = None,
+) -> DataMaskingService:
+    """Get or create the global DataMaskingService instance.
+
+    Args:
+        config_callback: Optional callback to get server masking config.
+            If None, the service will use a default security pattern group.
+
+    Returns:
+        The DataMaskingService instance
+    """
+    global _data_masking_service
+    if _data_masking_service is None:
+        _data_masking_service = DataMaskingService(config_callback)
+    return _data_masking_service
+
+
+def mask_tool_output(tool_output: str, server_name: Optional[str] = None) -> str:
+    """Apply data masking to tool output.
+
+    Args:
+        tool_output: The raw output from an MCP tool
+        server_name: Optional name of the MCP server for server-specific masking
+
+    Returns:
+        The masked output with sensitive data replaced
+    """
+    service = get_data_masking_service()
+
+    # Apply masking using default security pattern group
+    # This provides baseline protection even without server-specific config
+    try:
+        result_dict = {"result": tool_output}
+        if server_name:
+            # Try server-specific masking first
+            masked_dict = service.mask_response(result_dict, server_name)
+        else:
+            # Fall back to default security patterns
+            masked_dict = service.mask_data(result_dict, "security")
+        return masked_dict.get("result", tool_output)
+    except Exception as e:
+        logger.error(f"Error during data masking: {e}")
+        # On error, return masked placeholder for safety
+        return "[REDACTED: masking error]"
 
 
 def raise_for_sensitive_tool_args(tool_args: dict) -> None:
@@ -38,14 +132,25 @@ def get_tool_by_name(
 async def execute_tool_call(
     tool_name: str, tool_args: dict, all_mcp_tools: list[StructuredTool]
 ) -> tuple[str, str]:
-    """Execute a tool call and return the output and status."""
+    """Execute a tool call and return the output and status.
+
+    The output is automatically masked to prevent sensitive data leakage.
+    """
     try:
         tool = get_tool_by_name(tool_name, all_mcp_tools)
         tool_output = await tool.arun(_jsonify(tool_args))  # type: ignore [attr-defined]
+
+        # Apply data masking to the tool output
+        masked_output = mask_tool_output(str(tool_output))
+
         status = "success"
         logger.debug(
-            "Tool: %s | Args: %s | Output: %s", tool_name, tool_args, tool_output
+            "Tool: %s | Args: %s | Output (masked): %s",
+            tool_name,
+            tool_args,
+            masked_output[:500] if len(masked_output) > 500 else masked_output,
         )
+        tool_output = masked_output
     except Exception as e:
         # catching generic exception here - if it contains something it
         # shouldn't (eg. token in openshift tools), it is responsibility

--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -12,6 +12,7 @@ from ols.src.cache.cache_factory import CacheFactory
 from ols.src.quota.quota_limiter import QuotaLimiter
 from ols.src.quota.quota_limiter_factory import QuotaLimiterFactory
 from ols.src.quota.token_usage_history import TokenUsageHistory
+from ols.src.tools.tools import initialize_data_masking
 
 # as the index_loader.py is excluded from type checks, it confuses
 # mypy a bit, hence the [attr-defined] bellow
@@ -159,6 +160,10 @@ class AppConfig:
             # values
             self._query_filters = None
             self._rag_index_loader = None
+
+            # Initialize data masking service with MCP server configurations
+            if self.config.mcp_servers and self.config.mcp_servers.servers:
+                initialize_data_masking(self.config.mcp_servers.servers)
         except Exception as e:
             print(f"Failed to load config file {config_file}: {e!s}")
             print(traceback.format_exc())


### PR DESCRIPTION
## Description
Adds a data masking layer for MCP server request/response.

This implementation is blatantly adapted from https://github.com/codeready-toolchain/tarsy-bot/blob/master/backend/tarsy/services/data_masking_service.py. 

<!--- Describe your changes in detail -->

## Type of change


- [x] New feature
- [x] Optimization



<!--
## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
-->

<details>

Masking available Pattern Groups:

Group | Patterns Included
-- | --
basic | api_key, password
secrets | api_key, password, token
security | api_key, password, token, certificate, certificate_authority_data, email, ssh_key
kubernetes | kubernetes_secret (code-based), api_key, password, certificate_authority_data
all | All available patterns

</details>