### PR TITLE
Add agent loop test harness with fake OCP tools and conversation fixtures

### DIFF
--- a/tests/harness/README.md
+++ b/tests/harness/README.md
@@ -1,0 +1,65 @@
+# Agent Loop Test Harness
+
+Test the OLS agent loop with realistic tool interactions — without an
+OpenShift cluster.
+
+## What This Provides
+
+| Module | Purpose |
+|---|---|
+| `fake_tools.py` | Six fake OCP tools (`get_cluster_info`, `list_pods`, `describe_pod`, `drain_node`, `scale_deployment`, `delete_namespace`) with policy annotations |
+| `conversation_fixtures.py` | Canned conversations at five sizes for compaction and context-window testing |
+| `provider_matrix.py` | Parametrized cross-provider test utilities (OpenAI, Anthropic, Gemini) |
+| `conftest.py` | Fixtures for tools, provider config, and LLM proxy credentials |
+
+## Quick Start
+
+### Offline (mocked LLM — no credentials needed)
+
+```bash
+uv run pytest tests/harness/ -v -k "not live"
+```
+
+### Live (real LLM calls via proxy)
+
+```bash
+export OLS_TEST_LLM_BASE_URL="https://your-proxy.example.com/v1"
+export OLS_TEST_LLM_API_KEY="your-key"
+
+# Single provider
+uv run pytest tests/harness/ -v --provider=openai
+
+# All providers
+uv run pytest tests/harness/ -v --provider=all
+```
+
+### Override models per provider
+
+```bash
+export OLS_TEST_MODEL_OPENAI="gpt-4o"
+export OLS_TEST_MODEL_ANTHROPIC="claude-sonnet-4-20250514"
+export OLS_TEST_MODEL_GEMINI="gemini-2.5-pro"
+```
+
+## What This Tests
+
+- **Tool classification** — ALLOW / DENY / CONFIRM policy routing
+- **Tool execution** — coroutines return expected output and structured content
+- **Oversized output** — `describe_pod` generates ~50 KB to trigger compaction
+- **Conversation shapes** — fixtures exercise split-point logic, tool-result
+  pair protection, and sacred-first-message preservation
+- **Cross-provider edge cases** — parallel tool calls, text + tool in same
+  response, empty `tool_args`
+
+## Adding Fixtures
+
+Add new conversations to `conversation_fixtures.py` and register them in
+`CONVERSATION_FIXTURES`. Each fixture is a function returning
+`list[dict[str, Any]]` with standard message fields (`role`, `content`,
+and optionally `tool_calls`, `tool_call_id`).
+
+## Architecture Notes
+
+All interfaces use **plain dicts** — no LangChain types. Convert at the
+boundary when wiring into `DocsSummarizer` or the streaming endpoint.
+This keeps the harness portable to `lightspeed-stack` and other consumers.

--- a/tests/harness/__init__.py
+++ b/tests/harness/__init__.py
@@ -1,0 +1,1 @@
+"""Agent loop test harness with fake OCP tools and cross-provider fixtures."""

