### PR TITLE
Introduce TokenBudgetTracker for unified per-request token accounting

### DIFF
--- a/docs/ai/config.md
+++ b/docs/ai/config.md
@@ -115,3 +115,4 @@ Config-related constants live in `ols/constants.py`:
 | `DEFAULT_MAX_TOKENS_FOR_RESPONSE` | (int) | Default token limit |
 | `SUPPORTED_PROVIDER_TYPES` | frozenset | Validated against in `ProviderConfig.set_provider_type()` |
 | `SUPPORTED_AUTHENTICATION_MODULES` | frozenset | Validated in `AuthenticationConfig` |
+| `tool_round_cap_fraction` | (YAML: `ols_config.tool_round_cap_fraction`) | Global per-round MCP tool budget cap; bounds `TOOL_ROUND_CAP_FRACTION_MIN` / `MAX` in `ols/constants.py` |

--- a/docs/config.puml
+++ b/docs/config.puml
@@ -89,7 +89,6 @@ class "ModelConfig" as ols.app.models.config.ModelConfig {
   options : Optional[dict[str, Any]]
   parameters
   url : Optional[AnyHttpUrl]
-  validate_context_window_and_max_tokens() -> Self
   validate_inputs(data: Any) -> None
   validate_options(options: dict) -> dict[str, Any]
 }
@@ -113,6 +112,7 @@ class "OLSConfig" as ols.app.models.config.OLSConfig {
   system_prompt_path : Optional[str]
   tls_config
   tls_security_profile : Optional[TLSSecurityProfile]
+  tool_round_cap_fraction : float
   user_data_collection
   validate_yaml(disable_tls: bool) -> None
 }

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -37,6 +37,21 @@ class ReasoningSummary(StrEnum):
     DETAILED = "detailed"
 
 
+def validate_tool_round_cap_fraction_config(v: float) -> float:
+    """Validate ``tool_round_cap_fraction`` for ``OLSConfig``."""
+    if not (
+        constants.TOOL_ROUND_CAP_FRACTION_MIN
+        <= v
+        <= constants.TOOL_ROUND_CAP_FRACTION_MAX
+    ):
+        raise checks.InvalidConfigurationError(
+            f"tool_round_cap_fraction must be between "
+            f"{constants.TOOL_ROUND_CAP_FRACTION_MIN} and "
+            f"{constants.TOOL_ROUND_CAP_FRACTION_MAX}, got {v}"
+        )
+    return v
+
+
 class ModelParameters(BaseModel):
     """Model parameters."""
 
@@ -51,9 +66,13 @@ class ModelParameters(BaseModel):
     @classmethod
     def validate_tool_budget_ratio(cls, v: float) -> float:
         """Validate tool budget ratio is within bounds."""
-        if not 0.0 <= v <= 0.5:
+        if not (
+            constants.TOOL_BUDGET_RATIO_MIN <= v <= constants.TOOL_BUDGET_RATIO_MAX
+        ):
             raise checks.InvalidConfigurationError(
-                f"tool_budget_ratio must be between 0.0 and 0.5, got {v}"
+                f"tool_budget_ratio must be between "
+                f"{constants.TOOL_BUDGET_RATIO_MIN} and "
+                f"{constants.TOOL_BUDGET_RATIO_MAX}, got {v}"
             )
         return v
 
@@ -69,6 +88,8 @@ class ModelConfig(BaseModel):
 
     context_window_size: PositiveInt = constants.DEFAULT_CONTEXT_WINDOW_SIZE
     parameters: ModelParameters = ModelParameters()
+    # Set and validated against context_window_size in Config._compute_tool_budgets
+    # (max_tokens_for_response + max_tokens_for_tools must fit in the window).
     max_tokens_for_tools: int = 0
 
     options: Optional[dict[str, Any]] = None
@@ -103,16 +124,6 @@ class ModelConfig(BaseModel):
                     "key for model option must be string"
                 )
         return options
-
-    @model_validator(mode="after")
-    def validate_context_window_and_max_tokens(self) -> Self:
-        """Validate context window size against response token budget."""
-        if self.context_window_size <= self.parameters.max_tokens_for_response:  # type: ignore [operator]
-            raise checks.InvalidConfigurationError(
-                f"Context window size {self.context_window_size} must be greater than "
-                f"max_tokens_for_response ({self.parameters.max_tokens_for_response})"
-            )
-        return self
 
 
 class TLSConfig(BaseModel):
@@ -1144,6 +1155,8 @@ class OLSConfig(BaseModel):
 
     skills: Optional[SkillsConfig] = None
 
+    tool_round_cap_fraction: float = constants.DEFAULT_TOOL_ROUND_CAP_FRACTION
+
     def __init__(
         self, data: Optional[dict] = None, ignore_missing_certs: bool = False
     ) -> None:
@@ -1201,6 +1214,17 @@ class OLSConfig(BaseModel):
             self.tools_approval = ToolsApprovalConfig(**data.get("tools_approval"))
         if data.get("skills", None) is not None:
             self.skills = SkillsConfig(**data.get("skills"))
+
+        raw_cap = data.get(
+            "tool_round_cap_fraction", constants.DEFAULT_TOOL_ROUND_CAP_FRACTION
+        )
+        try:
+            cap = float(raw_cap)
+        except (TypeError, ValueError) as e:
+            raise checks.InvalidConfigurationError(
+                f"tool_round_cap_fraction must be a number, got {raw_cap!r}"
+            ) from e
+        self.tool_round_cap_fraction = validate_tool_round_cap_fraction_config(cap)
 
     def validate_yaml(self, disable_tls: bool = False) -> None:
         """Validate OLS config."""
@@ -1273,9 +1297,7 @@ class Config(BaseModel):
 
         # Validate MCP servers now that auth config is available
         self._validate_mcp_servers()
-
-        if self.mcp_servers.servers:
-            self._compute_tool_budgets()
+        self._compute_tool_budgets()
 
         # Always initialize dev config, even if there's no config for it.
         self.dev_config = DevConfig(**data.get("dev_config", {}))
@@ -1320,12 +1342,16 @@ class Config(BaseModel):
         )
 
     def _compute_tool_budgets(self) -> None:
-        """Compute tool token budgets for all models when MCP servers are configured."""
+        """Set tool token budget per model and ensure the context window fits reserved tokens."""
+        has_mcp = bool(self.mcp_servers.servers)
         for provider in self.llm_providers.providers.values():
             for model in provider.models.values():
-                model.max_tokens_for_tools = int(
-                    model.context_window_size * model.parameters.tool_budget_ratio
-                )
+                if has_mcp:
+                    model.max_tokens_for_tools = int(
+                        model.context_window_size * model.parameters.tool_budget_ratio
+                    )
+                else:
+                    model.max_tokens_for_tools = 0
                 reserved = (
                     model.parameters.max_tokens_for_response
                     + model.max_tokens_for_tools

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -85,6 +85,13 @@ TOKEN_BUFFER_WEIGHT = 1.1
 # Fraction of context window reserved for tool outputs (only when MCP servers configured).
 # Computed as int(context_window_size * ratio) at startup.
 DEFAULT_TOOL_BUDGET_RATIO = 0.25
+TOOL_BUDGET_RATIO_MIN = 0.1
+TOOL_BUDGET_RATIO_MAX = 0.6
+
+# Max fraction of remaining tool token budget usable in one tool-calling round.
+DEFAULT_TOOL_ROUND_CAP_FRACTION = 0.6
+TOOL_ROUND_CAP_FRACTION_MIN = 0.3
+TOOL_ROUND_CAP_FRACTION_MAX = 0.8
 
 
 # RAG related constants

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -5,7 +5,6 @@ import asyncio
 import json
 import logging
 import time
-from dataclasses import dataclass
 from typing import Any, AsyncGenerator, Coroutine, NamedTuple, Optional, TypeAlias
 
 from langchain_core.globals import set_debug
@@ -31,19 +30,17 @@ from ols.src.query_helpers.history_support import prepare_history
 from ols.src.query_helpers.query_helper import QueryHelper
 from ols.src.tools.tools import enforce_tool_token_budget, execute_tool_calls_stream
 from ols.utils.mcp_utils import ClientHeaders, build_mcp_config, get_mcp_tools
-from ols.utils.token_handler import TokenHandler
+from ols.utils.token_handler import (
+    PromptTooLongError,
+    TokenBudgetTracker,
+    TokenCategory,
+    TokenHandler,
+)
 
 logger = logging.getLogger(__name__)
 
 MIN_TOOL_EXECUTION_TOKENS = 100
 ToolCallDefinition: TypeAlias = tuple[str, dict[str, object], StructuredTool]
-
-
-@dataclass(slots=True)
-class ToolTokenUsage:
-    """Mutable holder for cumulative tool-token usage across helper boundaries."""
-
-    used: int
 
 
 class RoundLLMResult(NamedTuple):
@@ -154,6 +151,15 @@ class DocsSummarizer(QueryHelper):
             logger.debug("No MCP servers provided, tool calling is disabled")
             self._tool_calling_enabled = False
 
+        self._tracker = TokenBudgetTracker(
+            token_handler=TokenHandler(),
+            context_window_size=self.model_config.context_window_size,
+            max_response_tokens=self.model_config.parameters.max_tokens_for_response,
+            max_tool_tokens=self.model_config.max_tokens_for_tools,
+            round_cap_fraction=config.ols_config.tool_round_cap_fraction,
+        )
+        self._tracker.set_tool_loop_max_rounds(self._get_max_iterations())
+
         set_debug(self.verbose)
 
     def _prepare_llm(self) -> None:
@@ -173,19 +179,16 @@ class DocsSummarizer(QueryHelper):
         self,
         query: str,
         rag_retriever: Optional[BaseRetriever] = None,
-    ) -> tuple[TokenHandler, list[RagChunk], int, int]:
-        """Prepare token budget and RAG context for prompt construction.
+    ) -> list[RagChunk]:
+        """Prepare RAG context for prompt construction.
 
         Args:
             query: The query to be answered.
             rag_retriever: The retriever to get RAG data/context.
 
         Returns:
