### PR TITLE
feat: adding ols troubleshoot scenarios evals

### DIFF
--- a/eval/troubleshooting/Makefile
+++ b/eval/troubleshooting/Makefile
@@ -1,0 +1,51 @@
+# Usage:
+#   make all                        # Run all evals
+#   make envvar_missing             # Run a single eval by tag
+
+.PHONY: all envvar_missing batch_failure storage_binding \
+        namespace_pod_count scheduled_outage_detection periodic_failure_window \
+        config_drift_analysis readiness_probe_diagnosis \
+        ingress_rule_mismatch oom wrong_networkpolicy
+
+EVAL_CMD = API_KEY=$$(oc whoami -t) lightspeed-eval \
+           --system-config system.yaml \
+           --eval-data evals.yaml \
+           --output-dir results
+
+all: envvar_missing batch_failure storage_binding \
+     namespace_pod_count scheduled_outage_detection periodic_failure_window \
+     config_drift_analysis readiness_probe_diagnosis \
+     ingress_rule_mismatch oom wrong_networkpolicy
+
+envvar_missing:
+	$(EVAL_CMD) --tag envvar_missing
+
+batch_failure:
+	$(EVAL_CMD) --tag batch_failure
+
+storage_binding:
+	$(EVAL_CMD) --tag storage_binding
+
+namespace_pod_count:
+	$(EVAL_CMD) --tag namespace_pod_count
+
+scheduled_outage_detection:
+	$(EVAL_CMD) --tag scheduled_outage_detection
+
+periodic_failure_window:
+	$(EVAL_CMD) --tag periodic_failure_window
+
+config_drift_analysis:
+	$(EVAL_CMD) --tag config_drift_analysis
+
+readiness_probe_diagnosis:
+	$(EVAL_CMD) --tag readiness_probe_diagnosis
+
+ingress_rule_mismatch:
+	$(EVAL_CMD) --tag ingress_rule_mismatch
+
+oom:
+	$(EVAL_CMD) --tag oom
+
+wrong_networkpolicy:
+	$(EVAL_CMD) --tag wrong_networkpolicy

--- a/eval/troubleshooting/README.md
+++ b/eval/troubleshooting/README.md
@@ -1,0 +1,32 @@
+# OLS Troubleshoot Evals
+
+Evaluation scenarios for the OpenShift LightSpeed troubleshooting agent. Each scenario deploys a broken or misconfigured workload on a live cluster, asks the agent to diagnose the issue, and scores the response against an expected answer using LLM-based metrics.
+
+Scenarios require `oc` access to a running OpenShift cluster. Each one has a `setup.sh` (deploys the faulty resources), `verify.sh` (checks cluster state), and `cleanup.sh` (tears everything down).
+
+## Scenarios
+
+| Tag | Category | Description |
+|-----|----------|-------------|
+| `envvar_missing` | CrashLoop | Deployment crashes because the `DEPLOY_ENV` environment variable is undefined |
+| `batch_failure` | Job Failure | Job `inventory-sync-validator` repeatedly fails to connect to a database |
+| `storage_binding` | PVC Misconfiguration | Memcached pod stuck because its PersistentVolumeClaim cannot be provisioned |
+| `namespace_pod_count` | Namespace Matching | Count pods in `fleet-alpha` without accidentally including `fleet-alpha1` |
+| `scheduled_outage_detection` | Log Analysis | Detect a time-window outage in `report-generator` caused by an external API being unavailable |
+| `periodic_failure_window` | Log Analysis | Same as above but the agent must report the exact failure time window (03:00-03:05) |
+| `config_drift_analysis` | Log Analysis | Connection refused errors caused by a config reload that loaded staging settings in production |
+| `readiness_probe_diagnosis` | Pod Naming Ambiguity | Pod named `catalog-index-service` fails readiness probes; agent must not confuse it with a Kubernetes Service |
+| `ingress_rule_mismatch` | NetworkPolicy | `web-portal` times out reaching `api-gateway` because the NetworkPolicy only allows `tier=backend` ingress |
+| `oom` | OOMKill | Pod in CrashLoopBackOff due to a deliberate memory leak exceeding its 60Mi limit |
+| `wrong_networkpolicy` | NetworkPolicy (multi-turn) | Three-turn conversation: diagnose frontend-backend connectivity, identify the blocking NetworkPolicy, and propose a fix |
+
+## Running
+
+```bash
+# Single scenario
+make oom
+
+# All scenarios
+make all
+```
+

