### PR TITLE
adding A2A protocol to OLS

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1049,6 +1049,68 @@
                     }
                 }
             }
+        },
+        "/a2a": {
+            "post": {
+                "summary": " Handle Requests",
+                "description": "Handles incoming POST requests to the main A2A endpoint.\n\nParses the request body as JSON, validates it against A2A request types,\ndispatches it to the appropriate handler method, and returns the response.\nHandles JSON parsing errors, validation errors, and other exceptions,\nreturning appropriate JSON-RPC error responses.\n\nArgs:\n    request: The incoming Starlette Request object.\n\nReturns:\n    A Starlette Response object (JSONResponse or EventSourceResponse).\n\nRaises:\n    (Implicitly handled): Various exceptions are caught and converted\n    into JSON-RPC error responses by this method.",
+                "operationId": "_handle_requests_a2a_post",
+                "requestBody": {
+                    "description": "A2ARequest",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/A2ARequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/.well-known/agent-card.json": {
+            "get": {
+                "summary": " Handle Get Agent Card",
+                "description": "Handles GET requests for the agent card endpoint.\n\nArgs:\n    request: The incoming Starlette Request object.\n\nReturns:\n    A JSONResponse containing the agent card data.",
+                "operationId": "_handle_get_agent_card__well_known_agent_card_json_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/.well-known/agent.json": {
+            "get": {
+                "summary": " Handle Get Agent Card",
+                "description": "Handles GET requests for the agent card endpoint.\n\nArgs:\n    request: The incoming Starlette Request object.\n\nReturns:\n    A JSONResponse containing the agent card data.",
+                "operationId": "_handle_get_agent_card__well_known_agent_json_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -635,7 +635,9 @@ class MCPServerConfig(BaseModel):
 
     name: str = Field(
         title="MCP name",
-        description="MCP server name that must be unique",
+        description=(
+            "MCP server name. Must be unique across both MCP servers and A2A agents."
+        ),
     )
 
     url: str = Field(
@@ -782,6 +784,66 @@ class MCPServers(BaseModel):
             if server.name in server_names:
                 raise ValueError(f"Duplicate server name: '{server.name}'")
             server_names.add(server.name)
+        return self
+
+
+class A2AAgentConfig(BaseModel):
+    """A2A agent configuration.
+
+    Remote A2A agents that OLS can delegate work to. Each agent is discovered
+    via its Agent Card at startup and its skills are exposed as LangChain tools.
+    """
+
+    name: str = Field(
+        title="Agent name",
+        description=(
+            "A2A agent name. Must be unique across both A2A agents and MCP servers."
+        ),
+    )
+
+    url: str = Field(
+        title="Agent URL",
+        description="Base URL of the remote A2A agent (e.g. https://agent.example.com)",
+    )
+
+    timeout: Optional[int] = Field(
+        default=30,
+        title="Request timeout",
+        description="Timeout in seconds for requests to the A2A agent.",
+    )
+
+    headers: dict[str, str] = Field(
+        default_factory=dict,
+        title="Authorization headers",
+        description=(
+            "Headers to send to the A2A agent. Same format as MCP server headers: "
+            f"use '{constants.MCP_KUBERNETES_PLACEHOLDER}' for the kubernetes token, "
+            f"'{constants.MCP_CLIENT_PLACEHOLDER}' for client-provided token, "
+            "or a file path containing the secret value."
+        ),
+    )
+
+    _resolved_headers: dict[str, str] = PrivateAttr(default_factory=dict)
+
+    @property
+    def resolved_headers(self) -> dict[str, str]:
+        """Resolved headers (computed from headers)."""
+        return self._resolved_headers
+
+
+class A2AAgents(BaseModel):
+    """A2A agents configuration."""
+
+    agents: list[A2AAgentConfig] = []
+
+    @model_validator(mode="after")
+    def check_duplicate_agents(self) -> Self:
+        """Check if there are duplicate agents."""
+        agent_names = set()
+        for agent in self.agents:
+            if agent.name in agent_names:
+                raise ValueError(f"Duplicate A2A agent name: '{agent.name}'")
+            agent_names.add(agent.name)
         return self
 
 
@@ -1272,6 +1334,7 @@ class Config(BaseModel):
     ols_config: OLSConfig = OLSConfig()
     dev_config: DevConfig = DevConfig()
     mcp_servers: MCPServers = MCPServers()
+    a2a_agents: A2AAgents = A2AAgents()
 
     def __init__(
         self,
@@ -1303,6 +1366,14 @@ class Config(BaseModel):
 
         # Validate MCP servers now that auth config is available
         self._validate_mcp_servers()
+
+        # initialize A2A agents
+        self.a2a_agents = A2AAgents(agents=data.get("a2a_agents", []))
+        self._validate_a2a_agents()
+
+        # cross-validate names are unique across MCP servers and A2A agents
+        self._validate_unique_source_names()
+
         self._compute_tool_budgets()
 
         # Always initialize dev config, even if there's no config for it.
@@ -1347,12 +1418,36 @@ class Config(BaseModel):
             auth_module,
         )
 
+    def _validate_a2a_agents(self) -> None:
+        """Validate A2A agents with auth module context.
+
+        Filters out agents where authorization headers cannot be resolved.
+        """
+        auth_module = getattr(
+            getattr(self.ols_config, "authentication_config", None),
+            "module",
+            None,
+        )
+        self.a2a_agents.agents = checks.validate_mcp_servers(
+            self.a2a_agents.agents,
+            auth_module,
+        )
+
+    def _validate_unique_source_names(self) -> None:
+        """Ensure names are unique across MCP servers and A2A agents."""
+        mcp_names = {s.name for s in self.mcp_servers.servers}
+        for agent in self.a2a_agents.agents:
+            if agent.name in mcp_names:
+                raise checks.InvalidConfigurationError(
+                    f"A2A agent name '{agent.name}' conflicts with an MCP server name"
+                )
+
     def _compute_tool_budgets(self) -> None:
         """Set tool token budget per model and ensure the context window fits reserved tokens."""
-        has_mcp = bool(self.mcp_servers.servers)
+        has_tools = bool(self.mcp_servers.servers) or bool(self.a2a_agents.agents)
         for provider in self.llm_providers.providers.values():
             for model in provider.models.values():
-                if has_mcp:
+                if has_tools:
                     model.max_tokens_for_tools = int(
                         model.context_window_size * model.parameters.tool_budget_ratio
                     )

--- a/ols/app/routers.py
+++ b/ols/app/routers.py
@@ -1,5 +1,7 @@
 """REST API routers."""
 
+import logging
+
 from fastapi import FastAPI
 
 from ols.app.endpoints import (
@@ -14,6 +16,45 @@ from ols.app.endpoints import (
     tool_approvals,
 )
 from ols.app.metrics import metrics
+
+logger = logging.getLogger(__name__)
+
+
+def _mount_a2a_routes(app: FastAPI) -> None:
+    """Mount A2A protocol routes onto the FastAPI app.
+
+    Args:
+        app: The `FastAPI` app instance.
+    """
+    # pylint: disable=import-outside-toplevel
+    from a2a.server.apps import A2AFastAPIApplication
+    from a2a.server.events import InMemoryQueueManager
+    from a2a.server.request_handlers import DefaultRequestHandler
+    from a2a.server.tasks import InMemoryTaskStore
+
+    from ols.src.a2a.server import OLSAgentExecutor, build_agent_card
+
+    # pylint: enable=import-outside-toplevel
+
+    server_url = str(app.root_path or "http://localhost:8443")
+    agent_card = build_agent_card(server_url)
+
+    request_handler = DefaultRequestHandler(
+        agent_executor=OLSAgentExecutor(),
+        task_store=InMemoryTaskStore(),
+        queue_manager=InMemoryQueueManager(),
+    )
+
+    a2a_app = A2AFastAPIApplication(
+        agent_card=agent_card,
+        http_handler=request_handler,
+    )
+    a2a_app.add_routes_to_app(
+        app,
+        agent_card_url="/.well-known/agent-card.json",
+        rpc_url="/a2a",
+    )
+    logger.info("A2A protocol routes mounted at /a2a")
 
 
 def include_routers(app: FastAPI) -> None:
@@ -32,3 +73,4 @@ def include_routers(app: FastAPI) -> None:
     app.include_router(health.router)
     app.include_router(metrics.router)
     app.include_router(authorized.router)
+    _mount_a2a_routes(app)

--- a/ols/src/a2a/__init__.py
+++ b/ols/src/a2a/__init__.py
@@ -1,0 +1,1 @@
+"""A2A (Agent-to-Agent) protocol server support for OLS."""

--- a/ols/src/a2a/client.py
+++ b/ols/src/a2a/client.py
@@ -1,0 +1,545 @@
+"""A2A client: discover remote agent skills, wrap them as LangChain tools, and AgentsRAG."""
+
+import json
+import logging
+import re
+from collections.abc import Callable
+from typing import Any, Optional
+from uuid import uuid4
+
+import httpx
+from a2a.client.card_resolver import A2ACardResolver
+from a2a.client.client import ClientConfig
+from a2a.client.client_factory import ClientFactory
+from a2a.client.middleware import ClientCallContext, ClientCallInterceptor
+from a2a.types import (
+    AgentCard,
+    AgentSkill,
+    Message,
+    Part,
+    Role,
+    Task,
+    TaskState,
+    TextPart,
+)
+from langchain_core.tools.structured import StructuredTool
+from pydantic import BaseModel, Field
+
+from ols import config
+from ols.src.rag.hybrid_rag import HybridRAGBase
+from ols.utils.mcp_utils import ClientHeaders, resolve_server_headers
+
+logger = logging.getLogger(__name__)
+
+
+class A2AToolInput(BaseModel):
+    """Input schema for A2A tool invocations."""
+
+    query: str = Field(description="The text query to send to the remote agent.")
+
+
+class _HeaderInterceptor(ClientCallInterceptor):
+    """Inject authorization headers into every outbound A2A RPC call."""
+
+    def __init__(self, headers: dict[str, str]) -> None:
+        self._headers = headers
+
+    async def intercept(
+        self,
+        method_name: str,
+        request_payload: dict[str, Any],
+        http_kwargs: dict[str, Any],
+        agent_card: AgentCard | None,
+        context: ClientCallContext | None,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Add stored headers to the HTTP request kwargs."""
+        existing = http_kwargs.get("headers", {})
+        existing.update(self._headers)
+        http_kwargs["headers"] = existing
+        return request_payload, http_kwargs
+
+
+def _sanitize_tool_name(name: str) -> str:
+    """Convert a string into a valid LangChain tool name (alphanumeric + underscores)."""
+    return re.sub(r"[^a-zA-Z0-9_]", "_", name)
+
+
+async def _fetch_agent_card(
+    base_url: str,
+    headers: dict[str, str],
+    request_timeout: int,
+) -> AgentCard:
+    """Fetch an A2A agent card from its well-known endpoint."""
+    async with httpx.AsyncClient(
+        headers=headers, timeout=httpx.Timeout(request_timeout)
+    ) as http:
+        resolver = A2ACardResolver(http, base_url)
+        return await resolver.get_agent_card()
+
+
+def _extract_task_text(task: Task) -> str:
+    """Extract text content from a completed A2A Task.
+
+    Prefers artifact text; falls back to the status message.
+    """
+    parts: list[str] = []
+
+    if task.artifacts:
+        for artifact in task.artifacts:
+            parts.extend(
+                part.root.text
+                for part in artifact.parts
+                if isinstance(part.root, TextPart)
+            )
+
+    if parts:
+        return "\n".join(parts)
+
+    if task.status and task.status.message:
+        parts.extend(
+            part.root.text
+            for part in task.status.message.parts
+            if isinstance(part.root, TextPart)
+        )
+
+    return "\n".join(parts) if parts else ""
+
+
+def _extract_message_text(message: Message) -> str:
+    """Extract text content from an A2A Message response."""
+    return "\n".join(
+        part.root.text for part in message.parts if isinstance(part.root, TextPart)
+    )
+
+
+def _build_agent_tool(
+    agent_name: str,
+    skill: AgentSkill,
+    card: AgentCard,
+    headers: dict[str, str],
+    timeout: int,
+) -> StructuredTool:
+    """Wrap a remote A2A agent skill as a LangChain StructuredTool.
+
+    The returned tool sends a text query to the remote A2A agent and
+    collects the full (non-streaming) response.
+    """
+    tool_name = _sanitize_tool_name(f"{agent_name}_{skill.id}")
+
+    async def _invoke(query: str) -> str:
+        message = Message(
+            message_id=uuid4().hex,
+            role=Role.user,
+            parts=[Part(root=TextPart(text=query))],
+        )
+
+        request_metadata: dict[str, str] = {}
+        if skill.id:
+            request_metadata["skill_id"] = skill.id
+
+        client_config = ClientConfig(streaming=False)
+        interceptor = _HeaderInterceptor(headers)
+        factory = ClientFactory(client_config)
+        client = factory.create(card, interceptors=[interceptor])
+
+        try:
+            async for event in client.send_message(
+                message, request_metadata=request_metadata or None
+            ):
+                if isinstance(event, tuple):
+                    task, _ = event
+                    if task.status.state == TaskState.failed:
+                        error_text = (
+                            _extract_task_text(task)
+                            or "Remote agent returned an error."
+                        )
+                        raise RuntimeError(error_text)
+                    return _extract_task_text(task)
+                if isinstance(event, Message):
+                    return _extract_message_text(event)
+        finally:
+            await client.close()  # type: ignore [attr-defined]
+
+        return ""
+
+    return StructuredTool(
+        name=tool_name,
+        description=skill.description,
+        coroutine=_invoke,
+        args_schema=A2AToolInput,
+        metadata={"a2a_agent": agent_name, "a2a_skill_id": skill.id},
+    )
+
+
+async def _gather_a2a_tools(
+    agents: list[Any],
+    user_token: Optional[str] = None,
+    client_headers: ClientHeaders | None = None,
+    populate_to_rag: bool = False,
+) -> tuple[dict[str, Any], list[StructuredTool]]:
+    """Discover tools from a list of A2A agents.
+
+    Args:
+        agents: Agent config objects to query.
+        user_token: Kubernetes bearer token for resolving auth headers.
+        client_headers: Client-provided headers keyed by agent name.
+        populate_to_rag: Whether to populate discovered tools into AgentsRAG.
+
+    Returns:
+        Tuple of (agent-name-to-config dict, list of StructuredTools).
+    """
+    agents_config: dict[str, Any] = {}
+    all_tools: list[StructuredTool] = []
+
+    for agent_cfg in agents:
+        try:
+            headers = resolve_server_headers(agent_cfg, user_token, client_headers)
+            if headers is None:
+                continue
+
+            timeout = agent_cfg.timeout or 30
+            card = await _fetch_agent_card(agent_cfg.url, headers, timeout)
+
+            for skill in card.skills:
+                tool = _build_agent_tool(agent_cfg.name, skill, card, headers, timeout)
+                all_tools.append(tool)
+
+            agents_config[agent_cfg.name] = agent_cfg
+            logger.info(
+                "Discovered %d tools from A2A agent '%s'",
+                len(card.skills),
+                agent_cfg.name,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to discover tools from A2A agent '%s'",
+                agent_cfg.name,
+            )
+
+    if populate_to_rag and all_tools and config.agents_rag:
+        config.agents_rag.populate_agents(all_tools)
+
+    return agents_config, all_tools
+
+
+async def _populate_agents_rag(
+    user_token: Optional[str],
+    client_headers: ClientHeaders | None,
+) -> None:
+    """Populate AgentsRAG with tools from k8s-auth and client-auth A2A agents.
+
+    Args:
+        user_token: Optional user authentication token.
+        client_headers: Optional client-provided headers keyed by agent name.
+    """
+    if not config.k8s_a2a_agents_resolved:
+        k8s_agents_config, k8s_tools = await _gather_a2a_tools(
+            config.a2a_agents.agents,
+            user_token=user_token,
+            client_headers=None,
+            populate_to_rag=True,
+        )
+
+        if k8s_tools:
+            logger.info(
+                "Populated AgentsRAG with %d tools from %d k8s-auth A2A agents",
+                len(k8s_tools),
+                len(k8s_agents_config),
+            )
+            config.agents_rag.set_default_agents(list(k8s_agents_config.keys()))
+
+        config.k8s_a2a_agents_resolved = True
+
+    if client_headers:
+        client_agents_list = [
+            config.a2a_agents_dict[name]
+            for name in client_headers
+            if name in config.a2a_agents_dict
+        ]
+
+        if client_agents_list:
+            client_agents_config, client_tools = await _gather_a2a_tools(
+                client_agents_list,
+                user_token,
+                client_headers,
+                populate_to_rag=True,
+            )
+
+            if client_tools:
+                logger.info(
+                    "Added %d tools from %d client-auth A2A agents to AgentsRAG",
+                    len(client_tools),
+                    len(client_agents_config),
+                )
+
+
+async def get_a2a_tools(  # pylint: disable=too-many-return-statements
+    query: str,
+    user_token: Optional[str] = None,
+    client_headers: ClientHeaders | None = None,
+) -> list[StructuredTool]:
+    """Get A2A agent tools, using AgentsRAG filtering when configured.
+
+    Args:
+        query: The user's query for filtering tools.
+        user_token: Optional user authentication token.
+        client_headers: Optional client-provided headers keyed by agent name.
+
+    Returns:
+        List of StructuredTools from A2A agents (filtered if AgentsRAG configured).
+    """
+    if not config.a2a_agents.agents:
+        return []
+
+    if not config.agents_rag:
+        agents_config, all_tools = await _gather_a2a_tools(
+            config.a2a_agents.agents, user_token, client_headers
+        )
+        if not agents_config:
+            logger.debug("No A2A agents reachable, agent calling is disabled")
+            return []
+        logger.info("A2A agents provided: %s", list(agents_config.keys()))
+        return all_tools
+
+    await _populate_agents_rag(user_token, client_headers)
+
+    try:
+        client_agent_names = list(client_headers.keys()) if client_headers else None
+        filtered_result = config.agents_rag.retrieve_hybrid(
+            query, client_agents=client_agent_names
+        )
+    except Exception as e:
+        logger.error(
+            "Failed to filter tools using AgentsRAG: %s, falling back to all tools",
+            e,
+        )
+        _, all_tools = await _gather_a2a_tools(
+            config.a2a_agents.agents, user_token, client_headers
+        )
+        return all_tools
+
+    if filtered_result:
+        filtered_tool_names: set[str] = set()
+        agent_names: set[str] = set()
+        for agent_name, tools_list in filtered_result.items():
+            agent_names.add(agent_name)
+            for tool in tools_list:
+                if "name" in tool:
+                    filtered_tool_names.add(tool["name"])
+
+        filtered_agents_list = [
+            config.a2a_agents_dict[name]
+            for name in agent_names
+            if name in config.a2a_agents_dict
+        ]
+
+        if not filtered_agents_list:
+            logger.warning(
+                "No matching agents found in config for filtered tools. "
+                "Filtered tools referenced agents: %s",
+                agent_names,
+            )
+            return []
+
+        _, filtered_tools = await _gather_a2a_tools(
+            filtered_agents_list, user_token, client_headers
+        )
+        filtered_tools = [t for t in filtered_tools if t.name in filtered_tool_names]
+
+        logger.info(
+            "Filtered to %d tools from %d A2A agents based on query",
+            len(filtered_tools),
+            len(filtered_agents_list),
+        )
+        return filtered_tools
+
+    logger.warning("No A2A agent tools matched the query filter")
+    return []
+
+
+# ---------------------------------------------------------------------------
+# AgentsRAG
+# ---------------------------------------------------------------------------
+
+
+class AgentsRAG(HybridRAGBase):
+    """Hybrid RAG system for A2A agent tool retrieval.
+
+    Mirrors ToolsRAG but indexes tools discovered from remote A2A agents.
+    Internally stores the agent name under the Qdrant ``server`` metadata
+    key so the base-class dense-search filter works unchanged.
+    """
+
+    _COLLECTION = "a2a_agents"
+
+    def __init__(
+        self,
+        encode_fn: Callable[[str], list[float]],
+        alpha: float = 0.8,
+        top_k: int = 10,
+        threshold: float = 0.01,
+    ) -> None:
+        """Initialize the AgentsRAG system.
+
+        Args:
+            encode_fn: Function that encodes text into an embedding vector.
+            alpha: Weight for dense vs sparse (1.0 = full dense, 0.0 = full sparse).
+            top_k: Number of tools to retrieve.
+            threshold: Minimum similarity threshold for filtering results.
+        """
+        super().__init__(
+            collection=self._COLLECTION,
+            encode_fn=encode_fn,
+            alpha=alpha,
+            top_k=top_k,
+            threshold=threshold,
+        )
+        self.default_allowed_agents: set[str] = set()
+
+    def set_default_agents(self, agents: list[str]) -> None:
+        """Set the default agents that are always included in retrieval.
+
+        Args:
+            agents: List of agent names to use as defaults.
+        """
+        self.default_allowed_agents = set(agents)
+
+    def populate_agents(self, tools_list: list[StructuredTool]) -> None:
+        """Populate the RAG with tools discovered from A2A agents.
+
+        Args:
+            tools_list: LangChain tools returned by ``get_a2a_tools``.
+        """
+        ids: list[str] = []
+        dense_docs: list[str] = []
+        vectors: list[list[float]] = []
+        metadatas: list[dict[str, str]] = []
+
+        for tool in tools_list:
+            tool_dict = self._convert_agent_to_dict(tool)
+            text = self._build_text(tool_dict)
+            agent_name = tool_dict.get("server", "")
+
+            ids.append(f"{agent_name}::{tool_dict['name']}")
+            dense_docs.append(text)
+            vectors.append(self._encode(text))
+            metadatas.append(
+                {
+                    "tool_json": json.dumps(tool_dict),
+                    "server": agent_name,
+                }
+            )
+
+        self._index_documents(ids, dense_docs, vectors, metadatas=metadatas)
+
+    def retrieve_hybrid(
+        self,
+        query: str,
+        client_agents: list[str] | None = None,
+        k: int | None = None,
+        alpha: float | None = None,
+        threshold: float | None = None,
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Retrieve agent tools using hybrid (dense + sparse) search.
+
+        Args:
+            query: Search query describing what tools are needed.
+            client_agents: Optional list of client-specific agent names to include.
+            k: Number of results to return (default from instance).
+            alpha: Weight for dense vs sparse (1.0=dense, 0.0=sparse).
+            threshold: Minimum similarity score (default from instance).
+
+        Returns:
+            Dictionary mapping agent names to lists of matching tool dicts.
+        """
+        k = k if k is not None else self.top_k
+        alpha = alpha if alpha is not None else self.alpha
+        threshold = threshold if threshold is not None else self.threshold
+
+        allowed = self.default_allowed_agents
+        if client_agents:
+            allowed = allowed | set(client_agents)
+
+        q_vec = self._encode(query)
+
+        dense, dense_ids, dense_metas = self._dense_scores(
+            q_vec, k, allowed_servers=allowed
+        )
+        metadata_lookup = {
+            tool_id: json.loads(meta["tool_json"])
+            for tool_id, meta in zip(dense_ids, dense_metas)
+        }
+
+        sparse, sparse_metadata = self._retrieve_sparse_scores(
+            query, allowed_agents=allowed
+        )
+        for tool_id, tool_dict in sparse_metadata.items():
+            if tool_id not in metadata_lookup:
+                metadata_lookup[tool_id] = tool_dict
+
+        fused = self._fuse_scores(dense, sparse, alpha, k)
+
+        agent_tools: dict[str, list[dict[str, Any]]] = {}
+        for name, score in fused.items():
+            if score < threshold:
+                continue
+            if name not in metadata_lookup:
+                continue
+            tool = metadata_lookup[name]
+            agent = tool.pop("server", None)
+            if agent:
+                agent_tools.setdefault(agent, []).append(tool)
+
+        return agent_tools
+
+    def _convert_agent_to_dict(self, tool: StructuredTool) -> dict[str, Any]:
+        """Convert an A2A agent tool to a dict for indexing.
+
+        Maps the ``a2a_agent`` metadata key to ``server`` so the base-class
+        Qdrant filter works unchanged.
+        """
+        schema = getattr(tool, "args_schema", None)
+        if schema is not None and not isinstance(schema, dict):
+            schema = schema.model_json_schema()
+        return {
+            "name": tool.name,
+            "desc": tool.description or "",
+            "params": schema,
+            "server": (
+                tool.metadata.get("a2a_agent") if hasattr(tool, "metadata") else None
+            ),
+        }
+
+    def _build_text(self, t: dict[str, Any]) -> str:
+        """Build text representation for embedding: name + description."""
+        return f"{t['name']} {t['desc']}"
+
+    def _retrieve_sparse_scores(
+        self, query: str, allowed_agents: set[str] | None = None
+    ) -> tuple[dict[str, float], dict[str, dict[str, Any]]]:
+        """Retrieve BM25 scores with optional agent filtering.
+
+        Args:
+            query: The query string.
+            allowed_agents: Optional set of agent names to filter by.
+
+        Returns:
+            Tuple of (scores dict, metadata dict).
+        """
+        base_scores, meta_by_id = self._sparse_scores(query)
+        if not base_scores:
+            return {}, {}
+
+        scores: dict[str, float] = {}
+        metadata: dict[str, dict[str, Any]] = {}
+        for name, score in base_scores.items():
+            raw_meta = meta_by_id.get(name)
+            if raw_meta is None:
+                continue
+            tool_dict = json.loads(raw_meta["tool_json"])
+            if allowed_agents and tool_dict.get("server", "") not in allowed_agents:
+                continue
+            scores[name] = score
+            metadata[name] = tool_dict
+
+        return scores, metadata

--- a/ols/src/a2a/server.py
+++ b/ols/src/a2a/server.py
@@ -1,0 +1,197 @@
+"""A2A server components: Agent Card definition and OLS executor."""
+
+import logging
+
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+from a2a.server.tasks import TaskUpdater
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentProvider,
+    AgentSkill,
+    Part,
+    TextPart,
+)
+
+from ols import config, version
+from ols.app.models.models import StreamChunkType
+from ols.constants import SERVICE_NAME, QueryMode
+from ols.src.query_helpers.docs_summarizer import DocsSummarizer
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Skills
+# ---------------------------------------------------------------------------
+
+SKILL_ID_ASK = "openshift-ask"
+SKILL_ID_TROUBLESHOOTING = "openshift-troubleshooting"
+
+SKILL_ASK = AgentSkill(
+    id=SKILL_ID_ASK,
+    name="OpenShift and Kubernetes Q&A",
+    description=(
+        "Answers general questions about OpenShift and Kubernetes, "
+        "generates YAML manifests, and explains concepts."
+    ),
+    tags=["openshift", "kubernetes", "containers", "yaml"],
+    examples=[
+        "How do I create a deployment in OpenShift?",
+        "Generate a NetworkPolicy that allows traffic only from namespace 'frontend'.",
+        "What is the difference between a StatefulSet and a Deployment?",
+    ],
+    input_modes=["text/plain"],
+    output_modes=["text/plain"],
+)
+
+SKILL_TROUBLESHOOTING = AgentSkill(
+    id=SKILL_ID_TROUBLESHOOTING,
+    name="OpenShift Cluster Troubleshooting",
+    description=(
+        "Diagnoses and troubleshoots OpenShift and Kubernetes cluster issues. "
+        "Uses cluster version context to provide version-specific guidance."
+    ),
+    tags=["openshift", "kubernetes", "troubleshooting", "diagnostics"],
+    examples=[
+        "Why is my pod in CrashLoopBackOff?",
+        "My cluster upgrade to 4.15 is stuck, what should I check?",
+        "How do I debug ImagePullBackOff errors?",
+    ],
+    input_modes=["text/plain"],
+    output_modes=["text/plain"],
+)
+
+SKILL_ID_TO_MODE: dict[str, QueryMode] = {
+    SKILL_ID_ASK: QueryMode.ASK,
+    SKILL_ID_TROUBLESHOOTING: QueryMode.TROUBLESHOOTING,
+}
+
+DEFAULT_MODE = QueryMode.ASK
+
+# ---------------------------------------------------------------------------
+# Agent Card
+# ---------------------------------------------------------------------------
+
+
+def build_agent_card(server_url: str) -> AgentCard:
+    """Build an A2A AgentCard describing this OLS instance.
+
+    Args:
+        server_url: Base URL where the OLS server is reachable
+            (e.g. "https://ols.example.com").
+
+    Returns:
+        A fully populated AgentCard.
+    """
+    return AgentCard(
+        name=SERVICE_NAME,
+        description=(
+            "AI-powered assistant for OpenShift and Kubernetes. "
+            "Answers questions, generates YAML, troubleshoots clusters, "
+            "and provides guidance based on product documentation."
+        ),
+        url=server_url,
+        version=version.__version__,
+        provider=AgentProvider(
+            organization="Red Hat",
+            url="https://www.redhat.com",
+        ),
+        capabilities=AgentCapabilities(
+            streaming=True,
+            push_notifications=False,
+            state_transition_history=False,
+        ),
+        default_input_modes=["text/plain"],
+        default_output_modes=["text/plain"],
+        skills=[SKILL_ASK, SKILL_TROUBLESHOOTING],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Executor
+# ---------------------------------------------------------------------------
+
+
+class OLSAgentExecutor(AgentExecutor):
+    """Bridge between the A2A protocol and the OLS query pipeline.
+
+    Receives A2A messages, extracts text, runs DocsSummarizer, and
+    publishes the response back through the A2A event queue.
+    """
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        """Execute the OLS query pipeline for an A2A request."""
+        task_id = context.task_id
+        context_id = context.context_id
+        updater = TaskUpdater(event_queue, task_id, context_id)
+
+        query = context.get_user_input()
+        if not query.strip():
+            error_msg = updater.new_agent_message(
+                [Part(root=TextPart(text="Empty query received."))]
+            )
+            await updater.failed(message=error_msg)
+            return
+
+        skill_id = context.metadata.get("skill_id", "")
+        mode = SKILL_ID_TO_MODE.get(skill_id, DEFAULT_MODE)
+
+        logger.info("A2A task %s: query=%r, mode=%s", task_id, query[:200], mode.value)
+        await updater.start_work()
+
+        try:
+            summarizer = DocsSummarizer(mode=mode, streaming=True)
+            response_text = await self._run_summarizer(summarizer, query, context_id)
+        except Exception:
+            logger.exception("A2A task %s failed", task_id)
+            error_msg = updater.new_agent_message(
+                [
+                    Part(
+                        root=TextPart(
+                            text="An error occurred while processing your request."
+                        )
+                    )
+                ]
+            )
+            await updater.failed(message=error_msg)
+            return
+
+        await updater.add_artifact(
+            [Part(root=TextPart(text=response_text))],
+            name="response",
+            last_chunk=True,
+        )
+        await updater.complete()
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        """Cancel an in-progress task."""
+        updater = TaskUpdater(event_queue, context.task_id, context.context_id)
+        await updater.cancel()
+
+    @staticmethod
+    async def _run_summarizer(
+        summarizer: DocsSummarizer,
+        query: str,
+        conversation_id: str | None,
+    ) -> str:
+        """Run the DocsSummarizer and collect the full text response.
+
+        Args:
+            summarizer: Configured DocsSummarizer instance.
+            query: User query text.
+            conversation_id: A2A context_id used as OLS conversation_id.
+
+        Returns:
+            The complete response text.
+        """
+        chunks = [
+            chunk.text
+            async for chunk in summarizer.generate_response(
+                query,
+                config.rag_index_loader.get_retriever(),
+                conversation_id=conversation_id,
+            )
+            if chunk.type == StreamChunkType.TEXT
+        ]
+        return "".join(chunks)

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -19,6 +19,7 @@ from ols.app.models.models import (
     SummarizerResponse,
 )
 from ols.constants import GenericLLMParameters
+from ols.src.a2a.client import get_a2a_tools
 from ols.src.auth.k8s import CLUSTER_VERSION_UNAVAILABLE, K8sClientSingleton
 from ols.src.prompts.prompt_generator import GeneratePrompt
 from ols.src.query_helpers.history_support import prepare_history
@@ -374,9 +375,11 @@ class DocsSummarizer(QueryHelper):
 
         messages = final_prompt.model_copy()
         mcp_tools_query = f"{skill_content}\n\n{query}" if skill_content else query
-        all_mcp_tools = await get_mcp_tools(
-            mcp_tools_query, self.user_token, self.client_headers
+        mcp_tools, a2a_tools = await asyncio.gather(
+            get_mcp_tools(mcp_tools_query, self.user_token, self.client_headers),
+            get_a2a_tools(mcp_tools_query, self.user_token, self.client_headers),
         )
+        all_mcp_tools = mcp_tools + a2a_tools
         if skill is not None and skill_content is not None and has_support_files:
             all_mcp_tools.append(create_skill_support_tool(skill))
         tool_definitions_text = self._serialized_tool_definitions_text(all_mcp_tools)

--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -22,6 +22,9 @@ from ols.src.skills.skills_rag import SkillsRAG, load_skills_from_directory
 from ols.src.tools.tools_rag.hybrid_tools_rag import ToolsRAG
 from ols.utils.redactor import Redactor
 
+if TYPE_CHECKING:
+    from ols.src.a2a.client import AgentsRAG
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -32,7 +35,7 @@ if TYPE_CHECKING:
     from ols.src.tools.approval import PendingApprovalStoreBase
 
 
-class AppConfig:
+class AppConfig:  # pylint: disable=too-many-public-methods
     """Singleton class to load and store the configuration."""
 
     _instance = None
@@ -52,6 +55,7 @@ class AppConfig:
         self._quota_limiters: Optional[list[QuotaLimiter]] = None
         self._token_usage_history: Optional[TokenUsageHistory] = None
         self.k8s_tools_resolved = False
+        self.k8s_a2a_agents_resolved = False
         self._tools_approval: Optional[config_model.ToolsApprovalConfig] = None
         self._pending_approval_store: Optional["PendingApprovalStoreBase"] = None
 
@@ -74,6 +78,16 @@ class AppConfig:
     def mcp_servers_dict(self) -> dict[str, config_model.MCPServerConfig]:
         """Return dictionary mapping MCP server names to their configuration."""
         return {server.name: server for server in self.config.mcp_servers.servers}
+
+    @property
+    def a2a_agents(self) -> config_model.A2AAgents:
+        """Return the A2A agents configuration."""
+        return self.config.a2a_agents
+
+    @cached_property
+    def a2a_agents_dict(self) -> dict[str, config_model.A2AAgentConfig]:
+        """Return dictionary mapping A2A agent names to their configuration."""
+        return {agent.name: agent for agent in self.config.a2a_agents.agents}
 
     @property
     def dev_config(self) -> config_model.DevConfig:
@@ -220,6 +234,39 @@ class AppConfig:
         return None
 
     @cached_property
+    def agents_rag(self) -> Optional["AgentsRAG"]:
+        """Return the AgentsRAG instance for A2A agent filtering.
+
+        Only creates the instance if agent_filtering configuration exists
+        and there are A2A agents configured.
+        """
+        if (
+            self.config.ols_config.tool_filtering is not None
+            and self.config.a2a_agents
+            and len(self.config.a2a_agents.agents) > 0
+        ):
+            from ols.src.a2a.client import (  # pylint: disable=import-outside-toplevel
+                AgentsRAG,
+            )
+
+            agent_config = self.config.ols_config.tool_filtering
+            try:
+                embed_model = self._resolve_embed_model(agent_config.embed_model_path)
+            except Exception:
+                logger.exception(
+                    "Failed to load embedding model for A2A agent filtering; "
+                    "agent filtering disabled"
+                )
+                return None
+            return AgentsRAG(
+                encode_fn=embed_model.get_text_embedding,
+                alpha=agent_config.alpha,
+                top_k=agent_config.top_k,
+                threshold=agent_config.threshold,
+            )
+        return None
+
+    @cached_property
     def skills_rag(self) -> Optional[SkillsRAG]:
         """Return the SkillsRAG instance for skill selection.
 
@@ -299,8 +346,12 @@ class AppConfig:
             # Clear cached_property if it exists
             if "mcp_servers_dict" in self.__dict__:
                 del self.__dict__["mcp_servers_dict"]
+            if "a2a_agents_dict" in self.__dict__:
+                del self.__dict__["a2a_agents_dict"]
             if "tools_rag" in self.__dict__:
                 del self.__dict__["tools_rag"]
+            if "agents_rag" in self.__dict__:
+                del self.__dict__["agents_rag"]
             if "skills_rag" in self.__dict__:
                 del self.__dict__["skills_rag"]
         except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ dependencies = [
     "qdrant-client>=1.13.3",  # For ToolsRAG vector storage (pure Python, no Rust/Cargo)
     "rank-bm25>=0.2.2",  # For ToolsRAG sparse retrieval
     "python-frontmatter>=1.1.0",  # For parsing skill YAML frontmatter
+    "a2a-sdk[http-server]>=0.3.25",  # For A2A (Agent-to-Agent) protocol server support
 ]
 requires-python = ">=3.12,<3.13"
 readme = "README.md"
@@ -160,4 +161,4 @@ packages = ["ols"]
 
 [tool.pylint."MESSAGES CONTROL"]
 good-names = ["e"]
-disable = ["C0301", "C0302", "E0602", "E0611", "E1101", "R0902", "R0903", "R0913", "R0914", "W0102", "W0212", "W0511", "W0613", "W0621", "W0707", "W0718", "W0719", "R0801", "R0917"]
+disable = ["C0301", "C0302", "E0602", "E0611", "E1101", "R0401", "R0902", "R0903", "R0913", "R0914", "W0102", "W0212", "W0511", "W0613", "W0621", "W0707", "W0718", "W0719", "R0801", "R0917"]

--- a/tests/config/config_for_a2a_integration_tests.yaml
+++ b/tests/config/config_for_a2a_integration_tests.yaml
@@ -1,0 +1,40 @@
+---
+llm_providers:
+  - name: p1
+    type: openai
+    url: "https://url1"
+    credentials_path: tests/config/secret/apitoken
+    models:
+      - name: m1
+        url: "https://murl1"
+        credentials_path: tests/config/secret/apitoken
+        context_window_size: 8000
+        parameters:
+          max_tokens_for_response: 100
+      - name: m2
+        url: "https://murl2"
+
+ols_config:
+  conversation_cache:
+    type: memory
+    memory:
+      max_entries: 100
+  logging_config:
+    app_log_level: info
+  default_provider: p1
+  default_model: m1
+
+a2a_agents:
+  - name: mock-file-auth
+    url: http://localhost:14000
+    headers:
+      Authorization: tests/config/mcp_test_token.txt
+  - name: mock-client-auth
+    url: http://localhost:14001
+    headers:
+      Authorization: client
+
+dev_config:
+  disable_auth: true
+  enable_dev_ui: false
+  disable_tls: true

--- a/tests/integration/test_a2a_client_headers.py
+++ b/tests/integration/test_a2a_client_headers.py
@@ -1,0 +1,229 @@
+"""Integration tests for A2A client headers feature.
+
+These tests verify the A2A client headers functionality by:
+1. Configuring OLS with different A2A auth types (file-based, client-provided)
+2. Testing both /v1/query and /v1/streaming_query endpoints
+3. Verifying correct header resolution and agent selection
+
+The A2A card resolver is mocked to avoid actual network connections, but we test
+that the correct agents are contacted based on header availability.
+
+Test Coverage:
+- Query without client headers (graceful degradation - skips client-auth agent)
+- Query WITH client headers (includes client-auth agent)
+- Streaming query without client headers
+- Streaming query WITH client headers
+"""
+
+# we add new attributes into pytest instance, which is not recognized
+# properly by linters
+# pyright: reportAttributeAccessIssue=false
+
+from unittest.mock import patch
+
+import pytest
+from a2a.types import AgentCard, AgentSkill
+from fastapi.testclient import TestClient
+
+from ols import config
+from tests.mock_classes.mock_langchain_interface import mock_langchain_interface
+from tests.mock_classes.mock_llm_loader import mock_llm_loader
+
+A2A_FETCH_CARD_PATH = "ols.src.a2a.client._fetch_agent_card"
+
+
+def _make_card(agent_name: str) -> AgentCard:
+    """Build a minimal AgentCard for testing."""
+    return AgentCard(
+        name=agent_name,
+        description=f"Test agent {agent_name}",
+        url=f"http://{agent_name}:8080",
+        version="1.0",
+        skills=[
+            AgentSkill(
+                id="test-skill",
+                name="Test Skill",
+                description="A skill for integration testing",
+                tags=[],
+            )
+        ],
+        capabilities={},
+        default_input_modes=["text/plain"],
+        default_output_modes=["text/plain"],
+    )
+
+
+@pytest.fixture(scope="function")
+def _setup() -> None:
+    """Set up the test client for A2A integration tests."""
+    config.reload_from_yaml_file("tests/config/config_for_a2a_integration_tests.yaml")
+    config.k8s_a2a_agents_resolved = False
+
+    from ols.app.main import app  # pylint: disable=import-outside-toplevel
+
+    pytest.client = TestClient(app)  # type: ignore[attr-defined]
+
+
+def test_query_without_client_headers(_setup: None) -> None:
+    """Test query without client headers - mock-client-auth agent should be skipped."""
+    ml = mock_langchain_interface(None)
+
+    async def _fake_fetch_card(
+        base_url: str, headers: dict, request_timeout: int
+    ) -> AgentCard:
+        """Return a card only for file-auth agent."""
+        if "localhost:14000" in base_url:
+            return _make_card("mock-file-auth")
+        raise AssertionError(f"Unexpected agent URL: {base_url}")
+
+    with (
+        patch("ols.src.query_helpers.query_helper.load_llm", new=mock_llm_loader(ml)),
+        patch(A2A_FETCH_CARD_PATH, side_effect=_fake_fetch_card) as mock_fetch,
+    ):
+        response = pytest.client.post(  # type: ignore[attr-defined]
+            "/v1/query",
+            json={"query": "What tools are available?"},
+        )
+
+        assert response.status_code == 200
+
+        call_urls = [call.args[0] for call in mock_fetch.call_args_list]
+        assert any("localhost:14000" in url for url in call_urls)
+        assert not any("localhost:14001" in url for url in call_urls)
+
+
+def test_query_with_client_headers(_setup: None) -> None:
+    """Test query with client headers - both agents should be contacted."""
+    ml = mock_langchain_interface(None)
+
+    async def _fake_fetch_card(
+        base_url: str, headers: dict, request_timeout: int
+    ) -> AgentCard:
+        """Return cards for both agents."""
+        if "localhost:14000" in base_url:
+            return _make_card("mock-file-auth")
+        if "localhost:14001" in base_url:
+            return _make_card("mock-client-auth")
+        raise AssertionError(f"Unexpected agent URL: {base_url}")
+
+    with (
+        patch("ols.src.query_helpers.query_helper.load_llm", new=mock_llm_loader(ml)),
+        patch(A2A_FETCH_CARD_PATH, side_effect=_fake_fetch_card) as mock_fetch,
+    ):
+        mcp_headers = {
+            "mock-client-auth": {"Authorization": "Bearer my-client-token-456"}
+        }
+
+        response = pytest.client.post(  # type: ignore[attr-defined]
+            "/v1/query",
+            json={"query": "What tools are available?", "mcp_headers": mcp_headers},
+        )
+
+        assert response.status_code == 200
+
+        call_urls = [call.args[0] for call in mock_fetch.call_args_list]
+        assert any("localhost:14000" in url for url in call_urls)
+        assert any("localhost:14001" in url for url in call_urls)
+
+
+def test_query_client_headers_resolve_correctly(_setup: None) -> None:
+    """Test that client-provided headers are passed through to the agent card fetch."""
+    ml = mock_langchain_interface(None)
+
+    captured_headers: dict[str, dict] = {}
+
+    async def _fake_fetch_card(
+        base_url: str, headers: dict, request_timeout: int
+    ) -> AgentCard:
+        """Capture headers for verification."""
+        if "localhost:14000" in base_url:
+            captured_headers["mock-file-auth"] = headers
+            return _make_card("mock-file-auth")
+        if "localhost:14001" in base_url:
+            captured_headers["mock-client-auth"] = headers
+            return _make_card("mock-client-auth")
+        raise AssertionError(f"Unexpected agent URL: {base_url}")
+
+    with (
+        patch("ols.src.query_helpers.query_helper.load_llm", new=mock_llm_loader(ml)),
+        patch(A2A_FETCH_CARD_PATH, side_effect=_fake_fetch_card),
+    ):
+        mcp_headers = {
+            "mock-client-auth": {"Authorization": "Bearer my-client-token-456"}
+        }
+
+        response = pytest.client.post(  # type: ignore[attr-defined]
+            "/v1/query",
+            json={"query": "What tools are available?", "mcp_headers": mcp_headers},
+        )
+
+        assert response.status_code == 200
+
+        assert captured_headers["mock-file-auth"]["Authorization"] == (
+            "Bearer test-file-token-123"
+        )
+        assert captured_headers["mock-client-auth"]["Authorization"] == (
+            "Bearer my-client-token-456"
+        )
+
+
+def test_streaming_query_without_client_headers(_setup: None) -> None:
+    """Test streaming query without client headers - client-auth agent should be skipped."""
+    ml = mock_langchain_interface(None)
+
+    async def _fake_fetch_card(
+        base_url: str, headers: dict, request_timeout: int
+    ) -> AgentCard:
+        """Return a card only for file-auth agent."""
+        if "localhost:14000" in base_url:
+            return _make_card("mock-file-auth")
+        raise AssertionError(f"Unexpected agent URL: {base_url}")
+
+    with (
+        patch("ols.src.query_helpers.query_helper.load_llm", new=mock_llm_loader(ml)),
+        patch(A2A_FETCH_CARD_PATH, side_effect=_fake_fetch_card) as mock_fetch,
+    ):
+        response = pytest.client.post(  # type: ignore[attr-defined]
+            "/v1/streaming_query",
+            json={"query": "What tools are available?"},
+        )
+
+        assert response.status_code == 200
+
+        call_urls = [call.args[0] for call in mock_fetch.call_args_list]
+        assert any("localhost:14000" in url for url in call_urls)
+        assert not any("localhost:14001" in url for url in call_urls)
+
+
+def test_streaming_query_with_client_headers(_setup: None) -> None:
+    """Test streaming query with client headers - both agents should be contacted."""
+    ml = mock_langchain_interface(None)
+
+    async def _fake_fetch_card(
+        base_url: str, headers: dict, request_timeout: int
+    ) -> AgentCard:
+        """Return cards for both agents."""
+        if "localhost:14000" in base_url:
+            return _make_card("mock-file-auth")
+        if "localhost:14001" in base_url:
+            return _make_card("mock-client-auth")
+        raise AssertionError(f"Unexpected agent URL: {base_url}")
+
+    with (
+        patch("ols.src.query_helpers.query_helper.load_llm", new=mock_llm_loader(ml)),
+        patch(A2A_FETCH_CARD_PATH, side_effect=_fake_fetch_card) as mock_fetch,
+    ):
+        mcp_headers = {
+            "mock-client-auth": {"Authorization": "Bearer streaming-client-token-789"}
+        }
+
+        response = pytest.client.post(  # type: ignore[attr-defined]
+            "/v1/streaming_query",
+            json={"query": "What tools are available?", "mcp_headers": mcp_headers},
+        )
+
+        assert response.status_code == 200
+
+        call_urls = [call.args[0] for call in mock_fetch.call_args_list]
+        assert any("localhost:14000" in url for url in call_urls)
+        assert any("localhost:14001" in url for url in call_urls)

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -45,7 +45,9 @@ def _setup():
     ):
         # app.main need to be imported after the configuration is read
         from ols.app.main import app  # pylint: disable=C0415
+        from ols.app.metrics import setup_model_metrics  # pylint: disable=C0415
 
+        setup_model_metrics(config)
         pytest.client = TestClient(app)
 
 

--- a/tests/unit/a2a_protocol/__init__.py
+++ b/tests/unit/a2a_protocol/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for A2A protocol support."""

--- a/tests/unit/a2a_protocol/test_a2a.py
+++ b/tests/unit/a2a_protocol/test_a2a.py
@@ -1,0 +1,290 @@
+"""Unit tests for A2A protocol support."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from a2a.server.agent_execution import RequestContext
+from a2a.server.events import EventQueue
+from a2a.types import (
+    Message,
+    MessageSendParams,
+    Part,
+    Role,
+    TaskArtifactUpdateEvent,
+    TaskState,
+    TaskStatusUpdateEvent,
+    TextPart,
+)
+from fastapi import FastAPI
+
+from ols import config
+from ols.constants import QueryMode
+
+config.ols_config.authentication_config.module = "k8s"
+
+from ols.app.routers import _mount_a2a_routes  # noqa: E402
+from ols.src.a2a.server import (  # noqa: E402
+    SKILL_ASK,
+    SKILL_ID_ASK,
+    SKILL_ID_TO_MODE,
+    SKILL_ID_TROUBLESHOOTING,
+    SKILL_TROUBLESHOOTING,
+    OLSAgentExecutor,
+    build_agent_card,
+)
+
+# --- Agent Card tests ---
+
+
+def test_build_agent_card_has_required_fields():
+    """Verify the agent card contains all A2A-required fields."""
+    card = build_agent_card("https://ols.example.com")
+
+    assert card.name == "OpenShift LightSpeed"
+    assert card.url == "https://ols.example.com"
+    assert card.version
+    assert card.description
+    assert card.capabilities is not None
+    assert card.default_input_modes == ["text/plain"]
+    assert card.default_output_modes == ["text/plain"]
+
+
+def test_build_agent_card_has_two_skills():
+    """Verify the agent card advertises ask and troubleshooting skills."""
+    card = build_agent_card("https://ols.example.com")
+
+    assert len(card.skills) == 2
+    skill_ids = {s.id for s in card.skills}
+    assert skill_ids == {SKILL_ID_ASK, SKILL_ID_TROUBLESHOOTING}
+
+
+def test_build_agent_card_capabilities():
+    """Verify streaming is enabled and push notifications are disabled."""
+    card = build_agent_card("https://ols.example.com")
+
+    assert card.capabilities.streaming is True
+    assert card.capabilities.push_notifications is False
+
+
+def test_build_agent_card_provider():
+    """Verify the provider is Red Hat."""
+    card = build_agent_card("https://ols.example.com")
+
+    assert card.provider.organization == "Red Hat"
+    assert card.provider.url == "https://www.redhat.com"
+
+
+def test_build_agent_card_uses_provided_url():
+    """Verify the card URL matches the provided server_url."""
+    card = build_agent_card("https://custom.host:9443")
+    assert card.url == "https://custom.host:9443"
+
+
+def test_ask_skill_is_valid():
+    """Verify the ask skill constant is well-formed."""
+    assert SKILL_ASK.id == SKILL_ID_ASK
+    assert SKILL_ASK.name
+    assert SKILL_ASK.description
+    assert len(SKILL_ASK.tags) >= 2
+    assert len(SKILL_ASK.examples) >= 2
+
+
+def test_troubleshooting_skill_is_valid():
+    """Verify the troubleshooting skill constant is well-formed."""
+    assert SKILL_TROUBLESHOOTING.id == SKILL_ID_TROUBLESHOOTING
+    assert SKILL_TROUBLESHOOTING.name
+    assert SKILL_TROUBLESHOOTING.description
+    assert "troubleshooting" in SKILL_TROUBLESHOOTING.tags
+
+
+def test_skill_id_to_mode_mapping():
+    """Verify skill IDs map to the correct QueryMode values."""
+    assert SKILL_ID_TO_MODE[SKILL_ID_ASK] == QueryMode.ASK
+    assert SKILL_ID_TO_MODE[SKILL_ID_TROUBLESHOOTING] == QueryMode.TROUBLESHOOTING
+
+
+# --- Executor tests ---
+
+
+def _make_context(text: str, metadata: dict | None = None) -> RequestContext:
+    """Create a RequestContext with a user message containing the given text."""
+    message = Message(
+        role=Role.user,
+        parts=[Part(root=TextPart(text=text))],
+        message_id="msg-1",
+    )
+    params = MessageSendParams(message=message, metadata=metadata)
+    return RequestContext(request=params)
+
+
+def _make_event_queue() -> EventQueue:
+    """Create an EventQueue for capturing events."""
+    return EventQueue()
+
+
+@pytest.mark.asyncio
+async def test_execute_empty_query_fails_task():
+    """Verify that an empty query results in a failed task status."""
+    executor = OLSAgentExecutor()
+    context = _make_context("   ")
+    queue = _make_event_queue()
+
+    await executor.execute(context, queue)
+
+    event = await queue.dequeue_event()
+    assert isinstance(event, TaskStatusUpdateEvent)
+    assert event.status.state == TaskState.failed
+
+
+@pytest.mark.asyncio
+@patch("ols.src.a2a.server.DocsSummarizer")
+@patch("ols.src.a2a.server.config")
+async def test_execute_success_default_mode(mock_config, mock_summarizer_class):
+    """Verify a query without skill_id defaults to ask mode."""
+    from ols.app.models.models import StreamChunkType, StreamedChunk
+
+    async def fake_generate_response(*args, **kwargs):
+        yield StreamedChunk(type=StreamChunkType.TEXT, text="Hello from OLS")
+        yield StreamedChunk(type=StreamChunkType.END, data={})
+
+    mock_instance = MagicMock()
+    mock_instance.generate_response = fake_generate_response
+    mock_summarizer_class.return_value = mock_instance
+    mock_config.rag_index_loader.get_retriever.return_value = None
+
+    executor = OLSAgentExecutor()
+    context = _make_context("How do I create a deployment?")
+    queue = _make_event_queue()
+
+    await executor.execute(context, queue)
+
+    mock_summarizer_class.assert_called_once_with(mode=QueryMode.ASK, streaming=True)
+
+    event1 = await queue.dequeue_event()
+    assert isinstance(event1, TaskStatusUpdateEvent)
+    assert event1.status.state == TaskState.working
+
+    event2 = await queue.dequeue_event()
+    assert isinstance(event2, TaskArtifactUpdateEvent)
+    assert event2.artifact.parts[0].root.text == "Hello from OLS"
+
+    event3 = await queue.dequeue_event()
+    assert isinstance(event3, TaskStatusUpdateEvent)
+    assert event3.status.state == TaskState.completed
+
+
+@pytest.mark.asyncio
+@patch("ols.src.a2a.server.DocsSummarizer")
+@patch("ols.src.a2a.server.config")
+async def test_execute_troubleshooting_mode(mock_config, mock_summarizer_class):
+    """Verify skill_id in metadata selects troubleshooting mode."""
+    from ols.app.models.models import StreamChunkType, StreamedChunk
+
+    async def fake_generate_response(*args, **kwargs):
+        yield StreamedChunk(type=StreamChunkType.TEXT, text="Check pod events")
+        yield StreamedChunk(type=StreamChunkType.END, data={})
+
+    mock_instance = MagicMock()
+    mock_instance.generate_response = fake_generate_response
+    mock_summarizer_class.return_value = mock_instance
+    mock_config.rag_index_loader.get_retriever.return_value = None
+
+    executor = OLSAgentExecutor()
+    context = _make_context(
+        "Why is my pod in CrashLoopBackOff?",
+        metadata={"skill_id": SKILL_ID_TROUBLESHOOTING},
+    )
+    queue = _make_event_queue()
+
+    await executor.execute(context, queue)
+
+    mock_summarizer_class.assert_called_once_with(
+        mode=QueryMode.TROUBLESHOOTING, streaming=True
+    )
+
+    event1 = await queue.dequeue_event()
+    assert isinstance(event1, TaskStatusUpdateEvent)
+    assert event1.status.state == TaskState.working
+
+    event2 = await queue.dequeue_event()
+    assert isinstance(event2, TaskArtifactUpdateEvent)
+    assert event2.artifact.parts[0].root.text == "Check pod events"
+
+
+@pytest.mark.asyncio
+@patch("ols.src.a2a.server.DocsSummarizer")
+@patch("ols.src.a2a.server.config")
+async def test_execute_summarizer_error_fails_task(mock_config, mock_summarizer_class):
+    """Verify that a summarizer exception results in a failed task."""
+
+    async def failing_generator(*args, **kwargs):
+        raise RuntimeError("LLM error")
+        yield
+
+    mock_instance = MagicMock()
+    mock_instance.generate_response = failing_generator
+    mock_summarizer_class.return_value = mock_instance
+    mock_config.rag_index_loader.get_retriever.return_value = None
+
+    executor = OLSAgentExecutor()
+    context = _make_context("Some query")
+    queue = _make_event_queue()
+
+    await executor.execute(context, queue)
+
+    event1 = await queue.dequeue_event()
+    assert isinstance(event1, TaskStatusUpdateEvent)
+    assert event1.status.state == TaskState.working
+
+    event2 = await queue.dequeue_event()
+    assert isinstance(event2, TaskStatusUpdateEvent)
+    assert event2.status.state == TaskState.failed
+
+
+@pytest.mark.asyncio
+async def test_cancel():
+    """Verify cancel publishes a canceled status event."""
+    executor = OLSAgentExecutor()
+    context = _make_context("anything")
+    queue = _make_event_queue()
+
+    await executor.cancel(context, queue)
+
+    event = await queue.dequeue_event()
+    assert isinstance(event, TaskStatusUpdateEvent)
+    assert event.status.state == TaskState.canceled
+
+
+# --- Route mounting tests ---
+
+
+@patch("a2a.server.apps.A2AFastAPIApplication")
+@patch("a2a.server.request_handlers.DefaultRequestHandler")
+@patch("a2a.server.events.InMemoryQueueManager")
+@patch("a2a.server.tasks.InMemoryTaskStore")
+@patch("ols.src.a2a.server.build_agent_card")
+@patch("ols.src.a2a.server.OLSAgentExecutor")
+def test_mount_a2a_routes_adds_routes(
+    mock_executor_class,
+    mock_build_card,
+    mock_task_store,
+    mock_queue_manager,
+    mock_handler_class,
+    mock_a2a_app_class,
+):
+    """Verify _mount_a2a_routes integrates A2A SDK with the FastAPI app."""
+    app = FastAPI()
+    mock_a2a_instance = MagicMock()
+    mock_a2a_app_class.return_value = mock_a2a_instance
+
+    _mount_a2a_routes(app)
+
+    mock_build_card.assert_called_once()
+    mock_executor_class.assert_called_once()
+    mock_handler_class.assert_called_once()
+    mock_a2a_app_class.assert_called_once()
+    mock_a2a_instance.add_routes_to_app.assert_called_once_with(
+        app,
+        agent_card_url="/.well-known/agent-card.json",
+        rpc_url="/a2a",
+    )

--- a/tests/unit/a2a_protocol/test_a2a_client.py
+++ b/tests/unit/a2a_protocol/test_a2a_client.py
@@ -1,0 +1,504 @@
+"""Unit tests for A2A client: tool discovery, wrapping, and AgentsRAG."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from a2a.types import (
+    AgentCard,
+    AgentSkill,
+    Artifact,
+    Message,
+    Part,
+    Role,
+    Task,
+    TaskState,
+    TaskStatus,
+    TextPart,
+)
+from langchain_core.tools.structured import StructuredTool
+from pydantic import BaseModel, Field
+
+from ols.src.a2a.client import (
+    AgentsRAG,
+    _build_agent_tool,
+    _extract_message_text,
+    _extract_task_text,
+    _sanitize_tool_name,
+    get_a2a_tools,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_skill():
+    """Create a sample A2A AgentSkill."""
+    return AgentSkill(
+        id="troubleshoot",
+        name="Troubleshoot",
+        description="Diagnose OpenShift cluster issues",
+        tags=[],
+    )
+
+
+@pytest.fixture
+def sample_card(sample_skill):
+    """Create a sample A2A AgentCard with one skill."""
+    return AgentCard(
+        name="OLS Remote",
+        description="Remote OLS agent for testing",
+        url="http://remote-agent:8080",
+        version="1.0",
+        skills=[sample_skill],
+        capabilities={},
+        default_input_modes=["text/plain"],
+        default_output_modes=["text/plain"],
+    )
+
+
+@pytest.fixture
+def mock_agent_cfg():
+    """Create a mock A2A agent config."""
+    cfg = MagicMock()
+    cfg.name = "remote-agent"
+    cfg.url = "http://remote-agent:8080"
+    cfg.timeout = 15
+    cfg.headers = {}
+    cfg.resolved_headers = {}
+    return cfg
+
+
+@pytest.fixture
+def mock_tool():
+    """Create a mock StructuredTool with A2A metadata."""
+
+    class ToolInput(BaseModel):
+        query: str = Field(description="query")
+
+    return StructuredTool(
+        name="remote_agent_troubleshoot",
+        description="Diagnose OpenShift cluster issues",
+        func=lambda query: "",
+        args_schema=ToolInput,
+        metadata={"a2a_agent": "remote-agent", "a2a_skill_id": "troubleshoot"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_tool_name
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeToolName:
+    """Tests for _sanitize_tool_name."""
+
+    def test_alphanumeric_passes_through(self):
+        """Verify alphanumeric and underscore names are unchanged."""
+        assert _sanitize_tool_name("hello_world") == "hello_world"
+
+    def test_special_chars_replaced(self):
+        """Verify hyphens, dots, and slashes are replaced with underscores."""
+        assert _sanitize_tool_name("my-agent.skill/v2") == "my_agent_skill_v2"
+
+    def test_spaces_replaced(self):
+        """Verify spaces are replaced with underscores."""
+        assert _sanitize_tool_name("agent name") == "agent_name"
+
+
+# ---------------------------------------------------------------------------
+# _extract_task_text / _extract_message_text
+# ---------------------------------------------------------------------------
+
+
+class TestExtractText:
+    """Tests for text extraction helpers."""
+
+    def test_extract_task_text_from_artifacts(self):
+        """Verify artifact text is extracted from a completed task."""
+        task = Task(
+            id="t1",
+            contextId="ctx1",
+            status=TaskStatus(state=TaskState.completed),
+            artifacts=[
+                Artifact(
+                    artifactId="a1",
+                    parts=[Part(root=TextPart(text="artifact output"))],
+                )
+            ],
+        )
+        assert _extract_task_text(task) == "artifact output"
+
+    def test_extract_task_text_falls_back_to_status_message(self):
+        """Verify status message is used when no artifacts are present."""
+        task = Task(
+            id="t1",
+            contextId="ctx1",
+            status=TaskStatus(
+                state=TaskState.completed,
+                message=Message(
+                    message_id="m1",
+                    role=Role.agent,
+                    parts=[Part(root=TextPart(text="status fallback"))],
+                ),
+            ),
+        )
+        assert _extract_task_text(task) == "status fallback"
+
+    def test_extract_task_text_empty_when_no_text(self):
+        """Verify empty string is returned when task has no text content."""
+        task = Task(
+            id="t1",
+            contextId="ctx1",
+            status=TaskStatus(state=TaskState.completed),
+        )
+        assert _extract_task_text(task) == ""
+
+    def test_extract_message_text(self):
+        """Verify text parts of a message are joined with newlines."""
+        msg = Message(
+            message_id="m1",
+            role=Role.agent,
+            parts=[
+                Part(root=TextPart(text="line1")),
+                Part(root=TextPart(text="line2")),
+            ],
+        )
+        assert _extract_message_text(msg) == "line1\nline2"
+
+
+# ---------------------------------------------------------------------------
+# _build_agent_tool
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAgentTool:
+    """Tests for _build_agent_tool."""
+
+    def test_returns_structured_tool(self, sample_skill, sample_card):
+        """Verify _build_agent_tool returns a StructuredTool with correct metadata."""
+        tool = _build_agent_tool("remote-agent", sample_skill, sample_card, {}, 30)
+        assert isinstance(tool, StructuredTool)
+        assert tool.name == "remote_agent_troubleshoot"
+        assert tool.description == sample_skill.description
+        assert tool.metadata["a2a_agent"] == "remote-agent"
+        assert tool.metadata["a2a_skill_id"] == "troubleshoot"
+
+    @pytest.mark.asyncio
+    async def test_invoke_returns_task_text(self, sample_skill, sample_card):
+        """Verify invoking the tool returns extracted task text."""
+        tool = _build_agent_tool("remote-agent", sample_skill, sample_card, {}, 30)
+
+        task = Task(
+            id="t1",
+            contextId="ctx1",
+            status=TaskStatus(state=TaskState.completed),
+            artifacts=[
+                Artifact(
+                    artifactId="a1",
+                    parts=[Part(root=TextPart(text="tool result"))],
+                )
+            ],
+        )
+
+        mock_client = MagicMock()
+        mock_client.send_message.return_value = AsyncIterFromList([(task, None)])
+        mock_client.close = AsyncMock()
+
+        with patch("ols.src.a2a.client.ClientFactory") as mock_factory_cls:
+            mock_factory_cls.return_value.create.return_value = mock_client
+            result = await tool.ainvoke({"query": "why is pod crashing?"})
+
+        assert result == "tool result"
+        mock_client.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_invoke_raises_on_failed_task(self, sample_skill, sample_card):
+        """Verify RuntimeError is raised when the remote agent fails."""
+        tool = _build_agent_tool("remote-agent", sample_skill, sample_card, {}, 30)
+
+        task = Task(
+            id="t1",
+            contextId="ctx1",
+            status=TaskStatus(state=TaskState.failed),
+        )
+
+        mock_client = MagicMock()
+        mock_client.send_message.return_value = AsyncIterFromList([(task, None)])
+        mock_client.close = AsyncMock()
+
+        with (
+            patch("ols.src.a2a.client.ClientFactory") as mock_factory_cls,
+            pytest.raises(RuntimeError, match="Remote agent returned an error"),
+        ):
+            mock_factory_cls.return_value.create.return_value = mock_client
+            await tool.ainvoke({"query": "fail"})
+
+
+# ---------------------------------------------------------------------------
+# _gather_a2a_tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestGatherA2ATools:
+    """Tests for _gather_a2a_tools."""
+
+    async def test_discovers_tools_from_agent(self, mock_agent_cfg, sample_card):
+        """Verify tools are discovered from an agent's card skills."""
+        with (
+            patch("ols.src.a2a.client.resolve_server_headers", return_value={}),
+            patch(
+                "ols.src.a2a.client._fetch_agent_card",
+                new_callable=AsyncMock,
+                return_value=sample_card,
+            ),
+        ):
+            from ols.src.a2a.client import _gather_a2a_tools
+
+            agents_config, tools = await _gather_a2a_tools([mock_agent_cfg])
+
+        assert "remote-agent" in agents_config
+        assert len(tools) == 1
+        assert tools[0].name == "remote_agent_troubleshoot"
+
+    async def test_skips_agent_when_headers_unresolvable(self, mock_agent_cfg):
+        """Verify agent is skipped when headers cannot be resolved."""
+        with patch("ols.src.a2a.client.resolve_server_headers", return_value=None):
+            from ols.src.a2a.client import _gather_a2a_tools
+
+            agents_config, tools = await _gather_a2a_tools([mock_agent_cfg])
+
+        assert agents_config == {}
+        assert tools == []
+
+    async def test_skips_agent_on_fetch_error(self, mock_agent_cfg):
+        """Verify agent is skipped when card fetch raises an exception."""
+        with (
+            patch("ols.src.a2a.client.resolve_server_headers", return_value={}),
+            patch(
+                "ols.src.a2a.client._fetch_agent_card",
+                new_callable=AsyncMock,
+                side_effect=Exception("connection refused"),
+            ),
+        ):
+            from ols.src.a2a.client import _gather_a2a_tools
+
+            agents_config, tools = await _gather_a2a_tools([mock_agent_cfg])
+
+        assert agents_config == {}
+        assert tools == []
+
+    async def test_populates_rag_when_requested(self, mock_agent_cfg, sample_card):
+        """Verify AgentsRAG.populate_agents is called when populate_to_rag=True."""
+        mock_rag = MagicMock()
+        with (
+            patch("ols.src.a2a.client.resolve_server_headers", return_value={}),
+            patch(
+                "ols.src.a2a.client._fetch_agent_card",
+                new_callable=AsyncMock,
+                return_value=sample_card,
+            ),
+            patch("ols.src.a2a.client.config") as mock_config,
+        ):
+            mock_config.agents_rag = mock_rag
+            from ols.src.a2a.client import _gather_a2a_tools
+
+            await _gather_a2a_tools([mock_agent_cfg], populate_to_rag=True)
+
+        mock_rag.populate_agents.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# get_a2a_tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestGetA2ATools:
+    """Tests for get_a2a_tools."""
+
+    async def test_returns_empty_when_no_agents_configured(self):
+        """Verify empty list when no A2A agents are configured."""
+        with patch("ols.src.a2a.client.config") as mock_config:
+            mock_config.a2a_agents.agents = []
+            result = await get_a2a_tools("test query")
+        assert result == []
+
+    async def test_without_agents_rag(self, mock_agent_cfg, mock_tool):
+        """Verify all tools are returned when agents_rag is disabled."""
+        with (
+            patch("ols.src.a2a.client.config") as mock_config,
+            patch(
+                "ols.src.a2a.client._gather_a2a_tools",
+                new_callable=AsyncMock,
+                return_value=({"remote-agent": mock_agent_cfg}, [mock_tool]),
+            ),
+        ):
+            mock_config.a2a_agents.agents = [mock_agent_cfg]
+            mock_config.agents_rag = None
+
+            result = await get_a2a_tools("test query")
+
+        assert len(result) == 1
+        assert result[0].name == "remote_agent_troubleshoot"
+
+    async def test_with_agents_rag_first_call(self, mock_agent_cfg, mock_tool):
+        """Verify RAG is populated on the first call and tools are filtered."""
+        with (
+            patch("ols.src.a2a.client.config") as mock_config,
+            patch(
+                "ols.src.a2a.client._gather_a2a_tools",
+                new_callable=AsyncMock,
+                return_value=({"remote-agent": mock_agent_cfg}, [mock_tool]),
+            ),
+        ):
+            mock_config.a2a_agents.agents = [mock_agent_cfg]
+            mock_config.agents_rag = MagicMock()
+            mock_config.agents_rag.populate_agents = MagicMock()
+            mock_config.agents_rag.set_default_agents = MagicMock()
+            mock_config.agents_rag.retrieve_hybrid.return_value = {
+                "remote-agent": [{"name": "remote_agent_troubleshoot", "desc": "test"}]
+            }
+            mock_config.k8s_a2a_agents_resolved = False
+            mock_config.a2a_agents_dict = {"remote-agent": mock_agent_cfg}
+
+            result = await get_a2a_tools(
+                "test query", user_token="k8s-token"  # noqa: S106
+            )
+
+        assert len(result) == 1
+
+    async def test_rag_filtering_error_fallback(self, mock_agent_cfg, mock_tool):
+        """Verify all tools are returned when RAG filtering raises an error."""
+        with (
+            patch("ols.src.a2a.client.config") as mock_config,
+            patch(
+                "ols.src.a2a.client._gather_a2a_tools",
+                new_callable=AsyncMock,
+                return_value=({"remote-agent": mock_agent_cfg}, [mock_tool]),
+            ),
+        ):
+            mock_config.a2a_agents.agents = [mock_agent_cfg]
+            mock_config.agents_rag = MagicMock()
+            mock_config.agents_rag.retrieve_hybrid.side_effect = Exception("RAG error")
+            mock_config.k8s_a2a_agents_resolved = True
+
+            result = await get_a2a_tools("test query")
+
+        assert len(result) == 1
+        assert result[0].name == "remote_agent_troubleshoot"
+
+    async def test_no_matching_tools(self, mock_agent_cfg):
+        """Verify empty list when RAG returns no matching tools."""
+        with patch("ols.src.a2a.client.config") as mock_config:
+            mock_config.a2a_agents.agents = [mock_agent_cfg]
+            mock_config.agents_rag = MagicMock()
+            mock_config.agents_rag.retrieve_hybrid.return_value = {}
+            mock_config.k8s_a2a_agents_resolved = True
+
+            result = await get_a2a_tools("test query")
+
+        assert result == []
+
+    async def test_with_client_headers(self, mock_agent_cfg, mock_tool):
+        """Verify client_headers agents are included in RAG retrieval."""
+        with (
+            patch("ols.src.a2a.client.config") as mock_config,
+            patch(
+                "ols.src.a2a.client._gather_a2a_tools",
+                new_callable=AsyncMock,
+                return_value=({"remote-agent": mock_agent_cfg}, [mock_tool]),
+            ),
+        ):
+            mock_config.a2a_agents.agents = [mock_agent_cfg]
+            mock_config.agents_rag = MagicMock()
+            mock_config.agents_rag.retrieve_hybrid.return_value = {
+                "remote-agent": [{"name": "remote_agent_troubleshoot", "desc": "test"}]
+            }
+            mock_config.k8s_a2a_agents_resolved = True
+            mock_config.a2a_agents_dict = {"remote-agent": mock_agent_cfg}
+
+            client_headers = {"remote-agent": {"Authorization": "Bearer client-tok"}}
+            result = await get_a2a_tools(
+                "test query",
+                user_token="k8s-token",  # noqa: S106
+                client_headers=client_headers,
+            )
+
+        mock_config.agents_rag.retrieve_hybrid.assert_called_once()
+        call_kwargs = mock_config.agents_rag.retrieve_hybrid.call_args[1]
+        assert call_kwargs["client_agents"] == ["remote-agent"]
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# AgentsRAG
+# ---------------------------------------------------------------------------
+
+
+class TestAgentsRAG:
+    """Tests for the AgentsRAG class."""
+
+    @pytest.fixture
+    def agents_rag(self):
+        """Create an AgentsRAG with a placeholder encoder."""
+        return AgentsRAG(
+            encode_fn=lambda text: [0.1] * 8,
+            alpha=0.8,
+            top_k=10,
+            threshold=0.0,
+        )
+
+    def test_set_default_agents(self, agents_rag):
+        """Verify default allowed agents are stored as a set."""
+        agents_rag.set_default_agents(["agent-a", "agent-b"])
+        assert agents_rag.default_allowed_agents == {"agent-a", "agent-b"}
+
+    def test_populate_and_retrieve(self, agents_rag, mock_tool):
+        """Verify tools can be populated into RAG and retrieved by query."""
+        agents_rag.set_default_agents(["remote-agent"])
+        agents_rag.populate_agents([mock_tool])
+
+        result = agents_rag.retrieve_hybrid("troubleshoot cluster")
+        assert "remote-agent" in result
+        tool_dicts = result["remote-agent"]
+        assert len(tool_dicts) >= 1
+        assert tool_dicts[0]["name"] == "remote_agent_troubleshoot"
+
+    def test_convert_agent_to_dict(self, agents_rag, mock_tool):
+        """Verify tool is converted to dict with name, server, and desc."""
+        d = agents_rag._convert_agent_to_dict(mock_tool)
+        assert d["name"] == "remote_agent_troubleshoot"
+        assert d["server"] == "remote-agent"
+        assert d["desc"] == "Diagnose OpenShift cluster issues"
+
+    def test_build_text(self, agents_rag):
+        """Verify _build_text concatenates name and description."""
+        t = {"name": "my_tool", "desc": "does things"}
+        assert agents_rag._build_text(t) == "my_tool does things"
+
+
+# ---------------------------------------------------------------------------
+# Async iterator helper for mocking client.send_message
+# ---------------------------------------------------------------------------
+
+
+class AsyncIterFromList:
+    """Wrap a list as an async iterator for mocking."""
+
+    def __init__(self, items: list) -> None:
+        """Initialize with a list of items to iterate."""
+        self._items = items
+        self._idx = 0
+
+    def __aiter__(self):  # noqa: D105
+        return self
+
+    async def __anext__(self):  # noqa: D105
+        if self._idx >= len(self._items):
+            raise StopAsyncIteration
+        item = self._items[self._idx]
+        self._idx += 1
+        return item

--- a/tests/unit/app/test_routers.py
+++ b/tests/unit/app/test_routers.py
@@ -1,5 +1,7 @@
 """Unit tests for routers.py."""
 
+from unittest.mock import patch
+
 from ols import config
 
 # needs to be setup there before is_user_authorized is imported
@@ -32,7 +34,8 @@ class MockFastAPI:
         self.routers.append(router)
 
 
-def test_include_routers():
+@patch("ols.app.routers._mount_a2a_routes")
+def test_include_routers(mock_mount_a2a):
     """Test the function include_routers."""
     app = MockFastAPI()
     include_routers(app)
@@ -49,3 +52,4 @@ def test_include_routers():
     assert metrics.router in app.routers
     assert ols.router in app.routers
     assert streaming_ols.router in app.routers
+    mock_mount_a2a.assert_called_once_with(app)

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,29 @@ revision = 3
 requires-python = "==3.12.*"
 
 [[package]]
+name = "a2a-sdk"
+version = "0.3.25"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/83/3c99b276d09656cce039464509f05bf385e5600d6dc046a131bbcf686930/a2a_sdk-0.3.25.tar.gz", hash = "sha256:afda85bab8d6af0c5d15e82f326c94190f6be8a901ce562d045a338b7127242f", size = 270638, upload-time = "2026-03-10T13:08:46.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/f9/6a62520b7ecb945188a6e1192275f4732ff9341cd4629bc975a6c146aeab/a2a_sdk-0.3.25-py3-none-any.whl", hash = "sha256:2fce38faea82eb0b6f9f9c2bcf761b0d78612c80ef0e599b50d566db1b2654b5", size = 149609, upload-time = "2026-03-10T13:08:44.7Z" },
+]
+
+[package.optional-dependencies]
+http-server = [
+    { name = "fastapi" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+]
+
+[[package]]
 name = "absl-py"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2743,6 +2766,7 @@ wheels = [
 name = "ols"
 source = { editable = "." }
 dependencies = [
+    { name = "a2a-sdk", extra = ["http-server"] },
     { name = "aiohttp" },
     { name = "aiostream" },
     { name = "anthropic" },
@@ -2828,6 +2852,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "a2a-sdk", extras = ["http-server"], specifier = ">=0.3.25" },
     { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "aiostream", specifier = ">=0.7.0" },
     { name = "anthropic", specifier = ">=0.40.0" },


### PR DESCRIPTION
## Description

This PR has 2 parts:

**Part 1: A2A server **

Expose OLS as an A2A-compliant agent so that other AI agents can discover and invoke it over the A2A protocol. OLS publishes an Agent Card at /.well-known/agent-card.json advertising two skills -- general OpenShift Q&A and troubleshooting -- and accepts JSON-RPC requests at /a2a. Incoming A2A messages are routed through DocsSummarizer (the same LLM pipeline that powers /v1/query), with streaming support via task status updates. Also fixes a streaming edge case where a "stop" finish reason could cause incomplete tool-call chunks to be lost by deferring the stop signal until the async iterator is fully drained.
_Files changed:_
- ols/src/a2a/__init__.py — new package init
- ols/src/a2a/server.py — Agent Card builder and OLSAgentExecutor
- ols/app/routers.py — mount A2A routes (/a2a, /.well-known/agent-card.json)
- ols/src/query_helpers/docs_summarizer.py — fix stop-signal draining in streaming
- docs/openapi.json — updated OpenAPI spec
- pyproject.toml — add a2a-sdk dependency
- uv.lock — lockfile update
- tests/unit/a2a_protocol/__init__.py — new test package init
- tests/unit/a2a_protocol/test_a2a.py — server unit tests
- tests/unit/app/test_routers.py — router test update

**Part 2: A2A client**

Enable OLS to delegate work to remote A2A agents by discovering their skills at startup and wrapping them as LangChain StructuredTools that the existing tool-calling pipeline can invoke. Adds A2AAgentConfig and A2AAgents config models for declaring remote agents with URL, timeout, and header-based authentication (supporting Kubernetes tokens, client-provided tokens, and file-based secrets -- same mechanism as MCP). Includes AgentsRAG, a hybrid dense+sparse retrieval system that indexes discovered agent skills and filters them per query, reusing the existing tool_filtering config. MCP and A2A tool fetching runs in parallel via asyncio.gather. Agent name uniqueness is enforced across both A2A agents and MCP servers at config validation time. Covered by unit tests for all client components and integration tests verifying header resolution and agent selection through the FastAPI endpoints.
_Files changed:_
- ols/src/a2a/client.py — A2A client, tool builder, AgentsRAG
- ols/app/models/config.py — A2AAgentConfig, A2AAgents models, cross-collection validation
- ols/utils/config.py — agents_rag cached property, a2a_agents / a2a_agents_dict wiring
- ols/src/query_helpers/docs_summarizer.py — parallel MCP + A2A tool fetching
- pyproject.toml — pylint R0401 suppression
- tests/unit/a2a_protocol/test_a2a_client.py — client unit tests
- tests/config/config_for_a2a_integration_tests.yaml — integration test config
- tests/integration/test_a2a_client_headers.py — integration tests for header resolution
- tests/integration/test_metrics.py — fix metrics re-initialization for test isolation

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
https://redhat.atlassian.net/browse/OLS-2841
- Closes #
https://redhat.atlassian.net/browse/OLS-2841

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
