### PR TITLE
Use max(config, mode_default) for max_iterations

### DIFF
--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -1039,16 +1039,18 @@ class DocsSummarizer(QueryHelper):
     def _get_max_iterations(self) -> int:
         """Return configured max rounds for tool-calling loop.
 
-        An explicit ``max_iterations`` value in the OLS config overrides the
-        mode-specific default for all modes.  When the config value is None
-        (not set in YAML), the default is chosen based on the active query mode.
+        The result is the greater of the explicit ``max_iterations`` config
+        value and the mode-specific default.  This ensures the config can raise
+        the cap but never lower it below the mode's built-in minimum.  When the
+        config value is None (not set in YAML), the mode default is used as-is.
         """
-        explicit = config.ols_config.max_iterations
-        if explicit is not None:
-            return explicit
-        return constants.MAX_ITERATIONS_BY_MODE.get(
+        mode_default = constants.MAX_ITERATIONS_BY_MODE.get(
             self._mode, constants.DEFAULT_MAX_ITERATIONS
         )
+        explicit = config.ols_config.max_iterations
+        if explicit is not None:
+            return max(explicit, mode_default)
+        return mode_default
 
     def create_response(
         self,

--- a/tests/unit/query_helpers/test_docs_summarizer.py
+++ b/tests/unit/query_helpers/test_docs_summarizer.py
@@ -1061,13 +1061,32 @@ def test_get_max_iterations_troubleshooting_mode_no_override():
     assert summarizer._get_max_iterations() == DEFAULT_MAX_ITERATIONS_TROUBLESHOOTING
 
 
-def test_get_max_iterations_config_override():
-    """Test _get_max_iterations returns explicit config value regardless of mode."""
-    config.ols_config.max_iterations = 10
+def test_get_max_iterations_config_override_above_default():
+    """Test _get_max_iterations uses config value when it exceeds the mode default."""
+    config.ols_config.max_iterations = 20
     try:
         for mode in (QueryMode.ASK, QueryMode.TROUBLESHOOTING):
             summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None), mode=mode)
-            assert summarizer._get_max_iterations() == 10
+            assert summarizer._get_max_iterations() == 20
+    finally:
+        config.ols_config.max_iterations = None
+
+
+def test_get_max_iterations_config_override_below_default():
+    """Test _get_max_iterations uses mode default when it exceeds the config value."""
+    config.ols_config.max_iterations = 10
+    try:
+        summarizer = DocsSummarizer(
+            llm_loader=mock_llm_loader(None), mode=QueryMode.ASK
+        )
+        assert summarizer._get_max_iterations() == 10
+
+        summarizer = DocsSummarizer(
+            llm_loader=mock_llm_loader(None), mode=QueryMode.TROUBLESHOOTING
+        )
+        assert (
+            summarizer._get_max_iterations() == DEFAULT_MAX_ITERATIONS_TROUBLESHOOTING
+        )
     finally:
         config.ols_config.max_iterations = None
 


### PR DESCRIPTION
## Description

`_get_max_iterations` now returns `max(config_value, mode_default)` instead of using the config value unconditionally. This ensures the config can raise the iteration cap but never lower it below the mode's built-in floor (e.g. troubleshooting mode keeps its 15-iteration minimum even when config sets a lower value).

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- `test_get_max_iterations_ask_mode_no_override` — no config override, ASK mode returns default (5)
- `test_get_max_iterations_troubleshooting_mode_no_override` — no config override, TROUBLESHOOTING returns default (15)
- `test_get_max_iterations_config_override_above_default` — config=20 wins for both modes
- `test_get_max_iterations_config_override_below_default` — config=10 wins for ASK (default 5) but TROUBLESHOOTING keeps its default (15)