--- a/eval/troubleshooting/evals.yaml
+++ b/eval/troubleshooting/evals.yaml
@@ -1,0 +1,214 @@
+# --- envvar_missing: Crashloop detection ---
+- conversation_group_id: envvar_missing
+  tag: envvar_missing
+  description: "Crashloop detection - DEPLOY_ENV environment variable undefined"
+
+  turns:
+    - turn_id: envvar_missing
+      query: "What is the issue with order-fulfillment-daemon?"
+      expected_response: "The DEPLOY_ENV environment variable is undefined or missing"
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: scenarios/envvar_missing/setup.sh
+  cleanup_script: scenarios/envvar_missing/cleanup.sh
+
+# --- batch_failure: Job crash detection ---
+- conversation_group_id: batch_failure
+  tag: batch_failure
+  description: "Job crash detection - inventory-sync-validator cannot connect to database"
+
+  turns:
+    - turn_id: batch_failure
+      query: "What is the issue with job inventory-sync-validator in namespace catalog-mgmt"
+      expected_response: "The inventory-sync-validator job repeatedly fails to connect to the database at prod-db:3333"
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: scenarios/batch_failure/setup.sh
+  cleanup_script: scenarios/batch_failure/cleanup.sh
+
+# --- storage_binding: PVC misconfiguration detection ---
+- conversation_group_id: storage_binding
+  tag: storage_binding
+  description: "PVC misconfiguration detection - memcached PersistentVolumeClaim provisioning failure"
+
+  turns:
+    - turn_id: storage_binding
+      query: "What is the issue with memcached?"
+      expected_response: "The PersistentVolumeClaim (PVC) is misconfigured"
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: scenarios/storage_binding/setup.sh
+  cleanup_script: scenarios/storage_binding/cleanup.sh
+
+# --- namespace_pod_count: Exact namespace matching ---
+- conversation_group_id: namespace_pod_count
+  tag: namespace_pod_count
+  description: "Exact namespace matching - count pods in fleet-alpha without including fleet-alpha1"
+
+  turns:
+    - turn_id: namespace_pod_count
+      query: "How many pods are running in the fleet-alpha namespace?"
+      expected_response: "There are 6 pods running in the fleet-alpha namespace (not including pods from fleet-alpha1)"
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: scenarios/namespace_pod_count/setup.sh
+  cleanup_script: scenarios/namespace_pod_count/cleanup.sh
+
+# --- scheduled_outage_detection: Time window anomaly ---
+- conversation_group_id: scheduled_outage_detection
+  tag: scheduled_outage_detection
+  description: "Time window anomaly detection - report-generator API connection failures"
+
+  turns:
+    - turn_id: scheduled_outage
+      query: "The report-generator is processing historical records. Analyze the provided logs for the report-generator pod to identify any issues that occurred between 03:00 and 04:00"
+      expected_response: "Report generator pod experienced temporary issues between when it could not connect to an external API possibly due to a maintenance window"
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: scenarios/scheduled_outage_detection/setup.sh
+  cleanup_script: scenarios/scheduled_outage_detection/cleanup.sh
+
+# --- periodic_failure_window: Time window anomaly with time requirement ---
+- conversation_group_id: periodic_failure_window
+  tag: periodic_failure_window
+  description: "Time window anomaly detection - batch-processor with specific time window required"
+
+  turns:
+    - turn_id: periodic_failure
+      query: "The batch-processor is processing historical records. Some pod ERROR logs reported issues. Tell me when"
+      contexts:
+        - "Answer MUST include the time window of the issue (03:00-03:05)"
+      expected_response: "Batch processor pod reported issues between 03:00-03:05 when it could not connect to an external API possibly due to a maintenance window."
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: scenarios/periodic_failure_window/setup.sh
+  cleanup_script: scenarios/periodic_failure_window/cleanup.sh
+
+# --- config_drift_analysis: Log context analysis ---
+- conversation_group_id: config_drift_analysis
+  tag: config_drift_analysis
+  description: "Log context analysis - connection refused errors caused by config change"
+
+  turns:
+    - turn_id: config_drift
+      query: "What is causing connection refused errors in gateway-proxy in namespace ingress-layer?"
+      expected_response: "The first Connection refused errors started after a config reload that loaded staging database settings in production"
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: scenarios/config_drift_analysis/setup.sh
+  cleanup_script: scenarios/config_drift_analysis/cleanup.sh
+
+# --- readiness_probe_diagnosis: Pod naming ambiguity ---
+- conversation_group_id: readiness_probe_diagnosis
+  tag: readiness_probe_diagnosis
+  description: "Pod naming ambiguity - pod named catalog-index-service should not be confused with a Kubernetes Service"
+
+  turns:
+    - turn_id: readiness_probe
+      query: "What is the issue with catalog-index-service"
+      expected_response: "The catalog-index-service pod is not ready due to a failing readiness probe"
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: scenarios/readiness_probe_diagnosis/setup.sh
+  cleanup_script: scenarios/readiness_probe_diagnosis/cleanup.sh
+
+# --- ingress_rule_mismatch: Network policy diagnosis ---
+- conversation_group_id: ingress_rule_mismatch
+  tag: ingress_rule_mismatch
+  description: "Network policy diagnosis - web-portal timeouts due to misconfigured NetworkPolicy ingress rules"
+
+  turns:
+    - turn_id: ingress_rule
+      query: "Why is the web-portal getting timeouts connecting to api-gateway in namespace platform-core?"
+      expected_response: "Web-portal getting timeouts because NetworkPolicy on api-gateway only allows ingress from pods with tier backend label not frontend"
+      turn_metrics:
+        - custom:answer_correctness
+
+  setup_script: scenarios/ingress_rule_mismatch/setup.sh
+  cleanup_script: scenarios/ingress_rule_mismatch/cleanup.sh
+
+# --- oom: OOMKilled diagnosis ---
+- conversation_group_id: OOM
+  tag: oom
+
+  turns:
+    - turn_id: Investigate OOM
+      query: Why awesome-application is in CrashLoopBackOff?
+      contexts:
+        - "The awesome-application is in CrashLoopBackOff due to OOM kill"
+        - "The awesome-application is in out of memory due a memory leakage in the deployment command"
+        - "The responses should not include hints or suggestions to the user on what command to run and how. \
+          The preferred response, the ones that should get a better score, are the ones which points out an issue, and
+          possibly also a solution to address that"
+      expected_response: |
+        Root cause: the app container is being OOMKilled due to a deliberate memory leak in the pod command, while the container has a 60Mi memory limit.
+        Deployment awesome-application runs Python that appends ~1MB/sec forever.
+
+      turn_metrics:
+        - "custom:answer_correctness"
+  setup_script: scenarios/oom/setup.sh
+  cleanup_script: scenarios/oom/cleanup.sh
+
+  # --- networkpolicy: Network policy blocking frontend-backend traffic ---
+- conversation_group_id: Network Policy Issue
+  tag: wrong_networkpolicy
+
+  conversation_metrics:
+    - "geval:troubleshooting_continuity"
+    - "deepeval:conversation_completeness"
+    - "deepeval:conversation_relevancy"
+    - "deepeval:knowledge_retention"
+
+  turns:
+    - turn_id: Investigate the status of frontend application
+      query: What is the status of the frontend application
+      contexts:
+        - "Frontend pod logs show repeated 'ERROR: Connection timeout to backend-service!' and wget timeouts."
+        - "TCP checks to backend pod IP and backend service IP both time out"
+      expected_response: |
+        Frontend application is up and running, logs show errors about reaching the backend-service.
+      turn_metrics:
+        - "custom:answer_correctness"
+        - "geval:generic_troubleshooting_experience"
+
+    - turn_id: Why frontend is failing
+      query: Can you spot the root cause?
+      contexts:
+        - "backend-service Endpoints and EndpointSlice are correct and point to the backend pod."
+        - "backend pod is running and healthy, no errors in logs."
+        - "NetworkPolicy backend-network-policy only allows ingress to backend pods from other pods with label tier=backend, but frontend has tier=frontend."
+      expected_response: |
+        The backend-network-policy block ingress from pods with tier=frontend or app=frontend
+      turn_metrics:
+        - "custom:answer_correctness"
+        - "geval:generic_troubleshooting_experience"
+
+    - turn_id: Propose a fix for NetworkPolicy
+      query: "How can I modify the network policy to allow the frontend to communicate with the backend?"
+      contexts:
+        - "The current NetworkPolicy 'backend-network-policy' uses a podSelector with matchLabels: tier: backend."
+        - "The ingress rule currently only allows 'from' pods with label 'tier: backend'."
+        - "The frontend pods are confirmed to have the label 'tier: frontend'."
+      expected_response: |
+        You need to update the 'backend-network-policy' ingress rules.
+        Add a new item to the 'from' selector to include pods with the label 'tier: frontend'.
+        Example:
+        ingress:
+        - from:
+          - podSelector:
+              matchLabels:
+                tier: frontend
+      turn_metrics:
+        - "custom:answer_correctness"
+        - "geval:generic_troubleshooting_experience"
+
+  setup_script: scenarios/wrong_networkpolicy/setup.sh
+  cleanup_script: scenarios/wrong_networkpolicy/cleanup.sh

--- a/eval/troubleshooting/scenarios/batch_failure/cleanup.sh
+++ b/eval/troubleshooting/scenarios/batch_failure/cleanup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+oc delete namespace catalog-mgmt --ignore-not-found