-            A tuple containing token handler, RAG chunks, available token budget,
-            and max tokens reserved for tools.
+            RAG chunks truncated to fit the prompt budget.
         """
-        token_handler = TokenHandler()
-
         temp_prompt, temp_prompt_input = GeneratePrompt(
             query,
             ["sample"],
@@ -195,15 +198,16 @@ class DocsSummarizer(QueryHelper):
             self._mode,
             self._cluster_version,
         ).generate_prompt(self.model)
-        max_tokens_for_tools = (
-            self.model_config.max_tokens_for_tools if self.mcp_servers else 0
+        prompt_tokens = self._tracker.count_tokens(
+            temp_prompt.format(**temp_prompt_input)
         )
-        available_tokens = token_handler.calculate_and_check_available_tokens(
-            temp_prompt.format(**temp_prompt_input),
-            self.model_config.context_window_size,
-            self.model_config.parameters.max_tokens_for_response,
-            max_tokens_for_tools,
-        )
+        if prompt_tokens > self._tracker.prompt_budget:
+            raise PromptTooLongError(
+                f"Prompt length {prompt_tokens} exceeds "
+                f"LLM available context window limit "
+                f"{self._tracker.prompt_budget} tokens"
+            )
+        self._tracker.charge(TokenCategory.PROMPT, prompt_tokens)
 
         if rag_retriever:
             retrieved_nodes = rag_retriever.retrieve(query)
@@ -219,33 +223,50 @@ class DocsSummarizer(QueryHelper):
                     node.get_score(raise_error=False),
                 )
 
-            rag_chunks, available_tokens = token_handler.truncate_rag_context(
-                retrieved_nodes, available_tokens
+            rag_chunks = self._tracker.token_handler.truncate_rag_context(
+                retrieved_nodes, self._tracker.history_budget
             )
+            rag_tokens = sum(
+                self._tracker.count_tokens(chunk.text) for chunk in rag_chunks
+            )
+            self._tracker.charge(TokenCategory.RAG, rag_tokens)
         else:
             logger.warning("Proceeding without RAG content. Check start up messages.")
             rag_chunks = []
 
-        return token_handler, rag_chunks, available_tokens, max_tokens_for_tools
+        return rag_chunks
+
+    def _serialized_tool_definitions_text(
+        self, all_mcp_tools: list[StructuredTool]
+    ) -> str:
+        """Return JSON serialization of MCP tool definitions for token counting."""
+        if not all_mcp_tools:
+            return ""
+        return json.dumps(
+            [
+                {"name": t.name, "description": t.description, "schema": t.args}
+                for t in all_mcp_tools
+            ]
+        )
 
     def _build_final_prompt(
         self,
         query: str,
         history: list[BaseMessage],
         rag_chunks: list[RagChunk],
-        token_handler: TokenHandler,
-        max_tokens_for_tools: int,
         skill_content: Optional[str] = None,
+        *,
+        tool_definitions_tokens: int = 0,
     ) -> tuple[ChatPromptTemplate, dict[str, str]]:
-        """Build the final LLM prompt from collected context.
+        """Build the final LLM prompt and charge the token budget.
 
         Args:
             query: The user query.
             history: Truncated conversation history.
             rag_chunks: Retrieved RAG chunks.
-            token_handler: Token handler for budget checking.
-            max_tokens_for_tools: Token budget reserved for tools.
             skill_content: Optional skill body to inject into the prompt.
+            tool_definitions_tokens: Token count for MCP tool schemas (not in the
+                formatted prompt string); included in the prompt-budget check.
 
         Returns:
             Tuple of (prompt_template, llm_input_values).
@@ -265,12 +286,21 @@ class DocsSummarizer(QueryHelper):
             skill_content=skill_content,
         ).generate_prompt(self.model)
 
-        token_handler.calculate_and_check_available_tokens(
-            final_prompt.format(**llm_input_values),
-            self.model_config.context_window_size,
-            self.model_config.parameters.max_tokens_for_response,
-            max_tokens_for_tools,
-        )
+        self._log_tool_loop_iteration(0, self._get_max_iterations(), "prompt_built")
+        if (
+            self._tracker.total_used + tool_definitions_tokens
+            > self._tracker.prompt_budget
+        ):
+            if tool_definitions_tokens > 0:
+                raise PromptTooLongError(
+                    f"Tool definitions ({tool_definitions_tokens} tokens) with current "
+                    f"request ({self._tracker.total_used} tokens) exceed prompt budget "
+                    f"({self._tracker.prompt_budget} tokens)"
+                )
+            raise PromptTooLongError(
+                f"Prompt ({self._tracker.total_used} tokens) exceeds "
+                f"budget ({self._tracker.prompt_budget} tokens)"
+            )
 
         return final_prompt, llm_input_values
 
@@ -322,7 +352,7 @@ class DocsSummarizer(QueryHelper):
                 time.monotonic() - llm_start_time,
             )
             raise
-        logger.info(
+        logger.debug(
             "LLM invocation completed: provider=%s, model=%s, elapsed=%.2fs",
             self.provider,
             self.model,
@@ -456,6 +486,44 @@ class DocsSummarizer(QueryHelper):
                             )
         return result
 
+    def _accumulate_single_round_llm_chunk(
+        self,
+        chunk: AIMessageChunk,
+        *,
+        chunk_counter: int,
+        is_final_round: bool,
+        tool_call_chunks: list[AIMessageChunk],
+        all_chunks: list[AIMessageChunk],
+        streamed_chunks: list[StreamedChunk],
+    ) -> Optional[RoundLLMResult]:
+        if chunk.response_metadata.get("finish_reason") == "stop":  # type: ignore [attr-defined]
+            return RoundLLMResult(
+                tool_call_chunks,
+                all_chunks,
+                streamed_chunks,
+                should_stop=True,
+            )
+
+        all_chunks.append(chunk)
+
+        if getattr(chunk, "tool_call_chunks", None):
+            tool_call_chunks.append(chunk)
+        elif isinstance(chunk.content, str):
+            if chunk.content and not skip_special_chunk(
+                chunk.content, chunk_counter, self.model, is_final_round
+            ):
+                streamed_chunks.append(
+                    StreamedChunk(type=StreamChunkType.TEXT, text=chunk.content)
+                )
+        elif isinstance(chunk.content, list):
+            streamed_chunks.extend(
+                self._streamed_chunks_from_list_content(
+                    chunk.content, chunk_counter, is_final_round
+                )
+            )
+
+        return None
+
     async def _collect_round_llm_chunks(
         self,
         messages: ChatPromptTemplate,
@@ -470,6 +538,7 @@ class DocsSummarizer(QueryHelper):
         all_chunks: list[AIMessageChunk] = []
         streamed_chunks: list[StreamedChunk] = []
         chunk_counter = 0
+        early_stop_result: Optional[RoundLLMResult] = None
         try:
             async with asyncio.timeout(constants.TOOL_CALL_ROUND_TIMEOUT):
                 async for chunk in self._invoke_llm(
@@ -493,33 +562,20 @@ class DocsSummarizer(QueryHelper):
                         )
                         break
 
-                    if chunk.response_metadata.get("finish_reason") == "stop":  # type: ignore [attr-defined]
-                        return RoundLLMResult(
-                            tool_call_chunks,
-                            all_chunks,
-                            streamed_chunks,
-                            should_stop=True,
-                        )
+                    if early_stop_result is not None:
+                        continue
 
-                    all_chunks.append(chunk)
-
-                    if getattr(chunk, "tool_call_chunks", None):
-                        tool_call_chunks.append(chunk)
-                    elif isinstance(chunk.content, str):
-                        if chunk.content and not skip_special_chunk(
-                            chunk.content, chunk_counter, self.model, is_final_round
-                        ):
-                            streamed_chunks.append(
-                                StreamedChunk(
-                                    type=StreamChunkType.TEXT, text=chunk.content
-                                )
-                            )
-                    elif isinstance(chunk.content, list):
-                        streamed_chunks.extend(
-                            self._streamed_chunks_from_list_content(
-                                chunk.content, chunk_counter, is_final_round
-                            )
-                        )
+                    stop = self._accumulate_single_round_llm_chunk(
+                        chunk,
+                        chunk_counter=chunk_counter,
+                        is_final_round=is_final_round,
+                        tool_call_chunks=tool_call_chunks,
+                        all_chunks=all_chunks,
+                        streamed_chunks=streamed_chunks,
+                    )
+                    if stop is not None:
+                        early_stop_result = stop
+                        continue
 
                     chunk_counter += 1
         except TimeoutError:
@@ -540,6 +596,9 @@ class DocsSummarizer(QueryHelper):
             return RoundLLMResult(
                 tool_call_chunks, all_chunks, streamed_chunks, should_stop=True
             )
+
+        if early_stop_result is not None:
+            return early_stop_result
 
         return RoundLLMResult(
             tool_call_chunks, all_chunks, streamed_chunks, should_stop=False
@@ -572,7 +631,6 @@ class DocsSummarizer(QueryHelper):
         tool_call_message: ToolMessage,
         tool_name: str,
         tool: Optional[StructuredTool],
-        token_handler: TokenHandler,
         round_index: int,
     ) -> tuple[int, StreamedChunk]:
         """Convert a ToolMessage into a streamed tool_result chunk.
@@ -580,8 +638,9 @@ class DocsSummarizer(QueryHelper):
         Returns:
             A tuple of (token_count_for_tool_content, streamed_tool_result_chunk).
         """
-        content_tokens = token_handler.text_to_tokens(str(tool_call_message.content))
-        content_token_count = TokenHandler._get_token_count(content_tokens)
+        content_token_count = tool_call_message.additional_kwargs.get(
+            "token_count"
+        ) or self._tracker.count_tokens(str(tool_call_message.content))
 
         was_truncated = tool_call_message.additional_kwargs.get("truncated", False)
         base_status = tool_call_message.status
@@ -592,7 +651,7 @@ class DocsSummarizer(QueryHelper):
             else False
         )
 
-        logger.info(
+        logger.debug(
             json.dumps(
                 {
                     "event": "tool_result",
@@ -636,13 +695,8 @@ class DocsSummarizer(QueryHelper):
         all_tools_dict: dict[str, StructuredTool],
         duplicate_tool_names: set[str],
         messages: ChatPromptTemplate,
-        token_handler: TokenHandler,
-        tool_token_usage: ToolTokenUsage,
-        max_tokens_for_tools: int,
     ) -> AsyncGenerator[StreamedChunk, None]:
         """Resolve, execute, and stream one round of tool calls."""
-        tool_tokens_used = tool_token_usage.used
-
         # Finalize streamed chunks into complete tool calls.
         tool_calls = tool_calls_from_tool_calls_chunks(tool_call_chunks)
         tool_call_definitions, skipped_tool_messages = (
@@ -656,7 +710,6 @@ class DocsSummarizer(QueryHelper):
             logger.warning(
                 "No executable tools resolved from tool calls in round %s", round_index
             )
-            tool_token_usage.used = tool_tokens_used
             return
 
         # Accumulate the full AI message (reasoning + tool calls) so reasoning
@@ -677,17 +730,18 @@ class DocsSummarizer(QueryHelper):
             )
         messages.append(ai_tool_call_message)
 
-        # Charge token budget for the assistant tool-call message itself, so
-        # subsequent per-tool limits are computed from the remaining budget.
+        # Charge the AI message tokens (reasoning + tool-call JSON) before
+        # computing the round budget so the 20% reserve is measured against
+        # the true remaining tool budget.
         ai_content_text = (
             json.dumps(ai_tool_call_message.content)
             if isinstance(ai_tool_call_message.content, list)
             else str(ai_tool_call_message.content)
         )
-        ai_message_tokens = TokenHandler._get_token_count(
-            token_handler.text_to_tokens(ai_content_text + json.dumps(tool_calls))
+        ai_message_tokens = self._tracker.count_tokens(
+            ai_content_text + json.dumps(tool_calls)
         )
-        tool_tokens_used += ai_message_tokens
+        self._tracker.charge(TokenCategory.AI_ROUND, ai_message_tokens)
 
         # Build a mapping from tool_call_id -> tool_name for result enrichment.
         tool_id_to_name: dict[str, str] = {
@@ -700,7 +754,7 @@ class DocsSummarizer(QueryHelper):
             enriched: dict[str, Any] = {**tool_call}
             tool_name = str(tool_call.get("name", "unknown"))
             self._enrich_with_tool_metadata(enriched, all_tools_dict.get(tool_name))
-            logger.info(
+            logger.debug(
                 json.dumps(
                     {
                         "event": "tool_call",
@@ -714,38 +768,26 @@ class DocsSummarizer(QueryHelper):
             )
             yield StreamedChunk(type=StreamChunkType.TOOL_CALL, data=enriched)
 
-        remaining_tool_budget = max_tokens_for_tools - tool_tokens_used
-        round_budget = max(
-            MIN_TOOL_EXECUTION_TOKENS, remaining_tool_budget // (round_index + 1)
-        )
-        logger.debug(
-            "Tool budget: used=%d, remaining=%d, round=%d",
-            tool_tokens_used,
-            remaining_tool_budget,
-            round_budget,
-        )
-
         tool_calls_messages: list[ToolMessage] = []
+        remaining = self._tracker.tools_round_budget
         # Execute resolved tool calls and consume streamed execution events
         # (approval prompts + final tool results).
         if tool_call_definitions:
-            if remaining_tool_budget < MIN_TOOL_EXECUTION_TOKENS:
+            if remaining < MIN_TOOL_EXECUTION_TOKENS:
                 logger.warning(
                     "Skipping %d tool call(s) in round %s due to low remaining tool budget "
                     "(remaining=%d, minimum_required=%d)",
                     len(tool_call_definitions),
                     round_index,
-                    remaining_tool_budget,
+                    remaining,
                     MIN_TOOL_EXECUTION_TOKENS,
                 )
-                # Emit synthetic tool results for skipped executions so client/UI
-                # and conversation state remain consistent (one call -> one outcome).
                 for tool_id, _tool_args, tool in tool_call_definitions:
                     tool_calls_messages.append(
                         ToolMessage(
                             content=(
                                 f"Tool '{tool.name}' call skipped: remaining tool token budget "
-                                f"({remaining_tool_budget}) is below minimum required "
+                                f"({remaining}) is below minimum required "
                                 f"({MIN_TOOL_EXECUTION_TOKENS}). "
                                 "Do not retry this exact tool call."
                             ),
@@ -756,7 +798,7 @@ class DocsSummarizer(QueryHelper):
             else:
                 async for execution_event in execute_tool_calls_stream(
                     tool_call_definitions,
-                    round_budget,
+                    remaining,
                     streaming=self.streaming,
                 ):
                     match execution_event.event:
@@ -773,12 +815,10 @@ class DocsSummarizer(QueryHelper):
                                 execution_event,
                             )
 
-        # Merge synthetic skipped outcomes with real execution outcomes and
-        # append all of them to conversation state for the next LLM turn.
         all_tool_messages = skipped_tool_messages + tool_calls_messages
-        if remaining_tool_budget > 0:
+        if remaining > 0:
             all_tool_messages = enforce_tool_token_budget(
-                all_tool_messages, round_budget
+                all_tool_messages, remaining, self._tracker.token_handler
             )
         messages.extend(all_tool_messages)
 
@@ -789,14 +829,23 @@ class DocsSummarizer(QueryHelper):
                     tool_call_message=tool_call_message,
                     tool_name=tool_name,
                     tool=all_tools_dict.get(tool_name),
-                    token_handler=token_handler,
                     round_index=round_index,
                 )
             )
-            tool_tokens_used += content_token_count
+            self._tracker.charge(TokenCategory.TOOL_RESULT, content_token_count)
             yield tool_result_chunk
 
-        tool_token_usage.used = tool_tokens_used
+    def _log_tool_loop_iteration(
+        self, round_index: int, max_rounds: int, outcome: str
+    ) -> None:
+        """Log token budget after one tool-loop LLM iteration (and optional tools)."""
+        logger.info(
+            "Tool loop iteration %s/%s outcome=%s. %s",
+            round_index,
+            max_rounds,
+            outcome,
+            self._tracker.summary(round_index),
+        )
 
     async def iterate_with_tools(  # noqa: C901  # pylint: disable=R0912
         self,
@@ -805,6 +854,8 @@ class DocsSummarizer(QueryHelper):
         llm_input_values: dict[str, str],
         token_counter: GenericTokenCounter,
         all_mcp_tools: list[StructuredTool],
+        *,
+        tool_definitions_tokens: int | None = None,
     ) -> AsyncGenerator[StreamedChunk, None]:
         """Iterate through multiple rounds of LLM invocation with tool calling.
 
