### PR TITLE
Divide tool token budget evenly across parallel tool calls

### DIFF
--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -715,10 +715,14 @@ class DocsSummarizer(QueryHelper):
             yield StreamedChunk(type=StreamChunkType.TOOL_CALL, data=enriched)
 
         remaining_tool_budget = max_tokens_for_tools - tool_tokens_used
+        round_budget = max(
+            MIN_TOOL_EXECUTION_TOKENS, remaining_tool_budget // (round_index + 1)
+        )
         logger.debug(
-            "Tool budget: used=%d, remaining=%d",
+            "Tool budget: used=%d, remaining=%d, round=%d",
             tool_tokens_used,
             remaining_tool_budget,
+            round_budget,
         )
 
         tool_calls_messages: list[ToolMessage] = []
@@ -752,7 +756,7 @@ class DocsSummarizer(QueryHelper):
             else:
                 async for execution_event in execute_tool_calls_stream(
                     tool_call_definitions,
-                    remaining_tool_budget,
+                    round_budget,
                     streaming=self.streaming,
                 ):
                     match execution_event.event:
@@ -774,7 +778,7 @@ class DocsSummarizer(QueryHelper):
         all_tool_messages = skipped_tool_messages + tool_calls_messages
         if remaining_tool_budget > 0:
             all_tool_messages = enforce_tool_token_budget(
-                all_tool_messages, remaining_tool_budget
+                all_tool_messages, round_budget
             )
         messages.extend(all_tool_messages)
 