--- a/eval/troubleshooting/scenarios/batch_failure/fixtures/generate_logs.py
+++ b/eval/troubleshooting/scenarios/batch_failure/fixtures/generate_logs.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Simulate an inventory sync process that fails to reach its database."""
+
+import logging
+import sys
+
+logging.basicConfig(
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+    level=logging.INFO,
+    stream=sys.stdout,
+)
+log = logging.getLogger("inventory-sync")
+
+DB_HOST = "prod-db"
+DB_PORT = 3333
+MAX_RETRIES = 4
+
+
+def try_connect(attempt):
+    """Simulate a single TCP connection attempt to the database."""
+    log.info(
+        "Opening TCP socket to %s:%d (attempt %d/%d)",
+        DB_HOST,
+        DB_PORT,
+        attempt,
+        MAX_RETRIES,
+    )
+    log.error("Socket connect returned errno 111 - connection refused")
+    print(f"Target host: {DB_HOST}, port: {DB_PORT}")
+    log.warning("Pool stats: waiting=32, active=0, idle=0")
+
+
+def main():
+    """Run the inventory-sync failure simulation."""
+    log.info("inventory-sync-validator starting up")
+    log.info("Reading database coordinates from environment")
+    log.info("Resolved endpoint %s:%d via service discovery", DB_HOST, DB_PORT)
+
+    for attempt in range(1, MAX_RETRIES + 1):
+        try_connect(attempt)
+        log.error("Retry %d of %d exhausted", attempt, MAX_RETRIES)
+
+    log.critical("All connection attempts failed after %d retries", MAX_RETRIES)
+    print("FATAL: Unable to connect to required database")
+    log.info("Cleaning up resources before exit")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/troubleshooting/scenarios/batch_failure/fixtures/job.yaml
+++ b/eval/troubleshooting/scenarios/batch_failure/fixtures/job.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: inventory-sync-validator
+  namespace: catalog-mgmt
+  labels:
+    app: inventory-sync-validator
+    component: batch
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        job-name: inventory-sync-validator
+    spec:
+      restartPolicy: Never
+      volumes:
+      - name: scripts
+        secret:
+          secretName: inventory-sync-logs-script
+          defaultMode: 0555
+      containers:
+      - name: sync-worker
+        image: python:3.11-alpine
+        command: ["python3", "/opt/scripts/generate_logs.py"]
+        volumeMounts:
+        - name: scripts
+          mountPath: /opt/scripts
+          readOnly: true
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "48Mi"
+          limits:
+            memory: "96Mi"

--- a/eval/troubleshooting/scenarios/batch_failure/setup.sh
+++ b/eval/troubleshooting/scenarios/batch_failure/setup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="catalog-mgmt"
+JOB="inventory-sync-validator"
+
+oc create namespace "$NS" 2>/dev/null || true
+
+oc create secret generic inventory-sync-logs-script \
+  --from-file=generate_logs.py="$FIXTURE_DIR/generate_logs.py" \
+  -n "$NS" --dry-run=client -o yaml | oc apply -f -
+oc apply -f "$FIXTURE_DIR/job.yaml"
+
+# Wait for the job pod to produce the expected log sentinels
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 20 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  LOGS=$(oc logs -l "job-name=$JOB" -n "$NS" --tail=100 2>/dev/null || true)
+  if echo "$LOGS" | grep -q "Target host: prod-db, port: 3333" \
+  && echo "$LOGS" | grep -q "FATAL: Unable to connect to required database"; then
+    echo "Both sentinels found (attempt $ATTEMPT)"
+    exit 0
+  fi
+  echo "attempt $ATTEMPT/20 — waiting 3s…"
+  sleep 3
+done
+
+echo "Sentinels not found within 60s"
+oc logs -l "job-name=$JOB" -n "$NS" --tail=30 2>/dev/null || true
+exit 1

--- a/eval/troubleshooting/scenarios/config_drift_analysis/cleanup.sh
+++ b/eval/troubleshooting/scenarios/config_drift_analysis/cleanup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="ingress-layer"
+
+oc delete deployment gateway-proxy -n "$NS" --ignore-not-found --wait=false
+oc delete secret gateway-proxy-log-script -n "$NS" --ignore-not-found
+oc delete namespace "$NS" --ignore-not-found

--- a/eval/troubleshooting/scenarios/config_drift_analysis/fixtures/generate_logs.py
+++ b/eval/troubleshooting/scenarios/config_drift_analysis/fixtures/generate_logs.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Simulate a gateway-proxy that reloads config and starts hitting wrong endpoints."""
+
+import time
+
+
+def emit(ts, level, msg):
+    """Print a structured log line for the gateway-proxy component."""
+    print(f"ts={ts} level={level} component=gateway-proxy msg={msg}")
+
+
+def main():
+    """Generate gateway-proxy logs showing config drift from prod to staging."""
+    # Healthy startup
+    emit("2026-01-15T10:00:00.000Z", "INFO", "gateway-proxy v3.1.0 booting")
+    emit("2026-01-15T10:00:00.150Z", "INFO", "resolved upstream db-prod.internal:5432")
+    emit(
+        "2026-01-15T10:00:00.300Z", "INFO", "resolved upstream redis-prod.internal:6379"
+    )
+    emit("2026-01-15T10:00:00.450Z", "INFO", "upstream health=OK for all backends")
+    emit(
+        "2026-01-15T10:00:01.200Z",
+        "INFO",
+        "listening on :8080, ready to accept traffic",
+    )
+
+    # Normal requests
+    for path, ms in [
+        ("/api/users/123", 45),
+        ("/api/orders", 89),
+        ("/api/products", 34),
+    ]:
+        emit(f"2026-01-15T10:01:{ms:02d}.000Z", "INFO", f"200 {path} ({ms}ms)")
+    emit("2026-01-15T10:01:15.000Z", "INFO", "periodic probe result=healthy")
+
+    # Root cause: config drift
+    print("2026-01-15T10:05:00.000Z [WARN] Configuration file change detected")
+    emit(
+        "2026-01-15T10:05:00.100Z",
+        "INFO",
+        "hot-reload triggered by inotify event on /config/app.yaml",
+    )
+    emit(
+        "2026-01-15T10:05:00.250Z",
+        "WARN",
+        "new upstream db-staging.internal:5432 differs from previous db-prod.internal:5432",
+    )
+    emit(
+        "2026-01-15T10:05:00.400Z",
+        "WARN",
+        "new upstream redis-staging.internal:6379 differs from previous redis-prod.internal:6379",
+    )
+    emit(
+        "2026-01-15T10:05:00.550Z",
+        "WARN",
+        "environment=PRODUCTION but config references staging hosts",
+    )
+    emit("2026-01-15T10:05:00.700Z", "INFO", "draining existing connection pools")
+    emit(
+        "2026-01-15T10:05:00.850Z",
+        "INFO",
+        "attempting to establish pools to new upstreams",
+    )
+
+    # Connection refused flood
+    emit(
+        "2026-01-15T10:05:01.000Z",
+        "ERROR",
+        "tcp dial db-staging.internal:5432 => connection refused",
+    )
+    emit(
+        "2026-01-15T10:05:01.100Z",
+        "ERROR",
+        "tcp dial redis-staging.internal:6379 => connection refused",
+    )
+    emit(
+        "2026-01-15T10:05:01.200Z",
+        "ERROR",
+        "no healthy upstreams, entering degraded mode",
+    )
+
+    for i in range(1, 51):
+        s = f"{i + 1:02d}"
+        emit(
+            f"2026-01-15T10:05:{s}.000Z",
+            "ERROR",
+            f"502 GET /api/users/{1000+i} upstream_err=connection_refused",
+        )
+        emit(
+            f"2026-01-15T10:05:{s}.150Z",
+            "ERROR",
+            "pool reconnect db-staging.internal:5432 => refused",
+        )
+        emit(
+            f"2026-01-15T10:05:{s}.300Z",
+            "ERROR",
+            "pool reconnect redis-staging.internal:6379 => refused",
+        )
+        emit(
+            f"2026-01-15T10:05:{s}.450Z",
+            "DEBUG",
+            "backoff wait before next reconnect attempt",
+        )
+        emit(
+            f"2026-01-15T10:05:{s}.500Z",
+            "ERROR",
+            "502 POST /api/orders upstream_err=connection_refused",
+        )
+
+    for i in range(1, 51):
+        s = f"{i:02d}"
+        emit(
+            f"2026-01-15T10:06:{s}.000Z",
+            "ERROR",
+            "upstream db-staging.internal:5432 still refusing",
+        )
+        emit(
+            f"2026-01-15T10:06:{s}.100Z",
+            "ERROR",
+            "502 GET /api/products upstream_err=connection_refused",
+        )
+        emit(
+            f"2026-01-15T10:06:{s}.200Z", "ERROR", "all queries routed to fallback=none"
+        )
+        emit(f"2026-01-15T10:06:{s}.300Z", "WARN", "circuit breaker OPEN for db pool")
+        emit(
+            f"2026-01-15T10:06:{s}.400Z",
+            "ERROR",
+            "probe result=unhealthy reason=no_upstream",
+        )
+
+    emit("2026-01-15T10:07:00.000Z", "CRIT", "gateway degraded for 120s, paging oncall")
+    emit(
+        "2026-01-15T10:07:00.200Z",
+        "INFO",
+        "active config dump: db=db-staging.internal cache=redis-staging.internal env=PRODUCTION",
+    )
+    emit(
+        "2026-01-15T10:07:00.500Z",
+        "ERROR",
+        "staging network unreachable from production VPC",
+    )
+
+    for i in range(1, 31):
+        s = f"{i:02d}"
+        emit(
+            f"2026-01-15T10:07:{s}.000Z",
+            "ERROR",
+            "upstream db-staging.internal:5432 connection_refused",
+        )
+        emit(
+            f"2026-01-15T10:07:{s}.100Z",
+            "ERROR",
+            "upstream redis-staging.internal:6379 connection_refused",
+        )
+        print(
+            f"2026-01-15T10:07:{s}.200Z [HTTP] 500 GET /api/health - Connection refused"
+        )
+
+    # Keep pod running
+    while True:
+        time.sleep(30)
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/troubleshooting/scenarios/config_drift_analysis/fixtures/manifest.yaml
+++ b/eval/troubleshooting/scenarios/config_drift_analysis/fixtures/manifest.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway-proxy
+  namespace: ingress-layer
+  labels:
+    app: gateway-proxy
+    component: ingress
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gateway-proxy
+  template:
+    metadata:
+      labels:
+        app: gateway-proxy
+        component: ingress
+    spec:
+      containers:
+      - name: log-emitter
+        image: python:3.11-alpine
+        command: ["python3", "-u", "/opt/scripts/generate_logs.py"]
+        volumeMounts:
+        - name: scripts
+          mountPath: /opt/scripts
+          readOnly: true
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "48Mi"
+          limits:
+            memory: "96Mi"
+      volumes:
+      - name: scripts
+        secret:
+          secretName: gateway-proxy-log-script
+          defaultMode: 0555