@@ -814,6 +865,8 @@ class DocsSummarizer(QueryHelper):
             llm_input_values: Input values for the LLM
             token_counter: Counter for tracking token usage
             all_mcp_tools: All resolved MCP tools available for the request.
+            tool_definitions_tokens: When set, charge this value for tool definitions
+                without re-tokenizing; must match a prior count of the same payload.
 
         Yields:
             StreamedChunk objects representing parts of the response
@@ -835,24 +888,16 @@ class DocsSummarizer(QueryHelper):
                 sorted(duplicate_tool_names),
             )
 
-        # Track cumulative token usage for tool outputs
-        tool_tokens_used = 0
-        max_tokens_for_tools = self.model_config.max_tokens_for_tools
-        token_handler = TokenHandler()
-
-        # Account for tool definitions tokens (schemas sent to LLM)
         if all_mcp_tools:
-            tool_definitions_text = json.dumps(
-                [
-                    {"name": t.name, "description": t.description, "schema": t.args}
-                    for t in all_mcp_tools
-                ]
-            )
-            tool_definitions_tokens = TokenHandler._get_token_count(
-                token_handler.text_to_tokens(tool_definitions_text)
-            )
-            tool_tokens_used += tool_definitions_tokens
-            logger.debug("Tool definitions consume %d tokens", tool_definitions_tokens)
+            if tool_definitions_tokens is not None:
+                defs_tokens = tool_definitions_tokens
+            else:
+                tool_definitions_text = self._serialized_tool_definitions_text(
+                    all_mcp_tools
+                )
+                defs_tokens = self._tracker.count_tokens(tool_definitions_text)
+            self._tracker.charge(TokenCategory.TOOL_DEFINITIONS, defs_tokens)
+            logger.debug("Tool definitions consume %d tokens", defs_tokens)
 
         # Tool calling in a loop
         for i in range(1, max_rounds + 1):
@@ -873,46 +918,41 @@ class DocsSummarizer(QueryHelper):
             for streamed_chunk in round_result.streamed_chunks:
                 yield streamed_chunk
             if round_result.should_stop:
+                self._log_tool_loop_iteration(i, max_rounds, "llm_stream_stop")
                 return
 
             # exit if this was the final round
             if is_final_round:
+                self._log_tool_loop_iteration(i, max_rounds, "final_round")
                 break
 
             if not round_result.tool_call_chunks:
+                self._log_tool_loop_iteration(
+                    i, max_rounds, "model_finished_without_tools"
+                )
                 break
 
-            # tool calling part
-            if round_result.tool_call_chunks:
-                # Phase 2: resolve and execute tool calls for this round.
-                tool_token_usage = ToolTokenUsage(used=tool_tokens_used)
-                # No outer timeout here — each MCP server enforces its own
-                # configured timeout at the transport layer.
-                try:
-                    async for streamed_chunk in self._process_tool_calls_for_round(
-                        round_index=i,
-                        tool_call_chunks=round_result.tool_call_chunks,
-                        all_chunks=round_result.all_chunks,
-                        all_tools_dict=all_tools_dict,
-                        duplicate_tool_names=duplicate_tool_names,
-                        messages=messages,
-                        token_handler=token_handler,
-                        tool_token_usage=tool_token_usage,
-                        max_tokens_for_tools=max_tokens_for_tools,
-                    ):
-                        yield streamed_chunk
-                except Exception:
-                    logger.exception("Error executing tool calls in round %s", i)
-                    yield StreamedChunk(
-                        type=StreamChunkType.TEXT,
-                        text=(
-                            "I could not complete this request. " "Please try again."
-                        ),
-                    )
-                    return
-                tool_tokens_used = tool_token_usage.used
+            try:
+                async for streamed_chunk in self._process_tool_calls_for_round(
+                    round_index=i,
+                    tool_call_chunks=round_result.tool_call_chunks,
+                    all_chunks=round_result.all_chunks,
+                    all_tools_dict=all_tools_dict,
+                    duplicate_tool_names=duplicate_tool_names,
+                    messages=messages,
+                ):
+                    yield streamed_chunk
+            except Exception:
+                self._log_tool_loop_iteration(i, max_rounds, "tool_execution_failed")
+                logger.exception("Error executing tool calls in round %s", i)
+                yield StreamedChunk(
+                    type=StreamChunkType.TEXT,
+                    text="I could not complete this request. Please try again.",
+                )
+                return
+            self._log_tool_loop_iteration(i, max_rounds, "after_tool_execution")
 
