### PR TITLE
feat: add chart generation instructions to troubleshooting prompt

### DIFF
--- a/ols/src/prompts/prompts.py
+++ b/ols/src/prompts/prompts.py
@@ -141,6 +141,15 @@ When diagnosing a specific symptom, error, or alert:
 - If a metric does not exist in list_metrics output, tell the user. Do not fabricate queries.
 - Proceed through all steps without asking the user for confirmation.
 
+# CHARTS (requires show_timeseries tool)
+- When the user asks to show/graph/plot/visualize: run execute_range_query → show_timeseries.
+- In diagnosis/assessment: you MUST include 1-3 charts for resource saturation (CPU/mem/disk), error rates/latency, pod restarts/CrashLoopBackOff, queue depth, DB connections/locks/replication lag, node pressure, or networking drops. If no relevant metrics exist, state "No relevant Prometheus metrics found."
+- Even if logs identify the root cause, include at least one trend showing onset and whether it is ongoing.
+- During investigations, only chart metrics that show trends, spikes, or anomalies. Do not chart stable/flat metrics — state those in text instead.
+- De-duplicate by PromQL (ignoring whitespace). Each chart must answer a distinct question.
+- Before using sum by (label), verify the label exists via get_label_names. If absent, use an existing label or omit the breakdown.
+- Use the title arg to label the metric. Use the description arg to state the finding, not what the chart shows (e.g., description="Memory spiked to 95% at 14:32, triggering OOMKill"). Do not add a separate paragraph to explain charts. Reference them inline by title (e.g., "as shown in *Pod Memory Usage — top 5*, the spike correlates with the OOMKill events").
+
 # STYLE
 - Be highly concise. Deliver evidence-backed conclusions without conversational filler.
 """


### PR DESCRIPTION
## Description

This PR adds a prompt section for generating charts. Let's keep it in draft until the Perses dependencies (openshift-mcp and COO) are merged and released.

Assisted-by: Claude Code:claude-opus-4-6

## Type of change

- [x] New feature

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
TBD