--- a/eval/troubleshooting/scenarios/config_drift_analysis/setup.sh
+++ b/eval/troubleshooting/scenarios/config_drift_analysis/setup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="ingress-layer"
+APP="gateway-proxy"
+
+oc create namespace "$NS" 2>/dev/null || true
+
+# Inject the Python log generator as a secret, then apply the deployment
+oc create secret generic gateway-proxy-log-script \
+  --from-file=generate_logs.py="$FIXTURE_DIR/generate_logs.py" \
+  -n "$NS" --dry-run=client -o yaml | oc apply -f -
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+# Wait until the pod is ready and both sentinel log lines are present
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 40 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  if oc wait --for=condition=ready pod -l "app=$APP" -n "$NS" --timeout=2s 2>/dev/null; then
+    LOGS=$(oc logs -l "app=$APP" -n "$NS" --tail=10000 2>/dev/null || true)
+    if echo "$LOGS" | grep -q "Configuration file change detected" \
+    && echo "$LOGS" | grep -q '500 GET /api/health - Connection refused'; then
+      echo "Log sentinels found after $ATTEMPT checks"
+      exit 0
+    fi
+  fi
+  echo "check $ATTEMPT/40 — waiting 3s…"
+  sleep 3
+done
+
+echo "Sentinels not found within timeout"
+oc logs -l "app=$APP" -n "$NS" --tail=30 2>/dev/null || true
+exit 1

--- a/eval/troubleshooting/scenarios/envvar_missing/cleanup.sh
+++ b/eval/troubleshooting/scenarios/envvar_missing/cleanup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+oc delete -f "$(cd "$(dirname "$0")/fixtures" && pwd)/deployment.yaml" --ignore-not-found --wait=false
+oc delete namespace warehouse-ops --ignore-not-found

--- a/eval/troubleshooting/scenarios/envvar_missing/fixtures/deployment.yaml
+++ b/eval/troubleshooting/scenarios/envvar_missing/fixtures/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: warehouse-ops
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: order-fulfillment-daemon
+  namespace: warehouse-ops
+  labels:
+    app: order-fulfillment-daemon
+    component: fulfillment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: order-fulfillment-daemon
+  template:
+    metadata:
+      labels:
+        app: order-fulfillment-daemon
+    spec:
+      containers:
+      - name: fulfillment-container
+        image: busybox:1.36
+        command: ["/bin/sh"]
+        args:
+        - -c
+        - |
+          if [ -z "${DEPLOY_ENV}" ]; then
+            echo "Environment variable DEPLOY_ENV is undefined"
+            exit 1
+          fi
+          while true; do echo hello; sleep 10; done
+        resources:
+          requests:
+            cpu: "5m"
+            memory: "32Mi"

--- a/eval/troubleshooting/scenarios/envvar_missing/setup.sh
+++ b/eval/troubleshooting/scenarios/envvar_missing/setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="warehouse-ops"
+APP="order-fulfillment-daemon"
+
+oc apply -f "$FIXTURE_DIR/deployment.yaml"
+
+# Wait for the pod to appear
+echo "Waiting for $APP pod to be created…"
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 60 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  POD=$(oc get pods -n "$NS" -l "app=$APP" -o name 2>/dev/null | head -1)
+  [ -n "$POD" ] && break
+  sleep 5
+done
+[ -n "${POD:-}" ] || { echo "$APP pod never appeared"; oc get pods -n "$NS"; exit 1; }
+
+# Wait for CrashLoopBackOff
+echo "Pod exists — waiting for CrashLoopBackOff…"
+oc wait --for=jsonpath='{.status.containerStatuses[0].state.waiting.reason}'=CrashLoopBackOff \
+  pod -l "app=$APP" -n "$NS" --timeout=300s

--- a/eval/troubleshooting/scenarios/ingress_rule_mismatch/cleanup.sh
+++ b/eval/troubleshooting/scenarios/ingress_rule_mismatch/cleanup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="platform-core"
+oc delete deployment web-portal -n "$NS" --ignore-not-found
+oc delete deployment api-gateway -n "$NS" --ignore-not-found
+oc delete svc api-gateway-svc -n "$NS" --ignore-not-found
+oc delete networkpolicy restrict-api-gateway-ingress -n "$NS" --ignore-not-found
+oc delete namespace "$NS" --ignore-not-found

--- a/eval/troubleshooting/scenarios/ingress_rule_mismatch/fixtures/api-gateway.yaml
+++ b/eval/troubleshooting/scenarios/ingress_rule_mismatch/fixtures/api-gateway.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: platform-core
+  labels:
+    purpose: eval-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+  namespace: platform-core
+  labels:
+    app: api-gateway
+    tier: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-gateway
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+        tier: backend
+    spec:
+      containers:
+      - name: http-backend
+        image: nginxinc/nginx-unprivileged:alpine
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: "15m"
+            memory: "48Mi"
+          limits:
+            cpu: "100m"
+            memory: "96Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-gateway-svc
+  namespace: platform-core
+spec:
+  selector:
+    app: api-gateway
+  ports:
+  - port: 8080
+    targetPort: 8080
+    name: http
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: restrict-api-gateway-ingress
+  namespace: platform-core
+spec:
+  podSelector:
+    matchLabels:
+      app: api-gateway
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          tier: backend
+    ports:
+    - protocol: TCP
+      port: 8080

--- a/eval/troubleshooting/scenarios/ingress_rule_mismatch/fixtures/web-portal.yaml
+++ b/eval/troubleshooting/scenarios/ingress_rule_mismatch/fixtures/web-portal.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-portal
+  namespace: platform-core
+  labels:
+    app: web-portal
+    tier: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-portal
+  template:
+    metadata:
+      labels:
+        app: web-portal
+        tier: frontend
+    spec:
+      containers:
+      - name: portal
+        image: alpine:3.19
+        command: ["sh"]
+        args:
+        - -c
+        - |
+          apk add --no-cache curl >/dev/null 2>&1
+          while true; do
+            echo "[portal] probing api-gateway-svc on port 8080…"
+            if curl -sf --connect-timeout 5 http://api-gateway-svc:8080/ >/dev/null 2>&1; then
+              echo "[portal] api-gateway-svc responded OK"
+            else
+              echo "ERROR: Connection timeout to api-gateway-svc!"
+            fi
+            sleep 10
+          done
+        resources:
+          requests:
+            cpu: "5m"
+            memory: "32Mi"
+          limits:
+            memory: "48Mi"

--- a/eval/troubleshooting/scenarios/ingress_rule_mismatch/setup.sh
+++ b/eval/troubleshooting/scenarios/ingress_rule_mismatch/setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="platform-core"
+
+# Deploy api-gateway (backend + netpol) and wait for it
+oc apply -f "$FIXTURE_DIR/api-gateway.yaml"
+oc wait --for=condition=available deployment/api-gateway -n "$NS" --timeout=60s
+
+# Now deploy the web-portal (frontend) that will be blocked by the NetworkPolicy
+oc apply -f "$FIXTURE_DIR/web-portal.yaml"
+
+# Wait for the connection-timeout log line from the web-portal
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 30 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  if oc logs -l app=web-portal -n "$NS" --tail=20 2>/dev/null \
+     | grep -q "ERROR: Connection timeout to api-gateway-svc!"; then
+    echo "Timeout error detected (attempt $ATTEMPT)"
+    exit 0
+  fi
+  echo "attempt $ATTEMPT/30 — waiting 2s…"
+  sleep 2
+done
+
+echo "Connection timeout error not found within 60s"
+oc get pods -n "$NS"
+oc logs -l app=web-portal -n "$NS" --tail=10 2>/dev/null || true
+exit 1

--- a/eval/troubleshooting/scenarios/namespace_pod_count/cleanup.sh
+++ b/eval/troubleshooting/scenarios/namespace_pod_count/cleanup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+
+oc delete -f "$FIXTURE_DIR/manifests.yaml" --ignore-not-found
+oc delete namespace fleet-alpha fleet-alpha1 --ignore-not-found