-    async def generate_response(
+    async def generate_response(  # noqa: C901  # pylint: disable=too-many-branches
         self,
         query: str,
         rag_retriever: Optional[BaseRetriever] = None,
@@ -932,25 +972,7 @@ class DocsSummarizer(QueryHelper):
         Yields:
             StreamedChunk objects representing parts of the response
         """
-        token_handler, rag_chunks, available_tokens, max_tokens_for_tools = (
-            await self._prepare_prompt_context(query, rag_retriever)
-        )
-        history: list[BaseMessage] = []
-        truncated = False
-        async for item in prepare_history(
-            user_id=user_id,
-            conversation_id=conversation_id,
-            skip_user_id_check=skip_user_id_check,
-            available_tokens=available_tokens,
-            provider=self.provider,
-            model=self.model,
-            bare_llm=self.bare_llm,
-            token_handler=token_handler,
-        ):
-            if isinstance(item, StreamedChunk):
-                yield item
-            else:
-                history, truncated = item
+        rag_chunks = await self._prepare_prompt_context(query, rag_retriever)
 
         skill_content: Optional[str] = None
         skills_rag = config.skills_rag
@@ -966,15 +988,14 @@ class DocsSummarizer(QueryHelper):
                     )
                     skill = None
             if skill is not None:
-                skill_tokens = TokenHandler._get_token_count(
-                    token_handler.text_to_tokens(skill_content)
-                )
-                if skill_tokens > available_tokens * 0.8:
+                skill_tokens = self._tracker.count_tokens(skill_content)
+                available_for_skill = self._tracker.history_budget
+                if skill_tokens > available_for_skill * 0.8:
                     logger.warning(
                         "Skill '%s' requires %d tokens but only %d available; skipping",
                         skill.name,
                         skill_tokens,
-                        available_tokens,
+                        available_for_skill,
                     )
                     skill_content = None
                     yield StreamedChunk(
@@ -987,12 +1008,13 @@ class DocsSummarizer(QueryHelper):
                         },
                     )
                 else:
-                    if skill_tokens > available_tokens * 0.5:
+                    self._tracker.charge(TokenCategory.SKILL, skill_tokens)
+                    if skill_tokens > available_for_skill * 0.5:
                         logger.warning(
                             "Skill '%s' uses %d tokens (%.0f%% of available budget)",
                             skill.name,
                             skill_tokens,
-                            skill_tokens / available_tokens * 100,
+                            skill_tokens / available_for_skill * 100,
                         )
                     yield StreamedChunk(
                         type=StreamChunkType.SKILL_SELECTED,
@@ -1002,17 +1024,62 @@ class DocsSummarizer(QueryHelper):
                         },
                     )
 
+        history: list[BaseMessage] = []
+        truncated = False
+        available_tokens = self._tracker.history_budget
+        async for item in prepare_history(
+            user_id=user_id,
+            conversation_id=conversation_id,
+            skip_user_id_check=skip_user_id_check,
+            available_tokens=available_tokens,
+            provider=self.provider,
+            model=self.model,
+            bare_llm=self.bare_llm,
+            token_handler=self._tracker.token_handler,
+        ):
+            if isinstance(item, StreamedChunk):
+                yield item
+            else:
+                history, truncated = item
+
+        for msg in history:
+            if isinstance(msg.content, str):
+                self._tracker.charge(
+                    TokenCategory.HISTORY,
+                    self._tracker.count_tokens(msg.content),
+                )
+
         final_prompt, llm_input_values = self._build_final_prompt(
             query=query,
             history=history,
             rag_chunks=rag_chunks,
-            token_handler=token_handler,
-            max_tokens_for_tools=max_tokens_for_tools,
             skill_content=skill_content,
+            tool_definitions_tokens=0,
         )
 
         messages = final_prompt.model_copy()
         all_mcp_tools = await get_mcp_tools(query, self.user_token, self.client_headers)
+        tool_definitions_text = self._serialized_tool_definitions_text(all_mcp_tools)
+        tool_definitions_tokens = (
+            self._tracker.count_tokens(tool_definitions_text)
+            if tool_definitions_text
+            else 0
+        )
+        if (
+            self._tracker.total_used + tool_definitions_tokens
+            > self._tracker.prompt_budget
+        ):
+            if tool_definitions_tokens > 0:
+                raise PromptTooLongError(
+                    f"Tool definitions ({tool_definitions_tokens} tokens) with current "
+                    f"request ({self._tracker.total_used} tokens) exceed prompt budget "
+                    f"({self._tracker.prompt_budget} tokens)"
+                )
+            raise PromptTooLongError(
+                f"Prompt ({self._tracker.total_used} tokens) exceeds "
+                f"budget ({self._tracker.prompt_budget} tokens)"
+            )
+
         with TokenMetricUpdater(
             llm=self.bare_llm,
             provider=self.provider_config.type,
@@ -1024,6 +1091,7 @@ class DocsSummarizer(QueryHelper):
                 token_counter=token_counter,
                 llm_input_values=llm_input_values,
                 all_mcp_tools=all_mcp_tools,
+                tool_definitions_tokens=tool_definitions_tokens,
             ):
                 yield response
 

--- a/ols/src/tools/tools.py
+++ b/ols/src/tools/tools.py
@@ -30,7 +30,7 @@ RATE_LIMIT_RETRY_BACKOFF_SECONDS = 1.0
 DO_NOT_RETRY_REMINDER = "Do not retry this exact tool call."
 
 _TRUNCATION_WARNING = (
-    "\n\n[OUTPUT TRUNCATED - The tool returned more data than can be "
+    "\n[OUTPUT TRUNCATED - The tool returned more data than can be "
     "processed. Please ask a more specific question to get complete results.]"
 )
 _TRUNCATION_WARNING_TOKENS = TokenHandler._get_token_count(
@@ -98,6 +98,18 @@ def _is_rate_limited_tool_error(error: Exception) -> bool:
 _CHARS_PER_TOKEN_ESTIMATE = 4
 
 
+def _truncate_text_to_char_limit(text: str, max_chars: int) -> str:
+    """Return up to ``max_chars`` characters, cutting at the last newline when possible."""
+    if max_chars <= 0:
+        return ""
+    if len(text) <= max_chars:
+        return text
+    prefix = text[:max_chars]
+    cut = prefix.rfind("\n")
+    chunk = prefix[:cut].rstrip("\r") if cut > 0 else prefix
+    return chunk.strip()
+
+
 def _extract_text_from_tool_output(
     output: Any, tools_token_budget: int
 ) -> tuple[str, bool]:
@@ -111,8 +123,10 @@ def _extract_text_from_tool_output(
     response size at the transport layer, so a cheap character-level limit
     (tools_token_budget * 4) is applied here before any tokenization to
     avoid the CPU cost of tokenizing arbitrarily large tool responses.
-    Strings are cut at the last newline boundary; lists are truncated by
-    dropping trailing blocks that would exceed the limit.
+    Strings are cut at the last newline boundary. For lists, blocks are
+    concatenated until the limit; the first block alone may be shortened
+    to the limit before appending the truncation notice; later blocks are
+    dropped if they would exceed the limit.
 
     Args:
         output: Tool output, either a string or list of content blocks.
@@ -129,34 +143,51 @@ def _extract_text_from_tool_output(
         output = str(output)
         if len(output) <= max_chars:
             return output, False
-        cut = output[:max_chars].rfind("\n")
-        text = output[:cut].rstrip("\r") if cut > 0 else output[:max_chars]
-        logger.warning(
+        body = _truncate_text_to_char_limit(output, max_chars)
+        logger.debug(
             "Tool output pre-truncated from %d to %d chars (limit %d)",
             len(output),
-            len(text),
+            len(body),
             max_chars,
         )
-        return text + _TRUNCATION_WARNING, True
+        return body + _TRUNCATION_WARNING, True
 
-    parts: list[str] = []
+    joined = ""
     total = 0
+    blocks_kept = 0
     for block in output:
         chunk = (
             block["text"] if isinstance(block, dict) and "text" in block else str(block)
         )
         if total + len(chunk) > max_chars:
-            logger.warning(
+            if blocks_kept == 0:
+                room = max_chars - total
+                body = _truncate_text_to_char_limit(chunk, room)
+                logger.debug(
+                    "Tool output list: first block exceeds char budget "
+                    "(block_len=%d, limit=%d, total_blocks=%d); "
+                    "pre-truncating first block to %d chars",
+                    len(chunk),
+                    max_chars,
+                    len(output),
+                    len(body),
+                )
+                return body + _TRUNCATION_WARNING, True
+            logger.debug(
                 "Tool output pre-truncated at block %d of %d (limit %d chars)",
-                len(parts),
+                blocks_kept,
                 len(output),
                 max_chars,
             )
-            return "\n".join(parts) + _TRUNCATION_WARNING, True
-        parts.append(chunk)
+            return joined.strip() + _TRUNCATION_WARNING, True
+        if blocks_kept > 0:
+            joined += "\n" + chunk
+        else:
+            joined = chunk
+        blocks_kept += 1
         total += len(chunk)
 
-    return "\n".join(parts), False
+    return joined.strip(), False
 
 
 def get_tool_by_name(
@@ -198,7 +229,8 @@ async def execute_tool_call(
             result[0], tools_token_budget
         )
         if isinstance(result[1], dict):
-            structured_content = result[1].get("structured_content")
+            raw = result[1].get("structured_content")
+            structured_content = raw if isinstance(raw, dict) else None
     else:
         tool_output, was_truncated = _extract_text_from_tool_output(
             result, tools_token_budget
@@ -485,6 +517,7 @@ async def execute_tool_calls_stream(
 def enforce_tool_token_budget(
     tool_messages: list[ToolMessage],
     remaining_budget: int,
+    token_handler: TokenHandler,
 ) -> list[ToolMessage]:
     """Ensure combined tool outputs fit within the remaining token budget.
 
@@ -497,6 +530,7 @@ def enforce_tool_token_budget(
     Args:
         tool_messages: Tool result messages to enforce budget on.
         remaining_budget: Remaining token budget for tool outputs.
+        token_handler: Tokenizer to use for token counting and truncation.
 
     Returns:
         The same list of ToolMessages, with oversized ones truncated in place.
@@ -515,7 +549,6 @@ def enforce_tool_token_budget(
 
     # Tier 2: precise tokenization. The char estimate was ambiguous,
     # so tokenize each message to get exact counts.
-    token_handler = TokenHandler()
     token_lists = [
         token_handler.text_to_tokens(str(msg.content)) for msg in tool_messages
     ]
@@ -539,10 +572,24 @@ def enforce_tool_token_budget(
     if token_counts[longest_idx] // 2 >= excess:
         targets = [longest_idx]
         limits = [token_counts[longest_idx] - excess]
+        logger.debug(
+            "Truncating longest message [%d] from %d to %d tokens (excess %d)",
+            longest_idx,
+            token_counts[longest_idx],
+            limits[0],
+            excess,
+        )
     else:
         ratio = remaining_budget / total
         targets = list(range(len(token_counts)))
         limits = [max(1, int(token_counts[i] * ratio)) for i in targets]
+        logger.debug(
+            "Scaling all %d messages by %.2f (budget %d, total %d)",
+            len(targets),
+            ratio,
+            remaining_budget,
+            total,
+        )
 
     # Truncate targeted messages using pre-computed token lists (no
     # re-tokenization). Cut at the last newline to avoid mid-line splits.
@@ -553,15 +600,22 @@ def enforce_tool_token_budget(
             token_lists[idx][: max(0, limit - _TRUNCATION_WARNING_TOKENS)]
         )
         cut = raw.rfind("\n")
-        truncated_text = (
-            raw[:cut].rstrip("\r") if cut > 0 else raw
-        ) + _TRUNCATION_WARNING
+        body = raw[:cut].rstrip("\r") if cut > 0 else raw
+        truncated_text = body.strip() + _TRUNCATION_WARNING
+
+        token_counts[idx] = TokenHandler._get_token_count(
+            token_handler.text_to_tokens(truncated_text)
+        )
         msg = tool_messages[idx]
         tool_messages[idx] = ToolMessage(
             content=truncated_text,
             status=msg.status,
             tool_call_id=msg.tool_call_id,
-            additional_kwargs={**msg.additional_kwargs, "truncated": True},
+            additional_kwargs={
+                **msg.additional_kwargs,
+                "truncated": True,
+                "token_count": token_counts[idx],
+            },
         )
 
     return tool_messages

--- a/ols/utils/token_handler.py
+++ b/ols/utils/token_handler.py
@@ -1,6 +1,7 @@
 """Utility to handle tokens."""
 
 import logging
+from enum import Enum
 from math import ceil
 
 from langchain_core.messages import BaseMessage
@@ -14,9 +15,25 @@ from ols.constants import (
     RAG_SIMILARITY_CUTOFF,
     TOKEN_BUFFER_WEIGHT,
 )
-from ols.src.prompts.prompt_generator import format_retrieved_chunk
 
 logger = logging.getLogger(__name__)
+
+
+def format_retrieved_chunk(rag_content: str) -> str:
+    """Format a RAG document chunk with the standard prefix."""
+    return f"Document:\n{rag_content}"
+
+
+class TokenCategory(Enum):
+    """Named categories for token budget accounting."""
+
+    PROMPT = "prompt"
+    HISTORY = "history"
+    RAG = "rag"
+    SKILL = "skill"
+    TOOL_DEFINITIONS = "tool_definitions"
+    AI_ROUND = "ai_round"
+    TOOL_RESULT = "tool_result"
 
 
 class PromptTooLongError(Exception):
@@ -68,59 +85,9 @@ class TokenHandler:
         # We increase by certain percentage to nearest integer (ceil).
         return ceil(len(tokens) * TOKEN_BUFFER_WEIGHT)
 
-    def calculate_and_check_available_tokens(
-        self,
-        prompt: str,
-        context_window_size: int,
-        max_tokens_for_response: int,
-        max_tokens_for_tools: int = 0,
-    ) -> int:
-        """Get available tokens that can be used for prompt augmentation.
-
-        Args:
-            prompt: format prompt template to string before passing as arg
-            context_window_size: context window size of LLM
-            max_tokens_for_response: max tokens allowed for response (estimation)
-            max_tokens_for_tools: tokens reserved for tool outputs (only when MCP
-                servers are configured, default 0 means no reservation)
-
-        Returns:
-            available_tokens: int, tokens that can be used for augmentation.
-        """
-        logger.debug(
-            "Context window size: %d, Max generated tokens: %d, Reserved for tools: %d",
-            context_window_size,
-            max_tokens_for_response,
-            max_tokens_for_tools,
-        )
-
-        prompt_token_count = TokenHandler._get_token_count(self.text_to_tokens(prompt))
-        logger.debug("Prompt tokens: %d", prompt_token_count)
-
-        # The context_window_size is the maximum number of tokens that
-        # can be used for a "conversation" in the LLM model. This
-        # includes prompt AND response. Hence we need to subtract the
-        # prompt tokens, max tokens for response, and reserved tool tokens
-        # from the context window size.
-        available_tokens = (
-            context_window_size
-            - max_tokens_for_response
-            - max_tokens_for_tools
-            - prompt_token_count
-        )
-
-        if available_tokens < 0:
-            limit = context_window_size - max_tokens_for_response - max_tokens_for_tools
-            raise PromptTooLongError(
-                f"Prompt length {prompt_token_count} exceeds LLM "
-                f"available context window limit {limit} tokens"
-            )
-
-        return available_tokens
-
     def truncate_rag_context(
         self, retrieved_nodes: list[NodeWithScore], max_tokens: int = 500
-    ) -> tuple[list[RagChunk], int]:
+    ) -> list[RagChunk]:
         """Process retrieved node text and truncate if required.
 
         Args:
@@ -128,7 +95,7 @@ class TokenHandler:
             max_tokens: maximum tokens allowed for rag context
 
         Returns:
-            list of `RagChunk` objects, available tokens after context usage
+            List of `RagChunk` objects that fit within the token budget.
         """
         rag_chunks = []
         logger.info(
@@ -154,8 +121,7 @@ class TokenHandler:
                 )
                 break
 
-            node_text = node.get_text()
-            node_text = format_retrieved_chunk(node_text)
+            node_text = format_retrieved_chunk(node.get_text())
             tokens = self.text_to_tokens(node_text)
             tokens_count = TokenHandler._get_token_count(tokens)
             tokens_count += 1  # for new-line char
@@ -206,7 +172,7 @@ class TokenHandler:
         logger.info(
             "Final selection: %d documents chosen for RAG context", len(rag_chunks)
         )
-        return rag_chunks, max_tokens
+        return rag_chunks
 
     def limit_conversation_history(
         self, history: list[BaseMessage], limit: int = 0
@@ -231,3 +197,216 @@ class TokenHandler:
             index += 1
 
         return history, False
+
+    def calculate_and_check_available_tokens(
+        self,
+        prompt: str,
+        context_window_size: int,
+        max_tokens_for_response: int,
+        max_tokens_for_tools: int = 0,
+    ) -> int:
+        """Return tokens still available for context after the formatted prompt.
+
+        Raises:
+            PromptTooLongError: If the prompt alone exceeds the allowed budget.
+        """
+        prompt_tokens = TokenHandler._get_token_count(self.text_to_tokens(prompt))
+        context_limit = (
+            context_window_size - max_tokens_for_response - max_tokens_for_tools
+        )
+        if prompt_tokens > context_limit:
+            raise PromptTooLongError(
+                f"Prompt length {prompt_tokens} exceeds "
+                f"LLM available context window limit {context_limit} tokens"
+            )
+        return context_limit - prompt_tokens
+
+
+class TokenBudgetTracker:
+    """Per-request token budget accounting across the full context window.
+
+    Tracks every token allocation by category so that prompt construction,
+    tool-calling rounds, and AI responses all draw from one unified budget.
+    """
+
+    def __init__(
+        self,
+        token_handler: TokenHandler,
+        context_window_size: int,
+        max_response_tokens: int,
+        max_tool_tokens: int,
+        round_cap_fraction: float,
+    ) -> None:
+        """Initialize the tracker with the full context window parameters.
+
+        Args:
+            token_handler: Tokenizer used for all token counting.
+            context_window_size: Total context window of the LLM.
+            max_response_tokens: Tokens reserved for the LLM response.
+            max_tool_tokens: Tokens reserved for tool-related usage.
+            round_cap_fraction: Fraction of remaining tool budget available
+                per round (default DEFAULT_TOOL_ROUND_CAP_FRACTION).
+        """
+        self._token_handler = token_handler
+        self.context_window_size = context_window_size
+        self.max_response_tokens = max_response_tokens
+        self.max_tool_tokens = max_tool_tokens
+        self.round_cap_fraction = round_cap_fraction
+
+        self._usage: dict[TokenCategory, int] = dict.fromkeys(TokenCategory, 0)
+        self._tool_loop_max_rounds: int | None = None
+        self._last_tools_exec_budget: int | None = None
+        self._last_tool_rounds_left: int | None = None
+
+    @property
+    def token_handler(self) -> TokenHandler:
+        """The underlying tokenizer."""
+        return self._token_handler
+
+    def count_tokens(self, text: str) -> int:
+        """Count tokens in text using the underlying tokenizer."""
+        return TokenHandler._get_token_count(self._token_handler.text_to_tokens(text))
+
+    @property
+    def history_budget(self) -> int:
+        """Tokens available for history after prompt, RAG, and skill overhead."""
+        return (
+            self.prompt_budget
+            - self._usage[TokenCategory.PROMPT]
+            - self._usage[TokenCategory.RAG]
+            - self._usage[TokenCategory.SKILL]
+        )
+
+    def charge(self, category: TokenCategory, tokens: int) -> None:
+        """Add a token charge to the specified category.
+
+        Args:
+            category: Which budget category to charge.
+            tokens: Number of tokens to add.
+        """
+        self._usage[category] += tokens
+
+    def usage(self, category: TokenCategory) -> int:
+        """Return the current token usage for a category."""
+        return self._usage[category]
+
+    @property
+    def total_used(self) -> int:
+        """Total tokens used across all categories."""
+        return sum(self._usage.values())
+
+    @property
+    def prompt_budget(self) -> int:
+        """Tokens available for prompt content (system, history, RAG, skill)."""
+        return (
+            self.context_window_size - self.max_response_tokens - self.max_tool_tokens
+        )
+
+    @property
+    def remaining(self) -> int:
+        """Tokens remaining in the full context window."""
+        return self.context_window_size - self.max_response_tokens - self.total_used
+
+    @property
+    def prompt_budget_remaining(self) -> int:
+        """Tokens still available within the prompt budget."""
+        return self.prompt_budget - self.total_used
+
+    @property
+    def tool_budget_used(self) -> int:
+        """Tokens consumed from the tool execution slice (per-round AI + results).
+
+        Tool definition tokens are request-side input and are tracked under
+        ``TokenCategory.TOOL_DEFINITIONS`` for logging, but they are excluded
+        here so ``tool_budget_remaining`` reflects only execution traffic.
+        """
+        return (
+            self._usage[TokenCategory.AI_ROUND] + self._usage[TokenCategory.TOOL_RESULT]
+        )
+
+    @property
+    def tool_budget_remaining(self) -> int:
+        """Tokens still available within the tool budget."""
+        return max(0, self.max_tool_tokens - self.tool_budget_used)
+
+    @property
+    def tools_round_budget(self) -> int:
+        """Budget available for the current tool-calling round.
+
+        Caps at ``round_cap_fraction`` of the remaining tool budget so that
+        no single round can exhaust the entire tool allocation.
+        """
+        return int(self.tool_budget_remaining * self.round_cap_fraction)
+
+    def tools_round_execution_budget(self, tool_rounds_left: int) -> int:
+        """Token budget for one tool execution round (adaptive cap).
+
+        Returns the smaller of (1) ``round_cap_fraction`` of the remaining
+        tool pool and (2) ``tool_budget_remaining // horizon`` with
+        ``horizon = max(1, tool_rounds_left)``. Callers will pass an upper
+        bound on tool rounds still to come (for example ``max_rounds -
+        round_index``); this method does not read the tool loop state itself.
+
+        Args:
+            tool_rounds_left: Upper bound on tool rounds remaining including
+                this round; values below 1 are treated as 1.
+
+        Returns:
+            Token budget for a single round's tool execution, or 0 if the
+            tool pool is exhausted.
+        """
+        remaining_tool = self.tool_budget_remaining
+        if remaining_tool <= 0:
+            return 0
+        horizon = max(1, tool_rounds_left)
+        fraction_cap = int(remaining_tool * self.round_cap_fraction)
+        equal_share = remaining_tool // horizon
+        return min(fraction_cap, equal_share)
+
+    def set_tool_loop_max_rounds(self, max_rounds: int) -> None:
+        """Store the configured tool-loop bound for adaptive budget in :meth:`summary`."""
+        self._tool_loop_max_rounds = max_rounds
+
+    @property
+    def last_tools_exec_budget(self) -> int | None:
+        """Adaptive tool execution budget from the last :meth:`summary` call, if any."""
+        return self._last_tools_exec_budget
+
+    @property
+    def last_tool_rounds_left(self) -> int | None:
+        """Horizon ``max_rounds - round_index`` used for the last :meth:`summary` call."""
+        return self._last_tool_rounds_left
+
+    def summary(self, round_index: int) -> str:
+        """Return a per-round breakdown of token usage.
+
+        When :meth:`set_tool_loop_max_rounds` was called, appends one
+        ``tools_exec_budget`` line using :meth:`tools_round_execution_budget` with
+        ``tool_rounds_left = max_rounds - round_index`` and stores the values on
+        ``last_tools_exec_budget`` / ``last_tool_rounds_left``.
+        """
+        parts = [
+            f"Token budget after round {round_index}:",
+            f"prompt={self._usage[TokenCategory.PROMPT]}",
+            f"history={self._usage[TokenCategory.HISTORY]}",
+            f"rag={self._usage[TokenCategory.RAG]}",
+            f"skill={self._usage[TokenCategory.SKILL]}",
+            f"tool_defs={self._usage[TokenCategory.TOOL_DEFINITIONS]}",
+            f"ai_rounds={self._usage[TokenCategory.AI_ROUND]}",
+            f"tool_results={self._usage[TokenCategory.TOOL_RESULT]} |",
+            f"total_used={self.total_used}/{self.context_window_size}",
+            f"remaining={self.remaining}",
+            f"tool_remaining={self.tool_budget_remaining}/{self.max_tool_tokens}",
+        ]
+        if self._tool_loop_max_rounds is not None:
+            tool_rounds_left = self._tool_loop_max_rounds - round_index
+            exec_budget = self.tools_round_execution_budget(tool_rounds_left)
+            self._last_tools_exec_budget = exec_budget
+            self._last_tool_rounds_left = tool_rounds_left
+            parts.append(
+                f"tools_exec_budget={exec_budget} tool_rounds_left={tool_rounds_left}"
+            )
+        else:
+            self._last_tools_exec_budget = None
+            self._last_tool_rounds_left = None
+        return " ".join(parts)

--- a/scripts/evaluation/utils/rag.py
+++ b/scripts/evaluation/utils/rag.py
@@ -21,7 +21,7 @@ def retrieve_rag_chunks(query, model, model_config):
     )
 
     retriever = config.rag_index.as_retriever(similarity_top_k=RAG_CONTENT_LIMIT)
-    rag_chunks, _ = token_handler.truncate_rag_context(
+    rag_chunks = token_handler.truncate_rag_context(
         retriever.retrieve(query), available_tokens
     )
     return [rag_chunk.text for rag_chunk in rag_chunks]

--- a/tests/integration/test_approvals.py
+++ b/tests/integration/test_approvals.py
@@ -4,7 +4,7 @@
 # properly by linters
 # pyright: reportAttributeAccessIssue=false
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -150,7 +150,8 @@ def test_streaming_approval_always_emits_approval_and_rejection(_setup) -> None:
             side_effect=_single_tool_side_effect_factory(),
         ),
         patch(
-            "ols.src.query_helpers.docs_summarizer.TokenHandler.calculate_and_check_available_tokens",
+            "ols.src.query_helpers.docs_summarizer.TokenBudgetTracker.tools_round_budget",
+            new_callable=PropertyMock,
             return_value=1000,
         ),
         patch(
@@ -189,7 +190,8 @@ def test_streaming_approval_never_skips_approval_and_executes(_setup) -> None:
             side_effect=_single_tool_side_effect_factory(),
         ),
         patch(
-            "ols.src.query_helpers.docs_summarizer.TokenHandler.calculate_and_check_available_tokens",
+            "ols.src.query_helpers.docs_summarizer.TokenBudgetTracker.tools_round_budget",
+            new_callable=PropertyMock,
             return_value=1000,
         ),
         patch(
@@ -239,7 +241,8 @@ def test_streaming_approval_tool_annotations_mixed_tools(_setup) -> None:
             side_effect=_three_tools_side_effect_factory(),
         ),
         patch(
-            "ols.src.query_helpers.docs_summarizer.TokenHandler.calculate_and_check_available_tokens",
+            "ols.src.query_helpers.docs_summarizer.TokenBudgetTracker.tools_round_budget",
+            new_callable=PropertyMock,
             return_value=1000,
         ),
         patch(

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -5,7 +5,7 @@
 # pyright: reportAttributeAccessIssue=false
 
 import logging
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 import requests
@@ -1006,8 +1006,8 @@ def test_tool_calling(_setup, caplog) -> None:
             "ols.src.query_helpers.docs_summarizer.DocsSummarizer._invoke_llm"
         ) as mock_invoke,
         patch(
-            "ols.src.query_helpers.docs_summarizer.TokenHandler"
-            ".calculate_and_check_available_tokens",
+            "ols.src.query_helpers.docs_summarizer.TokenBudgetTracker.tools_round_budget",
+            new_callable=PropertyMock,
             return_value=1000,
         ),
     ):

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -256,6 +256,56 @@ def test_model_parameters():
     with pytest.raises(ValidationError):
         ModelParameters(verbosity="invalid")  # type: ignore[arg-type]
 
+    assert (
+        ModelParameters(
+            tool_budget_ratio=constants.TOOL_BUDGET_RATIO_MIN
+        ).tool_budget_ratio
+        == constants.TOOL_BUDGET_RATIO_MIN
+    )
+    assert ModelParameters(tool_budget_ratio=0.6).tool_budget_ratio == 0.6
+    with pytest.raises(InvalidConfigurationError, match="tool_budget_ratio"):
+        ModelParameters(tool_budget_ratio=0.0)
+    with pytest.raises(InvalidConfigurationError, match="tool_budget_ratio"):
+        ModelParameters(tool_budget_ratio=0.05)
+    with pytest.raises(InvalidConfigurationError, match="tool_budget_ratio"):
+        ModelParameters(tool_budget_ratio=0.61)
+
+
+def test_config_accepts_mcp_with_minimum_tool_budget_ratio():
+    """Full config load with MCP requires tool_budget_ratio within configured bounds."""
+    Config(
+        {
+            "llm_providers": [
+                {
+                    "name": "p1",
+                    "type": "openai",
+                    "url": "http://url1",
+                    "credentials_path": "tests/config/secret/apitoken",
+                    "models": [
+                        {
+                            "name": "m1",
+                            "url": "http://murl1/",
+                            "credentials_path": "tests/config/secret/apitoken",
+                            "parameters": {
+                                "tool_budget_ratio": constants.TOOL_BUDGET_RATIO_MIN,
+                                "max_tokens_for_response": 100,
+                            },
+                        }
+                    ],
+                }
+            ],
+            "ols_config": {
+                "default_provider": "p1",
+                "default_model": "m1",
+                "conversation_cache": {
+                    "type": "memory",
+                    "memory": {"max_entries": 100},
+                },
+            },
+            "mcp_servers": [{"name": "foo", "url": "http://localhost:8080/mcp"}],
+        }
+    )
+
 
 def test_model_config():
     """Test the ModelConfig model."""
@@ -376,15 +426,42 @@ def test_model_config_validation_improper_url():
 
 
 def test_model_config_higher_response_token():
-    """Test the model config with response token >= context window."""
+    """Context window must exceed max_tokens_for_response plus tool budget (zero without MCP)."""
     with pytest.raises(
         InvalidConfigurationError,
-        match=r"Context window size 2 must be greater than max_tokens_for_response \(2\)",
+        match=(
+            r"Model 'm1': context window size 2 must be greater than "
+            r"max_tokens_for_response \(2\) \+ tool budget \(0\)"
+        ),
     ):
-        ModelConfig(
-            name="test_model_name",
-            context_window_size=2,
-            parameters=ModelParameters(max_tokens_for_response=2),
+        Config(
+            {
+                "llm_providers": [
+                    {
+                        "name": "p1",
+                        "type": "openai",
+                        "url": "http://url1",
+                        "credentials_path": "tests/config/secret/apitoken",
+                        "models": [
+                            {
+                                "name": "m1",
+                                "url": "http://murl1/",
+                                "credentials_path": "tests/config/secret/apitoken",
+                                "context_window_size": 2,
+                                "parameters": {"max_tokens_for_response": 2},
+                            }
+                        ],
+                    }
+                ],
+                "ols_config": {
+                    "default_provider": "p1",
+                    "default_model": "m1",
+                    "conversation_cache": {
+                        "type": "memory",
+                        "memory": {"max_entries": 100},
+                    },
+                },
+            }
         )
 
 
@@ -2161,6 +2238,35 @@ def test_ols_config(tmpdir):
     assert ols_config.system_prompt_path is None
     assert ols_config.system_prompt is None
     assert ols_config.tls_security_profile == TLSSecurityProfile()
+    assert (
+        ols_config.tool_round_cap_fraction == constants.DEFAULT_TOOL_ROUND_CAP_FRACTION
+    )
+
+
+def test_ols_config_tool_round_cap_fraction():
+    """tool_round_cap_fraction is on OLSConfig and uses TOOL_ROUND_CAP_FRACTION bounds."""
+    base = {
+        "default_provider": "test_default_provider",
+        "default_model": "test_default_model",
+        "conversation_cache": {
+            "type": "memory",
+            "memory": {"max_entries": 100},
+        },
+    }
+    ols_min = OLSConfig(
+        {**base, "tool_round_cap_fraction": constants.TOOL_ROUND_CAP_FRACTION_MIN}
+    )
+    assert ols_min.tool_round_cap_fraction == constants.TOOL_ROUND_CAP_FRACTION_MIN
+    ols_max = OLSConfig(
+        {**base, "tool_round_cap_fraction": constants.TOOL_ROUND_CAP_FRACTION_MAX}
+    )
+    assert ols_max.tool_round_cap_fraction == constants.TOOL_ROUND_CAP_FRACTION_MAX
+
+    with pytest.raises(InvalidConfigurationError, match="tool_round_cap_fraction"):
+        OLSConfig({**base, "tool_round_cap_fraction": 0.29})
+
+    with pytest.raises(InvalidConfigurationError, match="tool_round_cap_fraction"):
+        OLSConfig({**base, "tool_round_cap_fraction": 0.81})
 
 
 def test_ols_config_with_custom_max_iterations():
@@ -2517,6 +2623,10 @@ def test_config():
     assert config.ols_config.authentication_config.module is not None
     assert config.ols_config.authentication_config.module == "foo"
     assert config.ols_config.expire_llm_is_ready_persistent_state == 2
+
+    for provider in config.llm_providers.providers.values():
+        for model in provider.models.values():
+            assert model.max_tokens_for_tools == 0
 
 
 def test_config_equality():
@@ -3966,7 +4076,8 @@ def test_proxy_config_default_values():
         os_proxy = os.getenv("HTTPS_PROXY")
     assert proxy_config.proxy_url == os_proxy
     assert proxy_config.proxy_ca_cert_path is None
-    assert proxy_config.no_proxy_hosts == []
+    expected_no_proxy = [h for h in os.getenv("no_proxy", "").split(",") if h]
+    assert proxy_config.no_proxy_hosts == expected_no_proxy
 
 
 def test_proxy_config_correct_values():

--- a/tests/unit/query_helpers/test_docs_summarizer.py
+++ b/tests/unit/query_helpers/test_docs_summarizer.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 from typing import ClassVar
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
@@ -17,6 +17,7 @@ from ols.app.models.models import StreamChunkType, StreamedChunk
 from ols.constants import (
     DEFAULT_MAX_ITERATIONS,
     DEFAULT_MAX_ITERATIONS_TROUBLESHOOTING,
+    DEFAULT_TOOL_ROUND_CAP_FRACTION,
     QueryMode,
 )
 
@@ -28,12 +29,16 @@ from ols.src.query_helpers.docs_summarizer import (  # noqa: E402
     DocsSummarizer,
     QueryHelper,
     RoundLLMResult,
-    ToolTokenUsage,
 )
 from ols.src.tools.tools import ApprovalRequiredEvent, ToolResultEvent  # noqa: E402
 from ols.utils.logging_configurator import configure_logging  # noqa: E402
 from ols.utils.mcp_utils import build_mcp_config, gather_mcp_tools  # noqa: E402
-from ols.utils.token_handler import TokenHandler  # noqa: E402
+from ols.utils.token_handler import (  # noqa: E402
+    PromptTooLongError,
+    TokenBudgetTracker,
+    TokenCategory,
+    TokenHandler,
+)
 from tests import constants  # noqa: E402
 from tests.mock_classes.mock_langchain_interface import (  # noqa: E402
     mock_langchain_interface,
@@ -406,7 +411,8 @@ def test_tool_calling_tool_execution(caplog):
         ),
         patch("ols.utils.mcp_utils.MultiServerMCPClient") as mock_mcp_client_cls,
         patch(
-            "ols.src.query_helpers.docs_summarizer.TokenHandler.calculate_and_check_available_tokens",
+            "ols.src.query_helpers.docs_summarizer.TokenBudgetTracker.tools_round_budget",
+            new_callable=PropertyMock,
             return_value=1000,
         ),
         patch(
@@ -445,6 +451,28 @@ def test_tool_calling_tool_execution(caplog):
         assert "get_namespaces_mock" in caplog.text
         assert "invalid_function_name" in caplog.text
         assert mock_invoke.call_count == 2
+
+
+def test_build_final_prompt_raises_when_tool_definitions_exceed_prompt_budget() -> None:
+    """Tool definitions token estimate is validated with the final prompt budget."""
+    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+    summarizer._tracker = TokenBudgetTracker(
+        token_handler=TokenHandler(),
+        context_window_size=1000,
+        max_response_tokens=100,
+        max_tool_tokens=200,
+        round_cap_fraction=0.6,
+    )
+    summarizer._tracker.set_tool_loop_max_rounds(5)
+    summarizer._tracker.charge(TokenCategory.PROMPT, 650)
+    with pytest.raises(PromptTooLongError, match="Tool definitions"):
+        summarizer._build_final_prompt(
+            query="q",
+            history=[],
+            rag_chunks=[],
+            skill_content=None,
+            tool_definitions_tokens=100,
+        )
 
 
 def test_tool_output_token_tracking_uses_buffer_weight(caplog):
@@ -637,7 +665,13 @@ async def test_collect_round_llm_chunks_targeted_paths():
 async def test_process_tool_calls_for_round_streams_approval_and_result():
     """Test _process_tool_calls_for_round streams approval + tool_result and updates state."""
     summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    token_usage = ToolTokenUsage(used=0)
+    summarizer._tracker = TokenBudgetTracker(
+        token_handler=TokenHandler(),
+        context_window_size=summarizer.model_config.context_window_size,
+        max_response_tokens=summarizer.model_config.parameters.max_tokens_for_response,
+        max_tool_tokens=1000,
+        round_cap_fraction=DEFAULT_TOOL_ROUND_CAP_FRACTION,
+    )
     messages: list = []
 
     async def _fake_execute(*args, **kwargs):
@@ -680,9 +714,6 @@ async def test_process_tool_calls_for_round_streams_approval_and_result():
                 all_tools_dict={"get_namespaces_mock": mock_tools_map[0]},
                 duplicate_tool_names=set(),
                 messages=messages,
-                token_handler=TokenHandler(),
-                tool_token_usage=token_usage,
-                max_tokens_for_tools=1000,
             )
         ]
 
@@ -693,7 +724,7 @@ async def test_process_tool_calls_for_round_streams_approval_and_result():
     ]
     assert streamed[1].data["approval_id"] == "aid-1"
     assert streamed[2].data["type"] == "tool_result"
-    assert token_usage.used > 0
+    assert summarizer._tracker.usage(TokenCategory.TOOL_RESULT) > 0
     assert len(messages) == 2
 
 
@@ -846,7 +877,6 @@ def test_resolve_tool_call_definitions_none_args_normalized_to_empty_dict():
 async def test_process_tool_calls_for_round_skipped_only_without_execution():
     """Test skipped-only path emits tool_result without calling executor."""
     summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    token_usage = ToolTokenUsage(used=0)
     messages: list = []
     tool = mock_tools_map[0]
     tool_call_chunks = [
@@ -870,9 +900,6 @@ async def test_process_tool_calls_for_round_skipped_only_without_execution():
                 all_tools_dict={tool.name: tool},
                 duplicate_tool_names=set(),
                 messages=messages,
-                token_handler=TokenHandler(),
-                tool_token_usage=token_usage,
-                max_tokens_for_tools=1000,
             )
         ]
 
@@ -889,7 +916,13 @@ async def test_process_tool_calls_for_round_skipped_only_without_execution():
 async def test_process_tool_calls_for_round_ignores_unexpected_execution_event(caplog):
     """Test unexpected tool execution events are ignored with warning."""
     summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    token_usage = ToolTokenUsage(used=0)
+    summarizer._tracker = TokenBudgetTracker(
+        token_handler=TokenHandler(),
+        context_window_size=summarizer.model_config.context_window_size,
+        max_response_tokens=summarizer.model_config.parameters.max_tokens_for_response,
+        max_tool_tokens=1000,
+        round_cap_fraction=DEFAULT_TOOL_ROUND_CAP_FRACTION,
+    )
     messages: list = []
     caplog.set_level(logging.WARNING)
 
@@ -929,9 +962,6 @@ async def test_process_tool_calls_for_round_ignores_unexpected_execution_event(c
                 all_tools_dict={"get_namespaces_mock": mock_tools_map[0]},
                 duplicate_tool_names=set(),
                 messages=messages,
-                token_handler=TokenHandler(),
-                tool_token_usage=token_usage,
-                max_tokens_for_tools=1000,
             )
         ]
 