--- a/ols/src/tools/tools.py
+++ b/ols/src/tools/tools.py
@@ -467,10 +467,12 @@ async def execute_tool_calls_stream(
     if not tool_calls:
         return
 
+    per_tool_budget = max(1, tools_token_budget // len(tool_calls))
+
     # Merge runs all per-tool generators concurrently on the event loop.
     merged = stream.merge(
         *(
-            _execute_single_tool_call_stream(tc, tools_token_budget, streaming)
+            _execute_single_tool_call_stream(tc, per_tool_budget, streaming)
             for tc in tool_calls
         )
     )

--- a/tests/unit/query_helpers/test_docs_summarizer.py
+++ b/tests/unit/query_helpers/test_docs_summarizer.py
@@ -1224,3 +1224,129 @@ def test_create_response_ignores_reasoning_chunks():
         result = summarizer.create_response("q")
 
     assert result.response == "answer"
+
+
+@pytest.mark.asyncio
+async def test_process_tool_calls_round_budget_leaves_room_for_next_round():
+    """Verify round budget cap so one heavy round does not exhaust the global budget."""
+    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+    tool = mock_tools_map[0]
+    all_tools_dict = {tool.name: tool}
+
+    max_tokens_for_tools = 2000
+    large_output = "word " * 3000
+
+    async def _fake_execute(*args, **kwargs):
+        yield ToolResultEvent(
+            data=ToolMessage(
+                content=large_output,
+                status="success",
+                tool_call_id="call_1",
+                additional_kwargs={"truncated": False},
+            )
+        )
+
+    tool_call_chunks = [
+        AIMessageChunk(
+            content="",
+            response_metadata={"finish_reason": "tool_calls"},
+            tool_calls=[{"name": tool.name, "args": {}, "id": "call_1"}],
+        )
+    ]
+
+    token_usage = ToolTokenUsage(used=0)
+    messages: list = []
+
+    with patch(
+        "ols.src.query_helpers.docs_summarizer.execute_tool_calls_stream",
+        side_effect=_fake_execute,
+    ):
+        _ = [
+            chunk
+            async for chunk in summarizer._process_tool_calls_for_round(
+                round_index=1,
+                tool_call_chunks=tool_call_chunks,
+                all_chunks=[],
+                all_tools_dict=all_tools_dict,
+                duplicate_tool_names=set(),
+                messages=messages,
+                token_handler=TokenHandler(),
+                tool_token_usage=token_usage,
+                max_tokens_for_tools=max_tokens_for_tools,
+            )
+        ]
+
+    used_after_round_1 = token_usage.used
+    remaining_after_round_1 = max_tokens_for_tools - used_after_round_1
+    assert remaining_after_round_1 > 0, (
+        f"Round 1 consumed the entire budget ({used_after_round_1}/{max_tokens_for_tools}), "
+        "leaving nothing for subsequent rounds"
+    )
+
+
+@pytest.mark.asyncio
+async def test_round_budget_decreases_progressively_with_round_index():
+    """Verify later rounds get a smaller share of the remaining budget."""
+    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+    tool = mock_tools_map[0]
+    all_tools_dict = {tool.name: tool}
+
+    max_tokens_for_tools = 10000
+    large_output = "word " * 5000
+
+    tool_call_chunks = [
+        AIMessageChunk(
+            content="",
+            response_metadata={"finish_reason": "tool_calls"},
+            tool_calls=[{"name": tool.name, "args": {}, "id": "call_1"}],
+        )
+    ]
+
+    budgets_passed_to_execute: list[int] = []
+
+    def _make_capture_generator(large_output_text: str):
+        async def _capture_budget(tool_calls, tools_token_budget, **kwargs):
+            budgets_passed_to_execute.append(tools_token_budget)
+            yield ToolResultEvent(
+                data=ToolMessage(
+                    content=large_output_text,
+                    status="success",
+                    tool_call_id="call_1",
+                    additional_kwargs={"truncated": False},
+                )
+            )
+
+        return _capture_budget
+
+    token_usage = ToolTokenUsage(used=0)
+
+    for round_idx in (1, 2, 3):
+        messages: list = []
+        with patch(
+            "ols.src.query_helpers.docs_summarizer.execute_tool_calls_stream",
+            side_effect=_make_capture_generator(large_output),
+        ):
+            _ = [
+                chunk
+                async for chunk in summarizer._process_tool_calls_for_round(
+                    round_index=round_idx,
+                    tool_call_chunks=tool_call_chunks,
+                    all_chunks=[],
+                    all_tools_dict=all_tools_dict,
+                    duplicate_tool_names=set(),
+                    messages=messages,
+                    token_handler=TokenHandler(),
+                    tool_token_usage=token_usage,
+                    max_tokens_for_tools=max_tokens_for_tools,
+                )
+            ]
+
+    assert len(budgets_passed_to_execute) == 3
+    assert budgets_passed_to_execute[0] > budgets_passed_to_execute[1], (
+        f"Round 2 budget ({budgets_passed_to_execute[1]}) should be smaller "
+        f"than round 1 ({budgets_passed_to_execute[0]})"
+    )
+    assert budgets_passed_to_execute[1] > budgets_passed_to_execute[2], (
+        f"Round 3 budget ({budgets_passed_to_execute[2]}) should be smaller "
+        f"than round 2 ({budgets_passed_to_execute[1]})"
+    )

--- a/tests/unit/tools/test_tools.py
+++ b/tests/unit/tools/test_tools.py
@@ -678,3 +678,46 @@ def test_enforce_tool_token_budget_preserves_metadata():
 
     assert result[0].tool_call_id == "my_call_id"
     assert result[0].status == "success"
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_calls_stream_divides_budget_per_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify each tool receives budget/N, not the full budget."""
+    budgets_seen: list[int] = []
+
+    original_execute_with_retries = tools_module._execute_with_retries
+
+    async def _spy_execute(
+        *, tool, tool_args, tools_token_budget
+    ) -> tuple[str, str, bool, dict | None]:
+        budgets_seen.append(tools_token_budget)
+        return await original_execute_with_retries(
+            tool=tool, tool_args=tool_args, tools_token_budget=tools_token_budget
+        )
+
+    monkeypatch.setattr(tools_module, "_execute_with_retries", _spy_execute)
+    monkeypatch.setattr(tools_module, "need_validation", lambda **kwargs: False)
+
+    total_budget = 9000
+    tool_calls = [
+        ("call_1", {}, FakeTool("tool1")),
+        ("call_2", {}, FakeTool("tool2")),
+        ("call_3", {}, FakeTool("tool3")),
+    ]
+
+    _ = [
+        event
+        async for event in execute_tool_calls_stream(
+            tool_calls, tools_token_budget=total_budget, streaming=False
+        )
+    ]
+
+    assert len(budgets_seen) == 3
+    expected_per_tool = total_budget // 3
+    for budget in budgets_seen:
+        assert budget == expected_per_tool, (
+            f"Tool received budget {budget}, expected {expected_per_tool} "
+            f"(total {total_budget} / 3 tools)"
+        )


### PR DESCRIPTION
## Description

Stacked on top of #2867 (progressive per-round budget decay).

Previously, `execute_tool_calls_stream` gave each parallel tool the **full** round budget as its character-level pre-truncation limit. With 5 tools and a 13K-token round budget, each tool pre-truncated at `13000 * 4 = 52000` chars, so the combined raw output could be 260K chars before `enforce_tool_token_budget` had to tokenize it all — expensive and wasteful.

This PR divides the budget evenly across tools before execution:

```python
per_tool_budget = max(1, tools_token_budget // len(tool_calls))
```

**Effect:** Each tool's `_extract_text_from_tool_output` now uses a proportional character limit (`per_tool_budget * 4`), so the combined pre-truncated output is approximately `tools_token_budget * 4` chars total — matching what `enforce_tool_token_budget` expects. This makes the tier-1 char estimate in `enforce_tool_token_budget` effective, skipping expensive tokenization when pre-truncation already guarantees fit.

## Type of change

- [x] Optimization

## Related Tickets & Documents

- Depends on #2867 (progressive per-round budget decay)
- Related #2844 (introduced `enforce_tool_token_budget`)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- Added `test_execute_tool_calls_stream_divides_budget_per_tool` — spies on `_execute_with_retries` to verify each of 3 tools receives `budget // 3` instead of the full budget.
- All unit and integration tests pass.

Made with [Cursor](https://cursor.com)