--- a/eval/troubleshooting/scenarios/namespace_pod_count/fixtures/manifests.yaml
+++ b/eval/troubleshooting/scenarios/namespace_pod_count/fixtures/manifests.yaml
@@ -1,0 +1,268 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fleet-alpha
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fleet-alpha1
+---
+# --- fleet-alpha: 6 workloads (mix of Pods and Deployments) ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dispatcher-north
+  namespace: fleet-alpha
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: dispatcher-north
+  template:
+    metadata:
+      labels:
+        unit: dispatcher-north
+    spec:
+      containers:
+        - name: runner
+          image: nginxinc/nginx-unprivileged:alpine
+          resources:
+            requests:
+              cpu: "5m"
+              memory: "16Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dispatcher-south
+  namespace: fleet-alpha
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: dispatcher-south
+  template:
+    metadata:
+      labels:
+        unit: dispatcher-south
+    spec:
+      containers:
+        - name: runner
+          image: nginxinc/nginx-unprivileged:alpine
+          resources:
+            requests:
+              cpu: "5m"
+              memory: "16Mi"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tracker-primary
+  namespace: fleet-alpha
+spec:
+  containers:
+    - name: nginx
+      image: nginxinc/nginx-unprivileged:alpine
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tracker-secondary
+  namespace: fleet-alpha
+spec:
+  containers:
+    - name: nginx
+      image: nginxinc/nginx-unprivileged:alpine
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: scheduler-main
+  namespace: fleet-alpha
+spec:
+  containers:
+    - name: nginx
+      image: nginxinc/nginx-unprivileged:alpine
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: logger-central
+  namespace: fleet-alpha
+spec:
+  containers:
+    - name: nginx
+      image: nginxinc/nginx-unprivileged:alpine
+---
+# --- fleet-alpha1: 9 workloads (Deployments only) ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingestion-node
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: ingestion-node
+  template:
+    metadata:
+      labels:
+        unit: ingestion-node
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: transform-node
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: transform-node
+  template:
+    metadata:
+      labels:
+        unit: transform-node
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: output-node
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: output-node
+  template:
+    metadata:
+      labels:
+        unit: output-node
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: validator-east
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: validator-east
+  template:
+    metadata:
+      labels:
+        unit: validator-east
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: validator-west
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: validator-west
+  template:
+    metadata:
+      labels:
+        unit: validator-west
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: store-primary
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: store-primary
+  template:
+    metadata:
+      labels:
+        unit: store-primary
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: store-replica
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: store-replica
+  template:
+    metadata:
+      labels:
+        unit: store-replica
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cache-handler
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: cache-handler
+  template:
+    metadata:
+      labels:
+        unit: cache-handler
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy-router
+  namespace: fleet-alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      unit: proxy-router
+  template:
+    metadata:
+      labels:
+        unit: proxy-router
+    spec:
+      containers:
+        - name: worker
+          image: nginxinc/nginx-unprivileged:alpine

--- a/eval/troubleshooting/scenarios/namespace_pod_count/setup.sh
+++ b/eval/troubleshooting/scenarios/namespace_pod_count/setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS_A="fleet-alpha"
+NS_B="fleet-alpha1"
+EXPECTED_A=6
+EXPECTED_B=9
+
+oc apply -f "$FIXTURE_DIR/manifests.yaml"
+
+# Wait for all pods to reach Running in both namespaces
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 20 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  COUNT_A=$(oc get pods -n "$NS_A" --no-headers --field-selector=status.phase=Running 2>/dev/null | wc -l | tr -d ' ')
+  COUNT_B=$(oc get pods -n "$NS_B" --no-headers --field-selector=status.phase=Running 2>/dev/null | wc -l | tr -d ' ')
+
+  if [ "$COUNT_A" -eq "$EXPECTED_A" ] && [ "$COUNT_B" -eq "$EXPECTED_B" ]; then
+    echo "Pod counts OK — $NS_A:$COUNT_A  $NS_B:$COUNT_B"
+    exit 0
+  fi
+  echo "attempt $ATTEMPT/20 — $NS_A:$COUNT_A/$EXPECTED_A  $NS_B:$COUNT_B/$EXPECTED_B — waiting 3s…"
+  sleep 3
+done
+
+echo "Expected pod counts not reached"
+oc get pods -n "$NS_A"
+oc get pods -n "$NS_B"
+exit 1

--- a/eval/troubleshooting/scenarios/oom/cleanup.sh
+++ b/eval/troubleshooting/scenarios/oom/cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="oom-scenario"
+oc delete deployment awesome-application -n "$NS" --ignore-not-found
+oc delete namespace "$NS" --ignore-not-found

--- a/eval/troubleshooting/scenarios/oom/fixtures/manifest.yaml
+++ b/eval/troubleshooting/scenarios/oom/fixtures/manifest.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: oom-scenario
+  labels:
+    purpose: eval-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: awesome-application
+  namespace: oom-scenario
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: awesome-application
+  template:
+    metadata:
+      labels:
+        app: awesome-application
+    spec:
+      containers:
+      - name: app
+        image: python:3.9-slim
+        resources:
+          limits:
+            memory: "60Mi"
+            cpu: "100m"
+          requests:
+            memory: "60Mi"
+            cpu: "100m"
+        command:
+        - python3
+        - -c
+        - |
+          import time
+          print("Starting application...")
+          # Create a memory leak
+          data = []
+          while True:
+              # Continuously append data to cause memory growth
+              data.append("x" * 1000000)  # 1MB of data each iteration
+              print(f"Allocated {len(data)} MB")
+              time.sleep(1)

--- a/eval/troubleshooting/scenarios/oom/setup.sh
+++ b/eval/troubleshooting/scenarios/oom/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="oom-scenario"
+APP="awesome-application"
+
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+# Wait for at least one pod to hit OOMKilled
+echo "Waiting for $APP to be OOMKilled…"
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 90 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  STATUSES=$(oc get pods -n "$NS" -l "app=$APP" \
+    -o jsonpath='{range .items[*]}{.status.containerStatuses[0].lastState.terminated.reason}{"\n"}{end}' 2>/dev/null || true)
+  if echo "$STATUSES" | grep -q "OOMKilled"; then
+    echo "OOMKilled detected (attempt $ATTEMPT)"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "OOMKilled not detected within timeout"
+oc get pods -n "$NS" -l "app=$APP"
+oc describe pods -n "$NS" -l "app=$APP" | tail -20
+exit 1

--- a/eval/troubleshooting/scenarios/periodic_failure_window/cleanup.sh
+++ b/eval/troubleshooting/scenarios/periodic_failure_window/cleanup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="data-pipeline"
+
+oc delete deployment batch-processor -n "$NS" --ignore-not-found --grace-period=0
+oc delete secret batch-processor-logs-script -n "$NS" --ignore-not-found
+oc delete namespace "$NS" --ignore-not-found