@@ -945,7 +975,7 @@ async def test_process_tool_calls_for_round_ignores_unexpected_execution_event(c
 def test_tool_result_chunk_for_message_preserves_metadata_and_logs_has_meta(caplog):
     """Test tool result chunk contains metadata enrichment and has_meta logging."""
     summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.DEBUG)
     tool = mock_tools_map[0]
     tool.metadata = {"mcp_server": "server-a", "_meta": {"app": "ui"}}
     message = ToolMessage(
@@ -959,7 +989,6 @@ def test_tool_result_chunk_for_message_preserves_metadata_and_logs_has_meta(capl
         tool_call_message=message,
         tool_name=tool.name,
         tool=tool,
-        token_handler=TokenHandler(),
         round_index=1,
     )
 
@@ -1243,129 +1272,3 @@ def test_create_response_ignores_reasoning_chunks():
         result = summarizer.create_response("q")
 
     assert result.response == "answer"
-
-
-@pytest.mark.asyncio
-async def test_process_tool_calls_round_budget_leaves_room_for_next_round():
-    """Verify round budget cap so one heavy round does not exhaust the global budget."""
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    tool = mock_tools_map[0]
-    all_tools_dict = {tool.name: tool}
-
-    max_tokens_for_tools = 2000
-    large_output = "word " * 3000
-
-    async def _fake_execute(*args, **kwargs):
-        yield ToolResultEvent(
-            data=ToolMessage(
-                content=large_output,
-                status="success",
-                tool_call_id="call_1",
-                additional_kwargs={"truncated": False},
-            )
-        )
-
-    tool_call_chunks = [
-        AIMessageChunk(
-            content="",
-            response_metadata={"finish_reason": "tool_calls"},
-            tool_calls=[{"name": tool.name, "args": {}, "id": "call_1"}],
-        )
-    ]
-
-    token_usage = ToolTokenUsage(used=0)
-    messages: list = []
-
-    with patch(
-        "ols.src.query_helpers.docs_summarizer.execute_tool_calls_stream",
-        side_effect=_fake_execute,
-    ):
-        _ = [
-            chunk
-            async for chunk in summarizer._process_tool_calls_for_round(
-                round_index=1,
-                tool_call_chunks=tool_call_chunks,
-                all_chunks=[],
-                all_tools_dict=all_tools_dict,
-                duplicate_tool_names=set(),
-                messages=messages,
-                token_handler=TokenHandler(),
-                tool_token_usage=token_usage,
-                max_tokens_for_tools=max_tokens_for_tools,
-            )
-        ]
-
-    used_after_round_1 = token_usage.used
-    remaining_after_round_1 = max_tokens_for_tools - used_after_round_1
-    assert remaining_after_round_1 > 0, (
-        f"Round 1 consumed the entire budget ({used_after_round_1}/{max_tokens_for_tools}), "
-        "leaving nothing for subsequent rounds"
-    )
-
-
-@pytest.mark.asyncio
-async def test_round_budget_decreases_progressively_with_round_index():
-    """Verify later rounds get a smaller share of the remaining budget."""
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    tool = mock_tools_map[0]
-    all_tools_dict = {tool.name: tool}
-
-    max_tokens_for_tools = 10000
-    large_output = "word " * 5000
-
-    tool_call_chunks = [
-        AIMessageChunk(
-            content="",
-            response_metadata={"finish_reason": "tool_calls"},
-            tool_calls=[{"name": tool.name, "args": {}, "id": "call_1"}],
-        )
-    ]
-
-    budgets_passed_to_execute: list[int] = []
-
-    def _make_capture_generator(large_output_text: str):
-        async def _capture_budget(tool_calls, tools_token_budget, **kwargs):
-            budgets_passed_to_execute.append(tools_token_budget)
-            yield ToolResultEvent(
-                data=ToolMessage(
-                    content=large_output_text,
-                    status="success",
-                    tool_call_id="call_1",
-                    additional_kwargs={"truncated": False},
-                )
-            )
-
-        return _capture_budget
-
-    token_usage = ToolTokenUsage(used=0)
-
-    for round_idx in (1, 2, 3):
-        messages: list = []
-        with patch(
-            "ols.src.query_helpers.docs_summarizer.execute_tool_calls_stream",
-            side_effect=_make_capture_generator(large_output),
-        ):
-            _ = [
-                chunk
-                async for chunk in summarizer._process_tool_calls_for_round(
-                    round_index=round_idx,
-                    tool_call_chunks=tool_call_chunks,
-                    all_chunks=[],
-                    all_tools_dict=all_tools_dict,
-                    duplicate_tool_names=set(),
-                    messages=messages,
-                    token_handler=TokenHandler(),
-                    tool_token_usage=token_usage,
-                    max_tokens_for_tools=max_tokens_for_tools,
-                )
-            ]
-
-    assert len(budgets_passed_to_execute) == 3
-    assert budgets_passed_to_execute[0] > budgets_passed_to_execute[1], (
-        f"Round 2 budget ({budgets_passed_to_execute[1]}) should be smaller "
-        f"than round 1 ({budgets_passed_to_execute[0]})"
-    )
-    assert budgets_passed_to_execute[1] > budgets_passed_to_execute[2], (
-        f"Round 3 budget ({budgets_passed_to_execute[2]}) should be smaller "
-        f"than round 2 ({budgets_passed_to_execute[1]})"
-    )

--- a/tests/unit/tools/test_tools.py
+++ b/tests/unit/tools/test_tools.py
@@ -1,6 +1,7 @@
 """Unit tests for tools module."""
 
 import asyncio
+import logging
 import time
 from typing import Any
 
@@ -19,6 +20,7 @@ from ols.src.tools.tools import (
     execute_tool_calls_stream,
     get_tool_by_name,
 )
+from ols.utils.token_handler import TokenHandler
 
 _LARGE_TOKEN_BUDGET = 100_000
 
@@ -137,6 +139,24 @@ class TupleOutputTool(StructuredTool):
             description=f"Tuple output tool {name}",
             func=lambda **kwargs: "unused",
             coroutine=_tuple_coro,
+            args_schema=FakeSchema,
+        )
+
+
+class NonDictStructuredContentTool(StructuredTool):
+    """Tool whose artifact reports structured_content that is not a dict."""
+
+    def __init__(self, name: str):
+        """Initialize mock tool."""
+
+        async def _coro(**kwargs: Any) -> tuple[Any, Any]:
+            return ("ok", {"structured_content": ["x"]})
+
+        super().__init__(
+            name=name,
+            description=f"Non-dict structured_content tool {name}",
+            func=lambda **kwargs: "unused",
+            coroutine=_coro,
             args_schema=FakeSchema,
         )
 