--- a/tests/harness/conftest.py
+++ b/tests/harness/conftest.py
@@ -1,0 +1,98 @@
+"""Pytest configuration for the agent loop test harness.
+
+Provides fixtures and CLI options for running integration-level tests
+with fake OCP tools against a real LLM (via an OpenAI-compatible proxy)
+or with a fully mocked LLM for offline unit testing.
+"""
+
+import os
+
+import pytest
+
+from ols import config
+
+from tests.harness.fake_tools import ALL_FAKE_TOOLS, POLICY_MAP, SAFE_TOOLS
+from tests.harness.provider_matrix import (
+    ENV_API_KEY,
+    ENV_BASE_URL,
+    ProviderConfig,
+    provider_config_for,
+)
+
+
+# ---------------------------------------------------------------------------
+# CLI options
+# ---------------------------------------------------------------------------
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register harness-specific CLI options."""
+    parser.addoption(
+        "--provider",
+        action="store",
+        default="all",
+        help="LLM provider to test: openai, anthropic, gemini, or all (default: all)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Autouse: reset OLS config between tests (matches unit test pattern)
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="function", autouse=True)
+def _reset_ols_config() -> None:
+    """Reset the OLS config singleton before each test."""
+    config.reload_empty()
+
+
+# ---------------------------------------------------------------------------
+# Tool fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture()
+def fake_tools():
+    """Return all six fake OCP tools as a ``list[StructuredTool]``."""
+    return list(ALL_FAKE_TOOLS)
+
+
+@pytest.fixture()
+def safe_tools():
+    """Return only the ALLOW-policy tools."""
+    return list(SAFE_TOOLS)
+
+
+@pytest.fixture()
+def policy_map():
+    """Return the tool-name → policy mapping dict."""
+    return dict(POLICY_MAP)
+
+
+# ---------------------------------------------------------------------------
+# Provider fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture()
+def provider_config(request: pytest.FixtureRequest) -> ProviderConfig:
+    """Build a ``ProviderConfig`` for the current parametrized provider.
+
+    Expects ``provider_name`` to be injected via ``@for_each_provider``.
+    Falls back to the ``--provider`` CLI option or the ``OLS_TEST_PROVIDER``
+    env var.
+    """
+    name = getattr(request, "param", None)
+    if name is None:
+        name = request.config.getoption("--provider", default="openai")
+    return provider_config_for(name)
+
+
+@pytest.fixture()
+def llm_proxy_url() -> str:
+    """Return the LLM proxy base URL or skip if unset."""
+    url = os.environ.get(ENV_BASE_URL)
+    if not url:
+        pytest.skip(f"{ENV_BASE_URL} not set — skipping live LLM tests")
+    return url
+
+
+@pytest.fixture()
+def llm_api_key() -> str:
+    """Return the LLM proxy API key or skip if unset."""
+    key = os.environ.get(ENV_API_KEY)
+    if not key:
+        pytest.skip(f"{ENV_API_KEY} not set — skipping live LLM tests")
+    return key

--- a/tests/harness/conversation_fixtures.py
+++ b/tests/harness/conversation_fixtures.py
@@ -1,0 +1,230 @@
+"""Canned conversation histories for agent loop testing.
+
+Each fixture returns a ``list[dict]`` of plain message dicts — no LangChain
+types — so the harness stays framework-agnostic.  Convert to/from
+``BaseMessage`` at the boundary if needed.
+
+Fixtures are sized to exercise specific compaction and context-window
+scenarios:
+
+=================  ======  ==========================================
+Fixture            Tokens  Purpose
+=================  ======  ==========================================
+short              ~2 k    Baseline — well under any context window
+medium             ~8 k    Moderate history, no compaction expected
+bloated_tool       ~50 k   Single oversized tool result triggers
+                           Stage 1 truncation
+sacred_first_msg   ~12 k   20 turns; first message carries critical
+                           system context that must survive compaction
+recent_tool        ~6 k    12 turns with tool call/result near the
+                           end — split-point must not break the pair
+=================  ======  ==========================================
+"""
+
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+_FILLER = (
+    "OpenShift Container Platform provides enterprise Kubernetes with "
+    "automated operations, consistent security, and developer productivity. "
+)
+
+
+def _pad(text: str, target_words: int) -> str:
+    """Repeat filler text until we hit roughly ``target_words`` words."""
+    words = text.split()
+    while len(words) < target_words:
+        words.extend(_FILLER.split())
+    return " ".join(words[:target_words])
+
+
+def _msg(role: str, content: str, **extra: Any) -> dict[str, Any]:
+    """Build a plain message dict."""
+    m: dict[str, Any] = {"role": role, "content": content}
+    m.update(extra)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# 1. Short conversation (~2k tokens / ~1.5k words)
+# ---------------------------------------------------------------------------
+def short_conversation() -> list[dict[str, Any]]:
+    """Return a 4-message conversation well under any context window."""
+    return [
+        _msg("user", "What version of OpenShift am I running?"),
+        _msg(
+            "assistant",
+            "Let me check your cluster version.",
+            tool_calls=[
+                {"name": "get_cluster_info", "args": {}, "id": "tc-short-1"}
+            ],
+        ),
+        _msg(
+            "tool",
+            '{"version": "4.15.2", "nodes": 6, "status": "healthy"}',
+            tool_call_id="tc-short-1",
+        ),
+        _msg(
+            "assistant",
+            "You are running OpenShift Container Platform version 4.15.2. "
+            "Your cluster has 6 nodes and is reporting a healthy status.",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 2. Medium conversation (~8k tokens / ~6k words)
+# ---------------------------------------------------------------------------
+def medium_conversation() -> list[dict[str, Any]]:
+    """Return a 10-message conversation with moderate token count."""
+    msgs: list[dict[str, Any]] = []
+    topics = [
+        ("How do I list pods in a namespace?", "You can use `oc get pods -n <namespace>`."),
+        ("What about deployments?", "Use `oc get deployments -n <namespace>`."),
+        ("How do I check node status?", "Run `oc get nodes` to see node conditions."),
+        ("Can I drain a node safely?", "Yes, use `oc adm drain <node> --ignore-daemonsets`."),
+        ("What is a PodDisruptionBudget?", _pad("A PDB limits voluntary disruptions.", 400)),
+    ]
+    for question, answer in topics:
+        msgs.append(_msg("user", question))
+        msgs.append(_msg("assistant", answer))
+    return msgs
+
+
+# ---------------------------------------------------------------------------
+# 3. Bloated tool result (~50k tokens)
+# ---------------------------------------------------------------------------
+_HUGE_YAML_LINE = "  - name: nginx-{i}\n    image: nginx:1.25\n    status: Running\n"
+
+
+def bloated_tool_result() -> list[dict[str, Any]]:
+    """Return a conversation containing a single massive tool output.
+
+    The tool result is ~50 000 tokens of YAML pod descriptions, designed to
+    trigger Stage 1 truncation in the CompactionService.
+    """
+    huge_output = "".join(_HUGE_YAML_LINE.format(i=i) for i in range(6000))
+    return [
+        _msg("user", "Show me all pods across every namespace."),
+        _msg(
+            "assistant",
+            "I'll list all pods cluster-wide.",
+            tool_calls=[
+                {"name": "list_pods", "args": {"namespace": "all"}, "id": "tc-bloat-1"}
+            ],
+        ),
+        _msg("tool", huge_output, tool_call_id="tc-bloat-1"),
+        _msg(
+            "assistant",
+            "Here is the full pod listing. There are approximately 6000 pods "
+            "across all namespaces. Several are in CrashLoopBackOff state.",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 4. Sacred first message (20 turns, ~12k tokens)
+# ---------------------------------------------------------------------------
+def sacred_first_message() -> list[dict[str, Any]]:
+    """Return a 20-turn conversation where the first message is critical.
+
+    The opening user message contains deployment constraints that the LLM must
+    retain even after compaction.  Tests that the compaction split-point
+    preserves the first message in the 'keep zone'.
+    """
+    sacred = (
+        "IMPORTANT CONTEXT: I am operating a production OCP 4.15 cluster on "
+        "AWS with FIPS mode enabled. All changes must be non-disruptive. "
+        "The cluster runs PCI-DSS workloads — no public endpoints, no "
+        "privileged containers, and all images must come from the internal "
+        "registry at registry.internal.example.com. Compliance scans run "
+        "every 4 hours. Do not suggest anything that violates these constraints."
+    )
+    msgs: list[dict[str, Any]] = [_msg("user", sacred)]
+
+    filler_exchanges = [
+        ("How do I check FIPS status?", "Run `oc get cm -n openshift-config`."),
+        ("List my machinesets.", "Use `oc get machinesets -n openshift-machine-api`."),
+        ("How do I add a worker node?", "Scale the machineset replicas."),
+        ("What StorageClasses are available?", "Run `oc get sc`."),
+        ("How do I configure an ImageContentSourcePolicy?", "Apply an ICSP manifest."),
+        ("Show me the cluster operators.", "Run `oc get co`."),
+        ("Any degraded operators?", "Check the DEGRADED column in `oc get co`."),
+        ("How do I update the cluster?", "Use `oc adm upgrade --to=<version>`."),
+        ("Can I pause machine config updates?", "Yes, pause the MCP."),
+    ]
+    for question, answer in filler_exchanges:
+        msgs.append(_msg("user", question))
+        msgs.append(
+            _msg("assistant", _pad(answer, 80))
+        )
+
+    msgs.append(_msg("user", "Now drain node worker-3 for maintenance."))
+    return msgs
+
+
+# ---------------------------------------------------------------------------
+# 5. Recent tool call (12 turns, ~6k tokens)
+# ---------------------------------------------------------------------------
+def recent_tool_conversation() -> list[dict[str, Any]]:
+    """Return a 12-turn conversation with a tool call near the end.
+
+    The tool_calls/tool message pair sits at positions -4/-3, so the
+    compaction split-point logic must not break the pair even when the
+    messages before it are in the compress zone.
+    """
+    msgs: list[dict[str, Any]] = []
+
+    early_exchanges = [
+        ("What is a DaemonSet?", "A DaemonSet ensures a pod runs on every node."),
+        ("How about StatefulSets?", "StatefulSets manage stateful applications."),
+        ("Explain PersistentVolumeClaims.", _pad("A PVC requests storage.", 120)),
+        ("What networking plugin does OCP use?", "OCP uses OVN-Kubernetes by default."),
+    ]
+    for question, answer in early_exchanges:
+        msgs.append(_msg("user", question))
+        msgs.append(_msg("assistant", answer))
+
+    msgs.append(_msg("user", "Scale my nginx deployment to 5 replicas."))
+    msgs.append(
+        _msg(
+            "assistant",
+            "I'll scale the nginx deployment for you.",
+            tool_calls=[
+                {
+                    "name": "scale_deployment",
+                    "args": {"name": "nginx", "replicas": 5},
+                    "id": "tc-recent-1",
+                }
+            ],
+        ),
+    )
+    msgs.append(
+        _msg(
+            "tool",
+            '{"scaled": "nginx", "replicas": 5, "previous_replicas": 1}',
+            tool_call_id="tc-recent-1",
+        ),
+    )
+    msgs.append(
+        _msg(
+            "assistant",
+            "Done — the nginx deployment has been scaled from 1 to 5 replicas.",
+        ),
+    )
+
+    return msgs
+
+
+# ---------------------------------------------------------------------------
+# Registry — all fixtures keyed by name for parametrized tests
+# ---------------------------------------------------------------------------
+CONVERSATION_FIXTURES: dict[str, Any] = {
+    "short": short_conversation,
+    "medium": medium_conversation,
+    "bloated_tool": bloated_tool_result,
+    "sacred_first_msg": sacred_first_message,
+    "recent_tool": recent_tool_conversation,
+}

--- a/tests/harness/fake_tools.py
+++ b/tests/harness/fake_tools.py
@@ -1,0 +1,222 @@
+"""Fake OCP tools for agent loop integration testing.
+
+Provides six StructuredTool instances that simulate real OpenShift operations
+without requiring an OCP cluster. Each tool carries a ``policy`` annotation in
+its metadata so the approval-gate tests can verify ALLOW / DENY / CONFIRM
+classification without parsing descriptions or hard-coding names.
+
+Tools
+-----
+get_cluster_info   - safe read, always allowed
+list_pods          - safe read, always allowed
+describe_pod       - safe read, returns oversized output to trigger compaction
+drain_node         - destructive, needs human confirmation
+scale_deployment   - mutating, needs human confirmation
+delete_namespace   - dangerous, always denied
+"""
+
+from typing import Any
+
+from langchain_core.tools.structured import StructuredTool
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Policy constants - used in tool metadata and by test assertions
+# ---------------------------------------------------------------------------
+POLICY_ALLOW = "allow"
+POLICY_CONFIRM = "confirm"
+POLICY_DENY = "deny"
+
+
+# ---------------------------------------------------------------------------
+# Arg schemas (pydantic v2)
+# ---------------------------------------------------------------------------
+class _Empty(BaseModel):
+    """Schema for tools that take no arguments."""
+
+
+class _NamespaceArgs(BaseModel):
+    namespace: str = Field(default="default", description="Kubernetes namespace")
+
+
+class _NodeArgs(BaseModel):
+    node_name: str = Field(description="Name of the node to drain")
+
+
+class _ScaleArgs(BaseModel):
+    name: str = Field(description="Deployment name")
+    replicas: int = Field(description="Target replica count")
+
+
+class _PodArgs(BaseModel):
+    name: str = Field(description="Pod name")
+    namespace: str = Field(default="default", description="Kubernetes namespace")
+
+
+# ---------------------------------------------------------------------------
+# Canned responses
+# ---------------------------------------------------------------------------
+CLUSTER_INFO_RESPONSE = (
+    '{"version": "4.15.2", "nodes": 6, "status": "healthy", '
+    '"platform": "AWS", "channel": "stable-4.15"}'
+)
+
+POD_LIST_RESPONSE = (
+    "NAME                      READY   STATUS             RESTARTS   AGE\n"
+    "nginx-abc123              1/1     Running            0          2d\n"
+    "postgres-def456           0/1     CrashLoopBackOff   47         5h\n"
+    "redis-ghi789              1/1     Running            0          12h\n"
+)
+
+DRAIN_RESPONSE_TPL = '{{"drained": "{node_name}", "pods_evicted": 12, "status": "completed"}}'
+
+SCALE_RESPONSE_TPL = '{{"scaled": "{name}", "replicas": {replicas}, "previous_replicas": 1}}'
+
+_DESCRIBE_POD_YAML_LINE = "  container: nginx\n  image: nginx:1.25\n  ports:\n    - 80/TCP\n"
+DESCRIBE_POD_RESPONSE = (
+    "apiVersion: v1\nkind: Pod\nmetadata:\n  name: {name}\n"
+    + _DESCRIBE_POD_YAML_LINE * 800
+)
+
+
+# ---------------------------------------------------------------------------
+# Async coroutines — each returns (text, artifact_dict)
+# ---------------------------------------------------------------------------
+async def _get_cluster_info(**_kwargs: Any) -> tuple[str, dict]:
+    return CLUSTER_INFO_RESPONSE, {}
+
+
+async def _list_pods(**kwargs: Any) -> tuple[str, dict]:
+    ns = kwargs.get("namespace", "default")
+    header = f"# Pods in namespace: {ns}\n"
+    return header + POD_LIST_RESPONSE, {
+        "structured_content": {
+            "pods": [
+                {"name": "nginx-abc123", "status": "Running", "restarts": 0},
+                {"name": "postgres-def456", "status": "CrashLoopBackOff", "restarts": 47},
+                {"name": "redis-ghi789", "status": "Running", "restarts": 0},
+            ]
+        }
+    }
+
+
+async def _drain_node(**kwargs: Any) -> tuple[str, dict]:
+    node_name = kwargs.get("node_name", "unknown")
+    return DRAIN_RESPONSE_TPL.format(node_name=node_name), {}
+
+
+async def _delete_namespace(**_kwargs: Any) -> tuple[str, dict]:
+    raise RuntimeError(
+        "delete_namespace should never execute — policy is DENY"
+    )
+
+
+async def _scale_deployment(**kwargs: Any) -> tuple[str, dict]:
+    name = kwargs.get("name", "unknown")
+    replicas = kwargs.get("replicas", 1)
+    return SCALE_RESPONSE_TPL.format(name=name, replicas=replicas), {}
+
+
+async def _describe_pod(**kwargs: Any) -> tuple[str, dict]:
+    name = kwargs.get("name", "unknown")
+    return DESCRIBE_POD_RESPONSE.format(name=name), {}
+
+
+# ---------------------------------------------------------------------------
+# StructuredTool definitions
+# ---------------------------------------------------------------------------
+def _build_tool(
+    name: str,
+    description: str,
+    coroutine: Any,
+    args_schema: type[BaseModel],
+    policy: str,
+) -> StructuredTool:
+    """Build a StructuredTool with policy metadata."""
+    return StructuredTool(
+        name=name,
+        description=description,
+        func=lambda **kw: None,
+        coroutine=coroutine,
+        response_format="content_and_artifact",
+        args_schema=args_schema,
+        metadata={"policy": policy, "mcp_server": "fake-ocp"},
+    )
+
+
+get_cluster_info = _build_tool(
+    name="get_cluster_info",
+    description="Return OpenShift cluster version, node count, and health status.",
+    coroutine=_get_cluster_info,
+    args_schema=_Empty,
+    policy=POLICY_ALLOW,
+)
+
+list_pods = _build_tool(
+    name="list_pods",
+    description="List pods in a namespace with status and restart counts.",
+    coroutine=_list_pods,
+    args_schema=_NamespaceArgs,
+    policy=POLICY_ALLOW,
+)
+
+describe_pod = _build_tool(
+    name="describe_pod",
+    description="Return the full YAML manifest for a pod (may be very large).",
+    coroutine=_describe_pod,
+    args_schema=_PodArgs,
+    policy=POLICY_ALLOW,
+)
+
+drain_node = _build_tool(
+    name="drain_node",
+    description="Cordon and drain a node, evicting all pods. Destructive operation.",
+    coroutine=_drain_node,
+    args_schema=_NodeArgs,
+    policy=POLICY_CONFIRM,
+)
+
+scale_deployment = _build_tool(
+    name="scale_deployment",
+    description="Scale a deployment to the specified replica count.",
+    coroutine=_scale_deployment,
+    args_schema=_ScaleArgs,
+    policy=POLICY_CONFIRM,
+)
+
+delete_namespace = _build_tool(
+    name="delete_namespace",
+    description="Delete a Kubernetes namespace and all its resources. DANGEROUS.",
+    coroutine=_delete_namespace,
+    args_schema=_NamespaceArgs,
+    policy=POLICY_DENY,
+)
+
+
+# ---------------------------------------------------------------------------
+# Convenience collections
+# ---------------------------------------------------------------------------
+ALL_FAKE_TOOLS: list[StructuredTool] = [
+    get_cluster_info,
+    list_pods,
+    describe_pod,
+    drain_node,
+    scale_deployment,
+    delete_namespace,
+]
+
+SAFE_TOOLS: list[StructuredTool] = [
+    get_cluster_info,
+    list_pods,
+    describe_pod,
+]
+
+DESTRUCTIVE_TOOLS: list[StructuredTool] = [
+    drain_node,
+    scale_deployment,
+    delete_namespace,
+]
+
+POLICY_MAP: dict[str, str] = {
+    t.name: t.metadata["policy"] for t in ALL_FAKE_TOOLS if t.metadata is not None
+}

--- a/tests/harness/provider_matrix.py
+++ b/tests/harness/provider_matrix.py
@@ -1,0 +1,130 @@
+"""Cross-provider parametrization utilities.
+
+Provides helpers that let a single test function run against multiple LLM
+providers (OpenAI, Anthropic, Gemini) via an OpenAI-compatible proxy.
+
+Usage::
+
+    from tests.harness.provider_matrix import for_each_provider
+
+    @for_each_provider
+    @pytest.mark.asyncio
+    async def test_tool_selection(provider_config):
+        \"\"\"Verify the LLM selects the right tool.\"\"\"
+        ...
+
+The proxy URL and API key come from environment variables.  If neither is
+set the entire harness is skipped gracefully — CI stays green.
+"""
+
+import os
+from dataclasses import dataclass, field
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Environment knobs
+# ---------------------------------------------------------------------------
+ENV_BASE_URL = "OLS_TEST_LLM_BASE_URL"
+ENV_API_KEY = "OLS_TEST_LLM_API_KEY"
+ENV_PROVIDER = "OLS_TEST_PROVIDER"
+
+SUPPORTED_PROVIDERS = ("openai", "anthropic", "gemini")
+
+
+# ---------------------------------------------------------------------------
+# Provider configuration dataclass
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class ProviderConfig:
+    """Immutable configuration for a single provider test run.
+
+    Attributes:
+        name: Provider identifier (``openai``, ``anthropic``, ``gemini``).
+        base_url: OpenAI-compatible proxy base URL.
+        api_key: API key for the proxy.
+        model: Model identifier to use for this provider.
+        extra: Provider-specific overrides (e.g. temperature, top_p).
+    """
+
+    name: str
+    base_url: str
+    api_key: str
+    model: str = ""
+    extra: dict = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Default model mapping — override via OLS_TEST_MODEL_<PROVIDER>
+# ---------------------------------------------------------------------------
+_DEFAULT_MODELS: dict[str, str] = {
+    "openai": os.environ.get("OLS_TEST_MODEL_OPENAI", "gpt-4o"),
+    "anthropic": os.environ.get("OLS_TEST_MODEL_ANTHROPIC", "claude-sonnet-4-20250514"),
+    "gemini": os.environ.get("OLS_TEST_MODEL_GEMINI", "gemini-2.5-pro"),
+}
+
+
+def _get_base_url() -> str | None:
+    return os.environ.get(ENV_BASE_URL)
+
+
+def _get_api_key() -> str | None:
+    return os.environ.get(ENV_API_KEY)
+
+
+# ---------------------------------------------------------------------------
+# Build ProviderConfig from environment
+# ---------------------------------------------------------------------------
+def provider_config_for(name: str) -> ProviderConfig:
+    """Build a ``ProviderConfig`` for *name* from environment variables.
+
+    Raises:
+        pytest.skip: When required env vars are missing.
+    """
+    base_url = _get_base_url()
+    api_key = _get_api_key()
+    if not base_url or not api_key:
+        pytest.skip(
+            f"{ENV_BASE_URL} and {ENV_API_KEY} must be set to run harness tests"
+        )
+
+    return ProviderConfig(
+        name=name,
+        base_url=base_url,
+        api_key=api_key,
+        model=_DEFAULT_MODELS.get(name, ""),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parametrize decorator
+# ---------------------------------------------------------------------------
+def _requested_providers() -> list[str]:
+    """Return the provider list requested via ``--provider`` or env var.
+
+    Falls back to all supported providers.
+    """
+    env = os.environ.get(ENV_PROVIDER, "")
+    if env.lower() == "all" or not env:
+        return list(SUPPORTED_PROVIDERS)
+    names = [p.strip().lower() for p in env.split(",")]
+    unknown = set(names) - set(SUPPORTED_PROVIDERS)
+    if unknown:
+        raise ValueError(
+            f"Unknown provider(s): {unknown}. "
+            f"Supported: {SUPPORTED_PROVIDERS}"
+        )
+    return names
+
+
+for_each_provider = pytest.mark.parametrize(
+    "provider_name",
+    _requested_providers(),
+    ids=lambda name: f"provider={name}",
+)
+"""Decorator that parametrizes a test across requested LLM providers.
+
+The test function receives a ``provider_name`` string parameter.  Use
+``provider_config_for(provider_name)`` inside the test to get the full
+``ProviderConfig``.
+"""

--- a/tests/harness/pytest.ini
+++ b/tests/harness/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+log_cli=false
+filterwarnings = 
+	ignore::DeprecationWarning

--- a/tests/harness/test_conversation_fixtures.py
+++ b/tests/harness/test_conversation_fixtures.py
@@ -1,0 +1,112 @@
+"""Tests for conversation fixture integrity.
+
+Validates that every canned conversation has the correct structure,
+role sequencing, and approximate token size for its intended scenario.
+"""
+
+import pytest
+
+from tests.harness.conversation_fixtures import (
+    CONVERSATION_FIXTURES,
+    bloated_tool_result,
+    medium_conversation,
+    recent_tool_conversation,
+    sacred_first_message,
+    short_conversation,
+)
+
+VALID_ROLES = {"user", "assistant", "tool", "system"}
+
+
+class TestFixtureStructure:
+    """Every fixture must return well-formed message dicts."""
+
+    @staticmethod
+    @pytest.mark.parametrize("name", list(CONVERSATION_FIXTURES.keys()))
+    def test_fixture_returns_list_of_dicts(name):
+        """Each fixture should return a non-empty list of dicts."""
+        msgs = CONVERSATION_FIXTURES[name]()
+        assert isinstance(msgs, list)
+        assert len(msgs) > 0
+        for msg in msgs:
+            assert isinstance(msg, dict)
+
+    @staticmethod
+    @pytest.mark.parametrize("name", list(CONVERSATION_FIXTURES.keys()))
+    def test_messages_have_role_and_content(name):
+        """Every message must have ``role`` and ``content`` keys."""
+        for msg in CONVERSATION_FIXTURES[name]():
+            assert "role" in msg, f"Missing 'role' in {msg}"
+            assert "content" in msg, f"Missing 'content' in {msg}"
+
+    @staticmethod
+    @pytest.mark.parametrize("name", list(CONVERSATION_FIXTURES.keys()))
+    def test_roles_are_valid(name):
+        """All roles must be one of the standard set."""
+        for msg in CONVERSATION_FIXTURES[name]():
+            assert msg["role"] in VALID_ROLES, f"Bad role: {msg['role']}"
+
+
+class TestToolMessagePairing:
+    """Tool messages must be preceded by an assistant message with tool_calls."""
+
+    @staticmethod
+    @pytest.mark.parametrize("name", list(CONVERSATION_FIXTURES.keys()))
+    def test_tool_results_have_matching_call(name):
+        """Every tool message must reference a tool_call_id from a prior assistant."""
+        msgs = CONVERSATION_FIXTURES[name]()
+        emitted_ids: set[str] = set()
+        for msg in msgs:
+            if msg["role"] == "assistant" and "tool_calls" in msg:
+                for tc in msg["tool_calls"]:
+                    emitted_ids.add(tc["id"])
+            if msg["role"] == "tool":
+                assert "tool_call_id" in msg, "Tool message missing tool_call_id"
+                assert msg["tool_call_id"] in emitted_ids, (
+                    f"tool_call_id {msg['tool_call_id']} not found in prior "
+                    f"assistant tool_calls"
+                )
+
+
+class TestFixtureSizes:
+    """Approximate size checks for each scenario."""
+
+    @staticmethod
+    def _total_chars(msgs: list[dict]) -> int:
+        return sum(len(str(m.get("content", ""))) for m in msgs)
+
+    def test_short_is_small(self):
+        """Short conversation should be under 2k chars."""
+        assert self._total_chars(short_conversation()) < 2_000
+
+    def test_medium_is_moderate(self):
+        """Medium conversation should be between 2k and 20k chars."""
+        total = self._total_chars(medium_conversation())
+        assert 2_000 < total < 20_000
+
+    def test_bloated_is_large(self):
+        """Bloated fixture should exceed 40k chars (oversized tool result)."""
+        assert self._total_chars(bloated_tool_result()) > 40_000
+
+    def test_sacred_starts_with_important_context(self):
+        """The first message in the sacred fixture must contain constraints."""
+        msgs = sacred_first_message()
+        first = msgs[0]["content"]
+        assert "FIPS" in first
+        assert "PCI-DSS" in first
+        assert msgs[0]["role"] == "user"
+
+    def test_sacred_has_many_turns(self):
+        """Sacred fixture should have at least 20 messages."""
+        assert len(sacred_first_message()) >= 20
+
+    def test_recent_tool_pair_near_end(self):
+        """The tool call/result pair must be in the last 5 messages."""
+        msgs = recent_tool_conversation()
+        tool_indices = [i for i, m in enumerate(msgs) if m["role"] == "tool"]
+        assert tool_indices, "No tool messages found"
+        last_tool_idx = tool_indices[-1]
+        assert last_tool_idx >= len(msgs) - 5, (
+            f"Tool result at index {last_tool_idx} is not near the end "
+            f"(total messages: {len(msgs)})"
+        )

--- a/tests/harness/test_fake_tools.py
+++ b/tests/harness/test_fake_tools.py
@@ -1,0 +1,156 @@
+"""Tests for the fake OCP tool definitions.
+
+Validates that every fake tool is a well-formed StructuredTool, returns
+the expected output shape, and carries the correct policy annotation.
+"""
+
+import pytest
+
+from tests.harness.fake_tools import (
+    ALL_FAKE_TOOLS,
+    DESTRUCTIVE_TOOLS,
+    POLICY_ALLOW,
+    POLICY_CONFIRM,
+    POLICY_DENY,
+    POLICY_MAP,
+    SAFE_TOOLS,
+    delete_namespace,
+    describe_pod,
+    drain_node,
+    get_cluster_info,
+    list_pods,
+    scale_deployment,
+)
+
+
+class TestToolDefinitions:
+    """Verify structural properties of the fake tool set."""
+
+    @staticmethod
+    def test_all_tools_count():
+        """Six tools should be registered."""
+        assert len(ALL_FAKE_TOOLS) == 6
+
+    @staticmethod
+    def test_safe_tools_are_allow_policy():
+        """Every safe tool must carry the ALLOW policy."""
+        for tool in SAFE_TOOLS:
+            assert tool.metadata["policy"] == POLICY_ALLOW, tool.name
+
+    @staticmethod
+    def test_destructive_tools_are_not_allow():
+        """No destructive tool should have the ALLOW policy."""
+        for tool in DESTRUCTIVE_TOOLS:
+            assert tool.metadata["policy"] != POLICY_ALLOW, tool.name
+
+    @staticmethod
+    def test_policy_map_covers_all_tools():
+        """The POLICY_MAP must have an entry for every tool."""
+        tool_names = {t.name for t in ALL_FAKE_TOOLS}
+        assert set(POLICY_MAP.keys()) == tool_names
+
+    @staticmethod
+    def test_all_tools_have_coroutine():
+        """Every tool must define an async coroutine."""
+        for tool in ALL_FAKE_TOOLS:
+            assert tool.coroutine is not None, f"{tool.name} missing coroutine"
+
+    @staticmethod
+    def test_all_tools_have_description():
+        """Every tool must have a non-empty description."""
+        for tool in ALL_FAKE_TOOLS:
+            assert tool.description, f"{tool.name} missing description"
+
+    @staticmethod
+    def test_unique_tool_names():
+        """Tool names must be unique."""
+        names = [t.name for t in ALL_FAKE_TOOLS]
+        assert len(names) == len(set(names))
+
+
+class TestToolExecution:
+    """Verify the coroutines return well-formed (text, artifact) tuples."""
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_get_cluster_info_returns_json():
+        """get_cluster_info should return parseable JSON text."""
+        text, artifact = await get_cluster_info.coroutine()
+        assert '"version"' in text
+        assert '"4.15.2"' in text
+        assert isinstance(artifact, dict)
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_list_pods_returns_structured_content():
+        """list_pods should return structured content in the artifact."""
+        text, artifact = await list_pods.coroutine(namespace="kube-system")
+        assert "kube-system" in text
+        assert "structured_content" in artifact
+        pods = artifact["structured_content"]["pods"]
+        assert len(pods) == 3
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_drain_node_uses_node_name():
+        """drain_node should include the node name in its response."""
+        text, _artifact = await drain_node.coroutine(node_name="worker-3")
+        assert "worker-3" in text
+        assert "pods_evicted" in text
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_scale_deployment_uses_args():
+        """scale_deployment should reflect the requested name and replicas."""
+        text, _ = await scale_deployment.coroutine(name="nginx", replicas=10)
+        assert "nginx" in text
+        assert "10" in text
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_describe_pod_produces_large_output():
+        """describe_pod should return output large enough to trigger compaction."""
+        text, _ = await describe_pod.coroutine(name="nginx-abc123")
+        assert len(text) > 40_000, "Output should be >40KB to trigger compaction"
+        assert "nginx-abc123" in text
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_delete_namespace_raises():
+        """delete_namespace should raise — it must never actually execute."""
+        with pytest.raises(RuntimeError, match="should never execute"):
+            await delete_namespace.coroutine()
+
+
+class TestPolicyClassification:
+    """Verify the policy annotations match the playbook spec."""
+
+    @staticmethod
+    def test_get_cluster_info_is_allow():
+        """Read-only cluster info should be allowed."""
+        assert POLICY_MAP["get_cluster_info"] == POLICY_ALLOW
+
+    @staticmethod
+    def test_list_pods_is_allow():
+        """Pod listing is a safe read."""
+        assert POLICY_MAP["list_pods"] == POLICY_ALLOW
+
+    @staticmethod
+    def test_describe_pod_is_allow():
+        """Describe is read-only despite large output."""
+        assert POLICY_MAP["describe_pod"] == POLICY_ALLOW
+
+    @staticmethod
+    def test_drain_node_is_confirm():
+        """Draining a node is destructive and requires confirmation."""
+        assert POLICY_MAP["drain_node"] == POLICY_CONFIRM
+
+    @staticmethod
+    def test_scale_deployment_is_confirm():
+        """Scaling is a mutation that requires confirmation."""
+        assert POLICY_MAP["scale_deployment"] == POLICY_CONFIRM
+
+    @staticmethod
+    def test_delete_namespace_is_deny():
+        """Deleting a namespace is always denied."""
+        assert POLICY_MAP["delete_namespace"] == POLICY_DENY


### PR DESCRIPTION
## Summary

Introduces `tests/harness/` — an integration-level test tier for exercising the agent loop with realistic tool interactions, without requiring an OpenShift cluster or a running OLS instance.

The repo currently has excellent unit test coverage (mocked) and e2e tests (full cluster), but no middle ground for testing the agent loop with realistic tool interactions and real LLM calls. This harness fills that gap.

### What's Included

| Module | Purpose |
|---|---|
| `fake_tools.py` | 6 `StructuredTool` instances simulating OCP operations (`get_cluster_info`, `list_pods`, `describe_pod`, `drain_node`, `scale_deployment`, `delete_namespace`) with `ALLOW` / `CONFIRM` / `DENY` policy annotations in metadata |
| `conversation_fixtures.py` | 5 canned conversation histories at different token sizes: short (~2k), medium (~8k), bloated tool result (~50k), sacred-first-message (20 turns), recent-tool-pair (12 turns) |
| `provider_matrix.py` | `@for_each_provider` decorator and `ProviderConfig` dataclass for cross-provider parametrization (OpenAI / Anthropic / Gemini) via an OpenAI-compatible proxy |
| `conftest.py` | Fixtures for tools, provider config, LLM proxy credentials; `--provider` CLI option |
| `README.md` | Setup, usage, and architecture notes |

### Design Decisions

- **Plain dicts, not LangChain types** — conversation fixtures use `list[dict]` with standard `role`/`content` fields. Convert to `BaseMessage` at the boundary. This keeps the harness portable to `lightspeed-stack`.
- **Policy annotations in tool metadata** — each tool carries `metadata={"policy": "allow|confirm|deny"}` so approval-gate tests can classify tools without parsing descriptions or hard-coding names.
- **Graceful skip when no proxy** — if `OLS_TEST_LLM_BASE_URL` / `OLS_TEST_LLM_API_KEY` are unset, live-LLM tests skip automatically. CI stays green.
- **Follows existing test tier pattern** — own `conftest.py`, `pytest.ini`, autouse config-reset fixture, same docstring/naming conventions as `tests/unit/`.

### Relationship to Existing Work

This harness can be used to validate the compaction and approval features in #2730 and #2769. The conversation fixtures are specifically designed to exercise compaction edge cases (oversized tool results, split-point protection for tool-call/tool-result pairs, sacred-first-message preservation), and the policy-annotated fake tools provide a ready-made test surface for approval-gate classification.

The `describe_pod` tool intentionally returns ~50KB of YAML to trigger Stage 1 truncation in any compaction implementation.

### Running

```bash
# Offline (no credentials needed)
uv run pytest tests/harness/ -v

# Live (real LLM calls via proxy)
export OLS_TEST_LLM_BASE_URL="https://your-proxy/v1"
export OLS_TEST_LLM_API_KEY="your-key"
uv run pytest tests/harness/ -v --provider=openai
```

## Test Plan

- [x] `uv run pytest tests/harness/ -v` — 45 tests pass
- [x] `ruff check tests/harness/` — clean
- [x] `black --check tests/harness/` — clean
- [x] `mypy tests/harness/ --ignore-missing-imports` — clean
- [ ] Reviewer verifies the harness integrates with existing `execute_tool_calls()` via the `StructuredTool` interface