--- a/eval/troubleshooting/scenarios/periodic_failure_window/fixtures/generate_logs.py
+++ b/eval/troubleshooting/scenarios/periodic_failure_window/fixtures/generate_logs.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Generate batch-processor logs showing a 03:00-03:05 failure window."""
+
+import csv
+import io
+import random
+import sys
+import time
+from datetime import datetime, timedelta
+
+INTERVAL = timedelta(minutes=2)
+FIELDS = ["timestamp", "severity", "source", "event", "detail"]
+UPSTREAM = "https://pipeline-intake.corp.net/submit"
+
+
+def write_row(writer, dt, severity, event, detail=""):
+    """Append a single CSV row to the writer."""
+    writer.writerow([dt.isoformat() + "Z", severity, "batch-processor", event, detail])
+
+
+def generate():
+    """Generate 24 hours of batch-processor logs with a recurring failure window."""
+    buf = io.StringIO()
+    writer = csv.writer(buf, quoting=csv.QUOTE_MINIMAL)
+
+    origin = datetime.utcnow()
+    cursor = origin - timedelta(hours=24)
+    seq = 0
+    diag_done = False
+
+    while cursor < origin:
+        h, m = cursor.hour, cursor.minute
+        is_bad = h == 3 and 0 <= m <= 5
+
+        if is_bad:
+            write_row(
+                writer,
+                cursor,
+                "ERROR",
+                "Batch submission failed",
+                f"POST {UPSTREAM} => connect timeout 5s",
+            )
+
+            if not diag_done:
+                diag_done = True
+                # This exact message is checked by setup/verify scripts
+                write_row(
+                    writer,
+                    cursor,
+                    "WARN",
+                    "Detected repeated failures during 03:00-03:05 window",
+                    "recurring pattern - likely upstream maintenance",
+                )
+        else:
+            ms = random.randint(90, 480)  # noqa: S311
+            write_row(
+                writer,
+                cursor,
+                "INFO",
+                f"Batch processed in {ms}ms",
+                f"records={random.randint(100, 5000)}",  # noqa: S311
+            )
+
+        if seq % 18 == 0:
+            write_row(
+                writer,
+                cursor,
+                "INFO",
+                "System health check passed",
+                f"ping={random.randint(1, 15)}ms",  # noqa: S311
+            )
+
+        cursor += INTERVAL
+        if random.random() < 0.12:  # noqa: S311
+            cursor += timedelta(seconds=random.randint(1, 6))  # noqa: S311
+        seq += 1
+
+    # sentinel line
+    cursor += timedelta(seconds=random.randint(1, 5))  # noqa: S311
+    write_row(
+        writer,
+        cursor,
+        "INFO",
+        "Job executed successfully in 167ms.",
+        "shutdown=graceful",
+    )
+
+    sys.stdout.write(buf.getvalue())
+    sys.stdout.flush()
+
+    while True:
+        time.sleep(3600)
+
+
+if __name__ == "__main__":
+    generate()

--- a/eval/troubleshooting/scenarios/periodic_failure_window/fixtures/manifest.yaml
+++ b/eval/troubleshooting/scenarios/periodic_failure_window/fixtures/manifest.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: batch-processor
+  namespace: data-pipeline
+  labels:
+    app: batch-processor
+    pipeline-stage: transform
+  annotations:
+    eval/scenario: periodic-failure-window
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: batch-processor
+  template:
+    metadata:
+      labels:
+        app: batch-processor
+        pipeline-stage: transform
+    spec:
+      containers:
+      - name: processor
+        image: python:3.11-alpine
+        command: ["python3", "-u"]
+        args: ["/opt/scripts/generate_logs.py"]
+        volumeMounts:
+        - name: log-scripts
+          mountPath: /opt/scripts
+          readOnly: true
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "48Mi"
+          limits:
+            cpu: "50m"
+            memory: "128Mi"
+      volumes:
+      - name: log-scripts
+        secret:
+          secretName: batch-processor-logs-script
+          defaultMode: 0555
+      restartPolicy: Always

--- a/eval/troubleshooting/scenarios/periodic_failure_window/setup.sh
+++ b/eval/troubleshooting/scenarios/periodic_failure_window/setup.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="data-pipeline"
+APP="batch-processor"
+
+oc create namespace "$NS" 2>/dev/null || true
+
+oc create secret generic batch-processor-logs-script \
+  --from-file=generate_logs.py="$FIXTURE_DIR/generate_logs.py" \
+  -n "$NS" --dry-run=client -o yaml | oc apply -f -
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+# Define the three sentinel strings we need
+SENTINELS=(
+  "Detected repeated failures during 03:00-03:05 window"
+  "System health check passed"
+  "Job executed successfully in 167ms."
+)
+
+ATTEMPT=0
+while true; do
+  ATTEMPT=$((ATTEMPT + 1))
+  [ "$ATTEMPT" -le 50 ] || { echo "Sentinels not found after 50 checks"; oc get pods -n "$NS"; exit 1; }
+
+  LOGS=$(oc logs -l "app=$APP" -n "$NS" --tail=10000 2>/dev/null || true)
+  ALL_FOUND=true
+  for s in "${SENTINELS[@]}"; do
+    echo "$LOGS" | grep -F "$s" >/dev/null || { ALL_FOUND=false; break; }
+  done
+
+  if $ALL_FOUND; then
+    echo "All sentinels found (attempt $ATTEMPT)"
+    exit 0
+  fi
+  echo "check $ATTEMPT/50 — waiting 3s…"
+  sleep 3
+done

--- a/eval/troubleshooting/scenarios/readiness_probe_diagnosis/cleanup.sh
+++ b/eval/troubleshooting/scenarios/readiness_probe_diagnosis/cleanup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+oc delete namespace discovery-hub --ignore-not-found --wait=false

--- a/eval/troubleshooting/scenarios/readiness_probe_diagnosis/fixtures/manifest.yaml
+++ b/eval/troubleshooting/scenarios/readiness_probe_diagnosis/fixtures/manifest.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: discovery-hub
+  labels:
+    purpose: eval-test
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: catalog-index-service
+  namespace: discovery-hub
+  labels:
+    app: catalog-index-service
+    tier: indexing
+  annotations:
+    eval/scenario: readiness-probe-diagnosis
+spec:
+  containers:
+  - name: indexer
+    image: busybox:1.36
+    command: ["sh", "-c", "while true; do echo 'Running...'; sleep 5; done"]
+    ports:
+    - containerPort: 9200
+      name: health
+    readinessProbe:
+      httpGet:
+        path: /healthz
+        port: 9200
+      initialDelaySeconds: 2
+      periodSeconds: 4
+      failureThreshold: 2
+    resources:
+      requests:
+        cpu: "5m"
+        memory: "32Mi"
+      limits:
+        memory: "64Mi"

--- a/eval/troubleshooting/scenarios/readiness_probe_diagnosis/setup.sh
+++ b/eval/troubleshooting/scenarios/readiness_probe_diagnosis/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="discovery-hub"
+POD_NAME="catalog-index-service"
+
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+# Poll for a Readiness probe failed event on the pod
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 60 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  EVENTS=$(oc get events -n "$NS" \
+    --field-selector "involvedObject.name=$POD_NAME,reason=Unhealthy" \
+    -o jsonpath='{.items[*].message}' 2>/dev/null || true)
+  if echo "$EVENTS" | grep -q "Readiness probe failed"; then
+    echo "Readiness probe failure event found (attempt $ATTEMPT)"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Readiness probe failure not detected within 60s"
+oc describe pod "$POD_NAME" -n "$NS"
+oc get events -n "$NS" --sort-by='.lastTimestamp' | tail -15
+exit 1

--- a/eval/troubleshooting/scenarios/scheduled_outage_detection/cleanup.sh
+++ b/eval/troubleshooting/scenarios/scheduled_outage_detection/cleanup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="analytics-platform"
+
+oc delete statefulset report-generator -n "$NS" --ignore-not-found --wait=false
+oc delete secret report-generator-logs-script -n "$NS" --ignore-not-found
+oc delete namespace "$NS" --ignore-not-found

--- a/eval/troubleshooting/scenarios/scheduled_outage_detection/fixtures/generate_logs.py
+++ b/eval/troubleshooting/scenarios/scheduled_outage_detection/fixtures/generate_logs.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Generate report-generator logs with a failure window between 03:00-03:05."""
+
+import random
+import sys
+import time
+from datetime import datetime, timedelta
+
+TICK = timedelta(seconds=10)
+FAILURE_START_HOUR = 3
+FAILURE_START_MIN = 0
+FAILURE_END_MIN = 5
+API_URL = "https://reports-upstream.internal/v2/ingest"
+
+
+def ts(dt):
+    """Format a datetime as an ISO 8601 timestamp with millisecond precision."""
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def in_failure_window(dt):
+    """Return True if dt falls within the 03:00-03:05 failure window."""
+    return (
+        dt.hour == FAILURE_START_HOUR
+        and FAILURE_START_MIN <= dt.minute <= FAILURE_END_MIN
+    )
+
+
+def emit(dt, level, msg, **extra):
+    """Print a structured log line for the report-generator component."""
+    parts = [
+        f"ts={ts(dt)}",
+        f"level={level}",
+        "component=report-generator",
+        f"msg={msg}",
+    ]
+    for k, v in extra.items():
+        parts.append(f"{k}={v}")
+    print(" ".join(parts))
+
+
+def run():
+    """Generate report-generator logs spanning 24 hours with a failure window."""
+    now = datetime.utcnow()
+    two_days_ago = now - timedelta(days=2)
+    cursor = two_days_ago - timedelta(hours=24)
+    iteration = 0
+    warning_emitted = False
+
+    while cursor < two_days_ago:
+        if in_failure_window(cursor):
+            emit(
+                cursor,
+                "ERROR",
+                "Report generation failed",
+                reason="upstream unreachable",
+                url=API_URL,
+                err="timeout after 5000ms",
+            )
+
+            if not warning_emitted:
+                warning_emitted = True
+                print(
+                    f"ts={ts(cursor)} level=WARN component=report-generator "
+                    f"msg=Detected repeated failures during 03:00-03:05 window "
+                    f"hint=possible scheduled maintenance upstream"
+                )
+        else:
+            duration = random.randint(80, 420)  # noqa: S311
+            emit(
+                cursor,
+                "INFO",
+                f"Report batch completed in {duration}ms",
+                rows=random.randint(50, 9000),  # noqa: S311
+            )
+
+        if iteration % 90 == 0:
+            emit(
+                cursor,
+                "INFO",
+                "System health check passed",
+                latency_ms=random.randint(1, 12),  # noqa: S311
+            )
+
+        cursor += TICK
+        if random.random() < 0.08:  # noqa: S311
+            cursor += timedelta(seconds=random.randint(1, 4))  # noqa: S311
+        iteration += 1
+
+    # sentinel so setup.sh knows logs are fully written
+    cursor += timedelta(seconds=random.randint(1, 5))  # noqa: S311
+    emit(cursor, "INFO", "Job executed successfully in 167ms.", final="true")
+    sys.stdout.flush()
+
+    while True:
+        time.sleep(3600)
+
+
+if __name__ == "__main__":
+    run()