@@ -325,6 +345,31 @@ def test_extract_text_from_tool_output_empty_list() -> None:
     ) == ("", False)
 
 
+def test_extract_text_first_block_exceeds_budget_keeps_prefix(caplog):
+    """First list block alone exceeds char cap: prefix is kept, then truncation notice."""
+    caplog.set_level(logging.DEBUG)
+    huge = "x" * 10_000
+    text, truncated = _extract_text_from_tool_output(
+        [{"type": "text", "text": huge}], tools_token_budget=10
+    )
+    assert truncated is True
+    assert "first block exceeds char budget" in caplog.text
+    assert "pre-truncating first block" in caplog.text
+    max_chars = 10 * 4
+    assert text.endswith(tools_module._TRUNCATION_WARNING)
+    assert text.startswith("x" * max_chars)
+
+
+def test_extract_text_all_empty_text_blocks() -> None:
+    """All text blocks empty: no truncation, joined text is whitespace-only."""
+    text, truncated = _extract_text_from_tool_output(
+        [{"type": "text", "text": ""}, {"type": "text", "text": ""}],
+        tools_token_budget=100,
+    )
+    assert truncated is False
+    assert not text.strip()
+
+
 def test_extract_text_from_tool_output_string_truncation():
     """Test that a long string is truncated at the last newline boundary."""
     long_output = "line\n" * 5000
@@ -379,6 +424,20 @@ async def test_execute_tool_call_with_content_and_artifact_tuple() -> None:
     )
     assert status == "success"
     assert output == "tuple content"
+    assert was_truncated is False
+    assert structured_content is None
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_call_non_dict_structured_content_becomes_none() -> None:
+    """Non-dict structured_content in artifact is ignored."""
+    status, output, was_truncated, structured_content = await execute_tool_call(
+        NonDictStructuredContentTool(name="bad_struct"),
+        {},
+        _LARGE_TOKEN_BUDGET,
+    )
+    assert status == "success"
+    assert output == "ok"
     assert was_truncated is False
     assert structured_content is None
 
@@ -624,13 +683,13 @@ def _make_tool_message(content: str, tool_call_id: str = "id") -> ToolMessage:
 
 def test_enforce_tool_token_budget_empty_list():
     """Test that an empty list is returned unchanged."""
-    assert enforce_tool_token_budget([], 100) == []
+    assert enforce_tool_token_budget([], 100, TokenHandler()) == []
 
 
 def test_enforce_tool_token_budget_under_budget():
     """Test that small messages pass through without truncation."""
     msgs = [_make_tool_message("short reply", "c1")]
-    result = enforce_tool_token_budget(msgs, 10000)
+    result = enforce_tool_token_budget(msgs, 10000, TokenHandler())
     assert len(result) == 1
     assert result[0].content == "short reply"
     assert result[0].additional_kwargs["truncated"] is False
@@ -644,7 +703,7 @@ def test_enforce_tool_token_budget_truncates_longest():
         _make_tool_message(long_content, "c_long"),
         _make_tool_message(short_content, "c_short"),
     ]
-    result = enforce_tool_token_budget(msgs, 2500)
+    result = enforce_tool_token_budget(msgs, 2500, TokenHandler())
 
     assert result[0].additional_kwargs["truncated"] is True
     assert "[OUTPUT TRUNCATED" in result[0].content
@@ -662,7 +721,7 @@ def test_enforce_tool_token_budget_proportional_truncation():
         _make_tool_message(content_a, "c_a"),
         _make_tool_message(content_b, "c_b"),
     ]
-    result = enforce_tool_token_budget(msgs, 20)
+    result = enforce_tool_token_budget(msgs, 20, TokenHandler())
 
     assert result[0].additional_kwargs["truncated"] is True
     assert result[1].additional_kwargs["truncated"] is True
@@ -674,7 +733,7 @@ def test_enforce_tool_token_budget_preserves_metadata():
     """Test that tool_call_id and status are preserved after truncation."""
     msgs = [_make_tool_message("word " * 1000, "my_call_id")]
     msgs[0].status = "success"
-    result = enforce_tool_token_budget(msgs, 20)
+    result = enforce_tool_token_budget(msgs, 20, TokenHandler())
 
     assert result[0].tool_call_id == "my_call_id"
     assert result[0].status == "success"

--- a/tests/unit/utils/test_token_handler.py
+++ b/tests/unit/utils/test_token_handler.py
@@ -6,8 +6,13 @@ from unittest import TestCase, mock
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 
-from ols.constants import TOKEN_BUFFER_WEIGHT
-from ols.utils.token_handler import PromptTooLongError, TokenHandler
+from ols.constants import DEFAULT_TOOL_ROUND_CAP_FRACTION, TOKEN_BUFFER_WEIGHT
+from ols.utils.token_handler import (
+    PromptTooLongError,
+    TokenBudgetTracker,
+    TokenCategory,
+    TokenHandler,
+)
 from tests.mock_classes.mock_retrieved_node import MockRetrievedNode
 
 
@@ -115,13 +120,10 @@ class TestTokenHandler(TestCase):
     def test_token_handler(self):
         """Test token handler for context."""
         retrieved_nodes = self._mock_retrieved_obj[:3]
-        rag_chunks, available_tokens = self._token_handler_obj.truncate_rag_context(
-            retrieved_nodes
-        )
+        rag_chunks = self._token_handler_obj.truncate_rag_context(retrieved_nodes)
 
         assert len(rag_chunks) == 3
         for i in range(3):
-            # New-line character is considered during calculation.
             assert (
                 rag_chunks[i].text
                 == "Document:\n" + self._mock_retrieved_obj[i].get_text()
@@ -130,7 +132,6 @@ class TestTokenHandler(TestCase):
                 rag_chunks[i].doc_url
                 == self._mock_retrieved_obj[i].metadata["docs_url"]
             )
-        assert available_tokens == 473
 
     @mock.patch("ols.utils.token_handler.TOKEN_BUFFER_WEIGHT", 1.05)
     @mock.patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 3)
@@ -138,14 +139,11 @@ class TestTokenHandler(TestCase):
     def test_token_handler_score(self):
         """Test token handler for context when score is higher than threshold."""
         retrieved_nodes = self._mock_retrieved_obj[:3]
-        rag_chunks, available_tokens = self._token_handler_obj.truncate_rag_context(
-            retrieved_nodes
-        )
+        rag_chunks = self._token_handler_obj.truncate_rag_context(retrieved_nodes)
         assert len(rag_chunks) == 1
         assert (
             rag_chunks[0].text == "Document:\n" + self._mock_retrieved_obj[0].get_text()
         )
-        assert available_tokens == 491
 
     @mock.patch("ols.utils.token_handler.TOKEN_BUFFER_WEIGHT", 1.05)
     @mock.patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 4)
@@ -155,7 +153,7 @@ class TestTokenHandler(TestCase):
         # Calculation for each chunk:
         # `Document:\n` -> 3 tokens for format, Actual text -> 5, new-line -> 1, total -> 9
 
-        rag_chunks, available_tokens = self._token_handler_obj.truncate_rag_context(
+        rag_chunks = self._token_handler_obj.truncate_rag_context(
             self._mock_retrieved_obj, 13
         )
         assert len(rag_chunks) == 2
@@ -163,26 +161,21 @@ class TestTokenHandler(TestCase):
             rag_chunks[1].text
             == "Document:\n" + self._mock_retrieved_obj[1].get_text()[:6]
         )