--- a/eval/troubleshooting/scenarios/scheduled_outage_detection/fixtures/manifest.yaml
+++ b/eval/troubleshooting/scenarios/scheduled_outage_detection/fixtures/manifest.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: report-generator
+  namespace: analytics-platform
+  labels:
+    app: report-generator
+    tier: analytics
+spec:
+  serviceName: report-generator
+  replicas: 1
+  selector:
+    matchLabels:
+      app: report-generator
+  template:
+    metadata:
+      labels:
+        app: report-generator
+        tier: analytics
+    spec:
+      containers:
+      - name: generator
+        image: python:3.11-alpine
+        command: ["python3", "-u", "/opt/scripts/generate_logs.py"]
+        volumeMounts:
+        - name: log-scripts
+          mountPath: /opt/scripts
+          readOnly: true
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "48Mi"
+          limits:
+            memory: "128Mi"
+      volumes:
+      - name: log-scripts
+        secret:
+          secretName: report-generator-logs-script
+          defaultMode: 0555

--- a/eval/troubleshooting/scenarios/scheduled_outage_detection/setup.sh
+++ b/eval/troubleshooting/scenarios/scheduled_outage_detection/setup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="analytics-platform"
+APP="report-generator"
+
+oc create namespace "$NS" 2>/dev/null || true
+
+oc create secret generic report-generator-logs-script \
+  --from-file=generate_logs.py="$FIXTURE_DIR/generate_logs.py" \
+  -n "$NS" --dry-run=client -o yaml | oc apply -f -
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+# Helper: check whether all three sentinel lines are in the pod logs
+logs_ready() {
+  local logs
+  logs=$(oc logs -l "app=$APP" -n "$NS" --tail=10000 2>/dev/null || true)
+  echo "$logs" | grep "Detected repeated failures during 03:00-03:05 window" >/dev/null || return 1
+  echo "$logs" | grep "System health check passed" >/dev/null || return 1
+  echo "$logs" | grep "Job executed successfully in 167ms\." >/dev/null || return 1
+}
+
+ATTEMPT=0
+until logs_ready; do
+  ATTEMPT=$((ATTEMPT + 1))
+  [ "$ATTEMPT" -lt 40 ] || { echo "Sentinels not found after 40 checks"; oc get pods -n "$NS"; exit 1; }
+  echo "check $ATTEMPT/40 — waiting 3s…"
+  sleep 3
+done
+echo "All log sentinels present (attempt $ATTEMPT)"

--- a/eval/troubleshooting/scenarios/storage_binding/cleanup.sh
+++ b/eval/troubleshooting/scenarios/storage_binding/cleanup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="cache-tier"
+oc delete pvc memcached-data-pvc -n "$NS" --ignore-not-found
+oc delete deployment memcached -n "$NS" --ignore-not-found
+oc delete svc memcached -n "$NS" --ignore-not-found
+oc delete namespace "$NS" --ignore-not-found

--- a/eval/troubleshooting/scenarios/storage_binding/fixtures/manifest.yaml
+++ b/eval/troubleshooting/scenarios/storage_binding/fixtures/manifest.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cache-tier
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: memcached-data-pvc
+  namespace: cache-tier
+  labels:
+    app: memcached
+spec:
+  storageClassName: standard-v2
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: memcached
+  namespace: cache-tier
+spec:
+  type: ClusterIP
+  selector:
+    app: memcached
+  ports:
+  - name: mc
+    port: 11211
+    targetPort: mc
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: memcached
+  namespace: cache-tier
+  labels:
+    app: memcached
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: memcached
+  template:
+    metadata:
+      labels:
+        app: memcached
+    spec:
+      initContainers:
+      - name: init-perms
+        image: busybox:1.36
+        command: ["sh", "-c", "chmod 777 /cache"]
+        volumeMounts:
+        - name: cache-vol
+          mountPath: /cache
+      containers:
+      - name: mc
+        image: memcached:1.6-alpine
+        args: ["-m", "128", "-p", "11211", "-u", "memcache", "-v"]
+        ports:
+        - containerPort: 11211
+          name: mc
+        volumeMounts:
+        - name: cache-vol
+          mountPath: /cache
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "192Mi"
+          limits:
+            cpu: "200m"
+            memory: "384Mi"
+      volumes:
+      - name: cache-vol
+        persistentVolumeClaim:
+          claimName: memcached-data-pvc

--- a/eval/troubleshooting/scenarios/storage_binding/setup.sh
+++ b/eval/troubleshooting/scenarios/storage_binding/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="cache-tier"
+PVC="memcached-data-pvc"
+
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+# Wait for ProvisioningFailed event on the PVC
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 60 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  STATUS=$(oc get events -n "$NS" \
+    --field-selector "involvedObject.name=$PVC,involvedObject.kind=PersistentVolumeClaim" \
+    -o jsonpath='{.items[*].reason}' 2>/dev/null || true)
+  if echo "$STATUS" | grep -q "ProvisioningFailed"; then
+    echo "ProvisioningFailed event detected (attempt $ATTEMPT)"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "ProvisioningFailed event not detected within 60s"
+oc describe pvc "$PVC" -n "$NS"
+exit 1

--- a/eval/troubleshooting/scenarios/wrong_networkpolicy/cleanup.sh
+++ b/eval/troubleshooting/scenarios/wrong_networkpolicy/cleanup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="service-mesh"
+oc delete deployment frontend -n "$NS" --ignore-not-found
+oc delete deployment backend -n "$NS" --ignore-not-found
+oc delete svc backend-service -n "$NS" --ignore-not-found
+oc delete networkpolicy backend-network-policy -n "$NS" --ignore-not-found
+oc delete namespace "$NS" --ignore-not-found

--- a/eval/troubleshooting/scenarios/wrong_networkpolicy/fixtures/manifest.yaml
+++ b/eval/troubleshooting/scenarios/wrong_networkpolicy/fixtures/manifest.yaml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: service-mesh
+  labels:
+    purpose: eval-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: service-mesh
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+        tier: backend
+    spec:
+      containers:
+      - name: backend
+        image: nginxinc/nginx-unprivileged:latest
+        ports:
+        - containerPort: 8080
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "10m"
+          limits:
+            memory: "64Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-service
+  namespace: service-mesh
+spec:
+  selector:
+    app: backend
+  ports:
+  - port: 8080
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: service-mesh
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+        tier: frontend
+    spec:
+      containers:
+      - name: frontend
+        image: busybox
+        command: ["/bin/sh"]
+        args:
+        - -c
+        - |
+          while true; do
+            echo "Trying to connect to backend-service..."
+            if wget -O- http://backend-service:8080 -T 5; then
+              echo "Success!"
+            else
+              echo "ERROR: Connection timeout to backend-service!"
+            fi
+            sleep 15
+          done
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "10m"
+          limits:
+            memory: "64Mi"
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: backend-network-policy
+  namespace: service-mesh
+spec:
+  podSelector:
+    matchLabels:
+      app: backend
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          tier: backend
+    ports:
+    - protocol: TCP
+      port: 8080