-        assert available_tokens == 0
 
     @mock.patch("ols.utils.token_handler.TOKEN_BUFFER_WEIGHT", 1.05)
     @mock.patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
     @mock.patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 3)
     def test_token_handler_token_minimum(self):
         """Test token handler when token count reached minimum threshold."""
-        rag_chunks, available_tokens = self._token_handler_obj.truncate_rag_context(
+        rag_chunks = self._token_handler_obj.truncate_rag_context(
             self._mock_retrieved_obj, 10
         )
         assert len(rag_chunks) == 1
-        assert available_tokens == 1
 
     def test_token_handler_empty(self):
         """Test token handler when node is empty."""
-        rag_chunks, available_tokens = self._token_handler_obj.truncate_rag_context(
-            [], 5
-        )
+        rag_chunks = self._token_handler_obj.truncate_rag_context([], 5)
         assert rag_chunks == []
-        assert available_tokens == 5
 
     def test_limit_conversation_history_when_no_history_exists(self):
         """Check the behaviour of limiting conversation history if it does not exists."""
@@ -324,3 +317,209 @@ class TestTokenHandler(TestCase):
                 max_tokens_for_response,
                 max_tokens_for_tools,
             )
+
+
+class TestTokenBudgetTracker(TestCase):
+    """Tests for TokenBudgetTracker budget properties."""
+
+    def test_prompt_budget_matches_window_minus_reservations(self):
+        """prompt_budget is context minus response and tool reservations."""
+        tracker = TokenBudgetTracker(
+            token_handler=TokenHandler(),
+            context_window_size=1000,
+            max_response_tokens=100,
+            max_tool_tokens=200,
+            round_cap_fraction=DEFAULT_TOOL_ROUND_CAP_FRACTION,
+        )
+        assert tracker.prompt_budget == 700
+
+    def test_prompt_budget_remaining_reflects_charges(self):
+        """prompt_budget_remaining decreases when categories accrue usage."""
+        tracker = TokenBudgetTracker(
+            token_handler=TokenHandler(),
+            context_window_size=1000,
+            max_response_tokens=100,
+            max_tool_tokens=200,
+            round_cap_fraction=DEFAULT_TOOL_ROUND_CAP_FRACTION,
+        )
+        assert tracker.prompt_budget_remaining == 700
+        tracker.charge(TokenCategory.PROMPT, 150)
+        assert tracker.prompt_budget_remaining == 550
+        tracker.charge(TokenCategory.HISTORY, 50)
+        assert tracker.prompt_budget_remaining == 500
+
+    def test_remaining_initial_and_relation_to_prompt_budget(self):
+        """Remaining is window minus response reservation minus all category usage."""
+        tracker = TokenBudgetTracker(
+            token_handler=TokenHandler(),
+            context_window_size=1000,
+            max_response_tokens=100,
+            max_tool_tokens=200,
+            round_cap_fraction=DEFAULT_TOOL_ROUND_CAP_FRACTION,
+        )
+        assert tracker.remaining == 900
+        assert tracker.prompt_budget_remaining == 700
+        assert (
+            tracker.remaining
+            == tracker.prompt_budget_remaining + tracker.max_tool_tokens
+        )
+
+    def test_remaining_decreases_with_prompt_and_tool_charges(self):
+        """Any category charge lowers remaining by the same amount."""
+        tracker = TokenBudgetTracker(
+            token_handler=TokenHandler(),
+            context_window_size=1000,
+            max_response_tokens=100,
+            max_tool_tokens=200,
+            round_cap_fraction=DEFAULT_TOOL_ROUND_CAP_FRACTION,
+        )
+        assert tracker.remaining == 900
+        tracker.charge(TokenCategory.PROMPT, 120)
+        assert tracker.remaining == 780
+        assert tracker.total_used == 120
+        tracker.charge(TokenCategory.TOOL_RESULT, 40)
+        assert tracker.remaining == 740
+        assert tracker.total_used == 160
+
+    def test_tool_budget_used_sums_only_tool_pool_categories(self):
+        """tool_budget_used includes AI round and tool results, not definitions."""
+        tracker = TokenBudgetTracker(
+            token_handler=TokenHandler(),
+            context_window_size=1000,
+            max_response_tokens=100,
+            max_tool_tokens=200,
+            round_cap_fraction=DEFAULT_TOOL_ROUND_CAP_FRACTION,
+        )
+        tracker.charge(TokenCategory.TOOL_DEFINITIONS, 11)
+        tracker.charge(TokenCategory.AI_ROUND, 22)
+        tracker.charge(TokenCategory.TOOL_RESULT, 33)
+        assert tracker.tool_budget_used == 55
+        tracker.charge(TokenCategory.PROMPT, 400)
+        tracker.charge(TokenCategory.HISTORY, 50)
+        assert tracker.tool_budget_used == 55
+
+    def test_tool_budget_remaining_clamps_at_zero(self):
+        """tool_budget_remaining does not go negative when over the tool cap."""
+        tracker = TokenBudgetTracker(
+            token_handler=TokenHandler(),
+            context_window_size=1000,
+            max_response_tokens=100,
+            max_tool_tokens=80,
+            round_cap_fraction=DEFAULT_TOOL_ROUND_CAP_FRACTION,
+        )
+        tracker.charge(TokenCategory.TOOL_RESULT, 150)
+        assert tracker.tool_budget_used == 150
+        assert tracker.tool_budget_remaining == 0
+
+    def test_tools_round_budget_scales_with_remaining_and_fraction(self):
+        """tools_round_budget is int(fraction * tool_budget_remaining)."""
+        tracker = TokenBudgetTracker(
+            token_handler=TokenHandler(),
+            context_window_size=1000,
+            max_response_tokens=100,
+            max_tool_tokens=100,
+            round_cap_fraction=0.5,
+        )
+        assert tracker.tool_budget_remaining == 100
+        assert tracker.tools_round_budget == 50
+        tracker.charge(TokenCategory.TOOL_RESULT, 60)
+        assert tracker.tool_budget_remaining == 40
+        assert tracker.tools_round_budget == 20
+
+    def test_tools_round_budget_truncates_with_int(self):
+        """Fractional product uses int truncation toward zero."""
+        tracker = TokenBudgetTracker(
+            token_handler=TokenHandler(),
+            context_window_size=1000,
+            max_response_tokens=100,
+            max_tool_tokens=100,
+            round_cap_fraction=0.6,
+        )
+        tracker.charge(TokenCategory.TOOL_RESULT, 33)
+        assert tracker.tool_budget_remaining == 67
+        assert tracker.tools_round_budget == int(67 * 0.6)
+
+    def test_tools_round_execution_budget_zero_when_tool_pool_exhausted(self):
+        """tools_round_execution_budget is 0 when nothing remains in the tool slice."""
+        tracker = TokenBudgetTracker(
+            token_handler=TokenHandler(),
+            context_window_size=1000,
+            max_response_tokens=100,
+            max_tool_tokens=50,
+            round_cap_fraction=0.6,
+        )
+        tracker.charge(TokenCategory.TOOL_RESULT, 50)
+        assert tracker.tools_round_execution_budget(5) == 0
+
+    def test_tools_round_execution_budget_equal_share_tightens_long_horizon(self):
+        """Long horizon makes equal-share smaller than fraction cap."""
+        tracker = TokenBudgetTracker(
+            token_handler=TokenHandler(),
+            context_window_size=10_000,
+            max_response_tokens=100,
+            max_tool_tokens=10_000,
+            round_cap_fraction=0.6,
+        )
+        assert tracker.tool_budget_remaining == 10_000
+        assert tracker.tools_round_execution_budget(19) == min(
+            int(10_000 * 0.6),
+            10_000 // 19,
+        )
+
+    def test_tools_round_execution_budget_fraction_cap_when_horizon_is_one(self):
+        """Single-round horizon leaves fraction cap as the tighter bound."""
+        tracker = TokenBudgetTracker(
+            token_handler=TokenHandler(),
+            context_window_size=1000,
+            max_response_tokens=100,
+            max_tool_tokens=500,
+            round_cap_fraction=0.6,
+        )
+        assert tracker.tools_round_execution_budget(1) == int(500 * 0.6)
+
+    def test_tools_round_execution_budget_non_positive_horizon_treated_as_one(self):
+        """tool_rounds_left below 1 uses horizon 1 (same as fraction-only for full R)."""
+        tracker = TokenBudgetTracker(
+            token_handler=TokenHandler(),
+            context_window_size=1000,
+            max_response_tokens=100,
+            max_tool_tokens=200,
+            round_cap_fraction=0.5,
+        )
+        assert tracker.tools_round_execution_budget(
+            0
+        ) == tracker.tools_round_execution_budget(1)
+        assert tracker.tools_round_execution_budget(-3) == 100
+
+    def test_summary_includes_tools_exec_budget_after_set_tool_loop_max_rounds(self):
+        """Summary appends tools_exec_budget when set_tool_loop_max_rounds was called."""
+        tracker = TokenBudgetTracker(
+            token_handler=TokenHandler(),
+            context_window_size=10_000,
+            max_response_tokens=100,
+            max_tool_tokens=10_000,
+            round_cap_fraction=0.6,
+        )
+        tracker.charge(TokenCategory.TOOL_DEFINITIONS, 500)
+        tracker.set_tool_loop_max_rounds(20)
+        round_index = 3
+        horizon = 20 - round_index
+        expected = tracker.tools_round_execution_budget(horizon)
+        text = tracker.summary(round_index)
+        assert f"tools_exec_budget={expected}" in text
+        assert f"tool_rounds_left={horizon}" in text
+        assert tracker.last_tools_exec_budget == expected
+        assert tracker.last_tool_rounds_left == horizon
+
+    def test_summary_omits_exec_budget_without_set_tool_loop_max_rounds(self):
+        """Summary does not mention tools_exec_budget until max rounds is registered."""
+        tracker = TokenBudgetTracker(
+            token_handler=TokenHandler(),
+            context_window_size=1000,
+            max_response_tokens=100,
+            max_tool_tokens=200,
+            round_cap_fraction=DEFAULT_TOOL_ROUND_CAP_FRACTION,
+        )
+        assert "tools_exec_budget" not in tracker.summary(1)
+        assert tracker.last_tools_exec_budget is None
+        assert tracker.last_tool_rounds_left is None


### PR DESCRIPTION
## Description

**Motivation**

The previous approach relied on a single available_tokens integer threaded through method calls, with no breakdown of what consumed the budget. Tool-calling rounds charged tokens via a mutable ToolTokenUsage dataclass passed between methods. AI messages emitted between rounds were not tracked at all. This made it impossible to diagnose context window exhaustion or reason about remaining budget.

**Summary**

Replace the ad-hoc token budget management scattered across DocsSummarizer with a centralized TokenBudgetTracker that tracks every token allocation by category (prompt, history, RAG, skill, tool definitions, AI rounds, tool results). This gives full visibility into where the context window is spent and prevents unaccounted token usage — notably AI messages between tool-calling rounds that were previously invisible.

**What changed**

- ols/utils/token_handler.py — Added TokenBudgetTracker class with per-category charging (TokenCategory enum), computed properties for prompt_budget, history_budget, tools_round_budget, and remaining, plus a summary() logging method. Moved format_retrieved_chunk here (was only used by TokenHandler). Simplified truncate_rag_context to return only the chunk list. Relocated calculate_and_check_available_tokens to the end of TokenHandler (unchanged logic).
- ols/src/query_helpers/docs_summarizer.py — DocsSummarizer now creates a TokenBudgetTracker in __init__ and charges tokens explicitly at each stage: PROMPT after initial prompt sizing, RAG after truncation, SKILL after loading, HISTORY after preparation. Skill resolution moved before history, so the history budget reflects skill overhead. Removed ToolTokenUsage dataclass and the token_handler/max_tokens_for_tools parameters threaded through _build_final_prompt and _process_tool_calls_for_round. Tool rounds charge AI_ROUND and TOOL_RESULT categories and log a per-round summary. DocsSummarizer drops from 1115 to 1087 lines.
- scripts/evaluation/utils/rag.py — Updated truncate_rag_context call to match new single-return signature.
- Tests — Updated unit and integration tests to patch TokenBudgetTracker properties instead of ToolTokenUsage, removed obsolete assertions on available_tokens returns, added new tests for tracker properties and budget computation.


## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
https://redhat.atlassian.net/browse/OLS-2875
- Closes #
https://redhat.atlassian.net/browse/OLS-2875

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