--- a/eval/troubleshooting/scenarios/wrong_networkpolicy/setup.sh
+++ b/eval/troubleshooting/scenarios/wrong_networkpolicy/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+NS="service-mesh"
+
+oc apply -f "$FIXTURE_DIR/manifest.yaml"
+
+# Wait for backend to be ready
+oc wait --for=condition=available deployment/backend -n "$NS" --timeout=60s
+
+# Wait for the connection timeout error in frontend logs
+ATTEMPT=0
+until [ "$ATTEMPT" -ge 30 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  if oc logs -l app=frontend -n "$NS" --tail=20 2>/dev/null \
+     | grep -q "ERROR: Connection timeout to backend-service!"; then
+    echo "Timeout error detected (attempt $ATTEMPT)"
+    exit 0
+  fi
+  echo "attempt $ATTEMPT/30 — waiting 3s…"
+  sleep 3
+done
+
+echo "Connection timeout error not found within 90s"
+oc get pods -n "$NS"
+oc logs -l app=frontend -n "$NS" --tail=10 2>/dev/null || true
+exit 1

--- a/eval/troubleshooting/system.yaml
+++ b/eval/troubleshooting/system.yaml
@@ -1,0 +1,164 @@
+# LightSpeed Evaluation Framework Configuration
+
+# LLM Configuration
+llm:
+  provider: "openai" # Judge LLM Provider (openai, gemini etc..)
+  model: "gpt-5-mini" # Model name for the provider
+  temperature: 0.0 # Generation temperature
+  max_tokens: 5000 # Maximum tokens in response
+  timeout: 300 # Request timeout in seconds
+  num_retries: 3 # Retry attempts
+  cache_enabled: false
+
+# API Configuration
+# Only query endpoint is supported
+api:
+  enabled: true # Enable API calls instead of using pre-filled data
+  api_base: http://localhost:8080 # Base API URL
+  endpoint_type: query # Use "streaming" or "query" endpoint
+  timeout: 300 # API request timeout in seconds
+
+  # API input configuration
+  provider: "openai" # LLM provider for queries
+  model: "gpt-4.1-mini" # Model to use for queries
+  no_tools: null # Whether to bypass tools and MCP servers (optional)
+  system_prompt: null # System prompt (default None)
+  cache_enabled: false
+  extra_request_params:
+    mode: troubleshooting
+
+embedding:
+  cache_enabled: false
+
+  # Authentication via API_KEY environment variable only for MCP server
+
+# Default metrics metadata
+metrics_metadata:
+  # Turn-level metrics metadata
+  turn_level:
+    "ragas:response_relevancy":
+      description: "How relevant the response is to the question"
+      default: false # This metric is applied by default when no turn_metrics specified
+
+    "ragas:faithfulness":
+      description: "How faithful the response is to the provided context"
+      default: false # By default the value is false
+
+    # Custom metrics
+    "custom:answer_correctness":
+      description: "Correctness vs expected answer using custom LLM evaluation"
+      default: false
+
+    "geval:generic_troubleshooting_experience":
+      criteria: |
+        The response must be evaluated based on the following points:
+          - The agent which is answering is a Troubleshooting Agent, and its ability to be helpful in the troubleshooting must be evaluated
+          - The response must include real data evidence retrieved by tool and should not rely on generic or suggestions to address a generic problem
+          - The output of the response is the result of one or more tool calls that allow the agent to retrieve the real cluster information
+          - Evidences pointing to real cluster resources must be provided otherwise the response is only supposition or suggestions. This is the worst case that must be penalized a lot
+      evaluation_params:
+        - query
+        - response
+        - contexts
+      evaluation_steps:
+        - "Step 1: Check if the response is based on real cluster evidence or is just providing generic suggestions to a problem. In the latter the test MUST fail, otherwise go to next step."
+        - "Step 2: Check if the response contains an analysis related to the query content"
+        - "Step 3: Check if the response was able to detect an issue related to the user query and the context"
+        - "Step 4: Check if the response was able to provide fix for the problem"
+      description: "Verify if the agent is performing the troubleshooting of the scenario"
+
+
+  # Conversation-level metrics metadata
+  conversation_level:
+    "deepeval:conversation_completeness":
+      default: false
+
+    "deepeval:conversation_relevancy":
+      default: false
+
+    "deepeval:knowledge_retention":
+      default: false
+
+    "geval:troubleshooting_continuity":
+      description: "Evaluates stateful debugging across turns using context as history"
+      evaluation_params:
+        - query
+        - response
+      criteria: |
+        The agent must demonstrate 'Stateful Troubleshooting'.
+        1. It must reference specific facts found in earlier turns.
+        2. It must not repeat tool calls already present in the conversation history.
+        3. It must use the current tool output to progress the investigation.
+      evaluation_steps:
+        - "Step 1: Verify the agent references findings from earlier conversation turns."
+        - "Step 2: Check the agent doesn't repeat diagnostic steps already completed."
+        - "Step 3: Verify the agent isn't asking for information already provided in the history."
+        - "Step 4: Confirm the agent uses real cluster data from the tools to answer the current 'query'."
+      rubrics:
+        - score_range: [0, 3]
+          expected_outcome: "Agent ignores history entirely, restarts the investigation, or provides generic help."
+        - score_range: [4, 7]
+          expected_outcome: "Agent maintains basic context but repeats questions or diagnostic steps unnecessarily."
+        - score_range: [8, 10]
+          expected_outcome: "Perfect continuity. References specific historical data to provide a conclusive fix."
+
+# Output Configuration
+output:
+  output_dir: "./eval_output"
+  base_filename: "evaluation"
+  enabled_outputs: # Enable specific output types
+    - csv # Detailed results CSV
+    - json # Summary statistics
+
+  # CSV columns to include
+  csv_columns:
+    - "conversation_group_id"
+    - "turn_id"
+    - "metric_identifier"
+    - "score"
+    - "result"
+    - "reason"
+    - "query"
+    - "response"
+    - "execution_time"
+
+# Visualization settings
+visualization:
+  figsize: [12, 8] # Graph size (width, height)
+  dpi: 300 # Image resolution
+
+  # Graph types to generate
+  enabled_graphs:
+    # - "pass_rates"            # Pass rate bar chart
+    - "score_distribution" # Score distribution box plot
+    # - "conversation_heatmap"  # Heatmap of conversation performance
+    - "status_breakdown" # Pie chart for pass/fail/error breakdown
+
+# Environment Variables - Automatically get set before any imports
+environment:
+  DEEPEVAL_TELEMETRY_OPT_OUT: "YES" # Disable DeepEval telemetry
+  DEEPEVAL_DISABLE_PROGRESS_BAR: "YES" # Disable DeepEval progress bars
+
+  LITELLM_LOG: ERROR # Suppress LiteLLM verbose logging
+
+# Logging Configuration
+logging:
+  # Source code logging level
+  source_level: INFO # DEBUG, INFO, WARNING, ERROR, CRITICAL
+
+  # Package logging level (imported libraries)
+  package_level: ERROR
+
+  # Log format and display options
+  log_format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+  show_timestamps: true
+
+  # Specific package log levels (override package_level for specific libraries)
+  package_overrides:
+    httpx: ERROR
+    urllib3: ERROR
+    requests: ERROR
+    matplotlib: ERROR
+    LiteLLM: WARNING
+    DeepEval: WARNING
+    ragas: WARNING


### PR DESCRIPTION
## Description
This PR introduces:
- 11 new scenarios to be used to evaluate the `troubleshooting` mode of OLS. (including evals definition and fixtures to reproduce the scenario in a running cluster)
- Makefile to quickly run evals through lightspeed-eva

## Type of change
- [x] Extending eval scenarios for `troubleshooting` mode

## Related Tickets & Documents

- https://redhat.atlassian.net/browse/OBSINTA-1271

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
A mandatory prerequisite is to have lightspeed-eval installed and a running Openshift cluster (including `oc` locally installed) 

```shell
cd eval/troubleshoot

make <scenario> # (i.e. make envvar_missing)
```

## Other
Depends on https://github.com/lightspeed-core/lightspeed-evaluation/pull/213 