### PR TITLE
OLS-2882 add spec files into what/how two-layer structure

### DIFF
--- a/.ai/spec/README.md
+++ b/.ai/spec/README.md
@@ -1,0 +1,44 @@
+# OpenShift LightSpeed Service -- Specifications
+
+These specs define the requirements, behaviors, and architecture for the OLS lightspeed-service. They are organized into two layers:
+
+- **[`what/`](what/README.md)** -- Behavioral rules: WHAT the system must do and WHY. Technology-neutral, testable assertions. Use these to understand requirements, fix bugs, or rebuild components.
+- **[`how/`](how/README.md)** -- Architecture specs: HOW the current implementation is structured. Module boundaries, data flow, design patterns. Use these to navigate, modify, and extend the codebase.
+
+## Scope
+
+These specs cover the **lightspeed-service** Python application only. The operator, console plugin, and RAG content pipeline are separate projects. Jira data covering all projects is in `.ai/jira-*.md` files.
+
+## Audience
+
+AI agents (Claude). Specs optimize for precision, unambiguous rules, and machine-parseable structure.
+
+## Quick Start
+
+| I want to... | Read |
+|--------------|------|
+| Understand what OLS does | `what/system-overview.md` |
+| Fix a bug in query processing | `what/query-processing.md` + `how/query-pipeline.md` |
+| Add a new LLM provider | `what/llm-providers.md` + `how/llm-providers.md` |
+| Understand the API | `what/api.md` |
+| Navigate the codebase | `how/project-structure.md` |
+| See what's planned | Look for `[PLANNED: OLS-XXXX]` in `what/` specs |
+
+## Conventions
+
+- `[PLANNED: OLS-XXXX]` markers in `what/` specs indicate existing rules about to change due to open Jira work
+- "Planned Changes" sections list new capabilities not yet in code
+- Config field names reference `olsconfig.yaml` paths (e.g., `ols_config.tool_filtering.threshold`)
+- Internal constants are stated as behavioral rules without numeric values; `how/` specs may include specific values
+
+## Project History
+
+OpenShift Lightspeed evolved through these phases:
+
+1. **Prototype** (Q4 2023): Basic chat with OpenAI + RAG from product docs
+2. **Early Access** (Q1-Q2 2024): Configuration system, conversation cache, auth, multi-provider, metrics, feedback
+3. **Tech Preview** (Q3 2024): Streaming, RHOAI/RHELAI providers, Azure Entra ID, TLS profiles
+4. **GA** (Q4 2024 - Q1 2025): PostgreSQL cache, quota management, FIPS, disconnected mode, transcripts
+5. **Post-GA** (2025-2026): MCP tools, context-aware queries, skills, tool approval, BYOK, custom system prompts, query modes, dynamic config reload
+
+Jira tracking: Features in OCPSTRAT project (label: OLS), Epics/Stories in OLS project.

--- a/.ai/spec/how/README.md
+++ b/.ai/spec/how/README.md
@@ -1,0 +1,25 @@
+# Architecture Specifications (how/)
+
+These specs describe HOW the OLS service is structured -- module boundaries, data flow, design patterns, key abstractions, and implementation decisions. They are grounded in the current Python/FastAPI codebase and should be updated when the code changes.
+
+## Spec Index
+
+| Spec | Description |
+|------|-------------|
+| [project-structure.md](project-structure.md) | Directory layout, module responsibilities, startup sequence, layer integration |
+| [query-pipeline.md](query-pipeline.md) | DocsSummarizer orchestration, stage-by-stage data flow, token budget algorithm, streaming interleaving |
+| [llm-providers.md](llm-providers.md) | Provider registry, decorator discovery, class hierarchy, parameter mapping, HTTP client setup |
+| [tools.md](tools.md) | MCP client lifecycle, tool gathering pipeline, approval state machine, retry/backoff, parallel execution |
+| [config.md](config.md) | AppConfig singleton, Pydantic class hierarchy, two-phase validation, dynamic reload mechanism |
+| [cache.md](cache.md) | Abstract cache interface, PostgreSQL schema, advisory locks, JSON serialization, in-memory LRU |
+
+## When to Read These
+
+- **Navigating the codebase**: Start with `project-structure.md` to understand where things live.
+- **Modifying a subsystem**: Read the relevant `how/` spec to understand the current architecture before making changes.
+- **Adding a new provider/cache backend/MCP server**: The `how/` specs include step-by-step guides for extension points.
+- **Debugging**: The data flow sections trace the exact path requests take through the code.
+
+## Relationship to what/ Specs
+
+The [`what/` specs](../what/README.md) define behavioral contracts (technology-neutral). These `how/` specs describe the implementation that fulfills those contracts. When the two diverge, the `what/` spec is the source of truth for correct behavior, and the `how/` spec should be updated to reflect the current code.

--- a/.ai/spec/how/cache.md
+++ b/.ai/spec/how/cache.md
@@ -1,0 +1,244 @@
+# Cache -- Architecture
+
+The cache subsystem provides persistent conversation history storage, keyed by
+user ID and conversation ID. It ships two backends (in-memory LRU and
+PostgreSQL) behind a common abstract interface, selected at startup via factory.
+
+## Module Map
+
+| File | Key symbols | Responsibility |
+|---|---|---|
+| `ols/src/cache/cache.py` | `Cache` (ABC) | Abstract interface. Defines `get`, `insert_or_append`, `delete`, `list`, `set_topic_summary`, `ready`. Also provides `construct_key` (static) for compound key creation and ID validation via `check_suid`. |
+| `ols/src/cache/in_memory_cache.py` | `InMemoryCache` | Thread-safe singleton LRU cache backed by a `deque` (for recency ordering) and a `dict` (for O(1) lookup). Capacity is measured in total message entries across all conversations. |
+| `ols/src/cache/postgres_cache.py` | `PostgresCache` | PostgreSQL-backed cache using `psycopg2`. Stores serialized JSON in a `bytea` column. Uses advisory locks for write serialization and a separate `conversations` metadata table. |
+| `ols/src/cache/cache_factory.py` | `CacheFactory.conversation_cache()` | Static factory. Maps config type string (`"memory"` / `"postgres"`) to concrete `Cache` subclass. |
+| `ols/src/cache/cache_error.py` | `CacheError` | Domain exception wrapping any database or cache operation failure. |
+| `ols/utils/postgres.py` | `PostgresBase`, `connection` decorator | Base class for all Postgres-backed components. Handles connect/reconnect, DDL execution under an advisory lock, and the `@connection` decorator that transparently reconnects before method calls. |
+| `ols/app/models/models.py` | `CacheEntry`, `ConversationData`, `MessageEncoder`, `MessageDecoder` | Data models. `CacheEntry` wraps a `HumanMessage`/`AIMessage` pair plus attachments and tool call data. Encoder/Decoder handle JSON serialization of LangChain message objects. |
+
+## Data Flow
+
+### Initialization
+
+```
+olsconfig.yaml
+  -> OLSConfig.__init__ builds ConversationCacheConfig (validates type + sub-config)
+  -> AppConfig.conversation_cache property (lazy)
+     -> CacheFactory.conversation_cache(config)
+        -> match config.type:
+             "memory"   -> InMemoryCache(config.memory)   [singleton]
+             "postgres" -> PostgresCache(config.postgres)  [connects + runs DDL]
+        -> returns Cache instance stored on AppConfig
+```
+
+### Read (get)
+
+```
+Endpoint / HistorySupport
+  -> config.conversation_cache.get(user_id, conversation_id, skip_user_id_check)
+  -> construct_key validates IDs (UUID format via check_suid)
+  -> InMemory: dict lookup, promote key to front of deque, return list[CacheEntry]
+  -> Postgres: @connection ensures live connection, SELECT value WHERE (user_id, conversation_id),
+               deserialize JSON via MessageDecoder, return list[CacheEntry]
+```
+
+### Write (insert_or_append)
+
+```
+ols.py endpoint
+  -> config.conversation_cache.insert_or_append(user_id, conversation_id, cache_entry, ...)
+  -> CacheEntry.to_dict() produces {"human_query": HumanMessage, "ai_response": AIMessage, ...}
+  -> InMemory: append to dict list, promote in deque, increment total_entries,
+               update ConversationData metadata, evict from tail if over capacity
+  -> Postgres: acquire advisory lock -> SELECT existing -> append to JSON array ->
+               UPDATE (or INSERT if new) -> upsert conversations metadata ->
+               _cleanup evicts oldest message if over capacity -> COMMIT
+```
+
+### List / Delete / SetTopicSummary
+
+All follow the same pattern: validate IDs, acquire lock (thread mutex for
+in-memory, `_tx_lock` for Postgres), perform the operation, return result.
+
+## Key Abstractions
+
+### Abstract Cache Interface
+
+All methods receive `user_id`, `conversation_id`, and `skip_user_id_check`.
+The compound cache key is `"{user_id}:{conversation_id}"`.
+
+| Method | Signature | Contract |
+|---|---|---|
+| `get` | `(user_id, conversation_id, skip_user_id_check) -> list[CacheEntry]` | Returns list of cache entries or `None`/`[]` if not found. |
+| `insert_or_append` | `(user_id, conversation_id, cache_entry, skip_user_id_check) -> None` | Creates new conversation or appends to existing. Triggers capacity eviction. |
+| `delete` | `(user_id, conversation_id, skip_user_id_check) -> bool` | Deletes all entries for a conversation. Returns `True` if something was deleted. |
+| `list` | `(user_id, skip_user_id_check) -> list[ConversationData]` | Returns all conversations for a user, sorted by `last_message_timestamp` descending. |
+| `set_topic_summary` | `(user_id, conversation_id, topic_summary, skip_user_id_check) -> None` | Upserts a human-readable summary for the conversation. |
+| `ready` | `() -> bool` | Health check. In-memory always returns `True`; Postgres checks connection liveness. |
+
+### CacheEntry
+
+A Pydantic model holding one exchange:
+
+- `query`: `HumanMessage` (LangChain)
+- `response`: `AIMessage` (LangChain), defaults to `AIMessage("")`
+- `attachments`: `list[Attachment]`
+- `tool_calls`: `list[dict]`
+- `tool_results`: `list[dict]`
+
+`to_dict()` serializes to `{"human_query": HumanMessage, "ai_response": AIMessage, "attachments": [...], "tool_calls": [...], "tool_results": [...]}`.
+
+`from_dict()` reconstructs from that shape.
+
+### ConversationData
+
+Metadata model returned by `list()`:
+
+- `conversation_id`: str
+- `topic_summary`: str (default `""`)
+- `last_message_timestamp`: float (Unix epoch)
+- `message_count`: int
+
+### Factory Pattern
+
+`CacheFactory.conversation_cache(config)` uses `match config.type` to dispatch.
+The config type constants are `"memory"` and `"postgres"` (defined in
+`ols/constants.py`).
+
+## Integration Points
+
+| Consumer | Usage |
+|---|---|
+| `ols/app/endpoints/ols.py` | Calls `insert_or_append` after generating a response to persist the exchange. |
+| `ols/app/endpoints/conversations.py` | Calls `list`, `get`, `delete`, `set_topic_summary` for the conversations REST API. |
+| `ols/src/query_helpers/history_support.py` | Calls `get` to retrieve history for context, `delete` + `insert_or_append` to rewrite compressed history. |
+| `ols/app/endpoints/health.py` | Calls `ready()` for the `/readiness` health check. |
+| `ols/utils/config.py` | `AppConfig.conversation_cache` property lazily creates the cache via `CacheFactory`. |
+
+## Implementation Notes
+
+### PostgreSQL Table Schema
+
+Two tables, created with `CREATE TABLE IF NOT EXISTS`:
+
+```sql
+CREATE TABLE IF NOT EXISTS cache (
+    user_id         text NOT NULL,
+    conversation_id text NOT NULL,
+    value           bytea,
+    updated_at      timestamp,
+    PRIMARY KEY(user_id, conversation_id)
+);
+CREATE INDEX IF NOT EXISTS timestamps ON cache (updated_at);
+
+CREATE TABLE IF NOT EXISTS conversations (
+    user_id                text NOT NULL,
+    conversation_id        text NOT NULL,
+    topic_summary          text DEFAULT '',
+    last_message_timestamp timestamp NOT NULL,
+    message_count          integer DEFAULT 0,
+    PRIMARY KEY(user_id, conversation_id)
+);
+```
+
+The `value` column in `cache` stores a JSON array of serialized `CacheEntry`
+dicts, encoded as UTF-8 bytes.
+
+### Advisory Lock Key Derivation
+
+Write operations acquire a PostgreSQL transaction-level advisory lock before
+reading+modifying the row:
+
+```sql
+SELECT pg_advisory_xact_lock(hashtext(user_id || conversation_id))
+```
+
+`hashtext` produces a 32-bit integer from the concatenated `user_id` and
+`conversation_id` strings. The lock is automatically released when the
+transaction commits or rolls back. This serializes concurrent writers to the
+same conversation without blocking unrelated conversations.
+
+Schema DDL is also guarded by a separate advisory lock:
+`pg_advisory_xact_lock(hashtext('ols_schema_init'))`.
+
+### JSON Serialization Format
+
+LangChain `HumanMessage` and `AIMessage` objects are serialized via
+`MessageEncoder`:
+
+```json
+{
+  "type": "human",
+  "content": "...",
+  "response_metadata": {},
+  "additional_kwargs": {}
+}
+```
+
+A full `CacheEntry` serializes as:
+
+```json
+{
+  "human_query": {"type": "human", "content": "...", ...},
+  "ai_response": {"type": "ai", "content": "...", ...},
+  "attachments": [...],
+  "tool_calls": [...],
+  "tool_results": [...]
+}
+```
+
+The `value` column stores a JSON array of these objects. `MessageDecoder` uses
+an `object_hook` that inspects the `"type"` key to reconstruct `HumanMessage`
+or `AIMessage`, and `"__type__": "CacheEntry"` to reconstruct `CacheEntry`
+objects. Deserialization reads the `bytea` column as `memoryview`, converts to
+`str` via `str(value, "utf-8")`, then passes through `json.loads` with
+`cls=MessageDecoder`.
+
+### In-Memory LRU Implementation
+
+- **Singleton**: `__new__` + `threading.Lock` ensures one instance per process.
+- **Data structures**: `dict[str, list[dict]]` for storage, `deque[str]` for
+  LRU ordering, `dict[str, ConversationData]` for metadata.
+- **Capacity**: Measured in total individual message entries across all
+  conversations (not number of conversations).
+- **LRU promotion**: On `get` or `insert_or_append`, the key is moved to the
+  front of the deque.
+- **Eviction**: When `total_entries > capacity`, the oldest single message
+  (first element of the list at the tail of the deque) is removed. If that
+  conversation's list becomes empty, the entire conversation is removed from
+  all data structures.
+
+### Thread Safety
+
+- **InMemoryCache**: A class-level `threading.Lock` guards singleton creation
+  and all mutation operations (`insert_or_append`, `delete`, `list`,
+  `set_topic_summary`). Note that `get` does not acquire the lock -- it only
+  does deque reordering which is not guarded.
+- **PostgresCache**: A per-instance `threading.Lock` (`_tx_lock`) serializes
+  all database operations at the application level. Within Postgres,
+  `pg_advisory_xact_lock` provides row-level write serialization across
+  processes/pods.
+- **Connection decorator**: The `@connection` decorator on `PostgresBase`
+  checks connection liveness and reconnects before each public method call.
+
+### Capacity Eviction (Postgres)
+
+After each `insert_or_append`, `_cleanup` runs:
+
+1. `SELECT COALESCE(SUM(json_array_length(...)), 0) FROM cache` to count total
+   message entries across all rows.
+2. If over capacity, select the oldest row (by `updated_at`).
+3. If that row has multiple messages, pop the first (oldest) message and update.
+4. If that row has only one message, delete the entire row.
+
+This removes one message per insert, keeping the total at or below capacity.
+
+### How to Add a New Cache Backend
+
+1. Create a new file in `ols/src/cache/` (e.g., `redis_cache.py`).
+2. Subclass `Cache` and implement all abstract methods: `get`,
+   `insert_or_append`, `delete`, `list`, `set_topic_summary`, `ready`.
+3. Add a config model for the new backend in `ols/app/models/config.py`.
+4. Add a constant for the new cache type in `ols/constants.py`.
+5. Add a `case` branch in `CacheFactory.conversation_cache()`.
+6. Add the corresponding config validation in `ConversationCacheConfig`.

--- a/.ai/spec/how/config.md
+++ b/.ai/spec/how/config.md
@@ -1,0 +1,195 @@
+# Configuration -- Architecture
+
+The configuration subsystem loads, validates, and exposes the entire service configuration through a singleton `AppConfig` object. Every other module in OLS reads its settings from this singleton rather than parsing files or environment variables directly.
+
+## Module Map
+
+### `ols/app/models/config.py` (Pydantic model hierarchy)
+
+The root model is `Config`, which composes the top-level sections:
+
+```
+Config (root)
+  ├── llm_providers: LLMProviders
+  │     └── providers: dict[str, ProviderConfig]
+  │           ├── type, url, credentials, project_id
+  │           ├── models: dict[str, ModelConfig]
+  │           │     ├── name, context_window_size, max_tokens_for_tools
+  │           │     └── parameters: ModelParameters (max_tokens_for_response, reasoning_*, tool_budget_ratio)
+  │           ├── tls_security_profile: TLSSecurityProfile
+  │           └── <provider>_config: OpenAIConfig | AzureOpenAIConfig | WatsonxConfig | ...
+  ├── ols_config: OLSConfig
+  │     ├── conversation_cache: ConversationCacheConfig → InMemoryCacheConfig | PostgresConfig
+  │     ├── logging_config: LoggingConfig
+  │     ├── reference_content: ReferenceContent → list[ReferenceContentIndex]
+  │     ├── authentication_config: AuthenticationConfig
+  │     ├── tls_config: TLSConfig
+  │     ├── tls_security_profile: TLSSecurityProfile
+  │     ├── proxy_config: ProxyConfig
+  │     ├── quota_handlers: QuotaHandlersConfig → PostgresConfig, SchedulerConfig, LimitersConfig
+  │     ├── user_data_collection: UserDataCollection
+  │     ├── query_filters: list[QueryFilter]
+  │     ├── default_provider, default_model, max_iterations, max_workers
+  │     ├── tool_filtering: ToolFilteringConfig
+  │     ├── tools_approval: ToolsApprovalConfig
+  │     ├── skills: SkillsConfig
+  │     └── tool_round_cap_fraction: float
+  ├── dev_config: DevConfig
+  │     └── enable_dev_ui, disable_auth, disable_tls, pyroscope_url, run_on_localhost, ...
+  └── mcp_servers: MCPServers
+        └── servers: list[MCPServerConfig]
+              ├── name, url, timeout
+              └── headers: dict[str, str] (raw) / _resolved_headers: dict[str, str] (resolved)
+```
+
+Provider-specific config classes (`OpenAIConfig`, `AzureOpenAIConfig`, `WatsonxConfig`, `RHOAIVLLMConfig`, `RHELAIVLLMConfig`, `GoogleVertexAnthropicConfig`, `GoogleVertexConfig`, `FakeConfig`) inherit from `ProviderSpecificConfig` (which carries `url`, `token`, `api_key`) and use `extra="forbid"` to reject typos.
+
+### `ols/utils/config.py` (AppConfig singleton)
+
+- `AppConfig` -- singleton class (`__new__` pattern) that wraps `Config` and provides lazy-initialized accessors for expensive resources.
+- Module-level `config: AppConfig = AppConfig()` -- the singleton instance, re-exported via `ols/__init__.py` as `from ols import config`.
+- `reload_from_yaml_file()` -- reads YAML, builds `Config`, runs `validate_yaml()`, replaces the internal `config` attribute, and clears cached resources.
+- `_load_config_from_yaml_stream()` -- static method that handles YAML parsing and Pydantic construction in one step.
+
+### `ols/utils/checks.py` (validation helpers)
+
+- `InvalidConfigurationError` -- the single exception type for all configuration validation failures.
+- `read_secret()` -- reads a secret value from a file path; if the path is a directory, appends a default filename (e.g., `apitoken`). Supports `raise_on_error=False` for optional secrets.
+- `get_attribute_from_file()` -- reads an arbitrary attribute value from a file path stored in config.
+- `is_valid_http_url()` -- validates URL scheme is http or https.
+- `dir_check()` / `file_check()` -- assert paths exist and are readable.
+- `get_log_level()` -- converts string log level names to `logging` integer constants.
+- `resolve_headers()` -- resolves MCP server authorization headers: reads secret files, or preserves `"kubernetes"` / `"client"` placeholders for runtime substitution.
+- `validate_mcp_servers()` -- filters MCP server list by resolving headers; drops servers whose headers cannot be resolved.
+
+## Data Flow
+
+### Startup path (runner.py)
+
+```
+1. runner.py reads OLS_CONFIG_FILE env var (default: olsconfig.yaml)
+2. config.reload_from_yaml_file(cfg_file)
+   a. Open YAML file, yaml.safe_load() → raw dict
+   b. Config(data, ignore_llm_secrets, ignore_missing_certs)
+      - Phase 1 (structural): Pydantic parsing + custom __init__ methods
+        - Each model's __init__ manually extracts fields from raw dicts
+        - model_validator(mode="before") runs on ModelConfig, ProxyConfig
+        - model_validator(mode="after") runs on PostgresConfig, UserDataCollection, MCPServers
+        - field_validator runs on ModelConfig.options, ModelParameters.tool_budget_ratio
+      - Phase 2 (cross-field / semantic): Config.__init__ calls
+        - _validate_mcp_servers() -- resolves headers with auth context
+        - _compute_tool_budgets() -- sets max_tokens_for_tools per model based on MCP presence
+   c. config.validate_yaml()
+      - Phase 3 (file-system / external): walks the entire tree calling validate_yaml()
+        on each sub-config, checking file existence, URL validity, TLS certs, etc.
+3. config is now fully initialized; other modules access it via `from ols import config`
+```
+
+### Access path (runtime)
+
+```
+any module → from ols import config → config.ols_config / config.llm_config / config.dev_config
+                                     → config.conversation_cache  (lazy, via @property)
+                                     → config.rag_index            (lazy, via @property)
+                                     → config.tools_rag            (lazy, via @cached_property)
+                                     → config.skills_rag           (lazy, via @cached_property)
+                                     → config.quota_limiters       (lazy, via @property)
+                                     → config.query_redactor       (lazy, via @property)
+```
+
+### Reload path
+
+```
+config.reload_from_yaml_file(path)
+  → build new Config from YAML (same as startup)
+  → replace self.config
+  → clear all lazy caches:
+      - self._query_filters = None
+      - self._rag_index_loader = None
+      - self._tools_approval = None
+      - self._pending_approval_store = None
+      - del self.__dict__["mcp_servers_dict"]   (cached_property)
+      - del self.__dict__["tools_rag"]          (cached_property)
+      - del self.__dict__["skills_rag"]         (cached_property)
+  → next access re-initializes each resource lazily
+```
+
+## Key Abstractions
+
+### Two lazy-caching strategies
+
+`AppConfig` uses two different patterns for lazy initialization, and they are invalidated differently on reload:
+
+1. **`@property` with `_field is None` guard** -- used for `conversation_cache`, `quota_limiters`, `token_usage_history`, `query_redactor`, `rag_index_loader`, `tools_approval`, `pending_approval_store`. Cleared by setting `self._field = None` in `reload_from_yaml_file()`.
+
+2. **`@cached_property`** -- used for `mcp_servers_dict`, `tools_rag`, `skills_rag`. These are stored in `self.__dict__` by Python's `cached_property` protocol. Cleared by `del self.__dict__["key"]` in `reload_from_yaml_file()`.
+
+### Two-phase validation
+
+1. **Structural validation** -- Pydantic model construction. Field types, `field_validator`, `model_validator(mode="before"|"after")`, and custom `__init__` logic that reads secrets from files and builds nested sub-configs.
+
+2. **Semantic validation** -- explicit `validate_yaml()` methods called after construction. These check cross-cutting concerns that require file-system access (TLS cert existence, directory readability, regex compilation) or cross-model references (default_provider must exist in llm_providers, default_model must exist in that provider).
+
+### Credential file resolution
+
+`checks.read_secret(data, path_key, default_filename)` implements a two-mode lookup:
+- If the path points to a **file**, reads it directly.
+- If the path points to a **directory**, appends `default_filename` (e.g., `apitoken`) and reads that file.
+
+This supports both Kubernetes secret volume mounts (directory of files) and explicit file paths. The `directory_name_expected` flag (used by Azure) enforces directory-only mode. The `raise_on_error` flag controls whether missing secrets are fatal or silently ignored.
+
+### TLS profile to cipher suite mapping
+
+`TLSSecurityProfile` validates against `ols/utils/tls.py`:
+- Profile types: `OldType` (rejected at validation), `IntermediateType`, `ModernType`, `Custom`.
+- Each profile maps to a predefined cipher suite list in `tls.TLS_CIPHERS`.
+- Minimum TLS version is enforced: `VersionTLS12` is the floor. Anything below is rejected.
+- For non-Custom profiles, any user-specified ciphers are validated against the profile's allowed set.
+- `ols/utils/ssl.py` consumes the validated profile to configure Uvicorn's SSL context.
+
+### Provider-specific config dispatch
+
+`ProviderConfig.set_provider_specific_configuration()` uses a `match/case` on `self.type` to instantiate the correct typed config class. It enforces that at most one `<provider>_config` block is present and that it matches the declared provider type. Each provider-specific class uses `extra="forbid"` to catch misconfigured fields early.
+
+## Integration Points
+
+- **Every module** reads config through `from ols import config` (re-export of the singleton).
+- **runner.py** -- loads config, then passes it to `start_uvicorn()`, `start_quota_scheduler()`, and triggers `load_index()` in a background thread.
+- **FastAPI app (main.py)** -- reads `config.dev_config`, `config.ols_config` at module import time (top-level statements), so config must be loaded before the app module is imported.
+- **LLM loader** -- reads `config.llm_config.providers[name]` and provider-specific sub-configs to construct LangChain LLM instances.
+- **Cache factory** -- reads `config.ols_config.conversation_cache` to create in-memory or Postgres cache.
+- **RAG index loader** -- reads `config.ols_config.reference_content` to load vector indexes.
+- **Quota system** -- reads `config.ols_config.quota_handlers` for storage and limiter configuration.
+- **MCP tools** -- reads `config.mcp_servers` for server URLs and resolved headers.
+- **Tools/Skills RAG** -- `config.tools_rag` and `config.skills_rag` are created from `tool_filtering` and `skills` config sections respectively, sharing the embedding model resolved via `_resolve_embed_model()`.
+- **TLS/SSL** -- `config.ols_config.tls_config` and `tls_security_profile` feed into Uvicorn's SSL parameters.
+
+## Implementation Notes
+
+### Config models use manual `__init__` instead of Pydantic's declarative parsing
+
+Most config models override `__init__` to accept a raw `dict` (or `Optional[dict]`) and manually extract fields. This is a legacy pattern predating Pydantic v2's improved `model_validator`. It means that adding a new field requires wiring it in the `__init__` method, not just declaring it on the class. Some models (`DevConfig`, `LoggingConfig`, `PostgresConfig`, `UserDataCollection`, `ModelConfig`, `ModelParameters`) use Pydantic's standard `**kwargs` construction instead.
+
+### Reload does not re-initialize the singleton
+
+`reload_from_yaml_file()` replaces `self.config` and clears cached resources, but does **not** create a new `AppConfig` instance. All modules holding a reference to the singleton continue to see the updated config. The `_conversation_cache` and `_quota_limiters` are **not** cleared on reload -- they persist across reloads. Only `_query_filters`, `_rag_index_loader`, `_tools_approval`, `_pending_approval_store`, and the three `cached_property` values are cleared.
+
+### Adding a new config section
+
+1. Create a Pydantic `BaseModel` subclass in `ols/app/models/config.py`.
+2. Add it as an `Optional` field on the appropriate parent model (`OLSConfig`, `Config`, etc.).
+3. Wire it in the parent's `__init__` method (extract from `data` dict, instantiate).
+4. If it needs file-system or cross-field checks, add a `validate_yaml()` method and call it from the parent's `validate_yaml()`.
+5. If it needs lazy resource initialization, add a `@property` or `@cached_property` on `AppConfig` and clear it in `reload_from_yaml_file()`.
+
+### `_compute_tool_budgets()` is called during `Config.__init__`
+
+This cross-cutting validation sets `max_tokens_for_tools` on every `ModelConfig` based on whether MCP servers are configured. It also enforces that `max_tokens_for_response + max_tokens_for_tools < context_window_size`. This runs after MCP server validation, so the server list is already filtered.
+
+### Proxy config falls through to environment variables
+
+`ProxyConfig` reads `https_proxy` / `HTTPS_PROXY` and `no_proxy` environment variables as defaults via `Field(default_factory=...)`. Explicit YAML values override these. The `model_validator(mode="before")` also sets `proxy_url` from env if not provided in the input dict, creating a double-fallback path.
+
+### MCP header resolution happens at config load time, not request time
+
+Secret file contents are read into `_resolved_headers` during `Config.__init__` (via `_validate_mcp_servers()` -> `checks.validate_mcp_servers()` -> `checks.resolve_headers()`). The special placeholders `"kubernetes"` and `"client"` are preserved as-is and substituted at request time by the MCP client layer.

--- a/.ai/spec/how/llm-providers.md
+++ b/.ai/spec/how/llm-providers.md
@@ -1,0 +1,184 @@
+# LLM Providers -- Architecture
+
+The LLM provider subsystem translates a (provider name, model name) pair from configuration into a ready-to-use LangChain `BaseChatModel` (or `LLM`) instance, hiding backend differences behind a registry-and-base-class pattern.
+
+## Module Map
+
+### `ols/src/llms/llm_loader.py` -- Entry point
+
+- `load_llm(provider, model, generic_llm_params)` -- The only function callers use. Reads `config.config.llm_providers`, resolves the provider config, looks up the provider class in the registry, instantiates it, and calls `.load()`.
+- `resolve_provider_config(provider, model, providers_config)` -- Validates that the provider name exists in config and that the model is listed under that provider. Returns `ProviderConfig`.
+- Exception hierarchy: `LLMConfigurationError` (base), `UnknownProviderError`, `UnsupportedProviderError`, `ModelConfigMissingError`.
+
+### `ols/src/llms/providers/registry.py` -- Provider registry
+
+- `LLMProvidersRegistry` -- Class-level dict (`llm_providers`) mapping string type names (e.g. `"openai"`, `"watsonx"`) to `LLMProvider` subclasses.
+- `register_llm_provider_as(provider_type)` -- Decorator factory. Each provider file decorates its class with `@register_llm_provider_as(constants.PROVIDER_*)`, which triggers registration at import time.
+
+### `ols/src/llms/providers/provider.py` -- Base class and parameter system
+
+- `AbstractLLMProvider` -- ABC defining the `default_params` property and `load()` method.
+- `LLMProvider(AbstractLLMProvider)` -- Concrete base. Constructor pipeline: `default_params` -> `_override_params` (merge caller params, then dev-config overrides) -> `_remap_to_llm_params` (generic-to-provider name translation) -> `_validate_parameters` (drop params not in the provider's allowed set).
+- `_construct_httpx_client(use_custom_certificate_store, use_async)` -- Builds `httpx.Client` or `httpx.AsyncClient` with proxy, TLS security profile, and custom certificate store support. Used by OpenAI-compatible providers.
+- `ProviderParameter(name, _type)` -- Frozen dataclass. The allowed-parameter sets use both name and type for validation (a parameter with the wrong type is rejected).
+- Parameter sets: `AzureOpenAIParameters`, `OpenAIParameters`, `RHOAIVLLMParameters`, `RHELAIVLLMParameters`, `WatsonxParameters`, `FakeProviderParameters`, `GoogleVertexAnthropicParameters`, `GoogleVertexParameters`. Collected in `available_provider_parameters` dict keyed by provider type string.
+- Generic-to-LLM mapping dicts: `AzureOpenAIParametersMapping`, `OpenAIParametersMapping`, `WatsonxParametersMapping`, etc. Collected in `generic_to_llm_parameters`.
+
+### Provider implementations
+
+| File | Class | Decorator key | LangChain class | Notes |
+|---|---|---|---|---|
+| `openai.py` | `OpenAI` | `"openai"` | `ChatOpenAI` | Reasoning params for o-series/gpt-5 models |
+| `azure_openai.py` | `AzureOpenAI` | `"azure_openai"` | `AzureChatOpenAI` | Entra ID token caching; see below |
+| `watsonx.py` | `Watsonx` | `"watsonx"` | `ChatWatsonx` | IBM-specific parameter names; see below |
+| `rhoai_vllm.py` | `RHOAIVLLM` | `"rhoai_vllm"` | `ChatOpenAI` | OpenAI-compatible, no default URL |
+| `rhelai_vllm.py` | `RHELAIVLLM` | `"rhelai_vllm"` | `ChatOpenAI` | OpenAI-compatible, no default URL |
+| `google_vertex.py` | `GoogleVertex` | `"google_vertex"` | `ChatGoogleGenerativeAI` | Service account credentials from JSON |
+| `google_vertex_anthropic.py` | `GoogleVertexAnthropic` | `"google_vertex_anthropic"` | `ChatAnthropicVertex` | Anthropic models on Vertex Model Garden |
+| `fake_provider.py` | `FakeProvider` | `"fake_provider"` | `FakeListLLM` / `FakeStreamingListLLM` | Testing only; monkey-patches `bind_tools` |
+
+### `ols/src/llms/providers/utils.py` -- Shared utilities
+
+- `credentials_str_to_dict(credentials_json)` -- Parses a JSON string of service account credentials into a dict. Used by both Google Vertex providers.
+- `VERTEX_AI_OAUTH_SCOPES` -- OAuth scope tuple for Vertex AI API access.
+
+## Data Flow
+
+```
+Caller (QueryHelper / health check)
+  |
+  v
+load_llm(provider="my_azure", model="gpt-4o", generic_llm_params={...})
+  |
+  |-- resolve_provider_config() validates provider + model exist in AppConfig
+  |-- LLMProvidersRegistry.llm_providers[provider_config.type] gets the class
+  |
+  v
+ProviderClass.__init__(model, provider_config, generic_llm_params)
+  |-- default_params property builds provider-specific defaults
+  |-- _override_params() merges: defaults < caller params < dev_config overrides
+  |-- _remap_to_llm_params() translates generic names to provider-specific names
+  |-- _validate_parameters() filters to only allowed (name, type) pairs
+  |
+  v
+ProviderClass.load()
+  |-- Constructs and returns a LangChain BaseChatModel (e.g. AzureChatOpenAI(**self.params))
+  |
+  v
+Caller receives BaseChatModel, uses it in LangChain chains or agent loops
+```
+
+## Key Abstractions
+
+### Registry: decorator-based auto-discovery
+
+Each provider file decorates its class at module level:
+
+```python
+@register_llm_provider_as(constants.PROVIDER_OPENAI)
+class OpenAI(LLMProvider):
+    ...
+```
+
+Registration happens at import time. The `__init__.py` for the providers package is empty -- providers are imported implicitly because `provider.py` is imported by `registry.py`, and each provider file imports from `registry.py`. The loader file imports `LLMProvidersRegistry` from `registry.py`, which transitively triggers all provider registrations through Python's module system.
+
+### Provider base class contract
+
+Every provider must:
+1. Define a `default_params` property returning a dict of provider-specific defaults.
+2. Implement `load()` returning a `BaseChatModel` or `LLM`.
+
+The base class handles parameter merging, remapping, and validation automatically in `__init__`.
+
+### Parameter mapping: generic to provider-specific
+
+Callers pass generic parameter names defined in `GenericLLMParameters`:
+
+| Generic name | OpenAI / Azure / VLLM | WatsonX | Google Vertex |
+|---|---|---|---|
+| `max_tokens_for_response` | `max_completion_tokens` | `max_new_tokens` | `max_output_tokens` |
+| `min_tokens_for_response` | (not mapped) | `min_new_tokens` | (not mapped) |
+| `top_k` | (not mapped) | `top_k` | (not mapped) |
+| `top_p` | (not mapped) | `top_p` | (not mapped) |
+| `temperature` | (not mapped) | `temperature` | (not mapped) |
+
+When a generic name has no mapping entry for a provider, it passes through unchanged and is then accepted or rejected by `_validate_parameters`.
+
+### ModelFamily enum
+
+`ModelFamily` in `ols/constants.py` defines `GPT` and `GRANITE`. It is not used by the provider subsystem itself but by downstream consumers (prompt generation, streaming chunk filtering) that detect model family by substring match against the model name: `ModelFamily.GRANITE in model_name`. Granite models get different agent instructions and different streaming-chunk skip logic.
+
+### Provider-specific configuration precedence
+
+Each provider follows the same pattern: read generic fields from `ProviderConfig` (url, credentials), then check for a provider-specific config object (e.g. `azure_config`, `watsonx_config`, `openai_config`) that overrides those values. The specific config always wins.
+
+## Integration Points
+
+### Callers
+
+- **`QueryHelper`** (`ols/src/query_helpers/query_helper.py`) -- Base class for `DocsSummarizer` and other query helpers. Holds `llm_loader` as an injectable callable (defaults to `load_llm`). Called for main query answering, history compression, and tool execution flows.
+- **Health endpoint** (`ols/app/endpoints/health.py`) -- Calls `load_llm` with the default provider/model to verify LLM connectivity at startup and during readiness probes.
+
+### Configuration
+
+- `ProviderConfig` and `ModelConfig` in `ols/app/models/config.py` supply all provider settings. `LLMProviders` holds the dict of named providers. The provider `type` field (defaulting to the provider name) determines which registered class handles it.
+- `config.dev_config.llm_params` provides developer overrides that take highest precedence in `_override_params`.
+
+### Constants
+
+- Provider type strings: `PROVIDER_OPENAI`, `PROVIDER_AZURE_OPENAI`, `PROVIDER_WATSONX`, `PROVIDER_RHOAI_VLLM`, `PROVIDER_RHELAI_VLLM`, `PROVIDER_FAKE`, `PROVIDER_GOOGLE_VERTEX`, `PROVIDER_GOOGLE_VERTEX_ANTHROPIC` in `ols/constants.py`.
+- `SUPPORTED_PROVIDER_TYPES` frozenset is checked during config validation (not by the registry).
+
+### TLS and proxy
+
+`LLMProvider._construct_httpx_client` reads `config.ols_config.proxy_config` for proxy URL, CA cert, and no-proxy host list, and `provider_config.tls_security_profile` for cipher and TLS version constraints. This affects all OpenAI-compatible providers (OpenAI, Azure OpenAI, RHOAI VLLM, RHELAI VLLM).
+
+## Implementation Notes
+
+### Adding a new provider
+
+1. Create `ols/src/llms/providers/my_provider.py`.
+2. Decorate the class: `@register_llm_provider_as(constants.PROVIDER_MY_PROVIDER)`.
+3. Subclass `LLMProvider`. Implement `default_params` (property) and `load()`.
+4. Add a constant `PROVIDER_MY_PROVIDER` to `ols/constants.py` and include it in `SUPPORTED_PROVIDER_TYPES`.
+5. Define the parameter set and generic mapping in `provider.py` and add entries to `available_provider_parameters` and `generic_to_llm_parameters`.
+6. Add the provider-specific config class to `ols/app/models/config.py` and wire it into `ProviderConfig`.
+
+### Azure Entra ID token caching
+
+`azure_openai.py` uses a module-level `TOKEN_CACHE` singleton (`TokenCache` dataclass). When credentials (API key) are not set, it fetches an Entra ID token via `ClientSecretCredential.get_token()` and caches it. The cache applies a 30-second leeway (`TOKEN_EXPIRATION_LEEWAY`) before the actual expiry to avoid using nearly-expired tokens. The cache is per-process (one per Uvicorn worker). The cache key is implicit -- there is a single `TOKEN_CACHE` instance, so it assumes one Azure provider per process.
+
+### WatsonX parameter name translation
+
+WatsonX uses IBM's `GenTextParamsMetaNames` constants for parameter keys instead of plain strings. The mapping in `WatsonxParametersMapping`:
+
+| Generic | WatsonX (`GenParams.*`) |
+|---|---|
+| `min_tokens_for_response` | `MIN_NEW_TOKENS` |
+| `max_tokens_for_response` | `MAX_NEW_TOKENS` |
+| `top_k` | `TOP_K` |
+| `top_p` | `TOP_P` |
+| `temperature` | `TEMPERATURE` |
+
+WatsonX also passes `params=self.params` to `ChatWatsonx` (as a nested dict), unlike OpenAI-compatible providers that spread params as `**self.params`.
+
+### OpenAI reasoning model handling
+
+Both `openai.py` and `azure_openai.py` detect o-series and gpt-5 models by name pattern (`self.model.startswith("o")` or `"gpt-5" in self.model`). For these models, temperature/top_p/frequency_penalty are omitted and reasoning parameters (effort, summary) are set instead. The `ModelParameters` config class provides `reasoning_effort`, `reasoning_summary`, and `verbosity` fields.
+
+### HTTP client setup
+
+`_construct_httpx_client` in the base class handles three concerns:
+1. **Proxy**: reads `proxy_config.proxy_url`, creates `httpx.Proxy` with optional SSL context for HTTPS proxies, and sets up `no_proxy` host bypass via httpx mounts.
+2. **Custom certificate store**: when `use_custom_certificate_store=True`, loads CA certs from `provider_config.certificates_store` (set automatically for OpenAI-compatible providers during config init).
+3. **TLS security profile**: when `tls_security_profile` is configured, constrains minimum TLS version and cipher suites via `ssl.SSLContext`.
+
+Each OpenAI-compatible provider creates both sync and async clients (`http_client` and `http_async_client`).
+
+### Parameter validation by name and type
+
+`_validate_parameters` checks both the parameter name and its Python type against the allowed set. A parameter named `temperature` with type `int` instead of `float` will be silently dropped with a warning log. This catches misconfigured parameters early but can be surprising if types do not match exactly.
+
+### Provider type defaults to provider name
+
+In `ProviderConfig.set_provider_type`, if no explicit `type` is set in the YAML, the provider's `name` is used as its type (lowercased). This means a provider named `"openai"` automatically gets type `"openai"` and resolves to the OpenAI provider class.

--- a/.ai/spec/how/project-structure.md
+++ b/.ai/spec/how/project-structure.md
@@ -1,0 +1,324 @@
+# Project Structure -- Architecture
+
+OpenShift LightSpeed (OLS) is a FastAPI service organized into four layers: `app/` (HTTP surface), `src/` (business logic), `utils/` (shared infrastructure), and `runners/` (process entry points). Each layer has strict import direction -- `app` depends on `src` and `utils`; `src` depends on `utils`; `runners` orchestrate startup.
+
+## Module Map
+
+### `ols/app/` -- FastAPI application layer
+
+| Path | Purpose |
+|---|---|
+| `app/main.py` | Creates the `FastAPI` instance, registers middleware (metrics counter, security headers, request/response logging), calls `routers.include_routers(app)`, optionally mounts Gradio dev UI, and stores config status. The module-level `app` object is the ASGI entry point referenced by Uvicorn as `ols.app.main:app`. |
+| `app/routers.py` | Single function `include_routers(app)` that attaches all endpoint routers. v1-prefixed: `ols`, `streaming_ols`, `mcp_client_headers`, `mcp_apps`, `tool_approvals`, `feedback`, `conversations`. Root-level: `health`, `metrics`, `authorized`. |
+| `app/endpoints/ols.py` | `POST /v1/query` -- synchronous query endpoint. Orchestrates the full request lifecycle: auth, redaction, attachment processing, provider/model validation, quota check, `DocsSummarizer` invocation, conversation history storage, transcript storage, and quota consumption. |
+| `app/endpoints/streaming_ols.py` | `POST /v1/streaming_query` -- streaming variant of the query endpoint. Uses the same `DocsSummarizer` but yields `StreamedChunk` objects via SSE. |
+| `app/endpoints/health.py` | `/readiness` and `/liveness` probes. Readiness checks RAG index, LLM connectivity (with persistent caching of success), and cache backend. |
+| `app/endpoints/feedback.py` | User feedback collection endpoint. |
+| `app/endpoints/conversations.py` | Conversation history listing and deletion. |
+| `app/endpoints/mcp_apps.py` | MCP application metadata endpoint. |
+| `app/endpoints/mcp_client_headers.py` | MCP client header management endpoint. |
+| `app/endpoints/tool_approvals.py` | Human-in-the-loop tool approval endpoint. |
+| `app/endpoints/authorized.py` | Authorization check endpoint. |
+| `app/metrics/metrics.py` | Prometheus metric definitions: `ols_rest_api_calls_total`, `ols_response_duration_seconds`, `ols_llm_calls_total`, `ols_llm_calls_failures_total`, `ols_llm_token_sent_total`, `ols_llm_token_received_total`, `ols_provider_model_configuration`. Exposes `GET /metrics` with auth. |
+| `app/metrics/token_counter.py` | `GenericTokenCounter` (LangChain callback) and `TokenMetricUpdater` (context manager) for tracking per-request token usage and updating Prometheus counters. |
+| `app/models/config.py` | All Pydantic configuration models: `Config`, `OLSConfig`, `LLMProviders`, `ProviderConfig`, `ModelConfig`, `DevConfig`, `ConversationCacheConfig`, `QuotaHandlersConfig`, `MCPServers`, `MCPServerConfig`, `ToolsApprovalConfig`, etc. |
+| `app/models/models.py` | Request/response Pydantic models: `LLMRequest`, `LLMResponse`, `CacheEntry`, `SummarizerResponse`, `StreamedChunk`, `RagChunk`, `Attachment`, `TokenCounter`, health response models, etc. |
+
+### `ols/src/` -- Core business logic
+
+| Path | Purpose |
+|---|---|
+| `src/auth/auth.py` | `get_auth_dependency(ols_config, virtual_path)` factory that returns the configured `AuthDependencyInterface` implementation based on the `authentication_config.module` setting (`k8s`, `noop`, or `noop-with-token`). |
+| `src/auth/auth_dependency_interface.py` | Abstract base class `AuthDependencyInterface(ABC)` -- all auth implementations must satisfy `async __call__(request) -> tuple[str, str, bool, str]` returning (user_id, user_name, skip_user_id_check, user_token). |
+| `src/auth/k8s.py` | Kubernetes TokenReview-based authentication. Contains `K8sClientSingleton` for cluster ID and version retrieval. |
+| `src/auth/noop.py` | No-op auth for local development (uses default user identity). |
+| `src/auth/noop_with_token.py` | No-op auth that still extracts a token from the request. |
+| `src/cache/cache.py` | Abstract `Cache(ABC)` base class. Defines compound key scheme (`user_id:conversation_id`), and abstract methods: `get`, `insert_or_append`, `delete`, `list`, `set_topic_summary`, `ready`. |
+| `src/cache/cache_factory.py` | `CacheFactory.conversation_cache(config)` -- factory method that returns `InMemoryCache` or `PostgresCache` based on `config.type`. |
+| `src/cache/in_memory_cache.py` | In-memory cache implementation with configurable max entries. |
+| `src/cache/postgres_cache.py` | PostgreSQL-backed cache using SQLAlchemy/psycopg2. |
+| `src/cache/cache_error.py` | `CacheError` exception class. |
+| `src/llms/llm_loader.py` | `load_llm(provider, model, generic_llm_params)` -- resolves provider config, looks up the provider class in `LLMProvidersRegistry`, instantiates it, and calls `.load()` to return a LangChain LLM. Also defines `resolve_provider_config()` and error classes (`LLMConfigurationError`, `UnknownProviderError`, `UnsupportedProviderError`, `ModelConfigMissingError`). |
+| `src/llms/providers/registry.py` | `LLMProvidersRegistry` -- class-level dict mapping provider type strings to `LLMProvider` subclasses. `@register_llm_provider_as("type")` decorator for self-registration. |
+| `src/llms/providers/provider.py` | `LLMProvider(AbstractLLMProvider)` base class. Handles generic-to-provider parameter remapping, parameter validation against allowed parameter sets, dev config overrides, and HTTPX client construction (TLS, proxy, custom certificate stores). |
+| `src/llms/providers/openai.py` | OpenAI provider implementation. |
+| `src/llms/providers/azure_openai.py` | Azure OpenAI provider implementation. |
+| `src/llms/providers/watsonx.py` | IBM WatsonX provider implementation. |
+| `src/llms/providers/rhoai_vllm.py` | Red Hat OpenShift AI vLLM provider. |
+| `src/llms/providers/rhelai_vllm.py` | RHEL AI vLLM provider. |
+| `src/llms/providers/google_vertex.py` | Google Vertex AI provider. |
+| `src/llms/providers/google_vertex_anthropic.py` | Google Vertex AI (Anthropic models) provider. |
+| `src/llms/providers/fake_provider.py` | Fake provider for testing and load testing. |
+| `src/prompts/prompts.py` | System prompt templates (`QUERY_SYSTEM_INSTRUCTION`, `TROUBLESHOOTING_SYSTEM_INSTRUCTION`). |
+| `src/prompts/prompt_generator.py` | `GeneratePrompt` class that assembles `ChatPromptTemplate` from query, RAG context, history, system prompt, tool-calling flag, mode, cluster version, and optional skill content. |
+| `src/query_helpers/query_helper.py` | `QueryHelper` base class for all query processing. Resolves provider/model defaults, selects system prompt by mode (`ask` or `troubleshooting`), and stores the LLM loader callable. |
+| `src/query_helpers/docs_summarizer.py` | `DocsSummarizer(QueryHelper)` -- the central orchestrator. Prepares LLM, builds prompts with RAG context, manages the multi-round tool-calling loop via `iterate_with_tools()`, handles streaming and synchronous response modes. Contains `TokenBudgetTracker` integration for token accounting across prompt, RAG, history, tool definitions, tool results, and AI rounds. |
+| `src/query_helpers/history_support.py` | `prepare_history()` -- retrieves and truncates conversation history from cache. |
+| `src/query_helpers/attachment_appender.py` | `append_attachments_to_query()` -- serializes attachments into the query text. |
+| `src/quota/quota_limiter.py` | Abstract `QuotaLimiter(ABC)` -- interface for `available_quota`, `ensure_available_quota`, `consume_tokens`, `revoke_quota`, `increase_quota`. |
+| `src/quota/quota_limiter_factory.py` | Factory that creates quota limiter instances from config. |
+| `src/quota/user_quota_limiter.py` | Per-user quota enforcement (PostgreSQL-backed). |
+| `src/quota/cluster_quota_limiter.py` | Cluster-wide quota enforcement. |
+| `src/quota/revokable_quota_limiter.py` | Quota limiter with periodic revocation support. |
+| `src/quota/quota_exceed_error.py` | `QuotaExceedError` exception. |
+| `src/quota/token_usage_history.py` | `TokenUsageHistory` -- records per-user token consumption to PostgreSQL for analytics. |
+| `src/rag/hybrid_rag.py` | Hybrid RAG retrieval logic. |
+| `src/rag_index/index_loader.py` | `IndexLoader` -- loads LlamaIndex vector indexes from configured reference content paths. Provides `get_retriever()` and `embed_model` for reuse. Excluded from MyPy type checking. |
+| `src/skills/skills_rag.py` | `SkillsRAG` -- hybrid BM25 + vector retrieval for skill selection. `load_skills_from_directory()` parses skill files with YAML frontmatter. |
+| `src/tools/tools.py` | `execute_tool_calls_stream()` -- runs resolved MCP tool calls with token budget enforcement and approval flow. `enforce_tool_token_budget()` truncates tool outputs that exceed remaining budget. |
+| `src/tools/approval.py` | `PendingApprovalStoreBase` and `create_pending_approval_store()` -- human-in-the-loop tool approval infrastructure. |
+| `src/tools/tools_rag/hybrid_tools_rag.py` | `ToolsRAG` -- hybrid BM25 + vector retrieval (using qdrant-client and rank-bm25) for filtering MCP tools by query relevance before sending to the LLM. |
+| `src/ui/gradio_ui.py` | `GradioUI` -- optional development UI that mounts a Gradio interface onto the FastAPI app. |
+| `src/config_status/config_status.py` | `extract_config_status()` and `store_config_status()` for telemetry about the active configuration. |
+
+### `ols/utils/` -- Shared utilities
+
+| Path | Purpose |
+|---|---|
+| `utils/config.py` | `AppConfig` singleton. Uses `__new__` for singleton enforcement. Lazy-initializes subsystems via `@property` and `@cached_property`: `conversation_cache`, `quota_limiters`, `token_usage_history`, `query_redactor`, `rag_index`, `rag_index_loader`, `tools_rag`, `skills_rag`, `pending_approval_store`. `reload_from_yaml_file()` parses YAML via `Config` Pydantic model and resets cached properties. The module-level `config` instance is the global singleton imported throughout the codebase. |
+| `utils/logging_configurator.py` | `configure_logging()` -- sets up Python logging from config. |
+| `utils/certificates.py` | `generate_certificates_file()` -- merges certifi CA bundle with any explicitly configured certificates into a single PEM file at `/tmp/ols.pem`. |
+| `utils/ssl.py` | `get_ssl_version()` and `get_ciphers()` -- resolves TLS security profile settings for Uvicorn. |
+| `utils/tls.py` | TLS utility functions for provider-level HTTPX clients: `ciphers_as_string()`, `min_tls_version()`, `ssl_tls_version()`. |
+| `utils/redactor.py` | `Redactor` -- applies configured query filters (regex-based PII redaction) to queries and attachments before logging or LLM submission. |
+| `utils/token_handler.py` | `TokenHandler` -- tiktoken-based token counting and RAG context truncation. `TokenBudgetTracker` -- per-request token budget management across categories (prompt, RAG, history, skill, tool definitions, tool results, AI rounds). `PromptTooLongError` exception. |
+| `utils/mcp_utils.py` | `build_mcp_config()` and `get_mcp_tools()` -- resolves MCP server configurations, applies tool filtering via `ToolsRAG`, and fetches tools from MCP servers using `langchain-mcp-adapters`. |
+| `utils/suid.py` | UUID generation and validation for conversation/user IDs. |
+| `utils/environments.py` | `configure_gradio_ui_envs()` and `configure_hugging_face_envs()` -- sets environment variables before other imports. |
+| `utils/checks.py` | `InvalidConfigurationError` and validation helpers. |
+| `utils/errors_parsing.py` | `parse_generic_llm_error()` and `handle_known_errors()` -- translates LLM provider exceptions into HTTP status codes and user-facing messages. |
+| `utils/postgres.py` | PostgreSQL connection utilities. |
+| `utils/pyroscope.py` | Optional Pyroscope profiling integration. |
+
+### `ols/runners/` -- Process entry points
+
+| Path | Purpose |
+|---|---|
+| `runners/uvicorn.py` | `start_uvicorn(config)` -- configures and starts Uvicorn with `workers=1`, TLS settings from config, host/port selection, and log level. Entry point string is `"ols.app.main:app"`. |
+| `runners/quota_scheduler.py` | `start_quota_scheduler(config)` -- spawns a daemon thread that periodically revokes/resets expired quotas in PostgreSQL via `INCREASE_QUOTA_STATEMENT` and `RESET_QUOTA_STATEMENT`. |
+
+### `ols/plugins/` -- Plugin system
+
+`plugins/__init__.py` provides `_import_modules_from_dir()` which dynamically imports all `.py` files from a given directory. Currently a placeholder; providers and tools are not yet migrated to this system.
+
+### `ols/customize/` -- Customization hooks
+
+`customize/ols/` is an empty directory (only `__pycache__`). Reserved for operator-injected customization files.
+
+### Key standalone files
+
+| Path | Purpose |
+|---|---|
+| `ols/constants.py` | All global constants: provider type strings (`PROVIDER_OPENAI`, etc.), `SUPPORTED_PROVIDER_TYPES`, `ModelFamily` enum, `QueryMode` enum (`ask`, `troubleshooting`), `GenericLLMParameters`, token budget constants (`DEFAULT_CONTEXT_WINDOW_SIZE`, `DEFAULT_MAX_TOKENS_FOR_RESPONSE`, `DEFAULT_TOOL_BUDGET_RATIO`), RAG constants (`RAG_CONTENT_LIMIT`, `RAG_SIMILARITY_CUTOFF`), cache constants, default auth module, HTTP headers to redact, attachment type/content type sets, SSL defaults, `RUNNING_IN_CLUSTER` flag. |
+| `ols/version.py` | `__version__ = "1.0.12"` -- single source of truth for the service version. Used by `pyproject.toml` via `hatch`. |
+| `runner.py` (project root) | Main entry point (`__main__`). Orchestrates the full startup sequence (see Data Flow below). |
+
+## Data Flow
+
+### Startup sequence (`runner.py`)
+
+1. **Environment setup**: `configure_gradio_ui_envs()` sets Gradio-related environment variables. This must happen before importing `ols.config` because the config import triggers module-level code.
+
+2. **Config import**: `from ols import config` -- this instantiates the `AppConfig` singleton at module level (`config: AppConfig = AppConfig()` in `ols/utils/config.py`). At this point, the config is empty.
+
+3. **Config loading**: `config.reload_from_yaml_file(cfg_file)` reads the YAML file specified by `OLS_CONFIG_FILE` (defaulting to `olsconfig.yaml`), parses it into a `Config` Pydantic model via `yaml.safe_load()`, and runs `config.validate_yaml()`. Resets all cached properties (`_query_filters`, `_rag_index_loader`, `tools_rag`, `skills_rag`, etc.).
+
+4. **Logging**: `configure_logging(config.ols_config.logging_config)` sets up Python logging.
+
+5. **HuggingFace environment**: `configure_hugging_face_envs(config.ols_config)` sets `HF_HOME`, `TRANSFORMERS_CACHE`, etc.
+
+6. **Certificate generation**: `generate_certificates_file()` merges certifi CA certs with any explicitly configured certificates into `/tmp/ols.pem`.
+
+7. **K8s auth init** (conditional): If `use_k8s_auth()` is true, initializes `K8sClientSingleton` and retrieves the cluster ID. Fails fast if cluster ID is unavailable.
+
+8. **Query redactor init**: Accessing `config.query_redactor` triggers lazy initialization of the `Redactor` instance from configured query filters.
+
+9. **Pyroscope** (conditional): If `dev_config.pyroscope_url` is set, starts profiling.
+
+10. **RAG index loading** (background thread): `threading.Thread(target=load_index)` starts a thread that accesses `config.rag_index`, which triggers `IndexLoader` initialization. This runs in parallel with server startup so the service can begin accepting health checks before indexes are loaded.
+
+11. **Quota scheduler** (background thread): `start_quota_scheduler(config)` spawns a daemon thread for periodic quota revocation (only if PostgreSQL-backed quotas are configured).
+
+12. **Uvicorn start**: `start_uvicorn(config)` starts the ASGI server with `workers=1`.
+
+### Module-level initialization in `app/main.py`
+
+When Uvicorn imports `ols.app.main`, additional module-level initialization occurs:
+
+1. **Gradio UI** (conditional): If `config.dev_config.enable_dev_ui` is true, imports `GradioUI` and mounts it onto the FastAPI app. This import pulls in heavy dependencies (Matplotlib, Pillow, etc.) that are intentionally deferred.
+
+2. **Metrics setup**: `metrics.setup_model_metrics(config)` initializes Prometheus gauges for all configured provider/model combinations.
+
+3. **Router registration**: `routers.include_routers(app)` attaches all endpoint routers.
+
+4. **Route path collection**: Builds `app_routes_paths` list for the metrics middleware to filter on.
+
+5. **Config status** (conditional): If `user_data_collection.config_status_enabled` is true, extracts and stores config status for telemetry.
+
+### Request flow (`POST /v1/query`)
+
+```
+Client
+  |
+  v
+FastAPI middleware (log_requests_responses -> rest_api_counter)
+  |
+  v
+ols.py: conversation_request()
+  |-- process_request()
+  |     |-- auth_dependency(request) -> (user_id, user_name, skip_check, token)
+  |     |-- retrieve_conversation_id() -> new or existing UUID
+  |     |-- redact_query() via config.query_redactor
+  |     |-- redact_attachments()
+  |     |-- append_attachments_to_query()
+  |     |-- validate_requested_provider_model() via llm_loader.resolve_provider_config()
+  |     |-- check_tokens_available() via quota_limiters
+  |
+  |-- generate_response()
+  |     |-- DocsSummarizer(provider, model, system_prompt, mode, user_token, client_headers)
+  |     |     |-- QueryHelper.__init__() -> resolves defaults, selects system prompt by mode
+  |     |     |-- _prepare_llm() -> loads LLM via llm_loader.load_llm()
+  |     |     |-- build_mcp_config() -> resolves MCP server configs
+  |     |     |-- TokenBudgetTracker() -> initializes per-request token accounting
+  |     |
+  |     |-- .create_response(query, rag_retriever, user_id, conversation_id)
+  |           |-- _prepare_prompt_context() -> RAG retrieval + truncation
+  |           |-- skills_rag.retrieve_skill() -> optional skill injection
+  |           |-- prepare_history() -> cache.get() + truncation
+  |           |-- _build_final_prompt() -> GeneratePrompt().generate_prompt()
+  |           |-- get_mcp_tools() -> tool filtering via ToolsRAG, tool fetching from MCP servers
+  |           |-- iterate_with_tools() -> multi-round LLM + tool execution loop
+  |                 |-- _invoke_llm() -> chain.astream() with optional bind_tools()
+  |                 |-- _process_tool_calls_for_round() -> execute_tool_calls_stream()
+  |
+  |-- store_conversation_history() via config.conversation_cache
+  |-- store_transcript() -> filesystem JSON
+  |-- consume_tokens() via quota_limiters + token_usage_history
+  |
+  v
+LLMResponse (conversation_id, response, referenced_documents, token counts, tool info)
+```
+
+## Key Abstractions
+
+### AppConfig singleton (`ols/utils/config.py`)
+
+The `AppConfig` class uses `__new__` to enforce a single instance. Subsystems are initialized lazily via `@property` (with manual `None`-check caching) or `@cached_property`. The module-level `config` variable is imported as `from ols import config` throughout the codebase, allowing `config.ols_config`, `config.conversation_cache`, `config.rag_index`, etc.
+
+Lazy properties with manual caching (resettable on reload): `conversation_cache`, `quota_limiters`, `token_usage_history`, `query_redactor`, `rag_index_loader`.
+
+Lazy properties with `@cached_property` (cleared by deleting from `__dict__` on reload): `mcp_servers_dict`, `tools_rag`, `skills_rag`.
+
+### LLM Provider Registry (`ols/src/llms/providers/registry.py`)
+
+`LLMProvidersRegistry` is a class with a `ClassVar[dict]` mapping provider type strings to `LLMProvider` subclasses. Providers self-register using the `@register_llm_provider_as("type")` decorator. `llm_loader.load_llm()` looks up the registry, instantiates the provider, and calls `.load()` to get a LangChain `BaseChatModel` or `LLM`.
+
+The `LLMProvider` base class handles: generic-to-provider parameter remapping (e.g., `max_tokens_for_response` to `max_completion_tokens` for OpenAI), parameter validation against allowed sets, dev config overrides, and HTTPX client construction with TLS/proxy support.
+
+### Auth dependency injection (`ols/src/auth/`)
+
+`AuthDependencyInterface(ABC)` defines the contract: `async __call__(request) -> (user_id, user_name, skip_user_id_check, user_token)`. The `get_auth_dependency()` factory selects the implementation based on `authentication_config.module`. Endpoints use FastAPI's `Depends(auth_dependency)` pattern.
+
+### Cache abstraction (`ols/src/cache/`)
+
+`Cache(ABC)` defines the interface with compound keys (`user_id:conversation_id`). `CacheFactory` selects `InMemoryCache` or `PostgresCache` based on config. Both implementations store lists of `CacheEntry` objects (query/response pairs with metadata).
+
+### Quota limiter abstraction (`ols/src/quota/`)
+
+`QuotaLimiter(ABC)` defines `available_quota`, `ensure_available_quota`, `consume_tokens`. `QuotaLimiterFactory` creates instances. The quota scheduler runs in a separate daemon thread for periodic revocation/reset against PostgreSQL.
+
+### Token budget tracking (`ols/utils/token_handler.py`)
+
+`TokenBudgetTracker` manages the per-request token budget across categories: `PROMPT`, `RAG`, `HISTORY`, `SKILL`, `TOOL_DEFINITIONS`, `TOOL_RESULT`, `AI_ROUND`. It partitions the context window into prompt budget and tool budget based on `DEFAULT_TOOL_BUDGET_RATIO`, and enforces per-round caps via `tools_round_budget`.
+
+### Router-based endpoint organization
+
+All endpoints use `APIRouter` instances with tag grouping. The `include_routers()` function in `app/routers.py` attaches them with appropriate prefixes (`/v1` for business endpoints, none for health/metrics).
+
+### Middleware stack (`app/main.py`)
+
+Two middleware functions registered via `@app.middleware("")`:
+- `log_requests_responses` -- debug-level request/response body and header logging (inner, runs first).
+- `rest_api_counter` -- Prometheus histogram for response duration, counter for API calls, and security header injection on non-health endpoints (outer, runs second).
+
+## Integration Points
+
+### app -> src
+
+- `app/endpoints/ols.py` imports `DocsSummarizer` from `src/query_helpers/docs_summarizer`
+- `app/endpoints/ols.py` imports `get_auth_dependency` from `src/auth/auth`
+- `app/endpoints/ols.py` imports `resolve_provider_config` from `src/llms/llm_loader`
+- `app/endpoints/health.py` imports `load_llm` from `src/llms/llm_loader`
+- `app/metrics/metrics.py` imports `get_auth_dependency` from `src/auth/auth`
+
+### app -> utils
+
+- `app/endpoints/ols.py` imports `errors_parsing`, `suid` from `utils/`
+- All endpoint modules import `config` from `ols` (which is `ols/utils/config.py`)
+- `app/main.py` imports `config`, `constants`, `version`
+
+### src -> src (internal)
+
+- `src/query_helpers/docs_summarizer.py` imports from `src/prompts/`, `src/tools/`, `src/auth/k8s`
+- `src/query_helpers/query_helper.py` imports `load_llm` from `src/llms/llm_loader`
+- `src/llms/llm_loader.py` imports `LLMProvidersRegistry` from `src/llms/providers/registry`
+
+### src -> utils
+
+- `src/query_helpers/docs_summarizer.py` imports `TokenHandler`, `TokenBudgetTracker` from `utils/token_handler`
+- `src/query_helpers/docs_summarizer.py` imports `mcp_utils` from `utils/`
+- `src/llms/providers/provider.py` imports `tls` from `utils/`
+
+### utils/config.py -> src (lazy imports)
+
+The `AppConfig` singleton imports factory classes from `src/` at module level: `CacheFactory`, `QuotaLimiterFactory`, `TokenUsageHistory`, `IndexLoader`, `SkillsRAG`, `ToolsRAG`. These are used in lazy `@property` methods, so the actual construction is deferred.
+
+### runners -> everything
+
+`runner.py` imports from `ols/constants`, `ols/runners/`, `ols/src/auth/`, `ols/utils/`, and `ols` (config). It orchestrates the startup sequence by calling into each subsystem.
+
+## Implementation Notes
+
+### Import order matters for lazy loading
+
+`runner.py` calls `configure_gradio_ui_envs()` before `from ols import config`. This is required because importing `ols.config` triggers `ols/utils/config.py` module-level code, and Gradio environment variables must be set before any transitive Gradio imports. The comment in `runner.py` is explicit: "We import config here to avoid triggering import of anything else via our code before other envs are set (mainly the gradio)."
+
+### Gradio dev UI is conditionally imported
+
+In `app/main.py`, the `GradioUI` import is inside an `if config.dev_config.enable_dev_ui:` block. This avoids importing Matplotlib, Pillow, and other heavy Gradio dependencies in production. The Gradio UI mounts onto the existing FastAPI app instance and may replace it (the `app` variable is reassigned).
+
+### Workers must be 1
+
+`runners/uvicorn.py` passes `workers=config.ols_config.max_workers` to `uvicorn.run()`. However, the comment says "use workers=1 so config loaded can be accessed from other modules." The singleton `AppConfig` is process-local; multiple workers would each have independent config instances. The RAG index loading thread would also be per-worker.
+
+### RAG index loads in background
+
+The RAG index thread (`threading.Thread(target=load_index)`) starts before Uvicorn so the server can accept liveness probes immediately. The readiness probe at `/readiness` checks `index_is_ready()` which returns `False` until the index is loaded. The `IndexLoader` is excluded from MyPy type checking (`# type: ignore [attr-defined]`).
+
+### Config reload resets cached properties differently
+
+Properties using manual `None`-check caching (`_conversation_cache`, `_query_filters`, `_rag_index_loader`, `_tools_approval`, `_pending_approval_store`) are reset by setting the backing field to `None`. Properties using `@cached_property` (`mcp_servers_dict`, `tools_rag`, `skills_rag`) are reset by deleting the key from `self.__dict__`. Both patterns coexist in `reload_from_yaml_file()`.
+
+### Auth dependency is resolved at module level
+
+In `app/endpoints/ols.py` and `app/metrics/metrics.py`, `auth_dependency = get_auth_dependency(config.ols_config, virtual_path=...)` executes at import time. This means the auth module selection is fixed when the endpoint module is first imported and cannot change without restarting the process.
+
+### Quota scheduler runs in a daemon thread
+
+`start_quota_scheduler()` spawns a daemon thread with an infinite `while True` / `sleep(period)` loop. Because it is a daemon thread, it is killed when the main process exits. The scheduler directly manipulates PostgreSQL via psycopg2 (not through the quota limiter abstraction).
+
+### Tool calling uses a multi-round streaming loop
+
+`DocsSummarizer.iterate_with_tools()` implements the agentic tool-calling loop. It streams LLM chunks, detects tool call requests, executes them via MCP, appends results to the message history, and re-invokes the LLM -- up to `max_rounds` iterations. The final round binds tools with `tool_choice="none"` to force a text-only response. Tool outputs are truncated by `enforce_tool_token_budget()` when they exceed the remaining token budget.
+
+### Entry point and build system
+
+The ASGI entry point is `ols.app.main:app`. The build system uses `hatchling` with version sourced from `ols/version.py`. Dependencies are managed by `uv` (not pip/poetry). Python target is `>=3.12,<3.13`. The wheel package includes only the `ols` package.
+
+### `RUNNING_IN_CLUSTER` detection
+
+`ols/constants.py` sets `RUNNING_IN_CLUSTER` by checking for `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` environment variables at import time. This is a static, process-lifetime decision.
+
+### Pending approval store uses deferred import
+
+`AppConfig.pending_approval_store` uses an inline import (`from ols.src.tools.approval import create_pending_approval_store`) to avoid circular imports. This is one of the few places in the codebase where inline imports are used intentionally.

--- a/.ai/spec/how/query-pipeline.md
+++ b/.ai/spec/how/query-pipeline.md
@@ -1,0 +1,305 @@
+# Query Pipeline -- Architecture
+
+The query pipeline is the core request-processing path that transforms a user question into an LLM-generated answer with optional RAG context, conversation history, skill injection, and multi-round tool calling. `DocsSummarizer` is the single orchestrator that owns this entire flow.
+
+## Module Map
+
+### `ols/app/endpoints/ols.py` -- Non-streaming entry point
+
+- `process_request()` -- Auth, redaction, attachment appending, quota check. Returns a `ProcessedRequest` dataclass.
+- `generate_response()` -- Constructs `DocsSummarizer`, calls either `create_response()` (sync) or `generate_response()` (async generator). Catches `PromptTooLongError` and generic LLM errors, translating them to HTTP status codes.
+- `store_conversation_history()` -- Persists the completed turn (query + response + tool data) to the conversation cache.
+- `store_transcript()` -- Writes a JSON transcript file to disk when collection is enabled.
+- `consume_tokens()` -- Deducts input/output tokens from all configured quota limiters.
+
+### `ols/app/endpoints/streaming_ols.py` -- Streaming entry point
+
+- `conversation_request()` -- FastAPI endpoint that returns a `StreamingResponse` wrapping the async generator.
+- `response_processing_wrapper()` -- Async generator that consumes `StreamedChunk` objects from `DocsSummarizer.generate_response()`, converts each to an SSE-formatted string, accumulates the full response text, then calls `store_data()` and `consume_tokens()` after the stream ends.
+- `stream_event()` -- Formats a single chunk as either plain text or SSE JSON (`data: {...}\n\n`) depending on the requested `media_type`.
+- `stream_start_event()` / `stream_end_event()` -- Bookend events for JSON media type streams.
+
+### `ols/src/query_helpers/docs_summarizer.py` -- The orchestrator
+
+- `DocsSummarizer(QueryHelper)` -- Central class. Constructed once per request.
+  - `__init__()` -- Loads LLM, resolves MCP tool servers, creates `TokenBudgetTracker`.
+  - `generate_response()` -- Async generator: the main pipeline stages (RAG, skill, history, prompt, tool loop). Yields `StreamedChunk` objects.
+  - `create_response()` -- Sync wrapper that drains `generate_response()` into a `SummarizerResponse`.
+  - `_prepare_prompt_context()` -- Builds a template prompt to measure base token cost, retrieves RAG nodes, truncates them to fit.
+  - `_build_final_prompt()` -- Assembles the real prompt with history, RAG, and skill content. Checks total against budget.
+  - `iterate_with_tools()` -- Multi-round tool-calling loop. Each round: invoke LLM, collect chunks, process tool calls, feed results back.
+  - `_collect_round_llm_chunks()` -- Streams one LLM invocation, separates text/reasoning chunks from tool-call chunks.
+  - `_process_tool_calls_for_round()` -- Resolves tool calls, executes them, emits `TOOL_CALL` and `TOOL_RESULT` streaming events.
+  - `_invoke_llm()` -- Binds tools to the LLM (or unbinds on final round) and streams via LangChain's `chain.astream()`.
+
+### `ols/src/query_helpers/query_helper.py` -- Base class
+
+- `QueryHelper` -- Resolves provider/model defaults, loads system prompt by mode (`ASK` vs `TROUBLESHOOTING`), stores `llm_loader` callable.
+
+### `ols/src/query_helpers/history_support.py` -- History compression
+
+- `prepare_history()` -- Async generator: retrieves cache entries, decides whether compression is needed, yields progress events and final `(history, truncated)` tuple.
+- `compress_conversation_history()` -- Splits entries into a "keep" tail and a "summarize" prefix, calls `summarize_entries()`, rewrites the cache with a synthetic summary entry.
+- `summarize_entries()` -- Calls the LLM to produce a conversational summary. Retries transient failures up to 3 times with exponential backoff.
+- `_split_entries_by_token_budget()` -- Walks entries newest-to-oldest, accumulating token counts until the budget is exhausted.
+
+### `ols/src/query_helpers/attachment_appender.py` -- Attachment formatting
+
+- `append_attachments_to_query()` -- Concatenates formatted attachment blocks to the query string.
+- `format_attachment()` -- Wraps content in Markdown code fences with language hint. YAML attachments get an intro message identifying the resource kind/name.
+
+### `ols/utils/token_handler.py` -- Token accounting
+
+- `TokenHandler` -- Stateless tokenizer wrapper (tiktoken `cl100k_base`). Methods: `text_to_tokens()`, `tokens_to_text()`, `truncate_rag_context()`, `limit_conversation_history()`, `calculate_and_check_available_tokens()`.
+- `TokenBudgetTracker` -- Per-request stateful budget tracker. Tracks usage by `TokenCategory` enum (PROMPT, HISTORY, RAG, SKILL, TOOL_DEFINITIONS, AI_ROUND, TOOL_RESULT).
+- `PromptTooLongError` -- Raised when any stage exceeds the available budget.
+
+## Data Flow
+
+### 1. Request intake (endpoint layer)
+
+```
+HTTP POST /query or /streaming_query
+  -> process_request()
+       auth -> user_id, user_token
+       redact_query() -> PII-scrubbed query
+       retrieve_attachments() -> redact_attachments()
+       append_attachments_to_query() -> query now includes attachment blocks
+       validate_requested_provider_model()
+       check_tokens_available() -> quota gate
+  -> generate_response()
+       constructs DocsSummarizer(provider, model, mode, user_token, client_headers, streaming)
+       calls create_response() [sync] or generate_response() [async generator]
+```
+
+### 2. DocsSummarizer.__init__
+
+```
+QueryHelper.__init__() -> resolve provider/model defaults, load system prompt
+_prepare_llm()         -> load LLM via llm_loader, store provider_config/model_config
+build_mcp_config()     -> resolve MCP server configs with user token/headers
+TokenBudgetTracker()   -> initialize with context_window_size, max_response_tokens,
+                          max_tool_tokens, round_cap_fraction
+set_tool_loop_max_rounds() -> store max iterations for adaptive budget
+```
+
+### 3. generate_response() stages
+
+```
+Stage 1: RAG context
+  _prepare_prompt_context(query, rag_retriever)
+    -> build template prompt, count base prompt tokens, charge PROMPT
+    -> retrieve RAG nodes, truncate to history_budget, charge RAG
+
+Stage 2: Skill selection
+  skills_rag.retrieve_skill(query) -> (skill, confidence)
+  skill.load_content()
+  if skill_tokens > available * 0.8: skip skill
+  else: charge SKILL, yield SKILL_SELECTED chunk
+
+Stage 3: History retrieval and compression
+  prepare_history() -> async generator
+    -> retrieve cache entries
+    -> if compression enabled and entries overflow budget:
+         yield HISTORY_COMPRESSION_START
+         compress_conversation_history()
+         yield HISTORY_COMPRESSION_END
+    -> yield (history_messages, truncated)
+  charge HISTORY for each message
+
+Stage 4: Final prompt assembly
+  _build_final_prompt(query, history, rag_chunks, skill_content)
+    -> GeneratePrompt(...).generate_prompt(model)
+    -> budget overflow check (including tool_definitions_tokens)
+
+Stage 5: Tool resolution
+  get_mcp_tools(query, user_token, client_headers)
+  count tool definition tokens, check against prompt budget
+
+Stage 6: Tool-calling loop (iterate_with_tools)
+  for round 1..max_rounds:
+    _collect_round_llm_chunks() -> text/reasoning chunks + tool_call chunks
+    yield text/reasoning StreamedChunks
+    if no tool calls or final round: break
+    _process_tool_calls_for_round():
+      resolve tool call definitions (skip duplicates, missing, invalid)
+      yield TOOL_CALL chunks
+      execute tools within round budget
+      yield TOOL_RESULT chunks
+      append AI message + tool messages to prompt for next round
+      charge AI_ROUND and TOOL_RESULT
+
+Stage 7: Finalization
+  yield END chunk with rag_chunks, truncated flag, token_counter
+```
+
+### 4. Post-generation (endpoint layer)
+
+```
+Non-streaming:
+  store_conversation_history() -> cache
+  store_transcript() -> filesystem
+  consume_tokens() -> quota limiters
+  return LLMResponse
+
+Streaming:
+  response_processing_wrapper() consumes the async generator:
+    yield stream_start_event (JSON mode)
+    for each StreamedChunk: yield formatted SSE event
+    on END chunk: extract rag_chunks, truncated, token_counter
+    store_data() -> cache + transcript
+    consume_tokens() -> quota limiters
+    yield stream_end_event with referenced docs and available quotas
+```
+
+## Key Abstractions
+
+### DocsSummarizer as orchestrator
+
+`DocsSummarizer` is the only class that knows the full pipeline sequence. It inherits from `QueryHelper` for provider/model/prompt defaults but adds all pipeline logic. Both the sync (`create_response`) and streaming paths funnel through the same `generate_response()` async generator -- the sync path simply drains it.
+
+### Token budget partitioning
+
+The context window is divided into three non-overlapping slices:
+
+```
+context_window_size = prompt_budget + max_response_tokens + max_tool_tokens
+
+prompt_budget = context_window_size - max_response_tokens - max_tool_tokens
+```
+
+Within `prompt_budget`, categories are charged in order: PROMPT (base template) -> RAG -> SKILL -> HISTORY. The `history_budget` property returns the remaining space after prompt, RAG, and skill tokens are deducted:
+
+```
+history_budget = prompt_budget - usage[PROMPT] - usage[RAG] - usage[SKILL]
+```
+
+Token counts use tiktoken's `cl100k_base` encoding with a 10% safety buffer (`TOKEN_BUFFER_WEIGHT = 1.1`, applied via `ceil(len(tokens) * 1.1)`).
+
+The tool execution budget is separate from the prompt budget. Within it, each round is capped at `round_cap_fraction` (default 0.6, configurable 0.3-0.8) of the remaining tool budget:
+
+```
+tools_round_budget = int(tool_budget_remaining * round_cap_fraction)
+```
+
+The adaptive `tools_round_execution_budget()` additionally considers horizon (rounds remaining) to distribute budget more evenly:
+
+```
+exec_budget = min(
+    int(remaining_tool * round_cap_fraction),
+    remaining_tool // max(1, tool_rounds_left)
+)
+```
+
+Tool definitions tokens (serialized JSON schemas of all MCP tools) are charged under `TOOL_DEFINITIONS` but excluded from the tool execution budget calculation -- only `AI_ROUND` and `TOOL_RESULT` consume the execution pool.
+
+### StreamedChunk types and interleaving during tool calling
+
+All pipeline output flows through `StreamedChunk(type, text, data)`. The `StreamChunkType` enum defines:
+
+| Type | When emitted | Payload |
+|---|---|---|
+| `TEXT` | LLM text tokens | `text` field |
+| `REASONING` | Model reasoning tokens (e.g. OpenAI o-series) | `text` field |
+| `TOOL_CALL` | Before tool execution | `data`: tool name, args, id, server metadata |
+| `APPROVAL_REQUIRED` | Tool requires user approval | `data`: approval request details |
+| `TOOL_RESULT` | After tool execution | `data`: id, name, status, content, round, structured_content |
+| `SKILL_SELECTED` | After skill retrieval | `data`: name, confidence, optional skipped/reason |
+| `HISTORY_COMPRESSION_START` | Before LLM-based compression | `data`: `{"status": "started"}` |
+| `HISTORY_COMPRESSION_END` | After compression completes | `data`: status, duration_ms |
+| `END` | Pipeline complete | `data`: rag_chunks, truncated, token_counter |
+
+During a multi-round tool call, the interleaving pattern is:
+
+```
+[round 1]
+  TEXT/REASONING chunks (partial answer or reasoning)
+  TOOL_CALL chunk (intent to call tool X)
+  TOOL_CALL chunk (intent to call tool Y)
+  TOOL_RESULT chunk (result from tool X)
+  TOOL_RESULT chunk (result from tool Y)
+[round 2]
+  TEXT/REASONING chunks (LLM incorporates tool results)
+  ... more TOOL_CALL/TOOL_RESULT if needed ...
+[final round]
+  TEXT chunks (final answer, tools unbound or tool_choice="none")
+END chunk
+```
+
+### History compression
+
+When `history_compression_enabled` is true, `prepare_history()` uses a two-phase approach:
+
+1. **Budget check**: `_split_entries_by_token_budget()` walks entries newest-to-oldest with an effective budget of `available_tokens * 0.85` (`HISTORY_TOKEN_BUDGET_RATIO`). If all entries fit, no compression occurs.
+
+2. **Compression**: When entries overflow, `compress_conversation_history()` keeps the most recent `entries_to_keep` entries (default 5) verbatim. All older entries are passed to `summarize_entries()`, which calls the LLM with a structured summarization prompt.
+
+3. **Retry logic**: `summarize_entries()` retries up to 3 attempts with exponential backoff (1s, 2s, 4s). Each attempt has a 20-second timeout (`SUMMARY_ATTEMPT_TIMEOUT_SECONDS`). Only transient errors (timeout, connection, rate limit, 429/502/503) trigger retries; other errors fail immediately.
+
+4. **Fallback**: If summarization fails entirely, the system falls back to keeping only the newest entries (or the single most recent entry if none fit). The compressed history is persisted back to the cache as a synthetic `[Previous conversation summary]` entry followed by the kept raw entries.
+
+When compression is disabled, `limit_conversation_history()` does simple newest-first truncation to fit the token budget.
+
+## Integration Points
+
+### LLM providers
+
+`DocsSummarizer` loads the LLM via `llm_loader` (default: `load_llm` from `ols.src.llms.llm_loader`). The bare LLM is used directly for streaming (`chain.astream()`) and for history summarization. Tools are bound per-round via LangChain's `bind_tools()` with `strict=False` to avoid Responses API issues.
+
+### Conversation cache
+
+Read path: `_retrieve_previous_input()` calls `config.conversation_cache.get()` to load full conversation history as `CacheEntry` objects.
+
+Write path: `store_conversation_history()` calls `config.conversation_cache.insert_or_append()`. During compression, `_rewrite_cache()` deletes then re-inserts the compressed entries.
+
+### RAG index
+
+`_prepare_prompt_context()` calls `rag_retriever.retrieve(query)` (LlamaIndex `BaseRetriever`). Results are filtered by `RAG_SIMILARITY_CUTOFF` (0.3) and truncated by `truncate_rag_context()` to fit the remaining token budget. Each accepted node becomes a `RagChunk(text, doc_url, doc_title)`.
+
+### MCP tools
+
+`build_mcp_config()` resolves server configurations from `config.mcp_servers.servers` with user token/headers. `get_mcp_tools()` fetches available tools from all configured MCP servers. Tool execution goes through `execute_tool_calls_stream()`, which yields `APPROVAL_REQUIRED` and `TOOL_RESULT` events.
+
+### Skills
+
+`config.skills_rag.retrieve_skill(query)` returns a matched skill and confidence score. The skill's content is loaded from disk and injected into the prompt via `GeneratePrompt`. If the skill would consume more than 80% of the available history budget, it is skipped.
+
+### Quota
+
+Pre-check: `check_tokens_available()` calls `quota_limiter.ensure_available_quota()` before processing. Post-response: `consume_tokens()` deducts the actual input/output token counts from all configured quota limiters and records usage in `token_usage_history`.
+
+### Prompts
+
+`GeneratePrompt` (from `ols.src.prompts.prompt_generator`) constructs the `ChatPromptTemplate` from the system prompt, RAG context, history, tool-calling flag, query mode, cluster version, and optional skill content. The system prompt is selected by mode: `QUERY_SYSTEM_INSTRUCTION` for ASK, `TROUBLESHOOTING_SYSTEM_INSTRUCTION` for TROUBLESHOOTING.
+
+## Implementation Notes
+
+### Token budget calculation algorithm
+
+The budget is calculated once in `DocsSummarizer.__init__` via `TokenBudgetTracker` and charged incrementally as each stage runs. The order matters: prompt template tokens are measured first (using a dummy prompt with placeholder history/RAG), then RAG tokens, then skill tokens, and finally history tokens. Each stage uses `history_budget` (the remaining headroom) as its ceiling, which naturally shrinks as prior stages consume tokens. If any stage would push total usage beyond `prompt_budget`, a `PromptTooLongError` is raised.
+
+### How streaming chunks interleave during tool calling
+
+In non-final rounds, the LLM is invoked with tools bound (no `tool_choice` constraint). `_collect_round_llm_chunks()` accumulates all chunks from one LLM invocation, separating tool-call chunks from text/reasoning chunks. Text chunks are yielded immediately for streaming. After the LLM stream ends, `_process_tool_calls_for_round()` emits `TOOL_CALL` events, executes the tools, then emits `TOOL_RESULT` events. The AI message (including any reasoning content) and all tool messages are appended to the prompt template for the next round.
+
+On the final round (round == max_rounds or no tools available), the LLM is invoked with `tool_choice="none"` and `strict=False` to force a text-only response. The Granite model family requires special handling: the first 6 chunks of a tool call (`"", "<", "tool", "_", "call", ">"`) are suppressed via `skip_special_chunk()` to avoid leaking tool-call markup to the user.
+
+### History compression retry logic
+
+`summarize_entries()` uses 3 attempts with delays of 1s, 2s (exponential backoff, `delay *= 2`). Each LLM call is wrapped in `asyncio.wait_for()` with a 20-second timeout. Only transient errors (containing keywords like "timeout", "connection", "rate limit", "429", "502", "503") trigger retries. Non-transient errors (e.g., auth failures, malformed responses) break immediately. If all attempts fail, `compress_conversation_history()` falls back to keeping only the newest raw entries without a summary.
+
+### Relationship between generate_response() and the streaming generator
+
+`generate_response()` is an async generator that yields `StreamedChunk` objects. For streaming endpoints, this generator is passed directly to `response_processing_wrapper()`, which consumes it chunk-by-chunk, formats each as SSE, and yields strings to FastAPI's `StreamingResponse`. For non-streaming endpoints, `create_response()` calls `run_async_safely()` around an inner `drain_generate_response()` coroutine that collects all chunks into a single `SummarizerResponse`. This means the same pipeline code runs for both paths -- the only difference is whether chunks are streamed to the client or buffered internally.
+
+### How attachments are positioned in the prompt
+
+Attachments are appended to the query string before it enters `DocsSummarizer`. The `append_attachments_to_query()` function concatenates each attachment after the original query text, separated by blank lines. Each attachment is wrapped in Markdown code fences with a language hint derived from its content type. YAML attachments additionally get an intro sentence like "For reference, here is the full resource YAML for Pod 'my-pod':". The modified query (with attachments) is what the LLM sees as the user message; the original query (without attachments) is preserved separately for transcript storage.
+
+### Round cap fraction for tool calling
+
+The `round_cap_fraction` (default 0.6, range 0.3-0.8) limits how much of the remaining tool budget any single round can consume. This prevents an early round from exhausting all tool tokens, leaving nothing for subsequent rounds. The fraction is applied to `tool_budget_remaining`, which tracks only execution traffic (`AI_ROUND` + `TOOL_RESULT` categories) -- tool definition tokens are charged separately and do not reduce the execution pool. If the remaining budget for a round falls below `MIN_TOOL_EXECUTION_TOKENS` (100), all tool calls for that round are skipped with an error message. Each LLM round also has a hard timeout of 300 seconds (`TOOL_CALL_ROUND_TIMEOUT`).
+
+### Max iterations by mode
+
+The tool-calling loop cap depends on the query mode: ASK defaults to 5 rounds, TROUBLESHOOTING defaults to 15 rounds. An explicit `max_iterations` config value can raise but never lower the mode-specific default. The final round always forces `tool_choice="none"` to guarantee a text answer.

--- a/.ai/spec/how/tools.md
+++ b/.ai/spec/how/tools.md
@@ -1,0 +1,246 @@
+# Tools -- Architecture
+
+The tools subsystem manages MCP (Model Context Protocol) server integration,
+tool discovery and filtering, human-in-the-loop approval gating, parallel tool
+execution with retry/backoff, and token-budget-aware result truncation.
+
+## Module Map
+
+| File | Key symbols | Responsibility |
+|---|---|---|
+| `ols/utils/mcp_utils.py` | `build_mcp_config`, `gather_mcp_tools`, `get_mcp_tools`, `resolve_header_value`, `_normalize_tool_schema` | MCP client lifecycle: builds per-server transport configs with placeholder resolution, connects to servers via `MultiServerMCPClient`, gathers tools with fault isolation (one failing server does not block others), deduplicates by name (first-seen wins), and normalizes schemas for OpenAI compatibility. Optionally routes through ToolsRAG for query-based filtering. |
+| `ols/src/tools/tools.py` | `execute_tool_calls_stream`, `enforce_tool_token_budget`, `execute_tool_call`, `_execute_with_retries`, `_extract_text_from_tool_output` | Tool execution engine: runs tool calls in parallel via `aiostream.merge`, applies retry/backoff for transient errors, extracts text from both string and content-block outputs, enforces per-tool and aggregate token budgets with a 3-tier truncation strategy. Emits typed streaming events (`ApprovalRequiredEvent`, `ToolResultEvent`). |
+| `ols/src/tools/approval.py` | `need_validation`, `get_approval_decision`, `set_approval_decision`, `register_pending_approval`, `InMemoryPendingApprovalStore` | Approval state machine: determines whether a tool call requires user approval (based on config strategy and tool annotations), registers pending approvals in an in-memory store backed by `asyncio.Event`, waits for decisions with configurable timeout, and cleans up state on completion. |
+| `ols/src/tools/tools_rag/hybrid_tools_rag.py` | `ToolsRAG`, `populate_tools`, `retrieve_hybrid`, `remove_tools` | Hybrid RAG for tool filtering: indexes tool name+description into Qdrant (in-memory) with dense embeddings and BM25 sparse vectors, retrieves relevant tools via reciprocal rank fusion (RRF) with configurable alpha weighting, grouped by server. Supports default servers (always included) and per-request client servers. |
+| `ols/app/endpoints/tool_approvals.py` | `submit_tool_approval_decision` | REST endpoint (`POST /tool-approvals/decision`) for receiving user approval/rejection decisions. Delegates to `set_approval_decision` and returns 404/409 for missing or already-resolved approvals. |
+| `ols/src/query_helpers/docs_summarizer.py` | `_resolve_tool_call_definitions`, `_process_tool_calls_for_round` | Caller-side orchestration: resolves LLM-emitted tool calls to executable definitions (validating name, args type, deduplication), invokes the execution engine, enforces the aggregate token budget, and emits streaming events for tool_call, approval_required, and tool_result. |
+
+## Data Flow
+
+### 1. MCP Client Setup (startup / per-request)
+
+```
+olsconfig.yaml (mcp_servers section)
+  -> MCPServerConfig list with name, url, headers, timeout
+  -> build_mcp_config(servers_list, user_token, client_headers)
+     -> For each server:
+        resolve_server_headers: substitute placeholders in header values
+          "kubernetes" -> "Bearer {user_token}" (k8s service account token)
+          "client"     -> value from client_headers[server_name][header_name]
+          other        -> literal value (resolved at config load from file/env)
+        Build MCPServerTransport dict: transport="streamable_http", url, headers, timeout
+        Optionally attach custom CA bundle via httpx_client_factory
+  -> MCPServersDict: {server_name -> transport config}
+```
+
+### 2. Tool Gathering (per-request or cached via ToolsRAG)
+
+```
+get_mcp_tools(query, user_token, client_headers)
+  -> If no ToolsRAG configured:
+       _gather_and_populate_tools -> gather_mcp_tools -> MultiServerMCPClient
+       -> Connect to each server independently (fault-isolated)
+       -> Collect StructuredTool list, tag each with metadata["mcp_server"]
+       -> _normalize_tool_schema: add empty "properties"/{} to no-arg tools
+       -> Deduplicate by name (first-seen wins, log warning for duplicates)
+  -> If ToolsRAG configured:
+       _populate_tools_rag (one-time for k8s servers, per-request for client servers)
+       -> Index tools into Qdrant via populate_tools
+       -> retrieve_hybrid(query, client_servers)
+          -> Dense: encode query -> cosine similarity in Qdrant
+          -> Sparse: BM25 over tokenized tool text (name + description)
+          -> RRF fusion with alpha weight (default 0.8 = mostly dense)
+          -> Filter by threshold, group by server
+       -> Gather only the filtered tools from their source servers
+```
+
+### 3. Tool Binding and LLM Interaction
+
+```
+DocsSummarizer.__init__
+  -> get_mcp_tools(query) returns list[StructuredTool]
+  -> llm.bind_tools(tools) attaches tool schemas to LLM
+
+LLM streaming response
+  -> Chunks with tool_call_chunks accumulated until finish_reason
+  -> tool_calls_from_tool_calls_chunks: merge partial chunks into complete calls
+  -> _resolve_tool_call_definitions: validate each call
+       Skip: missing name, duplicate name, unavailable tool, invalid args type
+       Accept: (tool_id, tool_args, StructuredTool) triple
+```
+
+### 4. Tool Execution (per round)
+
+```
+_process_tool_calls_for_round
+  -> Stream tool_call events to client
+  -> execute_tool_calls_stream(tool_call_definitions, tools_token_budget)
+     -> Split budget equally: per_tool_budget = total // len(calls)
+     -> aiostream.merge: run all tool generators concurrently
+        For each tool call:
+          1. _evaluate_and_emit_approval_event
+               need_validation(streaming, approval_type, tool_annotation)
+                 -> "never": skip
+                 -> "always": require approval
+                 -> "tool_annotations": require unless readOnlyHint=true
+               If needed: register_pending_approval -> yield approval_required event
+                          -> await get_approval_decision (asyncio.Event + timeout)
+                          -> If denied/timeout: yield rejection event, raise _ApprovalNotGrantedError
+          2. _execute_with_retries
+               Up to MAX_TOOL_CALL_RETRIES (2) + 1 attempts
+               Backoff: 0.2s * 2^attempt (transient), 1.0s * 2^attempt (429 rate limit)
+               On success: _extract_text_from_tool_output
+                 -> String or content-block list (langchain-mcp-adapters >= 0.2.0)
+                 -> Cheap char guard: tools_token_budget * 4 chars max
+                 -> Cut at last newline boundary, append truncation warning
+               On failure: return error status with truncated reason
+          3. Yield ToolResultEvent with ToolMessage
+  -> enforce_tool_token_budget(all_tool_messages, remaining_budget)
+       Tier 1: char estimate (len/4) -- if < 90% of budget, skip tokenization
+       Tier 2: precise tokenization -- if under budget, return as-is
+       Tier 3: truncation
+         If longest message can absorb excess (>= 2x excess): shrink only that one
+         Otherwise: scale all messages proportionally (ratio = budget/total)
+         Cut at last newline, append truncation warning
+  -> Yield tool_result streaming events, charge token budget
+  -> Append ToolMessages to conversation, loop back to LLM
+```
+
+## Key Abstractions
+
+### MCP Client Wrapper
+
+`MultiServerMCPClient` (from `langchain_mcp_adapters`) is the transport layer.
+OLS wraps it with fault isolation: `gather_mcp_tools` connects to each server
+individually so one unreachable server does not block others. Tool schemas are
+normalized post-collection to ensure OpenAI compatibility (adding empty
+`properties` dict to no-arg tools).
+
+### Approval State Machine
+
+States: `pending` -> `approved` | `rejected` | `timeout` | `error`
+
+The store is pluggable via `PendingApprovalStoreBase` ABC, with
+`InMemoryPendingApprovalStore` as the only implementation. Each pending approval
+is a `PendingApproval` dataclass holding an `asyncio.Event` for the waiter and a
+`decision: bool | None` field. The waiter blocks on `event.wait()` with
+`asyncio.wait_for` for timeout enforcement. The `finally` block always deletes
+the entry from the store, preventing memory leaks.
+
+Three approval strategies (`ApprovalType` enum):
+- `never` -- tools execute without approval (default)
+- `always` -- every tool call requires user approval
+- `tool_annotations` -- approval required unless the tool declares `readOnlyHint: true` in its MCP annotations
+
+Approval is only supported on streaming requests (non-streaming always skips).
+
+### Hybrid RAG for Tool Filtering
+
+`ToolsRAG` extends `HybridRAGBase`, using an in-memory Qdrant instance. Tool
+text is `name + description` (experimentally determined as best hit rate at
+99.1%). Retrieval uses reciprocal rank fusion of dense cosine similarity and
+BM25 sparse scores, with alpha=0.8 (mostly dense) and configurable top_k and
+threshold. Results are grouped by server name, enabling server-scoped tool
+gathering.
+
+Default servers (k8s-auth) are always included in results; client-auth servers
+are added per-request. The Qdrant upsert semantics mean re-indexing the same
+tool updates rather than duplicates.
+
+### 3-Tier Truncation Strategy
+
+Tool outputs can be arbitrarily large. The system uses three tiers to balance
+cost and precision:
+
+1. **Char estimate** (`len / 4`): if total is clearly under 90% of the token
+   budget, skip tokenization entirely.
+2. **Precise tokenization**: only invoked when the char estimate is ambiguous.
+   Tokenize each message to get exact counts.
+3. **Proportional truncation**: if one message dominates (can absorb the excess
+   while retaining half its content), shrink only that one. Otherwise scale all
+   messages proportionally. Always cut at the last newline to avoid mid-line
+   splits.
+
+A separate pre-extraction char guard (`budget * 4 chars`) prevents tokenizing
+arbitrarily large raw tool outputs before they even reach the budget enforcer.
+
+## Integration Points
+
+| Boundary | How it connects |
+|---|---|
+| **DocsSummarizer** | Calls `get_mcp_tools` during init to discover tools, binds them to LLM. Calls `execute_tool_calls_stream` and `enforce_tool_token_budget` during the tool-call loop. Emits `tool_call`, `approval_required`, and `tool_result` streaming events. |
+| **Tool Approvals Endpoint** | `POST /tool-approvals/decision` receives `{approval_id, approved}` from the client. Calls `set_approval_decision` which sets the `asyncio.Event`, unblocking the waiter in `get_approval_decision`. |
+| **TokenBudgetTracker** | DocsSummarizer charges tool results via `tracker.charge(TokenCategory.TOOL_RESULT, count)`. The tools_token_budget passed to execution is derived from the tracker's remaining budget. |
+| **Streaming Protocol** | Three event types flow to the client: `StreamChunkType.TOOL_CALL` (before execution), `StreamChunkType.APPROVAL_REQUIRED` (when gated), `StreamChunkType.TOOL_RESULT` (after execution). Each carries structured data including tool name, args, output, truncation status, and optional structured_content from MCP artifacts. |
+| **Config** | `MCPServers` / `MCPServerConfig` models define servers. `ToolsApprovalConfig` sets approval strategy and timeout. `ToolsRAGConfig` controls filtering parameters (alpha, top_k, threshold). All live under `OLSConfig`. |
+
+## Implementation Notes
+
+### Header Placeholder Resolution
+
+MCP server headers support three resolution modes in `resolve_header_value`:
+- `"kubernetes"` -- replaced with `"Bearer {user_token}"` from the request's k8s service account token
+- `"client"` -- replaced with the value from `client_headers[server_name][header_name]`, passed in the request body
+- Any other value -- used as-is (resolved at config load time, e.g., from file or environment variable)
+
+If resolution fails (missing token or missing client header), the entire server
+is skipped (`resolve_server_headers` returns `None`), and `build_mcp_config`
+omits it from the config dict.
+
+### Retry and Backoff
+
+`_execute_with_retries` implements exponential backoff with two tiers:
+- **Transient errors** (timeout, connection, OSError): base delay 0.2s, `0.2 * 2^attempt`
+- **Rate-limit errors** (429, "rate limit", "too many requests"): base delay 1.0s, `1.0 * 2^attempt`
+- Max retries: 2 (3 total attempts)
+- Non-transient errors fail immediately without retry
+- Error messages in tool results are truncated to 220 characters
+
+### Parallel Tool Execution
+
+When the LLM requests multiple tool calls in a single response, they execute
+concurrently via `aiostream.stream.merge`. Each tool gets an equal share of the
+token budget (`total_budget // num_calls`). Events (approval_required,
+tool_result) are yielded as they arrive from any tool, not in request order.
+
+### Tool Deduplication
+
+Two levels of deduplication exist:
+- **At gathering** (`_gather_and_populate_tools` with `deduplicate=True`): first-seen tool wins, duplicates from later servers are logged and dropped
+- **At call resolution** (`_resolve_tool_call_definitions`): if a tool name appears in the `duplicate_tool_names` set, the call is skipped with a non-retryable error message
+
+### Tool Schema Normalization
+
+`_normalize_tool_schema` patches dict-based schemas (not Pydantic models) that
+have `"type": "object"` but lack `"properties"`. This prevents `KeyError` in
+LangChain's `BaseTool.args` and OpenAI's function-calling validation. Empty
+`"required": []` is also added.
+
+### Adding a New MCP Server
+
+Adding a new MCP server requires only configuration changes, no code
+modifications:
+
+1. Add a server entry to the `mcp_servers.servers` list in `olsconfig.yaml`
+   with `name`, `url`, optional `headers` (with placeholder values if needed),
+   and optional `timeout`
+2. If the server requires the user's k8s token, set the header value to
+   `"kubernetes"`
+3. If the server requires client-provided credentials, set the header value to
+   `"client"` and document the required header names for API consumers
+4. Restart the service; tools from the new server will be discovered
+   automatically via `gather_mcp_tools`
+
+### Custom CA Bundle
+
+When `certificate_directory` is configured in `OLSConfig`, `build_mcp_config`
+creates an `httpx.AsyncClient` factory with a custom SSL context pointing to the
+CA bundle file. This factory is attached to every MCP server transport config,
+enabling connections to servers with internal/self-signed certificates.
+
+### Per-Round Timeout
+
+Each tool-call round (LLM streaming + tool execution) is wrapped in
+`asyncio.timeout(TOOL_CALL_ROUND_TIMEOUT)` (300 seconds) in the DocsSummarizer
+loop. This is separate from the per-tool retry timeouts and the approval
+decision timeout.

--- a/.ai/spec/what/README.md
+++ b/.ai/spec/what/README.md
@@ -1,0 +1,35 @@
+# Behavioral Specifications (what/)
+
+These specs define WHAT the OLS service must do -- testable behavioral rules, configuration surface, constraints, and planned changes. They are technology-neutral where possible and survive a complete rewrite in a different framework.
+
+## Spec Index
+
+| Spec | Description |
+|------|-------------|
+| [system-overview.md](system-overview.md) | Core capabilities, user personas, deployment models, system boundaries |
+| [api.md](api.md) | REST API contracts: all 16 endpoints, request/response shapes, streaming events, middleware |
+| [query-processing.md](query-processing.md) | 8-stage pipeline from user query to LLM response: redaction, RAG, history, skills, tools, storage |
+| [agent-modes.md](agent-modes.md) | ASK vs TROUBLESHOOTING: iteration limits, system prompts, behavioral differences |
+| [conversation-history.md](conversation-history.md) | Storage backends, CRUD operations, compression, user isolation, concurrency |
+| [llm-providers.md](llm-providers.md) | Provider contract, 8 providers with deviations, parameter system, reasoning models |
+| [rag.md](rag.md) | Document retrieval via FAISS, multi-index, BYOK, hybrid RAG (tool/skill filtering only) |
+| [auth.md](auth.md) | Three auth modules (k8s, noop, noop-with-token), permission scopes, user identity |
+| [tools.md](tools.md) | MCP tool integration: gathering, execution, token budget, filtering, approval workflow |
+| [skills.md](skills.md) | Skill discovery, selection via hybrid RAG, file concatenation, prompt injection |
+| [quota.md](quota.md) | Token usage limits per user and cluster, scheduler, usage history |
+| [config.md](config.md) | Configuration system: loading, validation, dynamic reload, all config sections |
+| [security.md](security.md) | TLS, FIPS, PII redaction, credential handling, tool approval security, MCP credentials |
+| [observability.md](observability.md) | Prometheus metrics (exact names), transcripts, feedback, logging, profiling |
+| [prompts.md](prompts.md) | System prompts (full text), agent instructions, composition order, placeholders |
+| [mcp-apps.md](mcp-apps.md) | MCP apps UI integration: resource discovery, direct tool calls, client auth headers |
+
+## How to Use These Specs
+
+- **Fixing a bug**: Read the relevant spec to understand correct behavior, then compare against the code.
+- **Adding a feature**: Check if the spec covers the requirement. Update the spec before implementing.
+- **Refactoring**: Use the specs as acceptance criteria. The implementation can change freely as long as it meets the behavioral rules.
+- **Understanding planned work**: Look for `[PLANNED: OLS-XXXX]` markers inline and "Planned Changes" sections.
+
+## Relationship to how/ Specs
+
+These `what/` specs define the behavioral contract. The [`how/` specs](../how/README.md) describe the current implementation architecture. Read `what/` to understand requirements, read `how/` to understand the codebase structure.

--- a/.ai/spec/what/agent-modes.md
+++ b/.ai/spec/what/agent-modes.md
@@ -1,0 +1,174 @@
+# Agent Modes
+
+The service supports two agent modes -- ASK and TROUBLESHOOTING -- that control
+the system prompt persona, agent instructions, and tool-calling iteration depth
+for each request. This file is the single source of truth for mode-specific
+behavior; other specs reference it rather than redefining mode rules.
+
+## Behavioral Rules
+
+### Mode Selection
+
+1. The mode is selected per request via the `mode` field on the API request
+   body (`LLMRequest.mode`). Mode is per-request, not per-session; different
+   requests in the same conversation may use different modes.
+
+2. The `mode` field accepts two values defined by the `QueryMode` enum: `ask`
+   (default) and `troubleshooting`. If omitted, the mode defaults to `ask`.
+
+### ASK Mode
+
+3. ASK mode serves general question-and-answer interactions about OpenShift
+   and related Red Hat products. The persona is a friendly, authoritative
+   technical expert focused on documentation knowledge.
+
+4. In ASK mode, the base system prompt is `QUERY_SYSTEM_INSTRUCTION`. This
+   prompt defines the "OpenShift Lightspeed" expert persona, scopes expertise
+   to OpenShift and listed Red Hat products, and instructs the LLM to
+   prioritize provided context and chat history as the primary source of truth.
+
+5. When tool calling is enabled (MCP servers are configured), ASK mode
+   appends agent instructions to the system prompt. For most models,
+   `AGENT_INSTRUCTION_GENERIC` is used; for Granite-family models,
+   `AGENT_INSTRUCTION_GRANITE` is used instead. Both variants are followed
+   by the shared `AGENT_SYSTEM_INSTRUCTION` block (tool-call deduplication
+   rules and concise style guide).
+
+6. ASK mode uses a default maximum tool-calling iteration limit of 5
+   (`DEFAULT_MAX_ITERATIONS`).
+
+### TROUBLESHOOTING Mode
+
+7. TROUBLESHOOTING mode serves diagnostic and remediation interactions
+   focused on live cluster issues. The persona is a specialist in OpenShift
+   troubleshooting and diagnostics.
+
+8. In TROUBLESHOOTING mode, the base system prompt is
+   `TROUBLESHOOTING_SYSTEM_INSTRUCTION`. This prompt includes the live
+   cluster's OpenShift version (injected via the `{cluster_version}`
+   placeholder) and defines three response structures based on query type:
+   diagnosis (evidence, root cause, fix), assessment (state summary, anomaly
+   flagging, severity ranking), and question (direct answer).
+
+9. The cluster version is retrieved from the Kubernetes API at request time
+   when the mode is TROUBLESHOOTING. In ASK mode the cluster version is not
+   retrieved and is set to a sentinel value.
+
+10. When tool calling is enabled, TROUBLESHOOTING mode appends
+    `TROUBLESHOOTING_AGENT_INSTRUCTION` followed by
+    `TROUBLESHOOTING_AGENT_SYSTEM_INSTRUCTION` to the system prompt. These
+    instructions define:
+    - A structured investigation protocol: scope affected resources, gather
+      evidence (logs, events, metrics, pods), cross-reference related
+      resources, follow causality chains, find root cause, correlate with
+      recent changes, and provide fixes or mitigations.
+    - Tool usage rules: verify arguments, no duplicate calls with same
+      arguments, build a complete picture before concluding, always check
+      logs even for "Running" pods, never guess pod names, sample up to 3
+      representative pods per deployment, never ask the user to run commands.
+    - A metrics investigation workflow: `get_alerts` first, then
+      `list_metrics` (with `name_regex`), then `get_label_names`, then
+      `get_label_values`, then `execute_instant_query` or
+      `execute_range_query`. Steps must not be skipped, and metric names must
+      not be guessed.
+
+11. TROUBLESHOOTING mode uses a default maximum tool-calling iteration limit
+    of 15 (`DEFAULT_MAX_ITERATIONS_TROUBLESHOOTING`).
+
+### Iteration Limit Resolution
+
+12. The effective iteration limit for a request is resolved as follows:
+    - Each mode has a built-in default: ASK = 5, TROUBLESHOOTING = 15.
+      These defaults are stored in `MAX_ITERATIONS_BY_MODE`.
+    - The administrator may set `ols_config.max_iterations` in the
+      configuration file to raise the cap. The effective limit is the greater
+      of the configured value and the mode's built-in default. The config
+      value can raise the cap but never lower it below the mode default.
+    - When `ols_config.max_iterations` is not set (None), the mode default
+      is used as-is.
+
+13. On the final iteration of the tool-calling loop (when the round index
+    equals the effective max), the LLM is invoked without tool bindings (or
+    with `tool_choice="none"`) to force a text-only answer. This guarantees
+    termination.
+
+### Common Behavior
+
+14. Both modes share the same token budget system (`TokenBudgetTracker`).
+    The context window is partitioned across system prompt, RAG context,
+    conversation history, tool definitions, tool outputs, and response
+    tokens. Mode does not change the budget partitioning rules.
+
+15. Both modes use the same RAG retrieval pipeline. Retrieved document
+    chunks are injected into the prompt identically regardless of mode.
+
+16. Both modes use the same conversation history handling: history is loaded
+    from the conversation cache, truncated to fit the available token budget,
+    and optionally compressed (when `ols_config.history_compression_enabled`
+    is true).
+
+17. Both modes use the same skill selection pipeline. A matched skill's
+    prompt content is injected into the system prompt regardless of mode.
+
+18. Both modes use the same streaming response format (`StreamedChunk` with
+    types: text, tool_call, tool_result, skill_selected,
+    history_compression_start, history_compression_end, reasoning, end).
+
+19. Both modes share the same tool token budget ratio
+    (`tool_budget_ratio`), tool round cap fraction
+    (`tool_round_cap_fraction`), and per-round tool execution timeout
+    (`TOOL_CALL_ROUND_TIMEOUT` = 300 seconds).
+
+### System Prompt Selection
+
+20. The system prompt for a request is determined by the following priority:
+    1. If `dev_config.enable_system_prompt_override` is true and the request
+       includes a `system_prompt` field, use the request-supplied prompt.
+    2. Else if `ols_config.system_prompt_path` is configured, use the
+       prompt loaded from that file.
+    3. Else use the mode's default prompt (`QUERY_SYSTEM_INSTRUCTION` for
+       ASK, `TROUBLESHOOTING_SYSTEM_INSTRUCTION` for TROUBLESHOOTING).
+
+## Configuration Surface
+
+| Field Path | Type | Default | Purpose |
+|---|---|---|---|
+| `LLMRequest.mode` | enum | `ask` | Per-request mode selection (`ask` or `troubleshooting`) |
+| `ols_config.max_iterations` | int | None (mode default) | Raise the tool-calling iteration cap above the mode default |
+| `ols_config.system_prompt_path` | string | None | Override the mode-default system prompt with a custom file |
+| `dev_config.enable_system_prompt_override` | bool | false | Allow per-request system prompt override (dev only) |
+
+## Constraints
+
+1. **Two modes only.** The `QueryMode` enum defines exactly two values:
+   `ask` and `troubleshooting`. No other mode values are accepted.
+
+2. **Mode does not persist.** Mode is a per-request property, not stored in
+   the conversation cache. Each request independently declares its mode.
+
+3. **Config cannot lower mode defaults.** Setting `ols_config.max_iterations`
+   to a value below the mode's built-in default has no effect; the mode
+   default is used instead.
+
+4. **Cluster version requires Kubernetes API.** TROUBLESHOOTING mode
+   retrieves the cluster version from the Kubernetes API. If the cluster
+   version is unavailable, a sentinel value is used and the prompt reflects
+   that the version is unknown.
+
+5. **Custom system prompt overrides both modes.** When
+   `ols_config.system_prompt_path` is set, the same custom prompt is used
+   for both ASK and TROUBLESHOOTING requests. Mode-specific agent
+   instructions are still appended when tool calling is enabled.
+
+6. **Granite agent instructions are ASK-only.** The Granite-specific agent
+   instruction variant (`AGENT_INSTRUCTION_GRANITE`) is only used in ASK
+   mode. TROUBLESHOOTING mode uses its own dedicated agent instructions
+   regardless of model family.
+
+## Planned Changes
+
+| Jira Key | Summary |
+|---|---|
+| OLS-2754 | Propose plan for autonomous investigation in TROUBLESHOOTING mode |
+| OLS-2894 | Autonomous, policy-driven AI agents for OpenShift (TP: OCP 5.0) |
+| OLS-2898 | Raise `max_iterations` to 50 and validate orchestration loop early-exit behavior |

--- a/.ai/spec/what/api.md
+++ b/.ai/spec/what/api.md
@@ -1,0 +1,778 @@
+# REST API
+
+The REST API is the only external interface to the OpenShift LightSpeed service. Every capability -- queries, conversations, feedback, tools, health checks, and metrics -- is exposed through HTTP endpoints defined here.
+
+## Behavioral Rules
+
+### General
+
+1. All paths are relative to the service root (e.g. `https://host:port`).
+2. All endpoints under `/v1` (except `/v1/feedback/status`) require authentication via bearer token in the `Authorization` header. The token is resolved into a user identity consisting of a user ID (UUID), a username, a `skip_user_id_check` flag, and a user token.
+3. All authenticated endpoints (except `/metrics`) enforce the `ols-access` authorization scope. The `/metrics` endpoint enforces a separate `ols-metrics-access` scope.
+4. Health probes (`/readiness`, `/liveness`) require no authentication and have no version prefix.
+5. Extra fields in request bodies are rejected with HTTP 422 for endpoints that use `"extra": "forbid"` in their Pydantic model (`LLMRequest`, `MCPAppResourceRequest`, `MCPAppToolCallRequest`, `ToolApprovalDecisionRequest`).
+6. The `conversation_id` field, wherever it appears, must be a valid SUID (UUID format). Invalid format returns HTTP 400.
+
+### Query Endpoints
+
+7. `POST /v1/query` accepts a question and returns a complete JSON response after the LLM finishes generating. [PLANNED: OLS-2682] This endpoint will be removed; streaming will become the only query path.
+8. `POST /v1/streaming_query` accepts the same request body as `/v1/query` and returns a streaming response using Server-Sent Events (SSE). The response `Content-Type` matches the request's `media_type` field.
+9. Both query endpoints share the same request processing pipeline: authenticate, retrieve/generate conversation ID, redact query and attachments, validate provider/model, check quota, append attachments, then invoke the LLM. See `what/query-processing.md` for pipeline behavior details.
+10. Both query endpoints store conversation history and (if enabled) transcripts after the response is generated.
+11. Token consumption is recorded against all configured quota limiters after each query. The response includes remaining quota per limiter.
+
+### Conversation Endpoints
+
+12. `GET /v1/conversations` returns all conversations belonging to the authenticated user.
+13. `GET /v1/conversations/{conversation_id}` returns the full chat history for one conversation, including messages, tool calls, and tool results per exchange.
+14. `DELETE /v1/conversations/{conversation_id}` deletes a conversation. A request to delete a non-existent conversation returns 200 with `success: false`, not 404.
+15. `PUT /v1/conversations/{conversation_id}` updates the topic summary of an existing conversation. The conversation must exist (404 if not).
+
+### Feedback Endpoints
+
+16. `GET /v1/feedback/status` returns whether feedback collection is enabled. No authentication required.
+17. `POST /v1/feedback` stores user feedback. Requires authentication and feedback collection to be enabled (403 if disabled).
+
+### MCP Endpoints
+
+18. `POST /v1/mcp-apps/resources` fetches a `ui://` resource from a configured MCP server. The URI must start with `ui://` and contain a path after the prefix.
+19. `POST /v1/mcp-apps/tools/call` proxies a tool call to a configured MCP server.
+20. `GET /v1/mcp/client-auth-headers` returns which MCP servers require client-provided authorization headers so clients know what to include in the `mcp_headers` field of query requests.
+21. `POST /v1/tool-approvals/decision` submits an approval or rejection for a pending tool execution request. Used during streaming queries when a tool call requires explicit user approval.
+
+### Infrastructure Endpoints
+
+22. `POST /authorized` validates the caller's credentials and authorization. The authentication check itself is the purpose of this endpoint. No `/v1` prefix.
+23. `GET /readiness` checks three subsystems: RAG index loaded (if configured), default LLM reachable, and conversation cache ready. All three must pass. The LLM readiness result is cached for a configurable duration. Returns 503 with cause if any subsystem fails.
+24. `GET /liveness` always returns `alive: true` if the process is running.
+25. `GET /metrics` returns Prometheus metrics in exposition format. Requires `ols-metrics-access` scope. No version prefix.
+
+---
+
+## Endpoint Reference
+
+### POST /v1/query
+
+Submit a question and receive a complete JSON response.
+
+**Auth**: Required (`ols-access` scope)
+
+#### Request body (LLMRequest)
+
+| Field           | Type                                         | Required | Default        | Description |
+|-----------------|----------------------------------------------|----------|----------------|-------------|
+| query           | string                                       | yes      | --             | The user's question |
+| conversation_id | string (UUID)                                | no       | auto-generated | Existing conversation to continue |
+| provider        | string                                       | no       | server default | LLM provider name |
+| model           | string                                       | no       | server default | LLM model name |
+| system_prompt   | string                                       | no       | null           | Override the default system prompt |
+| attachments     | array of Attachment                          | no       | null           | Supplementary content (see Attachments section) |
+| media_type      | string                                       | no       | `"text/plain"` | Must be `text/plain` or `application/json` |
+| mcp_headers     | object (server name -> header key/value map) | no       | null           | Client-provided auth headers for MCP servers |
+| mode            | string                                       | no       | `"ask"`        | Query mode: `ask` or `troubleshooting` |
+
+**Validation rules:**
+- `provider` and `model` must both be specified or both omitted. Specifying only one returns 422.
+- If specified, the provider/model pair must match a configured LLM provider (422 if not).
+- `media_type` must be exactly `text/plain` or `application/json` (422 if not).
+- Each attachment's `attachment_type` and `content_type` must be in the allowed sets (422 if not).
+- The caller's token quota is checked before processing. Exhausted quota returns 500.
+- The query and all attachment content are redacted (PII removal) before processing.
+
+[PLANNED: OLS-2682] This endpoint will be removed in favor of streaming-only.
+
+#### Response 200 (LLMResponse)
+
+| Field                | Type                        | Description |
+|----------------------|-----------------------------|-------------|
+| conversation_id      | string (UUID)               | The conversation this exchange belongs to |
+| response             | string                      | The LLM's answer |
+| referenced_documents | array of ReferencedDocument | Documents used to generate the answer (deduplicated, order-preserving) |
+| truncated            | boolean                     | True if conversation history was truncated to fit the context window |
+| input_tokens         | integer                     | Tokens sent to the LLM |
+| output_tokens        | integer                     | Tokens received from the LLM |
+| available_quotas     | object (limiter name -> int)| Remaining quota per configured limiter |
+| tool_calls           | array of object             | Tool invocations made during response generation |
+| tool_results         | array of object             | Results from tool invocations |
+
+**ReferencedDocument:**
+
+| Field     | Type   | Description |
+|-----------|--------|-------------|
+| doc_url   | string | URL of the documentation page |
+| doc_title | string | Title of the documentation page |
+
+#### Error responses
+
+| Status | Condition |
+|--------|-----------|
+| 400    | Invalid conversation ID format |
+| 401    | Missing or invalid credentials |
+| 403    | Caller lacks permission |
+| 413    | Prompt exceeds the LLM context window limit |
+| 422    | Invalid provider/model pair, invalid attachment type/content type, invalid media_type, or extra fields |
+| 500    | LLM unreachable, quota database error, quota exceeded, query redaction failure, conversation storage failure, or other internal error |
+
+---
+
+### POST /v1/streaming_query
+
+Submit a question and receive the response as a server-sent event stream. Accepts the same request body as `/v1/query`.
+
+**Auth**: Required (`ols-access` scope)
+
+#### Request body
+
+Identical to `POST /v1/query` (LLMRequest).
+
+#### Response 200
+
+A streaming response whose `Content-Type` matches the request's `media_type` field. See the Streaming Format section for event types and wire formats.
+
+#### Error responses
+
+| Status | Condition |
+|--------|-----------|
+| 401    | Missing or invalid credentials |
+| 403    | Caller lacks permission |
+| 500    | Internal error during request setup |
+
+Errors that occur after the stream has started (prompt too long, LLM failure) are delivered as in-stream error events rather than HTTP status codes.
+
+---
+
+### GET /v1/conversations
+
+List all conversations belonging to the authenticated user.
+
+**Auth**: Required (`ols-access` scope)
+
+#### Response 200 (ConversationsListResponse)
+
+| Field         | Type                       | Description |
+|---------------|----------------------------|-------------|
+| conversations | array of ConversationData  | The user's conversations |
+
+**ConversationData:**
+
+| Field                  | Type                     | Description |
+|------------------------|--------------------------|-------------|
+| conversation_id        | string (UUID)            | Unique conversation identifier |
+| topic_summary          | string                   | User-assigned summary (default empty string) |
+| last_message_timestamp | number (float, unix)     | Timestamp of the most recent message |
+| message_count          | integer                  | Number of message exchanges (default 0) |
+
+#### Error responses
+
+| Status | Condition |
+|--------|-----------|
+| 401    | Missing or invalid credentials |
+| 403    | Caller lacks permission |
+| 500    | Internal error |
+
+---
+
+### GET /v1/conversations/{conversation_id}
+
+Retrieve the full chat history for a specific conversation.
+
+**Auth**: Required (`ols-access` scope)
+
+**Path parameter**: `conversation_id` -- must be a valid UUID (SUID format).
+
+#### Response 200 (ConversationDetailResponse)
+
+| Field           | Type                   | Description |
+|-----------------|------------------------|-------------|
+| conversation_id | string (UUID)          | The conversation identifier |
+| chat_history    | array of ChatExchange  | Ordered list of message exchanges |
+
+**ChatExchange:**
+
+| Field        | Type             | Description |
+|--------------|------------------|-------------|
+| messages     | array of Message | A pair of user and assistant messages |
+| tool_calls   | array of object  | Tool invocations made during this exchange |
+| tool_results | array of object  | Results from tool invocations |
+
+**Message:**
+
+| Field   | Type   | Description |
+|---------|--------|-------------|
+| type    | string | `"user"` or `"assistant"` |
+| content | string | Message text |
+
+#### Error responses
+
+| Status | Condition |
+|--------|-----------|
+| 400    | Invalid conversation ID format |
+| 401    | Missing or invalid credentials |
+| 403    | Caller lacks permission |
+| 404    | Conversation does not exist |
+| 500    | Internal error |
+
+---
+
+### DELETE /v1/conversations/{conversation_id}
+
+Delete a conversation and its history.
+
+**Auth**: Required (`ols-access` scope)
+
+**Path parameter**: `conversation_id` -- must be a valid UUID.
+
+#### Response 200 (ConversationDeleteResponse)
+
+| Field           | Type    | Description |
+|-----------------|---------|-------------|
+| conversation_id | string  | The conversation that was targeted |
+| response        | string  | Human-readable result message |
+| success         | boolean | True if the conversation existed and was deleted; false if not found |
+
+A request to delete a non-existent conversation returns 200 with `success: false`, not 404.
+
+#### Error responses
+
+| Status | Condition |
+|--------|-----------|
+| 400    | Invalid conversation ID format |
+| 401    | Missing or invalid credentials |
+| 403    | Caller lacks permission |
+| 500    | Internal error |
+
+---
+
+### PUT /v1/conversations/{conversation_id}
+
+Update the topic summary of an existing conversation.
+
+**Auth**: Required (`ols-access` scope)
+
+**Path parameter**: `conversation_id` -- must be a valid UUID.
+
+#### Request body (ConversationUpdateRequest)
+
+| Field         | Type   | Required | Description |
+|---------------|--------|----------|-------------|
+| topic_summary | string | yes      | The new topic summary |
+
+#### Response 200 (ConversationUpdateResponse)
+
+| Field           | Type    | Description |
+|-----------------|---------|-------------|
+| conversation_id | string  | The conversation that was updated |
+| success         | boolean | True if the update succeeded |
+| message         | string  | Human-readable result message |
+
+#### Error responses
+
+| Status | Condition |
+|--------|-----------|
+| 400    | Invalid conversation ID format |
+| 401    | Missing or invalid credentials |
+| 403    | Caller lacks permission |
+| 404    | Conversation does not exist |
+| 500    | Internal error |
+
+---
+
+### GET /v1/feedback/status
+
+Check whether feedback collection is enabled.
+
+**Auth**: None required
+
+#### Response 200 (StatusResponse)
+
+| Field         | Type   | Description |
+|---------------|--------|-------------|
+| functionality | string | Always `"feedback"` |
+| status        | object | `{"enabled": true}` or `{"enabled": false}` |
+
+---
+
+### POST /v1/feedback
+
+Submit user feedback about a conversation exchange.
+
+**Auth**: Required (`ols-access` scope)
+
+**Precondition**: Feedback collection must be enabled. If disabled, returns 403.
+
+#### Request body (FeedbackRequest)
+
+| Field           | Type          | Required | Default | Description |
+|-----------------|---------------|----------|---------|-------------|
+| conversation_id | string (UUID) | yes      | --      | The conversation being rated |
+| user_question   | string        | yes      | --      | The question the user asked |
+| llm_response    | string        | yes      | --      | The response the LLM gave |
+| sentiment       | integer       | no       | null    | Rating: must be exactly `-1` or `1` |
+| user_feedback   | string        | no       | null    | Free-text feedback |
+
+**Validation rules:**
+- `conversation_id` must be a valid UUID.
+- `sentiment`, if provided, must be exactly `-1` or `1`.
+- At least one of `sentiment` or `user_feedback` must be provided.
+
+#### Response 200 (FeedbackResponse)
+
+| Field    | Type   | Description |
+|----------|--------|-------------|
+| response | string | Always `"feedback received"` |
+
+#### Error responses
+
+| Status | Condition |
+|--------|-----------|
+| 401    | Missing or invalid credentials |
+| 403    | Caller lacks permission, or feedback is disabled |
+| 422    | Validation error (invalid UUID, invalid sentiment, neither sentiment nor feedback provided) |
+| 500    | Feedback storage failure |
+
+---
+
+### POST /v1/mcp-apps/resources
+
+Fetch a `ui://` resource from a configured MCP server. Used by the console to load app content (HTML, JS, CSS) served by MCP servers.
+
+**Auth**: Required (`ols-access` scope)
+
+#### Request body (MCPAppResourceRequest)
+
+| Field        | Type                                         | Required | Default | Description |
+|--------------|----------------------------------------------|----------|---------|-------------|
+| resource_uri | string                                       | yes      | --      | Must start with `ui://` and contain a path after the prefix |
+| server_name  | string                                       | yes      | --      | Name of the MCP server as defined in service configuration |
+| mcp_headers  | object (server name -> header key/value map) | no       | null    | Client-provided auth headers for the MCP server |
+
+Extra fields are rejected (422).
+
+#### Response 200 (MCPAppResourceResponse)
+
+| Field        | Type                     | Description |
+|--------------|--------------------------|-------------|
+| uri          | string                   | The URI of the returned resource |
+| mime_type    | string                   | MIME type of the content (e.g. `text/html`) |
+| content      | string                   | The resource content (text or base64-encoded blob) |
+| content_type | string (`text` or `blob`)| Whether `content` is plaintext or base64 |
+| meta         | object or null           | Server-provided metadata (CSP policies, permissions, etc.) |
+
+#### Error responses
+
+| Status | Condition |
+|--------|-----------|
+| 400    | Invalid resource URI (does not start with `ui://` or path is empty) |
+| 401    | Missing credentials, or required MCP server credentials not provided |
+| 403    | Caller lacks permission |
+| 404    | MCP server not configured, or resource not found on the server |
+| 500    | Communication failure with the MCP server |
+
+---
+
+### POST /v1/mcp-apps/tools/call
+
+Proxy a tool call to a configured MCP server. Used by app iframes to invoke MCP tools.
+
+**Auth**: Required (`ols-access` scope)
+
+#### Request body (MCPAppToolCallRequest)
+
+| Field       | Type                                         | Required | Default | Description |
+|-------------|----------------------------------------------|----------|---------|-------------|
+| server_name | string                                       | yes      | --      | Name of the MCP server |
+| tool_name   | string                                       | yes      | --      | The tool to invoke |
+| arguments   | object                                       | no       | `{}`    | Arguments to pass to the tool |
+| mcp_headers | object (server name -> header key/value map) | no       | null    | Client-provided auth headers |
+
+Extra fields are rejected (422).
+
+#### Response 200 (MCPAppToolCallResponse)
+
+| Field              | Type                | Description |
+|--------------------|---------------------|-------------|
+| content            | array of ContentBlock | Content blocks returned by the tool |
+| structured_content | object or null      | Structured data for the app UI, if the tool provides it |
+| is_error           | boolean             | True if the tool call resulted in an error (default false) |
+
+**ContentBlock** is one of:
+
+- `{"type": "text", "text": "..."}` -- text content
+- `{"type": "image", "data": "...", "mimeType": "..."}` -- image data (base64)
+- `{"type": "audio", "data": "...", "mimeType": "..."}` -- audio data (base64)
+
+#### Error responses
+
+| Status | Condition |
+|--------|-----------|
+| 401    | Missing credentials, or required MCP server credentials not provided |
+| 403    | Caller lacks permission |
+| 404    | MCP server not configured |
+| 500    | Communication failure with the MCP server |
+
+---
+
+### POST /v1/tool-approvals/decision
+
+Submit an approval or rejection decision for a pending tool execution request. During streaming queries, certain tool calls may require explicit user approval before proceeding.
+
+**Auth**: Required (`ols-access` scope)
+
+#### Request body (ToolApprovalDecisionRequest)
+
+| Field       | Type    | Required | Description |
+|-------------|---------|----------|-------------|
+| approval_id | string  | yes      | Unique identifier of the pending approval request |
+| approved    | boolean | yes      | `true` to approve, `false` to reject |
+
+Extra fields are rejected (422).
+
+#### Response 200
+
+Empty body (no content, 200 status).
+
+#### Error responses
+
+| Status | Condition |
+|--------|-----------|
+| 401    | Missing or invalid credentials |
+| 403    | Caller lacks permission |
+| 404    | No pending approval found for the given `approval_id` |
+| 409    | The approval request has already been resolved (approved or rejected) |
+
+---
+
+### GET /v1/mcp/client-auth-headers
+
+Discover which MCP servers require the client to supply authorization headers. Clients should use this to populate the `mcp_headers` field in query requests.
+
+**Auth**: Required (`ols-access` scope)
+
+#### Response 200 (MCPHeadersResponse)
+
+| Field   | Type                         | Description |
+|---------|------------------------------|-------------|
+| servers | array of MCPServerHeaderInfo | Servers that need client-provided headers |
+
+**MCPServerHeaderInfo:**
+
+| Field            | Type            | Description |
+|------------------|-----------------|-------------|
+| server_name      | string          | Name of the MCP server |
+| required_headers | array of string | Header names the client must provide |
+
+---
+
+### POST /authorized
+
+Validate the caller's credentials and authorization to use the service. No `/v1` prefix.
+
+**Auth**: Required (`ols-access` scope) -- the authentication check itself is the purpose of this endpoint.
+
+#### Request body
+
+None required.
+
+#### Response 200 (AuthorizationResponse)
+
+| Field              | Type          | Description |
+|--------------------|---------------|-------------|
+| user_id            | string (UUID) | The authenticated user's ID |
+| username           | string        | The authenticated user's name |
+| skip_user_id_check | boolean       | Whether strict user ID validation is bypassed |
+
+#### Error responses
+
+| Status | Condition |
+|--------|-----------|
+| 401    | Missing or invalid credentials |
+| 403    | User is not authorized |
+| 500    | Unexpected error during token review |
+
+---
+
+### GET /readiness
+
+Kubernetes readiness probe. No authentication required. No version prefix.
+
+Checks three subsystems: RAG index loaded (if configured), default LLM reachable and responsive, and conversation cache backend ready. All three must pass. The LLM readiness result is cached; once confirmed ready, subsequent calls may return the cached result for a configurable duration (`expire_llm_is_ready_persistent_state`).
+
+#### Response 200 (ReadinessResponse)
+
+| Field  | Type    | Description |
+|--------|---------|-------------|
+| ready  | boolean | Always `true` |
+| reason | string  | `"service is ready"` |
+
+#### Response 503 (NotAvailableResponse)
+
+Structured error with cause indicating which subsystem is not ready: `"Index is not ready"`, `"LLM is not ready"`, or `"Cache is not ready"`.
+
+---
+
+### GET /liveness
+
+Kubernetes liveness probe. No authentication required. No version prefix. Always succeeds if the process is running.
+
+#### Response 200 (LivenessResponse)
+
+| Field | Type    | Description |
+|-------|---------|-------------|
+| alive | boolean | Always `true` |
+
+---
+
+### GET /metrics
+
+Prometheus/OpenMetrics metrics endpoint. No version prefix.
+
+**Auth**: Required (`ols-metrics-access` scope) -- a separate permission scope from the main API.
+
+#### Response 200
+
+Plain text in Prometheus exposition format (`Content-Type: text/plain`).
+
+---
+
+## Streaming Format
+
+The streaming query endpoint (`POST /v1/streaming_query`) supports two wire formats, selected by the `media_type` field in the request.
+
+### JSON streaming (application/json)
+
+Each event is delivered as a Server-Sent Events (SSE) data line:
+
+```
+data: {"event": "<event_type>", "data": {<payload>}}\n\n
+```
+
+#### Event catalog
+
+**start** -- Sent once at the beginning of the stream.
+
+```json
+{"event": "start", "data": {"conversation_id": "<uuid>"}}
+```
+
+**token** -- One text token from the LLM response.
+
+```json
+{"event": "token", "data": {"id": 0, "token": "Some text"}}
+```
+
+The `id` field is a zero-based sequential counter shared across all `token` and `reasoning` events.
+
+**reasoning** -- One token of chain-of-thought / reasoning content.
+
+```json
+{"event": "reasoning", "data": {"id": 0, "reasoning": "Let me think..."}}
+```
+
+**tool_call** -- The LLM is invoking a tool.
+
+```json
+{"event": "tool_call", "data": {"name": "tool_name", "args": {}, "id": "call_id", "type": "tool_call"}}
+```
+
+**approval_required** -- A tool call requires user approval before execution. The client must present the approval to the user and submit the decision via `POST /v1/tool-approvals/decision`.
+
+```json
+{"event": "approval_required", "data": {"approval_id": "...", ...}}
+```
+
+**tool_result** -- A tool execution has completed.
+
+```json
+{"event": "tool_result", "data": {"id": "call_id", "status": "success", "content": "...", "type": "tool_result", "round": 1}}
+```
+
+**skill_selected** -- A skill/capability was selected during processing.
+
+```json
+{"event": "skill_selected", "data": {"name": "skill_name"}}
+```
+
+**history_compression_start** -- Conversation history compression has begun (long conversations).
+
+```json
+{"event": "history_compression_start", "data": {}}
+```
+
+**history_compression_end** -- Conversation history compression has completed.
+
+```json
+{"event": "history_compression_end", "data": {}}
+```
+
+**end** -- Sent once after all processing is complete. Contains document references and token usage.
+
+```json
+{
+  "event": "end",
+  "data": {
+    "referenced_documents": [{"doc_title": "...", "doc_url": "..."}],
+    "truncated": false,
+    "input_tokens": 123,
+    "output_tokens": 456,
+    "reasoning_tokens": 0
+  },
+  "available_quotas": {"QuotaLimiterName": 998000}
+}
+```
+
+The `available_quotas` field is at the top level of the SSE payload, not inside `data`.
+
+**error** -- An error occurred during stream processing. The stream ends after this event.
+
+Prompt too long:
+```json
+{"event": "error", "data": {"status_code": 413, "response": "Prompt is too long", "cause": "details"}}
+```
+
+Generic error:
+```json
+{"event": "error", "data": {"response": "error summary", "cause": "details"}}
+```
+
+### Plain text streaming (text/plain)
+
+No SSE framing. Output is concatenated directly.
+
+| Event                      | Output format |
+|----------------------------|---------------|
+| start                      | Not emitted |
+| token                      | Raw token text |
+| reasoning                  | Raw reasoning text; a blank line (`\n\n`) separates the last reasoning token from the first text token |
+| tool_call                  | `\nTool call: {json}\n` |
+| approval_required          | `\nApproval request: {json}\n` |
+| tool_result                | `\nTool result: {json}\n` |
+| skill_selected             | `\nSkill selected: <name>\n` |
+| history_compression_start  | `\nHistory compression start: {json}\n` |
+| history_compression_end    | `\nHistory compression end: {json}\n` |
+| end (with references)      | `\n\n---\n\n<title>: <url>` (one line per document) |
+| end (no references)        | Empty string |
+| error (prompt too long)    | `Prompt is too long: <details>` |
+| error (generic)            | `<response>: <cause>` |
+
+---
+
+## Attachments
+
+Query requests may include attachments -- supplementary content the user provides alongside their question.
+
+### Allowed attachment types
+
+`alert`, `api object`, `configuration`, `error message`, `event`, `log`, `stack trace`
+
+### Allowed content types (MIME)
+
+`text/plain`, `application/json`, `application/yaml`, `application/xml`
+
+### Attachment schema
+
+| Field           | Type   | Required | Description |
+|-----------------|--------|----------|-------------|
+| attachment_type | string | yes      | One of the allowed attachment types |
+| content_type    | string | yes      | One of the allowed MIME content types |
+| content         | string | yes      | The actual attachment content |
+
+YAML attachments containing `kind` and `metadata.name` fields are treated as named Kubernetes resources.
+
+---
+
+## Query Modes
+
+The `mode` field on query requests controls which system prompt and iteration limits are used. See `what/query-processing.md` for processing details and `what/agent-modes.md` for mode-specific behavior.
+
+| Mode              | Default max iterations | Description |
+|-------------------|------------------------|-------------|
+| `ask`             | 5                      | General Q&A mode (default) |
+| `troubleshooting` | 15                     | Troubleshooting mode with higher iteration limit for tool use |
+
+---
+
+## Standard Error Response Format
+
+All error responses (4xx and 5xx) use one of two shapes:
+
+**Structured error** (most endpoints):
+
+```json
+{
+  "detail": {
+    "response": "Human-readable summary of the error",
+    "cause": "Technical detail or upstream error message"
+  }
+}
+```
+
+**Simple error** (401 and 403 on authenticated endpoints):
+
+```json
+{
+  "detail": "Human-readable error message"
+}
+```
+
+---
+
+## Middleware
+
+The service applies the following cross-cutting behaviors to all requests:
+
+### Metrics and security headers
+
+26. For every request to a known API route, measure and record response duration as a histogram metric labeled by path.
+27. After the response is generated, increment a request counter metric labeled by path and HTTP status code. The `/metrics` endpoint itself is excluded from the counter.
+28. Add security response headers to all responses except `/readiness`, `/liveness`, and `/metrics`:
+    - `X-Content-Type-Options: nosniff` (always)
+    - `Strict-Transport-Security: max-age=31536000; includeSubDomains` (only when TLS is enabled)
+
+### Request/response logging
+
+29. At debug log level, log the full request (client address, headers, body) and response (headers, body chunks for streaming) for every request.
+30. Sensitive header values are redacted to `XXXXX`:
+    - **Request headers**: `authorization`, `proxy-authorization`, `cookie`
+    - **Response headers**: `www-authenticate`, `proxy-authenticate`, `set-cookie`
+31. Logging of the `/metrics` endpoint can be suppressed via configuration (`suppress_metrics_in_log`).
+
+---
+
+## Configuration Surface
+
+- `ols_config.default_provider` / `ols_config.default_model` -- default LLM provider and model when not specified in the request.
+- `ols_config.authentication_config.module` -- authentication module (`k8s`, `noop`, `noop-with-token`).
+- `ols_config.user_data_collection.feedback_disabled` -- disables feedback collection (POST /v1/feedback returns 403).
+- `ols_config.user_data_collection.transcripts_disabled` -- disables transcript storage after queries.
+- `ols_config.user_data_collection.feedback_storage` -- filesystem path for feedback JSON files.
+- `ols_config.user_data_collection.transcripts_storage` -- filesystem path for transcript JSON files.
+- `ols_config.logging_config.suppress_metrics_in_log` -- suppress debug logging for `/metrics` requests.
+- `ols_config.expire_llm_is_ready_persistent_state` -- duration (seconds) to cache the LLM readiness check result. Negative or unset means cache indefinitely once ready.
+- `ols_config.reference_content` -- when set, the readiness probe checks that the RAG index is loaded.
+- `dev_config.disable_tls` -- disables TLS; affects whether HSTS header is added.
+- `dev_config.enable_dev_ui` -- mounts an embedded Gradio UI at the application root.
+- MCP server configuration -- defines available MCP servers, their URLs, timeouts, and header requirements. See `what/tools.md`.
+- Quota limiter configuration -- defines per-user and per-cluster token quotas. See `what/quota.md`.
+
+---
+
+## Constraints
+
+1. All conversation IDs must be valid SUIDs (UUID format). Invalid IDs are rejected with 400.
+2. `provider` and `model` must both be present or both absent in query requests.
+3. Feedback `sentiment` must be exactly `-1` or `1` if provided. At least one of `sentiment` or `user_feedback` must be set.
+4. Attachment types and content types are restricted to the fixed allowed sets. No extensibility mechanism.
+5. The streaming endpoint always returns HTTP 200 for the initial response; errors during generation are delivered as in-stream events.
+6. MCP resource URIs must start with `ui://` and have a non-empty path component.
+7. Tool approval decisions are idempotent in the forward direction only: once resolved, re-submitting returns 409.
+8. Security headers are applied to all responses except health probes and metrics.
+9. The `/metrics` endpoint uses a separate authorization scope (`ols-metrics-access`) from the rest of the API (`ols-access`).
+10. Extra fields in request bodies are rejected (422) for query, MCP, and tool approval endpoints.
+
+---
+
+## Planned Changes
+
+- [PLANNED: OLS-2682] Remove `/v1/query` endpoint. The streaming endpoint becomes the sole query interface.
+- [PLANNED: OLS-2680] Add OpenAI `/responses` API compatibility layer.
+- [PLANNED: OLS-2684] Remove client MCP headers (`mcp_headers` field).

--- a/.ai/spec/what/auth.md
+++ b/.ai/spec/what/auth.md
@@ -1,0 +1,106 @@
+# Authentication & Authorization
+
+Control which users can access the OpenShift LightSpeed service and what they are permitted to do, integrating with Kubernetes RBAC in production and providing bypass modes for development.
+
+## Behavioral Rules
+
+1. The system must support exactly three authentication modules: `k8s`, `noop`, and `noop-with-token`.
+2. The authentication module must be selected once at startup from configuration and must not change for the lifetime of the process.
+3. If no authentication module is specified in configuration, the system must default to `k8s`.
+4. If an unsupported module value is specified, the system must reject the configuration at startup.
+
+### k8s Module (Production)
+
+5. The system must extract a bearer token from the HTTP `Authorization` header on every request.
+6. If the `Authorization` header is absent, the system must reject the request with HTTP 401.
+7. If the header is present but does not contain a valid bearer token, the system must reject the request with HTTP 401.
+8. The system must validate the bearer token by submitting a Kubernetes TokenReview to the cluster API.
+9. If the TokenReview indicates the token is not authenticated, the system must reject the request with HTTP 403.
+10. After successful authentication, the system must check the user's permissions by submitting a Kubernetes SubjectAccessReview against a synthetic non-resource path using the `get` verb.
+11. The SubjectAccessReview must include the user's username and group memberships from the TokenReview result.
+12. If the SubjectAccessReview denies access, the system must reject the request with HTTP 403.
+13. On successful authentication and authorization, the system must return the user's UID, username, bearer token, and a flag indicating that user ID override is not permitted.
+14. When the authenticated username is `kube:admin`, the system must replace the user ID with the cluster ID retrieved from the OpenShift ClusterVersion resource.
+15. The k8s module must never allow callers to override the authenticated user ID.
+
+### noop Module (Development)
+
+16. The system must skip all authentication and authorization checks.
+17. The system must accept an optional `user_id` query parameter; when absent, it must use the default nil UUID identity.
+18. The system must allow callers to override the user ID (the skip-user-ID-check flag must be true).
+19. The system must never provide a user token (the returned token must be empty).
+
+### noop-with-token Module (Development with Token Forwarding)
+
+20. The system must not validate the bearer token against Kubernetes.
+21. The system must extract the bearer token from the `Authorization` header and return it for downstream use (e.g., MCP server requests that require a Kubernetes token).
+22. If the `Authorization` header is absent, the system must reject the request with HTTP 400.
+23. If the header is present but contains no valid bearer token, the system must reject the request with HTTP 400.
+24. The system must accept an optional `user_id` query parameter; when absent, it must use the default nil UUID identity.
+25. The system must allow callers to override the user ID (the skip-user-ID-check flag must be true).
+
+### Dev Auth Override
+
+26. When the dev-config auth-disable flag is set, the k8s and noop-with-token modules must bypass all checks and return the default identity with no token, regardless of request headers.
+27. Bypassed auth checks must log a warning unless warning suppression is enabled in the logging configuration.
+
+### Permission Scopes
+
+28. The system must define two permission scopes, each mapped to a synthetic non-resource path for SubjectAccessReview evaluation:
+    - **ols-access**: guards all query, conversation, feedback, tool-approval, MCP, and authorization-check endpoints.
+    - **metrics-access**: guards the Prometheus metrics endpoint.
+29. Each endpoint must declare exactly one permission scope at module load time.
+30. The synthetic paths are not real HTTP routes; they exist solely for Kubernetes RBAC policy evaluation.
+
+### User Identity Contract
+
+31. Every authentication module must return a four-element tuple: (user_id, username, skip_user_id_check, user_token).
+32. The user_id must be in UUID format.
+33. The default identity must use the nil UUID (`00000000-0000-0000-0000-000000000000`) and a fixed default username.
+34. [PLANNED: OLS-1393] The system must read the authenticated user's roles from the cluster and make them available to downstream processing.
+35. [PLANNED: OLS-1394] The system must filter content returned to the user based on their roles.
+
+### Cluster Information
+
+36. The system must retrieve the cluster ID from the OpenShift ClusterVersion custom resource (`spec.clusterID`).
+37. When not running inside a Kubernetes cluster, the cluster ID must default to `"local"`.
+38. The cluster ID must be cached for the lifetime of the process after first retrieval.
+39. The system must retrieve the cluster version from the ClusterVersion resource (`status.desired.version`).
+40. If the cluster version cannot be retrieved, the system must fall back to `"unknown"` rather than failing.
+41. The cluster version must be cached for the lifetime of the process (OLS pods restart during cluster upgrades, bounding staleness).
+42. When not running inside a Kubernetes cluster, the cluster version must always be `"unknown"`.
+
+### Kubernetes Client Lifecycle
+
+43. The Kubernetes API client must be initialized at most once per process (singleton).
+44. The singleton must support three configuration sources in priority order: explicit cluster API URL and auth token from config, in-cluster service account credentials, and local kubeconfig file.
+45. The Kubernetes API host may be overridden via configuration.
+46. TLS verification for the Kubernetes API may be disabled via configuration.
+47. A custom CA certificate path for the Kubernetes API may be provided via configuration.
+
+## Configuration Surface
+
+| Field path | Type | Default | Description |
+|---|---|---|---|
+| `ols_config.authentication_config.module` | string | `"k8s"` | Auth module: `k8s`, `noop`, or `noop-with-token` |
+| `ols_config.authentication_config.skip_tls_verification` | bool | `false` | Disable TLS verification for Kubernetes API calls |
+| `ols_config.authentication_config.k8s_cluster_api` | URL | (from kubeconfig) | Override Kubernetes API server URL |
+| `ols_config.authentication_config.k8s_ca_cert_path` | file path | (from kubeconfig) | Custom CA certificate for Kubernetes API TLS |
+| `dev_config.disable_auth` | bool | `false` | Bypass all auth checks (dev only) |
+| `dev_config.k8s_auth_token` | string | (none) | Override bearer token for Kubernetes API client initialization |
+| `ols_config.logging_config.suppress_auth_checks_warning_in_log` | bool | `false` | Suppress repeated auth-bypass warnings in dev mode |
+
+## Constraints
+
+1. The authentication module selection is immutable after process startup.
+2. The Kubernetes client singleton is initialized once and shared for the lifetime of the process; it cannot be reconfigured at runtime.
+3. The `noop` and `noop-with-token` modules are intended for development only and must not be used in production deployments.
+4. The `noop-with-token` module uses HTTP 400 (not 401) for missing or invalid tokens because the failure is a malformed request, not an authentication rejection.
+5. The cluster ID is required for `kube:admin` identity mapping; if it cannot be retrieved in-cluster, the system must raise an error.
+6. The cluster version is non-critical (used for prompt enrichment); retrieval failure must never block request processing.
+7. The SubjectAccessReview uses the `get` verb against a non-resource path; no actual Kubernetes resource is accessed.
+
+## Planned Changes
+
+- [OLS-1393] Read user roles from the cluster during authentication and attach them to the request context.
+- [OLS-1394] Use the retrieved user roles to filter content returned by the service.

--- a/.ai/spec/what/config.md
+++ b/.ai/spec/what/config.md
@@ -1,0 +1,162 @@
+# Configuration System
+
+The configuration system loads, validates, and manages the single YAML file that drives all service behavior. It provides two-phase validation, credential security, and runtime reload without service restart.
+
+## Behavioral Rules
+
+### Loading
+
+1. The service must read its configuration from a single YAML file whose path is specified by the `OLS_CONFIG_FILE` environment variable.
+2. The YAML file must be parsed using `yaml.safe_load` -- no arbitrary Python object deserialization.
+3. The configuration must be held in a process-wide singleton (`AppConfig`). All subsystems read from this singleton rather than loading the file independently.
+4. Both `ols_config` and `llm_providers` top-level sections are required. The service must refuse to start if either is missing.
+
+### Two-Phase Validation
+
+5. **Phase 1 -- Structural validation** occurs during initial parsing (Pydantic model construction and `__init__` methods). It enforces: type correctness, required field presence, value range constraints, enum membership, credential file reading, and sub-object construction. A failure in Phase 1 prevents the `Config` object from being created.
+6. **Phase 2 -- Semantic cross-validation** occurs after the full `Config` object is constructed, via `Config.validate_yaml()`. It enforces: `default_provider` references an existing provider in `llm_providers`, `default_model` references an existing model within that provider, file and directory paths are accessible on disk, TLS certificates exist when TLS is enabled, regex patterns in query filters compile, proxy URL format is valid, MCP server authorization headers resolve, and authentication module is a supported value.
+7. Both phases must pass before the configuration is considered valid. A failure at any point must raise `InvalidConfigurationError` with a descriptive message.
+
+### Dynamic Reload
+
+8. The service must support reloading configuration from the YAML file at runtime without process restart, via `AppConfig.reload_from_yaml_file()`.
+9. On reload, the new configuration must pass full two-phase validation before replacing the active configuration. If validation fails, the active configuration must remain unchanged and the error must be raised.
+10. On successful reload, **stateless subsystems** must be re-initialized from the new configuration: query filters, RAG index loader, tool approval config, pending approval store, MCP server dictionary, tools RAG, and skills RAG.
+11. On successful reload, **stateful subsystems** must persist their connections and state across reloads: conversation cache, quota limiters, and token usage history. These are not reset.
+
+### Credential Handling
+
+12. All credentials (API tokens, passwords, client secrets) must be read from files referenced by path in the configuration. Plaintext credential values must never appear directly in the YAML.
+13. Credential reading uses `checks.read_secret()`, which supports both file paths (reads the file content) and directory paths (reads a default-named file within the directory, e.g., `apitoken` for API tokens).
+14. The TLS key password, if needed, must also be read from a file path (`tls_key_password_path`), not stored as plaintext.
+
+### Default Values
+
+15. When `authentication_config.module` is not specified, it must default to `k8s` (Kubernetes RBAC).
+16. When `context_window_size` is not specified per model, it must default to 128000.
+17. When `max_tokens_for_response` is not specified per model, it must default to 4096.
+18. When `history_compression_enabled` is not specified, it must default to `true`.
+19. Proxy URL and no-proxy hosts must fall back to the `https_proxy`/`HTTPS_PROXY` and `no_proxy` environment variables, respectively, when not specified in config.
+
+## Configuration Surface
+
+### Top-Level Sections
+
+The YAML file has four top-level sections:
+
+| Section | Required | Purpose | Detail Spec |
+|---------|----------|---------|-------------|
+| `llm_providers` | Yes | Provider and model definitions | see what/llm-providers.md |
+| `ols_config` | Yes | All service behavior configuration | (fields enumerated below) |
+| `mcp_servers` | No | MCP server definitions | see what/tools.md |
+| `dev_config` | No | Developer-mode flags | (fields enumerated below) |
+
+### `ols_config` Fields
+
+| Field Path | Type | Default | Purpose | Detail Spec |
+|------------|------|---------|---------|-------------|
+| `ols_config.default_provider` | string | (required) | Selects the default LLM provider by name | -- |
+| `ols_config.default_model` | string | (required) | Selects the default model within the default provider | -- |
+| `ols_config.authentication_config` | object | module=k8s | Auth module selection and K8s API settings | see what/auth.md |
+| `ols_config.conversation_cache` | object | (required) | Cache backend selection and settings | see what/conversation-history.md |
+| `ols_config.tls_config` | object | -- | Service endpoint TLS certificate and key paths | see what/security.md |
+| `ols_config.proxy_config` | object | from env | HTTPS proxy URL, CA cert, no-proxy hosts | -- |
+| `ols_config.query_filters` | list | none | PII redaction patterns (name, regex, replacement) | see what/security.md |
+| `ols_config.logging_config` | object | INFO/WARNING | Log levels per component | see what/observability.md |
+| `ols_config.user_data_collection` | object | all disabled | Feedback and transcript collection settings | see what/observability.md |
+| `ols_config.tool_filtering` | object | none | Tool RAG filtering parameters | see what/tools.md |
+| `ols_config.tools_approval` | object | never | Tool approval strategy and timeout | see what/tools.md |
+| `ols_config.skills` | object | none | Skills directory and matching config | see what/skills.md |
+| `ols_config.quota_handlers` | object | none | Quota limiter storage, scheduler, and limiters | see what/quota.md |
+| `ols_config.reference_content` | object | none | RAG index paths and embeddings model | see what/rag.md |
+| `ols_config.system_prompt_path` | string | none | Path to file containing custom system prompt | -- |
+| `ols_config.history_compression_enabled` | bool | true | Toggle conversation history compression | -- |
+| `ols_config.max_iterations` | int | mode-dependent | Tool-calling loop iteration cap (ask=5, troubleshooting=15) | -- |
+| `ols_config.tool_round_cap_fraction` | float | 0.6 | Max fraction of remaining tool token budget usable per round (0.3--0.8) | -- |
+| `ols_config.max_workers` | int | 1 | Number of concurrent workers | -- |
+| `ols_config.expire_llm_is_ready_persistent_state` | int | -1 | Expiration for LLM readiness cache (-1 = never) | -- |
+| `ols_config.extra_ca` | list | [] | Additional CA certificate file paths | see what/security.md |
+| `ols_config.certificate_directory` | string | /tmp | Directory for assembled certificate stores | see what/security.md |
+| `ols_config.tlsSecurityProfile` | object | none | TLS security profile for service endpoints | see what/security.md |
+
+### `dev_config` Fields
+
+| Field Path | Type | Default | Purpose |
+|------------|------|---------|---------|
+| `dev_config.enable_dev_ui` | bool | false | Enable Gradio development UI |
+| `dev_config.disable_auth` | bool | false | Disable all authentication checks |
+| `dev_config.disable_tls` | bool | false | Disable TLS on service endpoints |
+| `dev_config.enable_system_prompt_override` | bool | false | Allow API requests to override system prompt |
+| `dev_config.k8s_auth_token` | string | none | Static Kubernetes auth token for testing |
+| `dev_config.run_on_localhost` | bool | false | Bind to localhost instead of all interfaces |
+| `dev_config.uvicorn_port_number` | int | none | Custom HTTP server port |
+| `dev_config.pyroscope_url` | string | none | Continuous profiling service URL |
+| `dev_config.llm_params` | dict | {} | Override LLM parameters for testing |
+
+### `mcp_servers` Fields
+
+| Field Path | Type | Default | Purpose |
+|------------|------|---------|---------|
+| `mcp_servers[].name` | string | (required) | Unique server name |
+| `mcp_servers[].url` | string | (required) | Server endpoint URL |
+| `mcp_servers[].timeout` | int | none | Request timeout in seconds |
+| `mcp_servers[].headers` | dict | {} | Auth headers (file paths, `kubernetes` placeholder, or `client` placeholder) |
+
+### `llm_providers` Fields
+
+Each provider entry under `llm_providers` supports:
+
+| Field Path | Type | Default | Purpose |
+|------------|------|---------|---------|
+| `llm_providers[].name` | string | (required) | Provider name |
+| `llm_providers[].type` | string | =name | Provider type (openai, azure_openai, watsonx, rhoai_vllm, rhelai_vllm, google_vertex, google_vertex_anthropic, fake_provider) |
+| `llm_providers[].url` | URL | none | Provider endpoint URL |
+| `llm_providers[].credentials_path` | string | none | Path to credential file or directory |
+| `llm_providers[].models[]` | list | (required, >= 1) | Model definitions |
+| `llm_providers[].models[].name` | string | (required) | Model identifier |
+| `llm_providers[].models[].context_window_size` | int | 128000 | Context window size in tokens |
+| `llm_providers[].models[].parameters.max_tokens_for_response` | int | 4096 | Tokens reserved for response |
+| `llm_providers[].models[].parameters.tool_budget_ratio` | float | 0.25 | Fraction of context window for tool outputs (0.1--0.6) |
+| `llm_providers[].models[].parameters.reasoning_effort` | enum | low | Reasoning effort level (low, medium, high) |
+| `llm_providers[].models[].parameters.reasoning_summary` | enum | concise | Reasoning summary style (auto, concise, detailed) |
+| `llm_providers[].models[].parameters.verbosity` | enum | low | General verbosity level (low, medium, high) |
+| `llm_providers[].models[].options` | dict | none | Arbitrary key-value model options |
+| `llm_providers[].<type>_config` | object | none | Provider-specific config (at most one per provider) |
+| `llm_providers[].tlsSecurityProfile` | object | none | TLS security profile for provider connection |
+
+## Constraints
+
+### Structural Invariants
+
+1. The `Config` object must always have both `ols_config` and `llm_providers` populated. Missing either is a fatal startup error.
+2. Every provider must have at least one model. A provider with zero models is rejected during Phase 1.
+3. At most one provider-specific configuration block (e.g., `openai_config`, `azure_openai_config`) may appear per provider entry. Multiple blocks are rejected.
+4. The provider-specific config block, if present, must match the provider's `type`. A mismatch is rejected.
+5. MCP server names must be unique across all entries. Duplicates are rejected by Pydantic validation.
+6. Per-model `context_window_size` must be strictly greater than `max_tokens_for_response + max_tokens_for_tools`. This is validated after tool budgets are computed.
+7. `tool_budget_ratio` must be between 0.1 and 0.6. `tool_round_cap_fraction` must be between 0.3 and 0.8.
+
+### Security Constraints
+
+8. Credentials must never be stored as plaintext values in the YAML. They must always be file path references resolved at load time.
+9. TLS cannot be enabled without both a certificate path and a key path configured.
+10. The TLS security profile must enforce a minimum of TLS 1.2. The `OldType` profile is rejected.
+11. MCP servers using the `kubernetes` authorization header placeholder require the authentication module to be `k8s` or `noop-with-token`. With any other auth module, the server is excluded (not a fatal error -- it is silently filtered out with a warning).
+
+### Cross-Validation Constraints
+
+12. `default_provider` must name a provider that exists in `llm_providers`.
+13. `default_model` must name a model that exists within the default provider's model list.
+14. `conversation_cache.type` must be either `memory` or `postgres`. The corresponding sub-section (`memory` or `postgres`) must be present when the type is specified.
+15. `authentication_config.module` must be one of: `k8s`, `noop`, `noop-with-token`.
+16. Provider `type` must be one of the supported provider types: openai, azure_openai, watsonx, rhoai_vllm, rhelai_vllm, google_vertex, google_vertex_anthropic, fake_provider.
+17. `project_id` is required when provider type is `watsonx`.
+
+### Tool Budget Computation
+
+18. When MCP servers are configured, each model's `max_tokens_for_tools` is computed as `context_window_size * tool_budget_ratio`. When no MCP servers are configured, `max_tokens_for_tools` is 0.
+19. After computing tool budgets, the system validates that `context_window_size > max_tokens_for_response + max_tokens_for_tools` for every model. Violation is a fatal configuration error.
+
+## Planned Changes
+
+- [PLANNED: OLS-2874] Enable Skills Configuration in OLSConfig CRD -- expose `ols_config.skills` through the operator's custom resource definition, allowing skills to be configured declaratively via the OLSConfig CR.

--- a/.ai/spec/what/conversation-history.md
+++ b/.ai/spec/what/conversation-history.md
@@ -1,0 +1,79 @@
+# Conversation History
+
+The conversation history subsystem preserves prior exchanges within a conversation so that multi-turn interactions benefit from earlier context, and exposes CRUD operations for managing conversations per user.
+
+## Behavioral Rules
+
+1. Every cache operation requires both a user_id and a conversation_id. Both must be valid UUIDs. Operations with an invalid ID must be rejected with a validation error before reaching the storage backend.
+
+2. When a query-response exchange is stored, the system must either append it to an existing conversation (if one exists for the given user_id + conversation_id) or create a new conversation. Each stored exchange contains the user query (HumanMessage), the AI response (AIMessage), any attachments submitted with the query, any tool calls requested by the model, and any tool results returned from tool execution.
+
+3. Retrieving history for a user_id + conversation_id must return all stored exchanges ordered oldest to newest. If no conversation exists for the given key, the system must return an empty result.
+
+4. Listing conversations for a user must return metadata for every conversation belonging to that user, ordered by last message timestamp (most recent first). Each entry includes: conversation_id, topic_summary, last_message_timestamp, and message_count.
+
+5. Deleting a conversation must remove both the message history and the conversation metadata. The operation must return whether the conversation existed prior to deletion.
+
+6. The topic summary for a conversation may be set or replaced at any time via the update operation. Setting a topic summary on a conversation that has no metadata record yet must create one.
+
+7. The readiness check must verify that the storage backend is operational. For in-memory storage, readiness is always true. For PostgreSQL, readiness requires a live, responsive database connection.
+
+8. When capacity is exceeded after storing an exchange, the system must evict the oldest message from the least-recently-used conversation. If that conversation has no remaining messages after eviction, the conversation and its metadata must be removed entirely. Eviction continues until total entries are within capacity.
+
+9. When history compression is enabled and conversation history exceeds the available token budget, the system must attempt LLM-based summarization of the oldest entries. A configurable number of the most recent entries are preserved verbatim and never summarized.
+
+10. If LLM summarization succeeds, the system must replace the summarized entries in the cache with a single synthetic summary entry (a HumanMessage containing "[Previous conversation summary]" paired with an AIMessage containing the summary text), followed by the preserved recent entries.
+
+11. If LLM summarization fails after retries, the system must fall back to simple truncation: use only the entries that fit within the token budget, discarding the oldest entries without any summary.
+
+12. If the cache rewrite after summarization fails, the compressed entries must still be used for the current request even though they are not persisted.
+
+13. When compression occurs during a streaming response, the system must emit a history_compression_start event before summarization begins and a history_compression_end event (with duration) after it completes.
+
+14. Summarization retries must use exponential backoff and must only retry on transient errors (timeouts, connection failures, rate limits). Non-transient errors must not be retried.
+
+15. The token budget allocated for history must include a safety margin (reduced from the raw available tokens) to prevent boundary overflows.
+
+16. Messages must be serialized to JSON for PostgreSQL storage using a custom encoder/decoder that preserves message type (human/ai), content, response metadata, and additional keyword arguments.
+
+17. Concurrent access to the same conversation must be serialized. For PostgreSQL, this must use database-level advisory locks scoped to the user_id + conversation_id, combined with a thread-level mutex. For in-memory storage, a thread-level mutex must serialize all mutations.
+
+18. The in-memory cache must be a singleton: all threads within a process share one cache instance.
+
+## Configuration Surface
+
+| Field path | Description |
+|---|---|
+| `ols_config.conversation_cache.type` | Storage backend type: `"memory"` or `"postgres"` |
+| `ols_config.conversation_cache.memory.max_entries` | Maximum total message entries for in-memory cache |
+| `ols_config.conversation_cache.postgres.host` | PostgreSQL server hostname |
+| `ols_config.conversation_cache.postgres.port` | PostgreSQL server port (1-65535) |
+| `ols_config.conversation_cache.postgres.dbname` | PostgreSQL database name |
+| `ols_config.conversation_cache.postgres.user` | PostgreSQL connection user |
+| `ols_config.conversation_cache.postgres.password_path` | Path to file containing PostgreSQL password |
+| `ols_config.conversation_cache.postgres.ssl_mode` | PostgreSQL SSL connection mode |
+| `ols_config.conversation_cache.postgres.ca_cert_path` | Path to CA certificate for PostgreSQL TLS |
+| `ols_config.conversation_cache.postgres.max_entries` | Maximum total message entries for PostgreSQL cache |
+| `ols_config.history_compression_enabled` | Whether to use LLM-based history compression (default: true) |
+
+## Constraints
+
+1. **User isolation is a security invariant.** A user must never be able to read, modify, list, or delete another user's conversations. Every cache operation must scope access by the authenticated user_id. There is no administrative bypass for cross-user access.
+
+2. Both user_id and conversation_id must be valid UUIDs (with or without dashes). Operations with malformed IDs must be rejected before any storage access occurs.
+
+3. Capacity is measured in total message entries across all conversations, not in number of conversations.
+
+4. PostgreSQL storage must use transactions with advisory locks for insert-or-append operations to prevent lost updates from concurrent writes to the same conversation.
+
+5. Cache errors from the storage backend must be wrapped in a domain-specific CacheError exception, preserving the original cause.
+
+6. The in-memory backend does not survive process restarts. It is suitable only for development and single-instance deployments.
+
+7. When compression is disabled, history that exceeds the token budget is truncated by the token handler (newest messages kept, oldest dropped) with no summarization attempt.
+
+## Planned Changes
+
+- [PLANNED: OLS-2713] Persistent chat -- UI-side conversation persistence, enabling users to resume conversations across browser sessions.
+- [PLANNED: OLS-141] Encrypting conversation state cache data, on disk and in memory.
+- [PLANNED: OLS-251] Scale Postgres Conversation Cache Backend for high-availability and multi-instance production deployments.

--- a/.ai/spec/what/llm-providers.md
+++ b/.ai/spec/what/llm-providers.md
@@ -1,0 +1,180 @@
+# LLM Provider System
+
+The provider system loads, configures, and communicates with LLM backends so that the core query pipeline operates identically regardless of which backend is in use.
+
+## Behavioral Rules
+
+### Provider Contract
+
+Every provider must satisfy all of the following:
+
+1. The system must maintain a provider registry. Each provider implementation registers itself by provider type string at import time, so that adding a new provider never requires modifying core loading code.
+
+2. When a provider/model combination is requested, the system must resolve the provider configuration from `olsconfig.yaml`, verify that the provider name exists and the model is listed under that provider, then look up the provider type in the registry to instantiate and load the LLM. If the provider name is not in configuration, a distinct "unknown provider" error must be raised. If the model is not configured for the provider, a distinct "model config missing" error must be raised. If the provider type has no registered implementation, a distinct "unsupported provider" error must be raised.
+
+3. Each provider must define default parameters appropriate to its backend. These defaults are the baseline for every LLM call.
+
+4. Parameters must follow a three-level precedence, applied in this order:
+   - **Provider defaults** (lowest priority) -- hardcoded sensible values for the backend.
+   - **Per-request parameters** -- caller-supplied generic parameters override defaults.
+   - **Admin overrides** (highest priority) -- values from the developer/debug configuration override everything, including per-request parameters.
+
+5. The system must translate generic parameter names to provider-specific names before passing them to the backend. Generic names include `max_tokens_for_response`, `min_tokens_for_response`, `temperature`, `top_k`, and `top_p`. Each provider declares its own mapping. Parameters with no mapping pass through with their original name.
+
+6. After remapping, the system must validate parameters against the provider's declared set of accepted parameter names and types. Parameters not recognized by the target provider must be silently filtered out with a warning log, not cause errors. Parameters with a recognized name but a `None` value must be allowed through.
+
+7. Each provider must produce both a synchronous and an asynchronous HTTP client (where applicable) and pass them to the LLM backend library. Both clients must respect the same proxy, TLS, and certificate settings.
+
+8. Each provider must support tool binding: the LLM instance returned by `load()` must accept `bind_tools()` to attach tool/function definitions for tool-calling workflows.
+
+9. Provider-specific configuration (e.g., `openai_config`, `azure_openai_config`) takes precedence over top-level provider fields (`url`, `credentials`) whenever both are present.
+
+10. Credentials must be read from files on disk (via `credentials_path`), not from environment variables or inline config values. The file path points to a directory or file containing the secret.
+
+### Reasoning Model Support
+
+11. Models must be classified as reasoning-capable or standard based on their name. A model is reasoning-capable if its name contains `gpt-5` or starts with `o` (the OpenAI o-series pattern).
+
+12. For reasoning-capable models, the provider must set reasoning-specific parameters (`reasoning_effort`, `reasoning_summary`, `verbosity`) drawn from the model's `parameters` configuration. Standard sampling parameters (`temperature`, `top_p`, `frequency_penalty`) must not be set.
+
+13. For standard (non-reasoning) models, the provider must set sampling parameters with sensible defaults (`temperature`, `top_p`, `frequency_penalty`). Reasoning parameters must not be set.
+
+14. `reasoning_effort` and `verbosity` accept values `low`, `medium`, or `high`. `reasoning_summary` accepts `auto`, `concise`, or `detailed`.
+
+### HTTP Client Requirements
+
+15. All providers communicating over HTTP must support proxy configuration. When `ols_config.proxy_config.proxy_url` is set, all HTTP clients must route through that proxy. If the proxy URL is HTTPS, a proxy-specific SSL context must be created using the configured proxy CA certificate.
+
+16. Hosts listed in `ols_config.proxy_config.no_proxy_hosts` must bypass the proxy entirely.
+
+17. Providers that use custom certificate stores (OpenAI, Azure OpenAI, RHOAI vLLM, RHELAI vLLM) must load the certificate bundle from `certificates_store` and use it for TLS verification.
+
+18. When `tlsSecurityProfile` is configured on the provider, the HTTP client must enforce the specified minimum TLS version and cipher suite list. When no security profile is set, the client must use default TLS verification (or the custom certificate store if applicable).
+
+## Per-Provider Deviations
+
+The following sections describe only what differs from the standard contract above. Behavior not mentioned is identical to the contract.
+
+### OpenAI (`openai`)
+
+19. Default URL: `https://api.openai.com/v1`. Uses `ChatOpenAI` from LangChain. No deviations from the standard contract. Uses custom certificate store.
+
+### Azure OpenAI (`azure_openai`)
+
+20. Must support two authentication modes:
+    - **API key**: When `credentials` (or `azure_openai_config.api_key`) is set, use it as the `api_key` parameter.
+    - **Entra ID service principal**: When no API key is present, obtain an Azure AD token using `tenant_id`, `client_id`, and `client_secret` from `azure_openai_config`. The token is scoped to `https://cognitiveservices.azure.com/.default`.
+
+21. Azure AD tokens must be cached per process. The cached token must be refreshed when it expires, with a 30-second safety margin before the actual expiration time. If token retrieval fails, the provider must log the error and return `None` for the token (degraded operation), not crash.
+
+22. If Entra ID auth is selected but any of `tenant_id`, `client_id`, or `client_secret` is missing, the provider must raise a specific error naming the absent field.
+
+23. `api_version` must be configurable, defaulting to `2024-02-15-preview`. `deployment_name` is configured separately from `model` name.
+
+24. Uses `AzureChatOpenAI` from LangChain. Uses custom certificate store.
+
+### WatsonX (`watsonx`)
+
+25. Requires `project_id` to be set in configuration. If `project_id` is missing, the system must reject the configuration at startup (not at first request).
+
+26. Requires `credentials` (API key) to be set. If missing, the provider must raise a ValueError at load time.
+
+27. Generic parameter names map to WatsonX-specific names: `max_tokens_for_response` maps to `MAX_NEW_TOKENS`, `min_tokens_for_response` maps to `MIN_NEW_TOKENS`, `temperature` maps to WatsonX's `TEMPERATURE`, `top_k` to `TOP_K`, `top_p` to `TOP_P`. Additional WatsonX-specific parameters include `DECODING_METHOD`, `RANDOM_SEED`, and `REPETITION_PENALTY`.
+
+28. Parameters are passed to the LLM constructor in a `params` dict (not as top-level keyword arguments). Uses `ChatWatsonx` from LangChain IBM. Does not use httpx clients or custom certificate stores.
+
+29. Default URL: `https://us-south.ml.cloud.ibm.com`.
+
+### RHOAI vLLM (`rhoai_vllm`)
+
+30. Uses the OpenAI-compatible API via `ChatOpenAI`. No default URL is defined (falls back to `https://api.openai.com/v1` but the admin must configure the actual endpoint). Uses custom certificate store.
+
+31. Sets standard sampling defaults (`temperature`, `top_p`, `frequency_penalty`) regardless of model name -- no reasoning model detection.
+
+### RHELAI vLLM (`rhelai_vllm`)
+
+32. Identical to RHOAI vLLM in behavior. Registered under a different type identifier (`rhelai_vllm`) to distinguish the deployment context in configuration.
+
+### Google Vertex AI - Gemini (`google_vertex`)
+
+33. Requires `credentials` as a JSON string containing a Google service account key. The JSON is parsed and used to create Google OAuth2 credentials scoped to `https://www.googleapis.com/auth/cloud-platform`.
+
+34. `project` and `location` are configured via `google_vertex_config`. Default location: `global`. Uses `ChatGoogleGenerativeAI` from LangChain with `vertexai=True`.
+
+35. Does not use httpx clients or custom certificate stores. `max_tokens_for_response` maps to `max_output_tokens`.
+
+### Google Vertex AI - Anthropic/Claude (`google_vertex_anthropic`)
+
+36. Same credential handling as Google Vertex (Gemini): requires JSON service account key, same OAuth2 scope.
+
+37. `project` and `location` are configured via `google_vertex_anthropic_config`. Default location: `us-east5`. Uses `ChatAnthropicVertex` from LangChain.
+
+38. Does not use httpx clients or custom certificate stores. `max_tokens_for_response` maps to `max_output_tokens`.
+
+### Fake Provider (`fake_provider`)
+
+39. Returns static preconfigured responses for testing. Supports a streaming mode that splits the response into chunks with a configurable sleep interval, and a non-streaming mode that returns the full response at once.
+
+40. Accepts `bind_tools()` but ignores the tools (returns the same LLM instance unchanged).
+
+41. Not intended for production use. Configured via `fake_provider_config` with fields: `stream`, `mcp_tool_call`, `response`, `chunks`, `sleep`.
+
+## Configuration Surface
+
+- `llm_providers[].name` -- Provider instance name (used as the lookup key).
+- `llm_providers[].type` -- Provider type string (must match a registered type: `openai`, `azure_openai`, `watsonx`, `rhoai_vllm`, `rhelai_vllm`, `google_vertex`, `google_vertex_anthropic`, `fake_provider`). Defaults to the provider name if not specified.
+- `llm_providers[].url` -- Base URL for the LLM API endpoint.
+- `llm_providers[].credentials_path` -- Path to file or directory containing the API key/token.
+- `llm_providers[].project_id` -- Required for WatsonX; project identifier.
+- `llm_providers[].api_version` -- Azure OpenAI API version (default: `2024-02-15-preview`).
+- `llm_providers[].deployment_name` -- Azure OpenAI deployment name.
+- `llm_providers[].models[]` -- List of model configurations under this provider.
+- `llm_providers[].models[].name` -- Model identifier passed to the backend.
+- `llm_providers[].models[].context_window_size` -- Token context window (default: 128000).
+- `llm_providers[].models[].credentials_path` -- Model-level credential override.
+- `llm_providers[].models[].parameters.max_tokens_for_response` -- Max tokens reserved for the LLM response (default: 4096).
+- `llm_providers[].models[].parameters.reasoning_effort` -- Reasoning effort level: `low`, `medium`, or `high` (default: `low`).
+- `llm_providers[].models[].parameters.reasoning_summary` -- Reasoning summary mode: `auto`, `concise`, or `detailed` (default: `concise`).
+- `llm_providers[].models[].parameters.verbosity` -- Verbosity for reasoning models: `low`, `medium`, or `high` (default: `low`).
+- `llm_providers[].models[].parameters.tool_budget_ratio` -- Fraction of context window reserved for tool outputs (default: 0.25, range: 0.1--0.6).
+- `llm_providers[].models[].options` -- Arbitrary key-value options dict passed through to the model.
+- `llm_providers[].tlsSecurityProfile` -- TLS security profile with `type`, `minTLSVersion`, and `ciphers`.
+- `llm_providers[].openai_config` -- Provider-specific: `url`, `credentials_path`.
+- `llm_providers[].azure_openai_config` -- Provider-specific: `url`, `deployment_name`, `credentials_path` (directory containing `apitoken`, `client_id`, `tenant_id`, `client_secret` files).
+- `llm_providers[].watsonx_config` -- Provider-specific: `url`, `credentials_path`, `project_id`.
+- `llm_providers[].rhoai_vllm_config` -- Provider-specific: `url`, `credentials_path`.
+- `llm_providers[].rhelai_vllm_config` -- Provider-specific: `url`, `credentials_path`.
+- `llm_providers[].google_vertex_config` -- Provider-specific: `project`, `location`.
+- `llm_providers[].google_vertex_anthropic_config` -- Provider-specific: `project`, `location`.
+- `llm_providers[].fake_provider_config` -- Testing: `stream`, `mcp_tool_call`, `response`, `chunks`, `sleep`.
+- `dev_config.llm_params` -- Admin/developer override parameters applied at highest precedence.
+- `ols_config.proxy_config.proxy_url` -- HTTP/HTTPS proxy URL for LLM traffic.
+- `ols_config.proxy_config.proxy_ca_cert_path` -- CA certificate for HTTPS proxy verification.
+- `ols_config.proxy_config.no_proxy_hosts` -- List of hostnames that bypass the proxy.
+
+## Constraints
+
+1. At most one provider-specific configuration block (e.g., `openai_config`, `azure_openai_config`) may appear per provider entry. If more than one is present, the system must reject the configuration at startup.
+
+2. The provider-specific configuration block must match the provider's `type`. If the type is `azure_openai` but the block present is `openai_config`, the system must reject the configuration.
+
+3. Provider type must be one of the supported set. An unrecognized type string is a startup configuration error.
+
+4. Every provider entry must have at least one model configured. Zero models is a startup configuration error.
+
+5. Minimum TLS version when a security profile is configured must be `VersionTLS12` or higher. Lower versions must be rejected at configuration time.
+
+6. Credentials are never logged. Parameters containing keys, tokens, or HTTP client objects must be redacted from log output.
+
+7. The certificate store path is computed at startup and points to a PEM bundle file in the certificate directory. It is only used by OpenAI-family providers (OpenAI, Azure OpenAI, RHOAI vLLM, RHELAI vLLM).
+
+8. Google Vertex providers require `credentials` to contain valid JSON representing a Google service account key. Non-JSON or non-object values must be rejected.
+
+9. The default context window size is 128,000 tokens. The default max tokens for response is 4,096. These defaults apply when not explicitly configured, but may not be accurate for all models -- administrators should set model-specific values.
+
+## Planned Changes
+
+- [PLANNED: OLS-1680] Support AWS Bedrock as an LLM provider, enabling models hosted on Amazon's managed inference service.
+- [PLANNED: OLS-2776] Support Anthropic as a direct LLM provider (not via Google Vertex), communicating with the Anthropic API natively.
+- [PLANNED: OLS-1320] Support short-lived (rotating) tokens for all providers, replacing static API keys with tokens that are refreshed periodically.
+- [PLANNED: OLS-1999] Support IBM WatsonX short-lived token authentication, enabling token-based auth that refreshes automatically rather than using a static API key.

--- a/.ai/spec/what/mcp-apps.md
+++ b/.ai/spec/what/mcp-apps.md
@@ -1,0 +1,148 @@
+# MCP Apps
+
+MCP Apps are a UI integration layer that allows the OpenShift console plugin
+to discover renderable resources and invoke tool calls on MCP servers directly,
+bypassing the LLM query pipeline. This is distinct from tool execution during
+LLM conversations (see `what/tools.md`).
+
+## Behavioral Rules
+
+### Resource Fetching
+
+1. The system must expose a `POST /v1/mcp-apps/resources` endpoint that
+   proxies resource reads to a named MCP server on behalf of the console UI.
+
+2. Only resources with the `ui://` URI scheme are valid. The system must
+   reject any resource URI that does not start with `ui://` or is empty
+   after the scheme prefix, returning HTTP 400.
+
+3. A resource request must specify the `server_name` identifying which
+   configured MCP server owns the resource, and the `resource_uri` to fetch.
+
+4. The system must open a Streamable HTTP MCP session to the target server,
+   call `read_resource` with the requested URI, and return the first content
+   block from the response.
+
+5. Resource content must be classified as either `"text"` (for text-based
+   content such as HTML, JS, CSS) or `"blob"` (for binary content such as
+   base64-encoded data). The MIME type must default to `text/html` when the
+   MCP server does not provide one.
+
+6. Resource-level metadata from the MCP server (CSP directives, permissions,
+   or other hints) must be forwarded to the client in the response `meta`
+   field.
+
+7. If the MCP server returns an empty content list for the requested URI,
+   the system must return HTTP 404.
+
+### Direct Tool Calls
+
+8. The system must expose a `POST /v1/mcp-apps/tools/call` endpoint that
+   proxies tool calls to a named MCP server outside the LLM conversation
+   flow.
+
+9. A tool call request must specify the `server_name`, `tool_name`, and
+   `arguments` (defaulting to an empty dict).
+
+10. The system must open a Streamable HTTP MCP session to the target server,
+    call the specified tool with the provided arguments, and return the
+    result.
+
+11. Tool call results must be returned as a list of typed content blocks.
+    Supported content block types are `text`, `image`, and `audio`.
+    Unsupported content types must be logged and omitted from the response.
+
+12. Structured content returned by the MCP server (e.g., rich data for UI
+    rendering) must be preserved and forwarded to the client separately from
+    the content block list.
+
+13. The `is_error` flag from the MCP tool result must be forwarded to the
+    client so the UI can distinguish successful calls from error responses.
+
+### Client Auth Header Discovery
+
+14. The system must expose a `GET /v1/mcp/client-auth-headers` endpoint that
+    tells clients which MCP servers require client-provided authentication
+    headers.
+
+15. The response must list each server that has at least one header configured
+    with the `"client"` placeholder, along with the names of the required
+    headers.
+
+16. Clients use this information to include the correct headers in subsequent
+    resource fetch or tool call requests via the `mcp_headers` field.
+
+### Authentication and Header Resolution
+
+17. All MCP Apps endpoints require the same authentication as the main query
+    endpoint (kubernetes token review via the `/ols-access` virtual path).
+
+18. Header resolution for MCP Apps follows the same rules as for LLM tool
+    calls (see `what/tools.md`, rules 2--3): `"kubernetes"` placeholders
+    resolve to the user's bearer token, `"client"` placeholders resolve from
+    the request's `mcp_headers` field, and literal values pass through.
+
+19. If header resolution fails for the target server (missing kubernetes token
+    or missing required client header), the system must return HTTP 401 with a
+    message identifying the server.
+
+20. If no MCP servers are configured, or the requested server name does not
+    match any configured server, the system must return HTTP 404.
+
+### Connection Parameters
+
+21. Each MCP Apps connection must use the target server's configured URL and
+    per-server timeout. When no timeout is configured for a server, the
+    default is 30 seconds.
+
+22. Any unhandled exception during resource fetching or tool execution must
+    return HTTP 500 with the error detail. The error must be logged.
+
+## Configuration Surface
+
+MCP Apps share MCP server configuration with the tool execution pipeline.
+See `what/tools.md` for the full `mcp_servers.servers[]` configuration table.
+
+| Field Path | Type | Default | Purpose |
+|---|---|---|---|
+| `mcp_servers.servers[].name` | string | required | Server identifier used in `server_name` request field |
+| `mcp_servers.servers[].url` | string | required | Server HTTP endpoint for Streamable HTTP sessions |
+| `mcp_servers.servers[].timeout` | int | 30 (apps) | Per-server timeout in seconds for app requests |
+| `mcp_servers.servers[].headers` | map | {} | Authorization headers; `"client"` placeholders drive discovery |
+
+## Constraints
+
+1. **MCP Apps are not LLM tool calls.** Resource fetches and direct tool calls
+   bypass the LLM query pipeline entirely. They do not participate in
+   conversation history, tool approval workflows, token budgeting, or retry
+   policies. Those behaviors apply only to tool calls within the LLM
+   generation loop (see `what/tools.md`).
+
+2. **Only `ui://` URIs are accepted.** The resource endpoint must never proxy
+   arbitrary URI schemes. This is enforced by validation before any MCP
+   session is opened.
+
+3. **Server must be configured.** Both resource and tool call endpoints
+   require the target server to be present in `mcp_servers.servers[]`.
+   There is no server auto-discovery; the admin must explicitly configure
+   every MCP server.
+
+4. **One content block per resource.** The resource endpoint returns only the
+   first content block from the MCP server response. Multi-block resources
+   are not supported.
+
+5. **No retry or fault isolation across servers.** Unlike tool gathering in
+   the query pipeline, MCP Apps target a single named server per request.
+   If that server is unavailable, the request fails. There is no retry
+   logic or fallback.
+
+6. **Shared auth boundary.** MCP Apps use the same authentication gate as the
+   query endpoint. A user who cannot access `/ols-access` cannot use MCP
+   Apps.
+
+## Planned Changes
+
+| Jira Key | Summary |
+|---|---|
+| OLS-2657 | MCP-apps UI productization strategy -- define the supported surface area, security model, and lifecycle for MCP-powered console apps |
+| OLS-2684 | Remove client MCP headers -- eliminating the `"client"` header placeholder will affect the client-auth-headers discovery endpoint and `mcp_headers` field (shared with `what/tools.md`) |

--- a/.ai/spec/what/observability.md
+++ b/.ai/spec/what/observability.md
@@ -1,0 +1,112 @@
+# Observability
+
+The service exposes Prometheus metrics, records conversation transcripts and user feedback to persistent storage, logs HTTP request/response details with header redaction, and optionally integrates with Pyroscope for continuous profiling.
+
+## Behavioral Rules
+
+### Prometheus Metrics
+
+1. The service exposes the following Prometheus metrics, all prefixed with `ols_`:
+
+   | Metric name | Type | Labels | Description |
+   |---|---|---|---|
+   | `ols_rest_api_calls_total` | Counter | `path`, `status_code` | Total REST API calls. Excludes `/metrics` endpoint. |
+   | `ols_response_duration_seconds` | Histogram | `path` | Duration of request handling. Includes all registered routes. |
+   | `ols_llm_calls_total` | Counter | `provider`, `model` | Total LLM invocations. |
+   | `ols_llm_calls_failures_total` | Counter | _(none)_ | Total failed LLM calls across all providers. |
+   | `ols_llm_token_sent_total` | Counter | `provider`, `model` | Cumulative input tokens sent to LLMs. |
+   | `ols_llm_token_received_total` | Counter | `provider`, `model` | Cumulative output tokens received from LLMs. |
+   | `ols_llm_reasoning_token_total` | Counter | `provider`, `model` | Cumulative reasoning summary tokens received from LLMs. |
+   | `ols_provider_model_configuration` | Gauge | `provider`, `model` | Configured provider/model combinations. Value `1` for the default, `0` for others. |
+
+2. The `_created` timestamp metadata on all counters must be suppressed (via `disable_created_metrics()`).
+
+3. The `ols_rest_api_calls_total` counter must NOT be incremented for requests to the `/metrics` path.
+
+4. The `ols_response_duration_seconds` histogram must be recorded for all registered application routes, including `/metrics`.
+
+5. The `ols_provider_model_configuration` gauge must be populated at startup from the configuration, before the first Prometheus scrape can occur. The default provider/model pair gets value `1`; all other configured pairs get `0`. If multiple provider entries resolve to the same `(provider_type, model_name)` key, a pair already set to `1` must not be overwritten with `0`.
+
+### Metrics Endpoint
+
+6. The metrics endpoint must be served at `GET /metrics`.
+
+7. The response must use Prometheus text exposition format (`text/plain; version=0.0.4; charset=utf-8`).
+
+8. Access to the metrics endpoint requires a separate permission scope, authorized via the virtual path `/ols-metrics-access`. A user authorized for the main API (`/ols-access`) is not automatically authorized to read metrics.
+
+### Token Counting
+
+9. For each LLM interaction, the service must count input tokens, output tokens, and reasoning tokens using a tokenizer (tiktoken `cl100k_base`).
+
+10. Input tokens are counted when the LLM call starts (from the prompt strings). Output tokens are counted as each text token is yielded. Reasoning tokens are counted separately from output tokens when the LLM emits structured content blocks with `type: "reasoning"` containing `summary` sub-blocks.
+
+11. The number of LLM calls within a single user request must be tracked (relevant for agentic tool-calling loops that invoke the LLM multiple times).
+
+12. Upon completion of an LLM interaction, token counts must be accumulated into the Prometheus counters `ols_llm_token_sent_total`, `ols_llm_token_received_total`, `ols_llm_reasoning_token_total`, and `ols_llm_calls_total`, all labeled by `provider` and `model`.
+
+13. Token counts must also be available per-request for quota enforcement and optionally recorded in the usage history database.
+
+### Transcript Recording
+
+14. The service must optionally record conversation transcripts as JSON files in a configurable directory.
+
+15. Each transcript file must contain: metadata (provider, model, user ID, conversation ID, query mode, ISO 8601 timestamp), the redacted user query, the LLM response, RAG chunks (as dicts), a truncation flag, merged tool calls and results, and attachments.
+
+16. Transcripts are organized under `{transcripts_storage}/{user_id}/{conversation_id}/{suid}.json`.
+
+17. Transcript recording is independently enabled or disabled. When disabled, no files are written and a debug log message is emitted. [PLANNED: OLS-1805 -- enhance transcripts with per-request token usage data]
+
+### User Feedback
+
+18. The service must accept user feedback via `POST /v1/feedback`. The request must include `conversation_id`, `user_question`, `llm_response`, and at least one of `sentiment` (integer, must be `-1` or `1`) or `user_feedback` (free-text string).
+
+19. Feedback is stored as individual JSON files in the configured feedback storage directory, each named `{suid}.json` and containing `user_id`, `timestamp`, and all feedback fields.
+
+20. Feedback collection is independently enabled or disabled. When disabled, the `POST` endpoint returns HTTP 403.
+
+21. The feedback status endpoint `GET /v1/feedback/status` must report whether feedback collection is enabled. This endpoint must NOT require authentication.
+
+### Request/Response Logging
+
+22. The service must log HTTP request and response details at DEBUG level, including client host/port, headers, and body content.
+
+23. The following request headers must be redacted (replaced with `XXXXX`) in log output: `authorization`, `proxy-authorization`, `cookie`.
+
+24. The following response headers must be redacted in log output: `www-authenticate`, `proxy-authenticate`, `set-cookie`.
+
+25. When `suppress_metrics_in_log` is enabled and the request path is `/metrics`, the request/response logging middleware must skip logging entirely.
+
+### Continuous Profiling
+
+26. The service must optionally integrate with Pyroscope for continuous CPU profiling. When configured, it registers with the Pyroscope server using application name `lightspeed-service`, with `oncpu=True` and `gil_only=True`.
+
+27. Pyroscope integration is activated only when a URL is provided in `dev_config.pyroscope_url` and the server is reachable. When not configured, no profiling code is loaded and no overhead is incurred.
+
+## Configuration Surface
+
+| Config field path | Type | Default | Purpose |
+|---|---|---|---|
+| `ols_config.logging_config.app_log_level` | string (log level name) | `info` | Log level for `ols.*` loggers |
+| `ols_config.logging_config.lib_log_level` | string (log level name) | `warning` | Log level for root/third-party loggers |
+| `ols_config.logging_config.uvicorn_log_level` | string (log level name) | `warning` | Log level for Uvicorn HTTP server |
+| `ols_config.logging_config.suppress_metrics_in_log` | bool | `false` | Suppress `/metrics` requests from debug logs |
+| `ols_config.user_data_collection.feedback_disabled` | bool | `true` | Disable user feedback collection |
+| `ols_config.user_data_collection.feedback_storage` | string (path) | _(none)_ | Directory for feedback JSON files (required when enabled) |
+| `ols_config.user_data_collection.transcripts_disabled` | bool | `true` | Disable transcript recording |
+| `ols_config.user_data_collection.transcripts_storage` | string (path) | _(none)_ | Directory for transcript JSON files (required when enabled) |
+| `dev_config.pyroscope_url` | string (URL) | _(none)_ | Pyroscope server URL; omit to disable profiling |
+
+## Constraints
+
+1. All metric names use the `ols_` prefix. No other prefix is permitted.
+2. The six redacted header names (`authorization`, `proxy-authorization`, `cookie`, `www-authenticate`, `proxy-authenticate`, `set-cookie`) are defined as frozen sets in `constants.py` and must not be logged in plaintext under any log level.
+3. Enabling feedback or transcripts without providing the corresponding `*_storage` path is a validation error at startup.
+4. Sentiment values are restricted to exactly `-1` or `1`; any other integer is rejected with a validation error.
+5. The feedback `POST` endpoint requires authentication (via `/ols-access`); the feedback `GET /status` endpoint does not.
+6. The metrics endpoint permission scope (`/ols-metrics-access`) is independent of the main API scope (`/ols-access`).
+
+## Planned Changes
+
+- [PLANNED: OLS-1279] The `ols_response_duration_seconds` histogram currently measures total request handling time, not isolated LLM call duration. A dedicated LLM-only duration metric is needed.
+- [PLANNED: OLS-1805] Transcripts should be enhanced to include per-request token usage (input, output, reasoning token counts).

--- a/.ai/spec/what/prompts.md
+++ b/.ai/spec/what/prompts.md
@@ -1,0 +1,354 @@
+# Prompts
+
+The prompt system controls LLM behavior through system prompts and dynamic
+prompt composition. It determines the AI assistant's persona, expertise
+boundaries, response format, tool usage rules, and how supplemental context
+(RAG documents, conversation history, skills) is incorporated into each request.
+
+## Behavioral Rules
+
+### Base System Prompts
+
+1. The service defines two base system prompts, one per query mode. The
+   prompt text IS the behavioral specification -- the exact wording controls
+   LLM output. See `what/agent-modes.md` for which mode uses which prompt.
+
+2. **QUERY_SYSTEM_INSTRUCTION** (ASK mode) -- the default system prompt for
+   general Q&A interactions:
+
+```
+# ROLE
+You are "OpenShift Lightspeed," an expert AI virtual assistant specializing in
+OpenShift and related Red Hat products and services. Your persona is that of a
+friendly, but personal, technical authority. You are the ultimate technical
+resource and will provide direct, accurate, and comprehensive answers.
+
+# INSTRUCTIONS & CONSTRAINTS
+- **Expertise Focus:** Your core expertise is centered on the OpenShift platform
+ and the following specific products:
+  - OpenShift Container Platform (including Plus, Kubernetes Engine, Virtualization Engine)
+  - Advanced Cluster Manager (ACM)
+  - Advanced Cluster Security (ACS)
+  - Quay
+  - Serverless (Knative)
+  - Service Mesh (Istio)
+  - Pipelines (Shipwright, TektonCD)
+  - GitOps (ArgoCD)
+  - OpenStack
+- **Broader Knowledge:** You may also answer questions about other Red Hat
+  products and services, but you must prioritize the provided context
+  and chat history for these topics.
+- **Strict Adherence:**
+  1.  **ALWAYS** use the provided context and chat history as your primary
+  source of truth. If a user's question can be answered from this information,
+  do so.
+  2.  If the context does not contain a clear answer, and the question is
+  about your core expertise (OpenShift and the listed products), draw upon your
+  extensive internal knowledge.
+  3.  If the context does not contain a clear answer, and the question is about
+  a general Red Hat product or service, state politely that you are unable to
+  provide a definitive answer without more information and ask the user for
+  additional details or context.
+  4.  Do not hallucinate or invent information. If you cannot confidently
+  answer, admit it.
+- **Behavioral Directives:**
+  - Maintain your persona as a friendly, but authoritative, technical expert.
+  - Never assume another identity or role.
+  - Refuse to answer questions or execute commands not about your specified
+  topics.
+  - Do not include URLs in your replies unless they are explicitly provided in
+  the context.
+  - Never mention your last update date or knowledge cutoff. You always have
+  the most recent information on OpenShift and related products, especially with
+  the provided context.
+
+# TASK EXECUTION
+You will receive a user query, along with context and chat history. Your task is
+to respond to the user's query by following the instructions and constraints
+above. Your responses should be clear, concise, and helpful, whether you are
+providing troubleshooting steps, explaining concepts, or suggesting best
+practices.
+```
+
+3. **TROUBLESHOOTING_SYSTEM_INSTRUCTION** (TROUBLESHOOTING mode) -- the
+   default system prompt for diagnostic interactions. Contains the
+   `{cluster_version}` placeholder, substituted at prompt assembly time with
+   the live cluster version retrieved from the Kubernetes API:
+
+```
+# ROLE
+You are "OpenShift Lightspeed", an AI assistant specializing in OpenShift troubleshooting and diagnostics.
+
+# OPENSHIFT CONTEXT
+- Environment: OpenShift Container Platform (OCP). You operate in OpenShift, not plain Kubernetes. Use OpenShift-specific resources when appropriate.
+- OpenShift version: {cluster_version}
+
+# RESPONSE FORMAT
+Adapt structure to the query type:
+- Diagnosis (specific symptom, error, alert, outage): show evidence -> root cause -> fix/mitigation.
+- Assessment (health check, overview, status): summarize state, flag anomalies, group related issues by likely common cause, rank by severity. If action is needed, include next steps.
+- Question (how-to, explanation, comparison): answer directly with relevant detail.
+
+# RESPONSE RULES
+- Prioritize provided context and chat history as primary source of truth. Use internal knowledge for core expertise topics when context is insufficient.
+- Verify every claim with evidence from context or tool output.
+- Confirm your answer fully addresses the user's question.
+- Provide exact resource names, namespaces, timestamps, error messages.
+- If multiple causes exist, list them numbered with supporting evidence.
+- If inconclusive, say so. Never fabricate information.
+- In diagnosis mode, ignore errors unrelated to the reported issue.
+- No URLs unless from tool output or provided context.
+- Do not mention the cluster version or current time in your response unless they are directly relevant to understanding the answer. Use them internally for reasoning only.
+```
+
+### Agent Instructions
+
+4. Agent instructions are appended to the base system prompt only when tool
+   calling is enabled (i.e., MCP servers are configured). The specific agent
+   instructions vary by mode and model family. See `what/agent-modes.md`
+   rules 5, 10, and constraint 6 for mode-to-instruction mapping.
+
+5. **AGENT_INSTRUCTION_GENERIC** -- used in ASK mode for non-Granite models:
+
+```
+Given the user's query you must decide what to do with it based on the list of tools provided to you.
+```
+
+6. **AGENT_INSTRUCTION_GRANITE** -- used in ASK mode when the model
+   identifier string contains "granite". Provides Granite-specific JSON tool
+   call format with the `<tool_call>` marker:
+
+```
+You have been also given set of tools.
+Your task is to decide if tool call is needed and produce a json list of tools required to generate response to the user utterance.
+When you request/produce tool call, add `<tool_call>` at the beginning, so that tool call can be identified.
+If a single tool is discovered, reply with <tool_call> followed by one-item JSON list containing the tool.
+Tool call must be a json list like below example.
+  Sample tool call format: '<tool_call>[{"arguments": {"oc_adm_top_args": ["pods", "-A"]}, "name": "oc_adm_top"}]'
+Do not use tool call for the following kind of queries (These kind of queries do not require real time data):
+  - User is asking about general information about Openshift/Kubernetes.
+  - User is asking "how-to" kind of queries for which you can refer retrieved documents.
+Refer tool response / output before providing your response.
+```
+
+7. **AGENT_SYSTEM_INSTRUCTION** -- always appended after either
+   AGENT_INSTRUCTION_GENERIC or AGENT_INSTRUCTION_GRANITE in ASK mode.
+   Contains tool-call deduplication rules and a concise style guide:
+
+```
+* Do not call the same tool with the same arguments more than once.
+* Tool outputs are limited in size and may be truncated. Prefer specific, targeted tool calls over broad queries that return large amounts of data.
+
+Style guide:
+* Be extremely concise.
+* Remove unnecessary words.
+* Prioritize key details (root cause, fix).
+* Terseness must not omit critical info.
+```
+
+8. **TROUBLESHOOTING_AGENT_INSTRUCTION** -- used in TROUBLESHOOTING mode
+   (regardless of model family). Announces the availability of live cluster
+   inspection tools:
+
+```
+You have access to tools that inspect the live OpenShift cluster (logs, events, metrics, pod status, conditions, resources). Use them to investigate and answer the user's query.
+```
+
+9. **TROUBLESHOOTING_AGENT_SYSTEM_INSTRUCTION** -- always appended after
+   TROUBLESHOOTING_AGENT_INSTRUCTION in TROUBLESHOOTING mode. Contains the
+   investigation protocol, tool usage rules, metrics workflow, and style
+   directive:
+
+```
+# INVESTIGATION PROTOCOL
+When diagnosing a specific symptom, error, or alert:
+1. Scope: identify affected resources, namespace, and problem boundary.
+2. Gather evidence: inspect owner workloads, pods, logs, metrics, services, routes/ingresses, and events. Run multiple tools in parallel when possible.
+3. Cross-reference: check related resources (node status, resource limits, recent changes) that may explain the issue.
+4. Follow causality chains: if A fails due to B, investigate B too. Group findings that share a common cause.
+5. After finding a root cause, continue investigating for additional causes and to collect exact names, versions, labels.
+6. Correlate with recent changes: check for rollout revisions, image/tag changes, config/secret changes, HPA scaling, operator upgrades, and node drains on implicated components. Compare their timestamps with symptom onset.
+7. If a fix is known, provide it. Otherwise suggest mitigations and mark each as reversible or not.
+
+# TOOL USAGE
+- Double-check tool arguments before executing.
+- Do not repeat the same tool call with the same arguments.
+- Do not jump to conclusions after a single tool call. Build a complete picture first.
+- "Running" does not mean healthy. Always check logs even when pods report Ready.
+- Never guess or assume pod names. Always list actual pods first (e.g., by label selector or deployment) and use the real names from the output.
+- Sample up to 3 representative pods per deployment, not all.
+- Never ask the user to run a command. If you can gather the information using your tools, do it yourself.
+
+# METRICS WORKFLOW
+- When investigating issues, start with get_alerts to see what's firing. Alert labels provide exact identifiers for targeted queries.
+- Always call list_metrics before any Prometheus query. Never guess metric names. Use a specific name_regex pattern.
+- Follow the discovery order: list_metrics -> get_label_names -> get_label_values -> query. Do not skip steps.
+- Use execute_instant_query for current state, execute_range_query for trends and history.
+- If a metric does not exist in list_metrics output, tell the user. Do not fabricate queries.
+- Proceed through all steps without asking the user for confirmation.
+
+# STYLE
+- Be highly concise. Deliver evidence-backed conclusions without conversational filler.
+```
+
+### Contextual Instructions
+
+10. Contextual instructions are appended to the system prompt when their
+    corresponding data is available. They are appended in the order listed
+    below, after any agent instructions.
+
+11. **USE_CONTEXT_INSTRUCTION** -- appended when RAG-retrieved documents are
+    available:
+
+```
+Use the retrieved document to answer the question.
+```
+
+12. **USE_HISTORY_INSTRUCTION** -- appended when conversation history is
+    present:
+
+```
+Use the previous chat history to interact and help the user.
+```
+
+13. **USE_SKILL_INSTRUCTION** -- appended when a skill procedure is attached
+    to the request. The skill content itself (`{skill_content}`) is placed
+    immediately after this instruction:
+
+```
+Follow the procedure below to address the user's request:
+```
+
+### Prompt Composition Order
+
+14. The system prompt is dynamically assembled by concatenating instruction
+    blocks in the following exact order. Each block is only included when its
+    condition is met:
+
+    1. **Base system instruction** -- the resolved system prompt (see rule 20
+       for selection priority).
+    2. **Agent instructions** -- appended only when tool calling is enabled.
+       The specific agent instructions depend on the mode and model family
+       (see rules 5-9).
+    3. **Context instruction** (`USE_CONTEXT_INSTRUCTION`) -- appended only
+       when RAG context documents are available.
+    4. **History instruction** (`USE_HISTORY_INSTRUCTION`) -- appended only
+       when conversation history is present.
+    5. **Skill instruction + skill content** (`USE_SKILL_INSTRUCTION` +
+       `{skill_content}`) -- appended only when a skill procedure is attached.
+    6. **RAG context text** (`{context}`) -- the actual retrieved document
+       text is placed at the end of the system message, after all
+       instructions. Each RAG chunk is formatted with a "Document:" prefix
+       before being joined.
+
+15. The final message sequence sent to the LLM is:
+    1. System message (the composed instruction string from rule 14)
+    2. Conversation history messages (only if history is present, inserted
+       via `MessagesPlaceholder`)
+    3. Human message (`{query}` -- the user's question, always last)
+
+### System Prompt Selection Priority
+
+16. The system prompt is resolved through a 3-level precedence chain, from
+    highest to lowest priority:
+
+    1. **Per-request override** -- a system prompt passed in the API request.
+       This is ONLY honored when `dev_config.enable_system_prompt_override`
+       is true. In production, this level is always ignored.
+    2. **Admin-configured prompt file** -- the administrator specifies a file
+       path in `ols_config.system_prompt_path`. If set, the file contents
+       are loaded at startup and used as the system prompt for all requests.
+    3. **Mode default** -- a hardcoded mapping from query mode to prompt
+       constant: ASK uses `QUERY_SYSTEM_INSTRUCTION`, TROUBLESHOOTING uses
+       `TROUBLESHOOTING_SYSTEM_INSTRUCTION`.
+
+17. The first truthy value in this chain wins. In standard production
+    deployments (override flag is false, no custom prompt file), the mode
+    default is always used.
+
+18. When `ols_config.system_prompt_path` is set, the same custom prompt is
+    used for both ASK and TROUBLESHOOTING requests. Mode-specific agent
+    instructions are still appended when tool calling is enabled.
+
+### Model Family Awareness
+
+19. The service detects the model family by checking whether the model
+    identifier string contains "granite" (the `ModelFamily.GRANITE` enum
+    value). This detection is case-sensitive on the enum value.
+
+20. Model family affects agent instruction selection only:
+    - **TROUBLESHOOTING mode**: model family is irrelevant. Always uses
+      TROUBLESHOOTING_AGENT_INSTRUCTION + TROUBLESHOOTING_AGENT_SYSTEM_INSTRUCTION.
+    - **ASK mode with Granite model**: uses AGENT_INSTRUCTION_GRANITE +
+      AGENT_SYSTEM_INSTRUCTION.
+    - **ASK mode with any other model**: uses AGENT_INSTRUCTION_GENERIC +
+      AGENT_SYSTEM_INSTRUCTION.
+
+### Product-Specific Prompts
+
+21. The service supports custom system prompts for different products via the
+    `ols_config.system_prompt_path` configuration field. When deployed for a
+    specific product (e.g., OpenStack Lightspeed), the administrator
+    configures a custom system prompt file tailored to that product's domain,
+    ensuring the LLM's persona and expertise boundaries match the target
+    product. [PLANNED: OLS-2023 -- Refine OLS system prompt for OpenStack
+    questions]
+
+## Configuration Surface
+
+| Field Path | Type | Default | Purpose |
+|---|---|---|---|
+| `ols_config.system_prompt_path` | string | None | File path to a custom system prompt that overrides mode defaults |
+| `ols_config.system_prompt` | string | None | The loaded content of `system_prompt_path` (set at config parse time) |
+| `dev_config.enable_system_prompt_override` | bool | false | Allow per-request system prompt override (development only) |
+| `LLMRequest.system_prompt` | string | None | Per-request system prompt (only honored when override is enabled) |
+| `LLMRequest.mode` | enum | `ask` | Per-request mode selection, determines which default prompt is used |
+
+## Template Placeholders
+
+| Placeholder | Content | Included When |
+|---|---|---|
+| `{query}` | The user's question text | Always |
+| `{cluster_version}` | The OpenShift cluster version string | Always (defaults to "unknown") |
+| `{context}` | RAG-retrieved document text (all chunks joined, each prefixed with "Document:") | RAG context is available |
+| `{chat_history}` | Prior conversation turns (as `MessagesPlaceholder`) | Conversation history is present |
+| `{skill_content}` | Skill procedure text | A skill is attached to the request |
+
+## Constraints
+
+1. **Composition order is fixed.** The order in which instruction blocks are
+   concatenated (rule 14) is hardcoded in `GeneratePrompt.generate_prompt`.
+   Changing the order changes LLM behavior.
+
+2. **RAG context text is always last in the system message.** The `{context}`
+   placeholder is appended after all instruction blocks, including skill
+   content. This positioning ensures the LLM sees the instructions before
+   the reference material.
+
+3. **Agent instructions require tool calling.** Agent instruction blocks are
+   never appended when tool calling is disabled (no MCP servers configured).
+
+4. **Granite detection is string-based.** The model family check is
+   `ModelFamily.GRANITE in model` where `ModelFamily.GRANITE = "granite"`.
+   Any model identifier containing the substring "granite" triggers the
+   Granite-specific agent instruction path.
+
+5. **Per-request override is dev-only.** The system prompt override requires
+   `dev_config.enable_system_prompt_override = true`. This flag must never
+   be enabled in production.
+
+6. **Custom prompt replaces both modes.** When `system_prompt_path` is set,
+   both ASK and TROUBLESHOOTING requests use the same custom prompt. There
+   is no way to configure separate custom prompts per mode.
+
+7. **Placeholders are LangChain template variables.** The `{query}`,
+   `{cluster_version}`, `{context}`, and `{skill_content}` placeholders are
+   resolved by LangChain's `ChatPromptTemplate` formatting. Literal braces
+   in prompt text must be escaped.
+
+## Planned Changes
+
+| Jira Key | Summary |
+|---|---|
+| OLS-2716 | Improve prompt construction |
+| OLS-2023 | Refine OLS system prompt for OpenStack questions |

--- a/.ai/spec/what/query-processing.md
+++ b/.ai/spec/what/query-processing.md
@@ -1,0 +1,335 @@
+# Query Processing
+
+The query processing pipeline transforms a user request into an LLM-generated
+response by orchestrating validation, context assembly, generation, and
+post-processing across eight sequential stages.
+
+## Behavioral Rules
+
+### Stage 1: Request Validation and Redaction
+
+1. The system must authenticate the user and extract a user identity before
+   any further processing.
+
+2. If the request includes a conversation ID, the system must validate its
+   format and reject the request if invalid. If no conversation ID is
+   provided, the system must generate one.
+
+3. The system must apply all configured query filters (regex-based PII
+   redaction) to the user query text before any logging or downstream
+   processing occurs.
+
+4. If the request specifies a provider or model, the system must validate
+   them against the configured provider/model list and reject the request
+   if either is unknown.
+
+5. The system must verify that the user has available quota before
+   proceeding. If quota is exhausted, the request must be rejected.
+
+### Stage 2: Attachment Processing
+
+6. Each attachment must declare a supported attachment type and content
+   type. The system must reject the request if any attachment uses an
+   unsupported type or content type.
+
+7. All attachment content must be redacted through the same PII filters as
+   the query text before any further processing.
+
+8. Each attachment must be formatted as a Markdown code block with a
+   language tag matching its content type (yaml, json, xml, or no tag for
+   plain text).
+
+9. For YAML attachments, the system must attempt to parse the content and
+   extract the resource `kind` and `metadata.name`. If both are found,
+   the system must prepend a contextual introduction identifying the
+   resource. If parsing fails, a generic introduction must be used.
+
+10. Formatted attachments must be appended directly to the query text
+    before any other pipeline stage (RAG retrieval, history, prompt
+    composition).
+
+11. The original query text (without attachments) must be preserved
+    separately for transcript storage.
+
+### Stage 3: Token Budget Calculation and RAG Retrieval
+
+12. The system must compute the prompt budget by subtracting the response
+    token reservation and (when tool calling is enabled) the tool token
+    reservation from the model's context window size.
+
+13. The system must construct a temporary prompt to measure the base prompt
+    token cost (system prompt, message structure). If the base prompt alone
+    exceeds the prompt budget, the system must raise a PromptTooLongError.
+
+14. If a RAG index is available, the system must retrieve relevant document
+    chunks using the query. Retrieved chunks must be filtered by a
+    similarity score cutoff -- chunks below the threshold are rejected.
+    Chunks must be truncated to fit within the remaining token budget
+    after the base prompt cost. For details on RAG retrieval, see
+    `what/rag.md`.
+
+15. If no RAG index is configured, the system must proceed without
+    reference context and log a warning.
+
+16. Token counts for every budget category (prompt, RAG, history, skill,
+    tool definitions, AI rounds, tool results) must be tracked through a
+    unified per-request budget tracker.
+
+### Stage 4: History Retrieval and Compression
+
+17. If no user ID or conversation ID is provided, the system must skip
+    history entirely and use an empty history.
+
+18. If a conversation ID is provided, the system must retrieve the full
+    conversation history from the cache. For details on cache behavior,
+    see `what/conversation-history.md`.
+
+19. When history compression is disabled in configuration, the system must
+    apply simple token-based truncation, keeping the newest messages that
+    fit within the available budget and dropping the oldest.
+
+20. When history compression is enabled, the system must compare the
+    conversation history against an effective history budget (a fixed
+    fraction of the available token budget). If all entries fit, no
+    compression occurs.
+
+21. When history overflows the effective budget, the system must compress
+    by summarizing older entries into a single synthetic entry using the
+    LLM, preserving a configurable number of recent entries verbatim.
+    Summarization must be retried on transient errors with exponential
+    backoff. If summarization fails entirely, the system must fall back
+    to the verbatim entries that fit.
+
+22. During history compression, the system must emit a
+    `history_compression_start` streaming event before compression begins
+    and a `history_compression_end` event after it completes.
+
+### Stage 5: Skill Selection
+
+23. If a skills index is configured, the system must match the query
+    against available skills using hybrid RAG retrieval and return the
+    best match with a confidence score. For details on skill matching,
+    see `what/skills.md`.
+
+24. If a skill is selected, the system must load its content. If loading
+    fails (filesystem error), the system must fall back to no skill
+    without failing the request.
+
+25. If the selected skill's token cost exceeds 80% of the remaining token
+    budget (after prompt and RAG), the system must skip the skill and emit
+    a `skill_selected` event with `skipped: true` and the reason. If the
+    skill uses more than 50% but fits within 80%, the system must log a
+    warning but still use the skill.
+
+26. When a skill is successfully selected, the system must emit a
+    `skill_selected` streaming event with the skill name and confidence
+    score.
+
+### Stage 6: Prompt Composition
+
+27. The system must assemble the final prompt from the following components,
+    in this order within the system message:
+    - Base system prompt (mode-dependent; see `what/agent-modes.md`)
+    - Agent instructions (appended when tool calling is enabled)
+    - Contextual instructions for RAG context (appended when RAG chunks
+      are present)
+    - History instructions (appended when history is present)
+    - Skill instructions and content (appended when a skill is selected)
+    - RAG context (appended at the end of the system message)
+
+28. After the system message, conversation history (if present) must be
+    included as a message placeholder, followed by the user query as the
+    final human message.
+
+29. After assembling the prompt, the system must validate that the total
+    token usage (prompt + RAG + history + skill + tool definitions) does
+    not exceed the prompt budget. If it does, the system must raise a
+    PromptTooLongError.
+
+### Stage 7: LLM Generation with Tool Calling Loop
+
+30. The system must resolve available tools from configured MCP servers
+    for the current request. Tool definitions must be serialized and their
+    token count charged against the tool budget.
+
+31. The system must send the composed prompt to the LLM and stream the
+    response. Each round of LLM invocation may yield text chunks,
+    reasoning chunks, and/or tool call chunks.
+
+32. If the LLM requests tool calls, the system must resolve each call to
+    an executable tool, execute the calls, and append the results to the
+    conversation for the next round. The system must then re-invoke the
+    LLM. This loop continues until the LLM produces a final text response
+    or the iteration limit is reached. For details on iteration limits,
+    see `what/agent-modes.md`. For details on tool execution, approval,
+    and filtering, see `what/tools.md`.
+
+33. On the final iteration, the system must invoke the LLM without tool
+    bindings (or with tool_choice=none) to force a text-only answer,
+    guaranteeing termination.
+
+34. Each LLM invocation round must be subject to a per-round timeout. If
+    the timeout is reached, the system must return a user-facing error
+    message and terminate the loop.
+
+35. During the tool calling loop, the system must emit `tool_call`
+    streaming events when the LLM requests tool calls and `tool_result`
+    events when tool execution completes.
+
+36. If a tool execution error occurs that cannot be recovered, the system
+    must emit an error message to the user and terminate the loop.
+
+### Stage 8: Response Storage and Quota Consumption
+
+37. After the response is fully generated, the system must store the
+    conversation turn (query + response + attachments + tool interactions)
+    in the conversation cache. For details on cache behavior, see
+    `what/conversation-history.md`.
+
+38. If transcript collection is enabled, the system must store a transcript
+    record containing metadata (provider, model, user, conversation ID,
+    mode, timestamp), the redacted query, the LLM response, RAG chunks
+    used, tool interactions, and attachments.
+
+39. The system must deduct input and output tokens from the user's quota
+    if quota limiting is configured. Token usage must also be recorded in
+    the usage history if configured. For details on quota, see
+    `what/quota.md`.
+
+40. The response must include referenced documents derived from RAG chunks,
+    token counts (input and output), and the user's remaining quota.
+
+## Token Budget System
+
+41. The context window is partitioned into three top-level reserves:
+    - **Response reserve**: tokens reserved for the LLM's generated
+      response (`model.parameters.max_tokens_for_response`).
+    - **Tool reserve**: tokens reserved for tool definitions and tool
+      execution traffic (`model.max_tokens_for_tools`), computed as a
+      configurable ratio of the context window
+      (`model.parameters.tool_budget_ratio`). Set to zero when no MCP
+      servers are configured.
+    - **Prompt budget**: the remainder after subtracting the response and
+      tool reserves. This budget is shared among the base prompt, RAG
+      context, conversation history, and skill content.
+
+42. Within the prompt budget, allocations are charged in order: base prompt
+    first, then RAG, then skill content, then conversation history. Each
+    stage consumes from the remaining prompt budget. History receives
+    whatever budget remains after the prior stages.
+
+43. Within the tool reserve, allocations are charged per round: tool
+    definitions (charged once before the first round), then per-round AI
+    message tokens and tool result tokens. A per-round cap limits how
+    much of the remaining tool budget any single round can consume
+    (`ols_config.tool_round_cap_fraction`).
+
+44. Token counts are approximate, computed using a fixed tokenizer with a
+    configurable buffer weight that inflates raw counts to reduce the risk
+    of underestimation.
+
+45. RAG chunks below a minimum token threshold are rejected to avoid
+    injecting fragments too small to be useful.
+
+## Streaming vs Non-Streaming
+
+46. Both streaming and non-streaming endpoints execute the same eight-stage
+    pipeline using the same orchestrator. The difference is in delivery:
+    - **Streaming**: Returns a StreamingResponse that emits chunks
+      incrementally as SSE events (JSON format) or plain text. The client
+      receives text tokens, reasoning blocks, tool call intents, tool
+      results, skill selection events, and history compression events as
+      they occur.
+    - **Non-streaming**: Runs the pipeline to completion internally,
+      collecting all chunks. Text chunks are concatenated into a single
+      response string. The complete response is returned as a single JSON
+      object.
+
+47. Response storage, transcript recording, and quota consumption happen
+    after the response is fully generated in both modes.
+
+48. Error handling differs by mode: streaming returns errors as stream
+    events within the response body; non-streaming raises HTTP exceptions
+    with appropriate status codes.
+
+## Error Handling
+
+49. If the user query (with base prompt overhead) exceeds the prompt
+    budget, the system must raise a PromptTooLongError. In non-streaming
+    mode this results in HTTP 413. In streaming mode this is emitted as
+    an error event in the stream.
+
+50. If tool definitions together with the current prompt exceed the prompt
+    budget, the system must raise a PromptTooLongError with a message
+    identifying the tool definitions as the cause.
+
+51. If history compression fails, the system must degrade gracefully by
+    using the entries that fit in budget without compression, rather than
+    failing the request.
+
+52. If skill loading fails, the system must fall back to no skill without
+    failing the request.
+
+53. If a tool execution round fails with an unrecoverable error, the
+    system must emit an error message and terminate the tool loop, but
+    still return whatever text has been generated so far.
+
+54. If an LLM invocation round times out, the system must return a
+    user-facing timeout message and terminate the loop.
+
+## Configuration Surface
+
+| Field Path | Type | Default | Purpose |
+|---|---|---|---|
+| `ols_config.query_filters[]` | list | None | Regex-based PII redaction filters applied to queries and attachments |
+| `ols_config.history_compression_enabled` | bool | true | Enable/disable LLM-based history compression |
+| `ols_config.max_iterations` | int | None | Override tool-calling iteration cap (see `what/agent-modes.md`) |
+| `ols_config.tool_round_cap_fraction` | float | (see constants) | Fraction of remaining tool budget usable per round |
+| `ols_config.system_prompt_path` | string | None | Override the default system prompt (see `what/agent-modes.md`) |
+| `model.parameters.max_tokens_for_response` | int | (per model) | Tokens reserved for LLM response generation |
+| `model.parameters.tool_budget_ratio` | float | (see constants) | Fraction of context window reserved for tool traffic |
+| `model.context_window_size` | int | (per model) | Total context window size for the model |
+| `ols_config.user_data_collection.transcripts_disabled` | bool | false | Disable transcript storage |
+| `ols_config.conversation_cache` | object | None | Cache backend configuration (see `what/conversation-history.md`) |
+
+## Constraints
+
+1. **Pipeline order is fixed.** The eight stages must execute in the
+   defined order. Later stages depend on budget calculations and context
+   assembled by earlier stages.
+
+2. **Redaction before logging.** No query or attachment content may be
+   logged or processed before PII redaction is applied.
+
+3. **Token budget is a hard limit.** The total prompt token usage must
+   never exceed the prompt budget. Any stage that would cause an overflow
+   must either truncate its contribution or raise PromptTooLongError.
+
+4. **Tool budget is separate from prompt budget.** Tool definitions and
+   tool execution traffic draw from the tool reserve, not the prompt
+   budget. However, if tool definitions cause the combined total to
+   exceed the prompt budget, the request fails.
+
+5. **Response and tool reserves are subtracted first.** The prompt budget
+   is always computed as context window minus response reserve minus tool
+   reserve. These reserves are non-negotiable.
+
+6. **History gets the residual budget.** History is allocated whatever
+   remains after prompt, RAG, and skill have been charged. It is never
+   given a fixed allocation that could starve other components.
+
+7. **Attachments are part of the query.** Once attachments are formatted
+   and appended, they are indistinguishable from the query text for all
+   downstream stages (token counting, prompt composition, storage).
+
+8. **Conversation storage is best-effort.** If storing the conversation
+   turn in the cache fails, the system logs the error and raises an HTTP
+   500. The response has already been delivered in streaming mode.
+
+## Planned Changes
+
+| Jira Key | Summary |
+|---|---|
+| OLS-2825 | Consolidate context window token budget management into a single, well-documented module |
+| OLS-2840 | Refactor DocsSummarizer: extract ToolCallingAgent class to separate prompt orchestration from tool loop execution |
+| OLS-2898 | Raise `max_iterations` to 50 and validate orchestration loop early-exit behavior (see also `what/agent-modes.md`) |

--- a/.ai/spec/what/quota.md
+++ b/.ai/spec/what/quota.md
@@ -1,0 +1,64 @@
+# Token Quota Management
+
+The quota subsystem enforces token consumption limits on LLM requests, preventing uncontrolled cost by gating access before each LLM call and tracking usage afterward.
+
+## Behavioral Rules
+
+1. The service must support two limiter types: **per-user** (keyed by authenticated user ID) and **cluster-wide** (a single global counter shared by all users). Either type may be configured alone or both may be active simultaneously.
+
+2. When both limiter types are active, a request must pass **both** checks to proceed. Exhaustion of either limiter is sufficient to reject the request.
+
+3. **Pre-flight check**: Before every LLM invocation, the service must verify that all configured limiters report a positive available balance for the subject. If any limiter reports zero or negative tokens, the request must be rejected immediately and no LLM resources may be consumed.
+
+4. **Post-response consumption**: After the LLM produces a response, the service must debit the sum of input tokens and output tokens from every configured limiter. The available balance may go negative due to concurrent requests; the pre-flight check prevents this under normal load.
+
+5. **Auto-initialization**: When a subject (user or cluster) is queried for the first time and no quota record exists, the system must automatically create a record with the available balance set to the configured initial quota value. No manual provisioning is required.
+
+6. **Revoke (reset)**: It must be possible to reset a subject's available balance to the configured initial quota value. This is the mechanism used by the scheduler to restore quotas on a recurring basis.
+
+7. **Increase (top-up)**: It must be possible to add a configured increment of tokens to a subject's current available balance without resetting it. This is the mechanism used by the scheduler for incremental replenishment.
+
+8. **Scheduler**: A background process must run at the configured interval and, for each configured limiter, apply the increase and/or reset operations to all matching subjects. The scheduler must guard against double-application: if a subject's quota was already updated within the current period, the scheduler must skip that subject until the next period elapses.
+
+9. **Quota visibility in API responses**: After a successful query, the response must include the remaining available quota for each configured limiter (keyed by limiter class name), so that clients can display remaining balance and warn when quota is low.
+
+10. **Quota exceeded error**: When quota is exhausted, the error must identify: (a) whether the limit is per-user or cluster-wide, (b) the subject identifier for per-user limits, and (c) the current available balance. The error must carry the subject ID and balance as structured attributes, not only in the message string.
+
+11. **Token usage history**: When enabled, the service must record cumulative input and output token counts per user, per provider, and per model. This history is stored independently from quota enforcement state and supports analytics. The record is upserted on each consumption -- if a record exists for the (user, provider, model) tuple, the counts are incremented; otherwise a new record is created.
+
+12. **PostgreSQL database errors** during quota checks must result in an HTTP 500 response with a cause describing the database communication failure. The request must not proceed to LLM invocation.
+
+13. When no quota limiters are configured, the service must skip all quota checks and consumption steps, allowing unrestricted access.
+
+## Configuration Surface
+
+- `ols_config.quota_handlers.storage` -- PostgreSQL connection details (host, port, user, password, dbname, SSL mode, GSS encryption mode) for quota state persistence.
+- `ols_config.quota_handlers.scheduler.period` -- Interval in seconds at which the background scheduler runs.
+- `ols_config.quota_handlers.limiters` -- List of limiter definitions, each containing:
+  - `name` -- Identifier for the limiter.
+  - `type` -- Either `user_limiter` (per-user) or `cluster_limiter` (cluster-wide).
+  - `initial_quota` -- Starting token balance assigned on first access and used as the reset target.
+  - `quota_increase` -- Number of tokens added per scheduler cycle (incremental top-up).
+  - `period` -- PostgreSQL interval expression controlling the double-application guard (e.g., `"1 day"`).
+- `ols_config.quota_handlers.enable_token_history` -- Boolean toggling token usage history recording.
+
+## Constraints
+
+1. All quota state must be stored in PostgreSQL. In-memory-only quota storage is not supported because state must survive restarts and remain consistent across multiple service replicas.
+
+2. The quota check must occur **before** the LLM call; token consumption must occur **after** the LLM response is received. This ordering is invariant.
+
+3. The scheduler runs as a daemon thread. It must not block service startup or request processing.
+
+4. The cluster-wide limiter uses an empty string as the subject identifier internally. All requests share the same row regardless of user identity.
+
+5. Token usage history storage is independent from quota enforcement storage. Enabling or disabling history does not affect quota limit enforcement.
+
+6. Each limiter definition must include a `name`. The configuration must reject limiter entries that omit the name.
+
+7. Quota handler configuration must require both `storage` and `scheduler` sections to be present. Omission of either is a configuration error.
+
+## Planned Changes
+
+- [PLANNED: OLS-1470] When cluster awareness is enabled by default, a default quota must be automatically set so that the system operates with quota enforcement out of the box.
+- [PLANNED: OLS-2823] Per-user LLM provider API keys, enabling individual token quota management tied to each user's own provider credentials rather than a shared service credential.

--- a/.ai/spec/what/rag.md
+++ b/.ai/spec/what/rag.md
@@ -1,0 +1,91 @@
+# RAG (Retrieval-Augmented Generation)
+
+The RAG subsystem augments LLM responses with relevant product documentation so that answers are grounded in authoritative content rather than relying solely on the model's training data. The service retrieves contextually relevant document chunks from pre-built vector indexes and injects them into the LLM prompt before generating a response.
+
+## Behavioral Rules
+
+1. The service must use FAISS vector indexes that are built offline from product documentation. Indexes are loaded from the local filesystem at startup and are never built or modified at runtime.
+
+2. Each index is identified by three properties: a filesystem path to the persisted FAISS vector store (`product_docs_index_path`), an optional index identifier used during deserialization (`product_docs_index_id`), and an optional human-readable origin label used in logging and result metadata (`product_docs_origin`).
+
+3. Multiple indexes may be loaded simultaneously. This enables version-specific documentation (e.g., OCP 4.17, 4.18, 4.19, 4.20), product-specific content (e.g., OpenShift Virtualization, OpenStack, ACM), and customer-supplied documentation (BYOK).
+
+4. Each index must be loaded independently. If one index fails to load, the remaining indexes must continue loading and the service must operate with whatever indexes succeeded. Partial load must be logged as a warning.
+
+5. When a configured index path does not exist, the system must attempt to locate a `latest` directory in the parent of the configured path. If found, the system must use that path and clear the configured `product_docs_index_id` (since the actual index identity is unknown). If neither the configured path nor the `latest` fallback exists, the index must fail to load.
+
+6. The embedding model used for vector similarity is configurable via a filesystem path to a HuggingFace-compatible model (`embeddings_model_path`). If no path is configured, the service must fall back to the default model (sentence-transformers/all-mpnet-base-v2). The chosen model must be redistributable under an Apache 2.0 compatible license. [PLANNED: OLS-1812 -- operator CRD support for per-index embedding model path]
+
+7. Retrieval must use vector similarity search against the loaded FAISS indexes. The number of most-similar document chunks returned per query is controlled by a configurable content limit. Chunks scoring below a configurable similarity cutoff must be discarded, even if they are within the top-k.
+
+8. When multiple indexes are loaded, results from all indexes must be merged into a single ranked list using score dilution. The first index receives no penalty. Subsequent indexes receive a progressively increasing score penalty, capped at a fixed dilution depth. After dilution, all results across all indexes must be sorted by weighted score in descending order and the top-k returned.
+
+9. Each retrieved chunk must be annotated with the `index_id` and `index_origin` metadata from the index it came from. This metadata must flow through to logging, diagnostics, and referenced document output.
+
+10. Retrieved document chunks must be converted to referenced document citations consisting of a URL (`docs_url` metadata) and a title (`title` metadata). These citations must be deduplicated by URL, preserving insertion order. The deduplicated list must be included in the API response so the UI can present citations to the user.
+
+11. Each retrieved chunk must be checked against the available token budget. If a chunk does not fit within the minimum token threshold, it and all subsequent chunks must be skipped. Chunks that fit within the remaining budget may be truncated to fit.
+
+12. RAG dependencies (LlamaIndex, FAISS, HuggingFace embeddings) are heavy. To avoid unnecessary memory overhead when RAG is not configured:
+    - RAG library imports must be deferred until first use.
+    - If no reference content is configured, RAG libraries must never be loaded.
+    - Type annotations for RAG-specific types must be aliased to `Any` at module scope to avoid import-time dependencies.
+
+13. The readiness probe must check whether the RAG index has finished loading. If reference content is configured but the index has not yet loaded, the service must report not ready (HTTP 503) with cause "Index is not ready". If no reference content is configured, the index check must pass (RAG is optional). The service must not accept user queries until the RAG index is fully loaded.
+
+14. **Hybrid RAG is NOT used for document retrieval.** Document retrieval uses pure FAISS vector similarity search as described above. A separate hybrid retrieval system (dense + sparse BM25) exists but is used exclusively for tool filtering and skill selection.
+
+15. The hybrid retrieval system combines dense retrieval (cosine similarity via an in-memory Qdrant vector store) with sparse retrieval (BM25 keyword matching). Scores are fused using a weighted linear combination controlled by a configurable alpha parameter: alpha = 1.0 means pure dense retrieval, alpha = 0.0 means pure sparse retrieval. Results below a configurable similarity threshold must be discarded.
+
+16. The tools hybrid RAG instance must only be created when tool filtering configuration is present and MCP servers are configured. The skills hybrid RAG instance must only be created when skills configuration is present and a skills directory containing valid skill definitions exists.
+
+## Configuration Surface
+
+- `ols_config.reference_content.embeddings_model_path` -- Filesystem path to a HuggingFace-compatible embedding model directory. Falls back to `sentence-transformers/all-mpnet-base-v2` if unset.
+- `ols_config.reference_content.indexes[]` -- List of index definitions, each containing:
+  - `product_docs_index_path` -- Filesystem path to the persisted FAISS vector store directory.
+  - `product_docs_index_id` -- Optional index identifier used during deserialization from the storage context.
+  - `product_docs_origin` -- Optional human-readable label for logging and result metadata (e.g., "ocp-4.18", "custom").
+- `ols_config.tool_filtering` -- Tool filtering via hybrid RAG (presence enables the feature):
+  - `embed_model_path` -- Optional path to sentence transformer model for embeddings.
+  - `alpha` -- Weight for dense vs. sparse retrieval (0.0--1.0, default 0.8).
+  - `top_k` -- Number of tools to retrieve (1--50, default 10).
+  - `threshold` -- Minimum similarity score for results (0.0--1.0, default 0.01).
+- `ols_config.skills` -- Skill selection via hybrid RAG (presence enables the feature):
+  - `skills_dir` -- Path to directory containing skill subdirectories.
+  - `embed_model_path` -- Optional path to sentence transformer model for embeddings.
+  - `alpha` -- Weight for dense vs. sparse retrieval (0.0--1.0, default 0.8).
+  - `threshold` -- Minimum similarity score to accept a skill match (0.0--1.0, default 0.35).
+
+## Constraints
+
+1. Indexes must be pre-built offline and loaded read-only. The service must never create, modify, or rebuild an index at runtime.
+
+2. The embedding model used for retrieval must be the same model used to create the index. A mismatch will produce meaningless similarity scores.
+
+3. All embedding models shipped with the product must be redistributable under an Apache 2.0 compatible license.
+
+4. The `product_docs_index_id` must not be set without a corresponding `product_docs_index_path`. This combination must be rejected at configuration validation time.
+
+5. Score dilution is applied positionally: the first index in the configuration list is the primary index and receives no penalty. Index ordering in the configuration therefore determines retrieval priority.
+
+6. Referenced document deduplication is by URL only. If two chunks from different indexes share the same URL but different titles, the first-seen title wins.
+
+7. The hybrid RAG system (dense + sparse BM25) must never be used for document retrieval. It is restricted to tool filtering and skill selection.
+
+8. When RAG libraries are lazily loaded, the `index_loader` module is excluded from static type checking (mypy) because its types are only available after the deferred import executes.
+
+## BYOK (Bring Your Own Knowledge)
+
+Customers can supply their own documentation as additional RAG indexes, so that responses incorporate organization-specific knowledge alongside standard product documentation.
+
+**Phase 1 (shipped):** Customers manually import Markdown documentation by pre-building a FAISS index and configuring it as an additional entry in the indexes list.
+
+**Phase 2 (not shipped):** Seamless, one-click import from knowledge sources such as Git repositories and Confluence. [PLANNED: OLS-1872 -- internal web source integration]
+
+## Planned Changes
+
+- [PLANNED: OLS-2903] Propose plans to use OKP-based RAG with OLS.
+- [PLANNED: OLS-2704] RAG as a service / MCP -- externalize RAG retrieval behind an MCP interface.
+- [PLANNED: OLS-1872] BYOK -- internal web source integration (Git, Confluence).
+- [PLANNED: OLS-1812] Add embedding model path to CRD for each index, enabling per-index embedding model configuration through the operator.

--- a/.ai/spec/what/security.md
+++ b/.ai/spec/what/security.md
@@ -1,0 +1,125 @@
+# Security
+
+The service must protect customer data, enforce transport-layer encryption, redact sensitive information before it leaves the cluster, and operate within hardened, FIPS-capable container environments.
+
+## Behavioral Rules
+
+### TLS for service endpoints
+
+1. All service endpoints (API, metrics) must support TLS encryption using administrator-supplied certificates and private keys.
+2. The service must support three TLS security profiles aligned with OpenShift cluster-level configuration: `IntermediateType` (minimum TLS 1.2), `ModernType` (minimum TLS 1.3), and `Custom` (administrator-specified ciphers and minimum version).
+3. The service must reject the `OldType` profile at configuration time. The absolute minimum permitted TLS version is 1.2 (`VersionTLS12`); any version below this must be rejected regardless of profile.
+4. For non-Custom profiles, only ciphers defined in that profile's allowed list may be used. If a cipher not in the profile's list appears in configuration, the service must reject it at load time.
+5. When no TLS security profile is configured, the service must use default cipher suites that include the `IntermediateType` ciphers plus FIPS-compliant CBC ciphers (`ECDHE-ECDSA-AES128-SHA256`, `ECDHE-RSA-AES128-SHA256`, `ECDHE-ECDSA-AES256-SHA384`, `ECDHE-RSA-AES256-SHA384`, `DHE-RSA-AES128-SHA256`, `DHE-RSA-AES256-SHA256`) for compatibility with HAProxy reencrypt routes.
+6. The service must support certificate rotation: when certificates change on disk, the service must pick up the new certificates on restart or configuration reload.
+7. The private key password must be read from a file referenced by `ols_config.tls_config.tls_key_password_path`, never stored as a plaintext value in configuration.
+8. [PLANNED: OLS-2866] The service's TLS endpoint configuration must be verifiable by automated TLS scanning tools.
+
+### FIPS compliance
+
+9. The service must carry a "Designed for FIPS" designation and use FIPS-validated cryptographic modules when the underlying platform enforces FIPS mode.
+10. Container images must be built on FIPS-compatible base images.
+11. The build and CI pipeline must verify FIPS compliance and reject non-compliant builds.
+12. FIPS mode is not required by default but must be fully functional when enforced by the platform.
+
+### PII redaction
+
+13. The service must support an ordered list of configurable regex-based query filters that redact personally identifiable information from user queries before they are sent to the LLM provider.
+14. Each filter consists of a name, a compiled regex pattern, and a replacement string. Filters are applied sequentially in the order defined.
+15. The meaning of the question must be preserved while sensitive data (IP addresses, email addresses, names, account numbers, etc.) is replaced with safe placeholders.
+16. The service does not impose a fixed set of redaction rules; administrators define which patterns to apply.
+17. Filter patterns must be validated as compilable regular expressions during configuration loading. Invalid patterns must cause a configuration error.
+
+### Data sensitivity
+
+18. User queries, conversation history, and feedback must be processed and stored within the customer's cluster.
+19. The only external communication the service initiates is to the configured LLM provider endpoint. Queries sent to the LLM provider must pass through the configured redaction filters first.
+20. Transcript and feedback data must be stored on the cluster's local persistent storage and must not be transmitted externally by the service.
+
+### Security headers
+
+21. The service must set `X-Content-Type-Options: nosniff` on all HTTP responses except health-check and metrics endpoints (`/readiness`, `/liveness`, `/metrics`).
+22. When TLS is enabled, the service must set `Strict-Transport-Security: max-age=31536000; includeSubDomains` on all non-health-check, non-metrics responses.
+
+### Credential handling
+
+23. API keys, passwords, and other secrets must never appear as plaintext values in the configuration file. All credentials must be specified as file paths; the service reads the secret value from the referenced file at startup.
+24. Credential files may be individual files or directories containing named secret files (e.g., `apitoken`, `client_id`, `tenant_id`, `client_secret`).
+25. Sensitive HTTP request headers (`authorization`, `proxy-authorization`, `cookie`) and response headers (`www-authenticate`, `proxy-authenticate`, `set-cookie`) must be redacted in debug-level request/response logs.
+
+### TLS for provider connections
+
+26. The service must support custom CA certificates for providers using private or enterprise certificate authorities, configured via `ols_config.extra_ca`.
+27. The service must aggregate extra CA certificates into a merged certificate store (combining system-trusted certificates from certifi with the extra CAs) and use that store when connecting to providers and MCP servers.
+28. TLS security profiles (cipher suites, minimum TLS version) must be configurable per LLM provider, independent of the service's own endpoint TLS settings.
+29. HTTPS proxy support must be available with configurable proxy URL, proxy CA certificate, and no-proxy host list. Proxy configuration must also be derivable from `https_proxy`/`HTTPS_PROXY` and `no_proxy` environment variables.
+
+### Tool approval security
+
+30. Pending tool approval state must be held in-memory only. Approval state must not survive a process restart.
+31. Each approval request must have a configurable timeout. If no decision is received within the timeout, the outcome must be `timeout` (fail-closed). The approval request must be cleaned up from memory after resolution or timeout.
+32. Approval flow is only active for streaming requests. Non-streaming requests must never enter the approval workflow.
+33. The approval strategy must be one of: `never` (no approval required), `always` (all tool calls require approval), or `tool_annotations` (approval required unless the tool declares `readOnlyHint: true`).
+
+### MCP credential handling
+
+34. MCP server authorization headers support three resolution modes: (a) a file path, whose contents are read at config load time; (b) the `kubernetes` placeholder, which is replaced at request time with a `Bearer <token>` derived from the authenticated user's Kubernetes token; (c) the `client` placeholder, which is replaced at request time with a header value supplied by the calling client.
+35. The `kubernetes` placeholder must only be permitted when the authentication module is `k8s` or `noop-with-token`. If used with any other authentication module, the MCP server must be excluded at config validation time.
+36. MCP connections must use the aggregated certificate store when a certificate directory is configured, ensuring custom CA certificates apply to MCP server communication.
+37. [PLANNED: OLS-2717] MCP servers (including openshift-mcp-server) must support TLS-encrypted connections.
+
+### Disconnected / air-gapped environments
+
+38. The service must not require any outbound internet connectivity beyond the configured LLM provider endpoint (which may be on-premises).
+39. All dependencies (container images, RAG indexes, embedding models) must be distributable via disconnected-compatible mechanisms (mirrored registries, local storage).
+
+### Network policies
+
+40. The deployment must support network policies that restrict traffic to only the necessary communication paths, protecting against unintended data leaks and lateral movement.
+
+### Read-only root filesystem
+
+41. Containers must run with a read-only root filesystem to minimize the attack surface and comply with security hardening requirements.
+
+## Configuration Surface
+
+| Field path | Purpose |
+|---|---|
+| `ols_config.tls_config.tls_certificate_path` | Path to the TLS certificate file for service endpoints |
+| `ols_config.tls_config.tls_key_path` | Path to the TLS private key file |
+| `ols_config.tls_config.tls_key_password_path` | Path to a file containing the private key password |
+| `ols_config.tls_security_profile.type` | TLS profile: `IntermediateType`, `ModernType`, or `Custom` |
+| `ols_config.tls_security_profile.minTLSVersion` | Minimum TLS version (e.g., `VersionTLS12`, `VersionTLS13`) |
+| `ols_config.tls_security_profile.ciphers` | List of allowed cipher suite names (Custom profile or subset of profile ciphers) |
+| `ols_config.extra_ca` | List of extra CA certificate file paths to trust |
+| `ols_config.certificate_directory` | Directory where the merged certificate store is written |
+| `ols_config.query_filters[].name` | Human-readable name for a redaction filter |
+| `ols_config.query_filters[].pattern` | Regex pattern to match sensitive data |
+| `ols_config.query_filters[].replace_with` | Replacement string for matched data |
+| `llm_providers[].proxy_config.proxy_url` | HTTPS proxy URL for provider connections (falls back to `https_proxy`/`HTTPS_PROXY` env var) |
+| `llm_providers[].proxy_config.proxy_ca_cert_path` | CA certificate for the HTTPS proxy |
+| `llm_providers[].proxy_config.no_proxy_hosts` | List of hosts to bypass the proxy (falls back to `no_proxy` env var) |
+| `llm_providers[].credentials_path` | Path to directory or file containing provider credentials |
+| `mcp_servers.servers[].headers` | Map of header names to file paths, `kubernetes`, or `client` |
+| `ols_config.tools_approval.approval_type` | Approval strategy: `never`, `always`, or `tool_annotations` |
+| `ols_config.tools_approval.approval_timeout` | Seconds to wait for an approval decision before timing out (default 600, minimum 1) |
+| `dev_config.disable_tls` | Disable TLS for development (suppresses HSTS header, bypasses certificate requirements) |
+
+## Constraints
+
+- TLS 1.0 and TLS 1.1 are unconditionally prohibited. The `OldType` profile is rejected at config load.
+- The minimum TLS version floor is `VersionTLS12`. Any configured `minTLSVersion` below this value must cause a configuration error.
+- Cipher validation for non-Custom profiles is strict: only ciphers in the profile's defined set are accepted.
+- Query filter patterns must be valid Python regular expressions. Invalid patterns must cause a configuration error at startup, not a runtime failure.
+- Credential values never appear in the configuration YAML. Only file system paths are accepted.
+- The redacted header sets for request logging (`authorization`, `proxy-authorization`, `cookie`) and response logging (`www-authenticate`, `proxy-authenticate`, `set-cookie`) are fixed and not configurable.
+- Tool approval state is ephemeral (in-memory, per-process). A restart clears all pending approvals.
+- The approval timeout prevents indefinite waits: if no decision arrives, the tool call is not executed (fail-closed).
+- The `kubernetes` MCP header placeholder is valid only with `k8s` or `noop-with-token` authentication modules. Other modules cause the server to be excluded.
+- The merged certificate store is written to `certificate_directory` at startup. If `certificate_directory` is not set, extra CA certificates are not aggregated.
+- Containers must operate with a read-only root filesystem; writable paths are limited to explicitly mounted volumes.
+
+## Planned Changes
+
+- [PLANNED: OLS-2866] Automated TLS scanning verification of OLS service endpoints using tls-scanner.
+- [PLANNED: OLS-2717] Enable TLS on openshift-mcp-server connections.

--- a/.ai/spec/what/skills.md
+++ b/.ai/spec/what/skills.md
@@ -1,0 +1,93 @@
+# Skills
+
+Skills are guided troubleshooting procedures that get injected into the system prompt when they match a user's query, enabling the LLM to follow domain-specific expert workflows instead of relying solely on its training data.
+
+## Behavioral Rules
+
+### Skill Definition
+
+1. A skill is a directory containing a `skill.md` file with YAML frontmatter. The frontmatter must include a `name` field (string). The `description` field is optional but strongly recommended -- it is the primary text used for matching against user queries. The body of `skill.md` and any additional text files in the directory tree form the skill content.
+
+2. The `skill.md` filename match is case-insensitive (`skill.md`, `SKILL.md`, `Skill.md` are all valid). Only one skill definition file per directory is recognized.
+
+3. Each skill directory may contain any number of supporting files alongside `skill.md`. These files are included in the skill content when the skill is selected.
+
+### Discovery
+
+4. At startup, the system must scan the configured `skills_dir` directory. Each immediate subdirectory is treated as a potential skill. Directories are scanned in sorted order.
+
+5. A subdirectory is registered as a skill only if it contains a valid `skill.md` file with parseable YAML frontmatter that includes a `name` field. Subdirectories without a valid `skill.md` must be silently skipped (logged at debug level).
+
+6. If the configured `skills_dir` does not exist, the system must log a warning and proceed with no skills. This is not a fatal error.
+
+7. If parsing the YAML frontmatter of a `skill.md` file fails, or if the frontmatter lacks a `name` field, the system must log a warning and skip that subdirectory.
+
+8. Discovery indexes each skill's `name` and `description` into the hybrid RAG retrieval system for later matching. The index is populated eagerly at startup, but skill file content is loaded on demand only when selected.
+
+### Selection
+
+9. When a query arrives (see `what/query-processing.md`, Stage 5), the system must match the query against indexed skills using hybrid RAG retrieval (dense embedding similarity + sparse BM25 text matching). Dense and sparse scores are fused using a weighted linear combination controlled by the `skills.alpha` parameter.
+
+10. Only the single best-matching skill is selected per query. There is no multi-skill composition.
+
+11. The match must meet a minimum relevance threshold configured via `skills.threshold` (default 0.35). If no skill exceeds the threshold, no skill is applied and the query proceeds without skill content.
+
+12. The skills threshold (default 0.35) is intentionally higher than the tool filtering threshold (default 0.01), because selecting the wrong skill degrades answer quality more than including an irrelevant tool.
+
+### Token Budget Check
+
+13. After selection, the system must load the skill's content and verify that the total content fits within the available token budget. Skill content is loaded on demand -- not at startup -- so large skill directories do not consume memory until needed.
+
+14. If the skill's token cost exceeds 80% of the remaining token budget (after prompt and RAG), the system must skip the skill, emit a `skill_selected` streaming event with `skipped: true` and the reason, and proceed without skill content.
+
+15. If the skill uses more than 50% but fits within 80% of the remaining budget, the system must log a warning but still use the skill.
+
+16. If loading the skill content fails (filesystem error), the system must fall back to no skill without failing the request.
+
+### File Concatenation Order
+
+17. Skill content is assembled by recursively reading all files in the skill directory tree (`rglob`), sorted alphabetically. The concatenation order is:
+    - The body of `skill.md` (everything after YAML frontmatter) is always placed first.
+    - All other readable files follow, each prefixed with a Markdown header showing its relative path (e.g., `## subdir/checklist.md`).
+
+18. Files that cannot be read as UTF-8 (binary files, encoding errors) must be silently skipped.
+
+19. The parts are joined with double newlines (`\n\n`) between each section.
+
+### Prompt Injection
+
+20. When a skill is selected and passes the token budget check, the concatenated skill content is injected into the system prompt with the `USE_SKILL_INSTRUCTION` contextual instruction ("Follow the procedure below to address the user's request:"). The skill content is placed immediately after this instruction. See `what/query-processing.md`, Stage 6, for the full prompt assembly order.
+
+21. When a skill is successfully selected, the system must emit a `skill_selected` streaming event with the skill name and confidence score.
+
+### No Skill Selected
+
+22. If no skill meets the threshold, or if skills are not configured (`ols_config.skills` is absent), or if the skills directory is empty or missing, the query proceeds without skill content. This is normal operation, not an error.
+
+## Configuration Surface
+
+- `ols_config.skills` -- Presence of this section enables skill selection. If absent, skills are entirely disabled.
+  - `skills.skills_dir` -- Path to the directory containing skill subdirectories. Default: `"skills"`.
+  - `skills.embed_model_path` -- Optional path to a sentence transformer model for skill matching embeddings. Falls back to the global RAG embedding model when available, or the default `sentence-transformers/all-mpnet-base-v2` model.
+  - `skills.alpha` -- Weight for dense vs. sparse retrieval blending (0.0--1.0, default 0.8). A value of 1.0 means pure dense (semantic) retrieval; 0.0 means pure sparse (keyword BM25) retrieval.
+  - `skills.threshold` -- Minimum relevance score to accept a skill match (0.0--1.0, default 0.35).
+
+## Constraints
+
+1. Only one skill may be selected per query. There is no mechanism for combining multiple skills in a single response.
+
+2. Skill directories are read-only at runtime. The system never creates, modifies, or deletes skill files.
+
+3. The embedding model used for skill retrieval at query time must be the same model used to populate the index at startup. There is no mechanism to change the model without restarting the service.
+
+4. Skill content must fit within the available token budget. There is no chunking or summarization of skill content -- it is used in full or not at all.
+
+5. The hybrid retrieval uses an in-memory Qdrant vector store. All indexed skills must fit in memory. The maximum top-k for retrieval is capped at 20, but effectively capped at the number of loaded skills when fewer than 20 exist.
+
+6. Skill selection runs synchronously on the query path. Slow embedding models will add latency to every query when skills are configured.
+
+## Planned Changes
+
+- [PLANNED: OLS-2873] Create end-to-end tests to verify skills in OLS, covering skill discovery, selection, prompt injection, and token budget enforcement.
+- [PLANNED: OLS-2874] Enable skills configuration in the OLSConfig CRD, so that skills can be configured via the OpenShift operator rather than only through the config file.
+- [PLANNED: OLS-2842] Evaluate skills/tools usage in OLS to measure selection accuracy, false positive rates, and impact on response quality.

--- a/.ai/spec/what/system-overview.md
+++ b/.ai/spec/what/system-overview.md
@@ -1,0 +1,351 @@
+# System Overview
+
+OpenShift LightSpeed (OLS) is an AI-powered assistant service that answers
+natural-language questions about OpenShift and related Red Hat products by
+orchestrating LLM calls, RAG-augmented prompts, multi-turn conversation
+history, and live cluster introspection via MCP tools. [PLANNED: OLS-2743]
+The service is being rebranded to "Red Hat OpenShift Intelligent Assistant."
+
+## Behavioral Rules
+
+### Identity and Scope
+
+1. The service is a REST API server (currently named "OpenShift LightSpeed")
+   that processes user queries, orchestrates LLM interactions, and returns
+   AI-generated responses. It does NOT include the operator, the console UI
+   plugin, or the RAG content build pipeline. [PLANNED: OLS-2743] The
+   service name will change to "Red Hat OpenShift Intelligent Assistant."
+
+2. The service is product-agnostic at its core. It can serve as an AI
+   assistant for any Red Hat product by changing the system prompt
+   (configurable via `ols_config.system_prompt_path`), loading
+   product-specific RAG content, and adjusting topic guardrails. The service
+   detects its deployment context (e.g., OpenStack Lightspeed) and applies
+   the appropriate system prompt automatically.
+
+3. The service exposes a versioned REST API under the `/v1` prefix. All
+   query, feedback, conversation, MCP, and tool-approval endpoints are
+   versioned. Health and metrics endpoints are unversioned.
+
+### Chat and Query Processing
+
+4. The service accepts a natural-language question from a user and returns
+   an AI-generated answer. The service enforces topic guardrails so the LLM
+   responds only to questions relevant to the configured product domain.
+   Off-topic or harmful queries are rejected.
+
+5. Two query modes control the system prompt and tool-calling depth:
+   **ASK** (general product questions) and **TROUBLESHOOTING** (diagnostic
+   and remediation questions with more tool-calling iterations allowed).
+   The mode is specified per request.
+
+6. Responses are streamed token-by-token to the client as the LLM generates
+   them, reducing perceived latency. A non-streaming endpoint is also
+   available that returns the complete response.
+
+7. Before sending a question to the LLM, the service retrieves relevant
+   chunks from a pre-built product documentation index (RAG) and injects
+   them into the prompt. Retrieved chunks must exceed a similarity threshold
+   to be included. The RAG index is versioned per product release so answers
+   match the user's cluster version.
+
+8. The service maintains per-user, per-conversation history. History is
+   injected into subsequent prompts for multi-turn context. History is
+   truncated to fit within the model's context window. When history
+   compression is enabled (configurable via
+   `ols_config.history_compression_enabled`), the service summarizes
+   older history to reduce token consumption.
+
+9. Users cannot access another user's conversation history. Conversation
+   cache entries are keyed by both conversation ID and authenticated user
+   identity.
+
+10. Users can attach contextual data to their questions. Supported
+    attachment types: alert, api object, configuration, error message,
+    event, log, stack trace. Supported content types: text/plain,
+    application/json, application/yaml, application/xml. Attachments are
+    included in the prompt so the LLM can reason about the user's specific
+    situation.
+
+### LLM Providers
+
+11. The service supports the following LLM provider types: OpenAI, Azure
+    OpenAI (including Entra ID / service-principal authentication),
+    WatsonX, RHOAI vLLM, RHEL AI vLLM, Google Vertex (Anthropic), and
+    Google Vertex. The administrator configures providers and models via
+    `llm_providers` in the configuration file. [PLANNED: OLS-2521] Google
+    Gemini model support is being added. [PLANNED: OLS-2776] Anthropic as a
+    direct LLM provider is planned. [PLANNED: OLS-1680] AWS Bedrock as an
+    LLM provider is planned. [PLANNED: OLS-1660] Llama Stack integration
+    is in progress.
+
+12. A default provider and model are configured at the service level via
+    `ols_config.default_provider` and `ols_config.default_model`. The
+    service abstracts provider differences so all capabilities work
+    uniformly regardless of backend.
+
+### MCP Tools and Skills
+
+13. The service acts as an MCP (Model Context Protocol) client, connecting
+    to externally deployed MCP servers to provide tools for querying live
+    cluster state. MCP servers are configured via `mcp_servers.servers` in
+    the configuration file, each with a name, URL, optional timeout, and
+    authorization headers.
+
+14. MCP authorization headers support three resolution modes: a static file
+    path, the placeholder `kubernetes` (uses the user's Kubernetes token),
+    or the placeholder `client` (uses a client-provided header value).
+
+15. Tool execution can require user approval before running. The approval
+    strategy is configurable via `ols_config.tools_approval.approval_type`:
+    `never` (no approval needed), `always` (all tool calls require
+    approval), or `tool_annotations` (approval based on per-tool
+    annotations). Approval requests time out after a configurable period
+    (default 600 seconds).
+
+16. When MCP tools are configured, the LLM may request tool calls during
+    query processing. The service executes tool calls against MCP servers
+    and feeds results back to the LLM in an iterative loop. The maximum
+    number of iterations is mode-dependent: ASK mode has a lower default
+    limit than TROUBLESHOOTING mode. A per-request override is available
+    via `ols_config.max_iterations`.
+
+17. Tool filtering can be enabled (via `ols_config.tool_filtering`) to
+    select the most relevant tools for a given query using hybrid
+    dense/sparse retrieval, reducing noise and improving tool-call accuracy.
+
+18. The service supports skills -- configurable prompt strategies loaded
+    from a skills directory (configurable via `ols_config.skills.skills_dir`).
+    Skills are matched to user queries using hybrid RAG retrieval with a
+    configurable similarity threshold. When a skill matches, its specialized
+    prompt and tool combination are used instead of the generic chat flow.
+
+### Token Budget and Context Window
+
+19. Each request operates within a token budget derived from the model's
+    context window size (configurable per model, default 128,000 tokens).
+    The budget is partitioned across system prompt, RAG context, history,
+    tool outputs, and response tokens.
+
+20. When MCP tools are configured, a configurable fraction of the context
+    window is reserved for tool outputs (configurable via model-level
+    `tool_budget_ratio`, default 25%, range 10%-60%). Within each
+    tool-calling round, a cap limits how much of the remaining tool budget
+    can be consumed (configurable via `ols_config.tool_round_cap_fraction`,
+    default 60%, range 30%-80%).
+
+21. The maximum tokens reserved for the LLM response is configurable per
+    model (default 4,096 tokens).
+
+### Quota Management
+
+22. Administrators can define usage quotas per user and per cluster. Quotas
+    limit the number of LLM tokens consumed over a configurable time
+    window. Quota configuration is under `ols_config.quota_handlers` and
+    requires a PostgreSQL storage backend and a scheduler period.
+
+23. When a user or cluster exceeds their token quota, the service rejects
+    the request.
+
+### Data Redaction
+
+24. Before sending prompts to an LLM provider, the service applies
+    configurable regex-based query filters to redact sensitive data.
+    Filters are defined via `ols_config.query_filters`, each specifying a
+    name, regex pattern, and replacement string.
+
+### Authentication and Authorization
+
+25. By default, users authenticate via Kubernetes token validation. The
+    service verifies the user's cluster API token on each request. The
+    authentication module is configurable via
+    `ols_config.authentication_config.module`. Supported modules: `k8s`,
+    `noop` (disabled), `noop-with-token` (testing with token). The default
+    is `k8s`.
+
+26. Authorization is controlled through standard Kubernetes RBAC. The
+    service checks access against a virtual path (`/ols-access`) using the
+    authenticated user's token.
+
+27. All API endpoints except health and metrics require authentication.
+    Health endpoints (`/readiness`, `/liveness`) and the `/metrics` endpoint
+    are unauthenticated.
+
+### TLS and Security
+
+28. All endpoints are TLS-encrypted in production. TLS certificates are
+    configured via `ols_config.tls_config`. TLS can be disabled for
+    development via `dev_config.disable_tls`.
+
+29. The service respects the cluster-level TLS security profile for cipher
+    suite and minimum TLS version selection (configurable via
+    `ols_config.tlsSecurityProfile`). The `OldType` profile is rejected;
+    minimum allowed TLS version is 1.2.
+
+30. Security response headers (X-Content-Type-Options, Strict-Transport-
+    Security) are added to all API responses except health and metrics
+    endpoints.
+
+31. HTTP request and response logs redact sensitive headers (authorization,
+    proxy-authorization, cookie, www-authenticate, proxy-authenticate,
+    set-cookie).
+
+32. Connections to LLM providers use TLS. Credentials are read from file
+    paths specified in the provider configuration. Extra CA certificates
+    can be configured via `ols_config.extra_ca`.
+
+### User Feedback
+
+33. Users can submit feedback (positive/negative with optional free-text)
+    on responses. Feedback is stored locally on the cluster filesystem.
+    Feedback can be forwarded to Red Hat via the Insights telemetry
+    pipeline. Feedback collection is configurable via
+    `ols_config.user_data_collection.feedback_disabled` (disabled by
+    default).
+
+34. When feedback is disabled, the feedback endpoint returns HTTP 403.
+
+### Conversation Management
+
+35. Conversation history is stored in a persistent cache. Two storage
+    backends are supported: in-memory (suitable for development and
+    single-replica deployments, with configurable max entries and LRU
+    eviction) and PostgreSQL (required for production and multi-replica
+    deployments). Configured via `ols_config.conversation_cache.type`.
+
+36. The service exposes endpoints for listing, retrieving, updating (rename),
+    and deleting conversations. All conversation operations are scoped to
+    the authenticated user.
+
+### Observability
+
+37. The service exposes Prometheus-compatible metrics at `/metrics`
+    covering: REST API call counts by path and status code, response
+    duration histograms by path, LLM call counts, LLM call failure counts,
+    LLM tokens sent and received, LLM reasoning tokens, and provider/model
+    configuration gauge.
+
+38. Conversation transcripts can be optionally recorded for quality
+    analysis. Configured via
+    `ols_config.user_data_collection.transcripts_disabled` (disabled by
+    default).
+
+39. Configuration status (summary of provider, model, and enabled features)
+    can be reported for aggregate product analytics when feedback or
+    transcript collection is enabled.
+
+### Health Probes
+
+40. The service exposes `/readiness` and `/liveness` health endpoints.
+    Liveness always returns healthy if the process is running. Readiness
+    checks three conditions: RAG index is loaded (if configured), LLM
+    provider is reachable and responding, and conversation cache is ready.
+    All three must pass for the service to report ready.
+
+41. The LLM readiness check result is cached to avoid repeated probe calls
+    to the LLM. The cache expiration is configurable via
+    `ols_config.expire_llm_is_ready_persistent_state`.
+
+### Development Mode
+
+42. A developer configuration section (`dev_config`) allows: enabling an
+    embedded Gradio UI (`enable_dev_ui`), disabling authentication
+    (`disable_auth`), disabling TLS (`disable_tls`), overriding the system
+    prompt at request time (`enable_system_prompt_override`), configuring a
+    Pyroscope profiling URL (`pyroscope_url`), and binding to localhost
+    (`run_on_localhost`).
+
+## Configuration Surface
+
+All configuration is read from `olsconfig.yaml` (path overridden via the
+`OLS_CONFIG_FILE` environment variable). The top-level structure:
+
+| Section | Purpose |
+|---|---|
+| `llm_providers` | List of LLM provider configurations (name, type, URL, credentials, models) |
+| `ols_config.default_provider` / `default_model` | Default LLM backend for queries |
+| `ols_config.reference_content` | RAG index paths and embeddings model path |
+| `ols_config.conversation_cache` | Cache backend selection (memory or postgres) and settings |
+| `ols_config.authentication_config` | Auth module, K8s API URL, CA cert, TLS skip |
+| `ols_config.tls_config` | TLS certificate and key paths |
+| `ols_config.tlsSecurityProfile` | Cluster TLS profile (type, minTLSVersion, ciphers) |
+| `ols_config.query_filters` | Regex-based redaction filters (name, pattern, replace_with) |
+| `ols_config.quota_handlers` | Token quota configuration (storage, scheduler, limiters) |
+| `ols_config.user_data_collection` | Feedback and transcript collection toggles and storage paths |
+| `ols_config.logging_config` | Log levels for app, libraries, and uvicorn; metric log suppression |
+| `ols_config.system_prompt_path` | Path to custom system prompt file |
+| `ols_config.max_iterations` | Override default max tool-calling iterations |
+| `ols_config.history_compression_enabled` | Enable/disable history summarization (default: true) |
+| `ols_config.proxy_config` | HTTP/HTTPS proxy and no-proxy settings |
+| `ols_config.extra_ca` | Additional CA certificate file paths |
+| `ols_config.tool_filtering` | Tool filtering via hybrid RAG (embed model, alpha, top_k, threshold) |
+| `ols_config.tools_approval` | Tool execution approval strategy and timeout |
+| `ols_config.skills` | Skills directory, embed model, alpha, threshold |
+| `ols_config.tool_round_cap_fraction` | Max fraction of tool budget usable per round |
+| `mcp_servers.servers` | List of MCP server configurations (name, URL, timeout, headers) |
+| `dev_config` | Development-only toggles (UI, auth, TLS, profiling, localhost) |
+
+## Constraints
+
+1. **Service-only scope.** This specification covers the lightspeed-service
+   Python application only. The operator (lightspeed-operator), console
+   plugin (lightspeed-console), RAG content pipeline (lightspeed-rag-content),
+   and evaluation framework (lightspeed-evaluation) are separate components.
+
+2. **Conversation isolation.** Conversations are scoped to the authenticated
+   user identity. No cross-user access is permitted.
+
+3. **Context window hard limit.** All prompt components (system prompt, RAG
+   context, history, attachments, tool outputs, response budget) must fit
+   within the model's context window. The service truncates history and RAG
+   context as needed; if the prompt still exceeds the limit after truncation,
+   the request is rejected with HTTP 413.
+
+4. **TLS minimum version.** The `OldType` TLS security profile is rejected.
+   Minimum allowed TLS protocol version is 1.2.
+
+5. **RAG is read-only.** The service loads and queries pre-built RAG indexes
+   at startup. It does not build, modify, or update indexes at runtime.
+
+6. **MCP servers are external.** The service connects to MCP servers as a
+   client. MCP servers are independently deployed, configured, and secured.
+
+7. **Authentication default.** When no authentication module is configured,
+   the default is Kubernetes token validation (`k8s`).
+
+8. **Supported architectures.** The service supports x86_64 and ARM
+   (aarch64).
+
+9. **FIPS readiness.** The service is designed for FIPS -- it uses
+   FIPS-validated cryptographic modules, follows FIPS guidelines, and is
+   deployable on FIPS-enabled OpenShift clusters.
+
+10. **Disconnected operation.** All features work without internet access,
+    provided the LLM provider is reachable from the cluster.
+
+11. **HCP compatibility.** The service is compatible with OpenShift Hosted
+    Control Planes deployments.
+
+## Planned Changes
+
+| Jira Key | Summary |
+|---|---|
+| OLS-2743 | Rebranding to "Red Hat OpenShift Intelligent Assistant" |
+| OLS-2894 | Autonomous, policy-driven AI agents for OpenShift (TP: OCP 5.0) |
+| OLS-1660 | Use of Llama Stack in OLS |
+| OLS-2521 | Support Google Gemini model in OLS |
+| OLS-2776 | Support Anthropic as a direct LLM provider |
+| OLS-1680 | Support AWS Bedrock as LLM provider |
+| OLS-2823 | Per-user LLM provider API keys |
+| OLS-1881 | Bring your own LLM for OLS |
+| OLS-1882 | Localization support for OLS messages |
+| OLS-2154 | Manage MCP servers with MCP gateway |
+| OLS-2491 | MCP client improvements |
+| OLS-1884 | Customer policies to make output compliant |
+| OLS-1886 | User ability to create support ticket from OLS console |
+| OLS-1872 | BYOK -- internal web source integration |
+| OLS-1679 | ROSA-aware answering in OpenShift Lightspeed |
+| OLS-1806 | ARO-aware answering in OpenShift Lightspeed |
+| OLS-1811 | Root cause analysis using OLS |
+| OLS-1824 | Insights MCP adoption in OLS |
+| OCPSTRAT-2985 | Make maxToolCallingIterations configurable via OLSConfig CR |

--- a/.ai/spec/what/tools.md
+++ b/.ai/spec/what/tools.md
@@ -1,0 +1,255 @@
+# Tools
+
+MCP (Model Context Protocol) tool integration enables the LLM to call external
+tools -- such as querying cluster state, performing actions, or fetching data --
+making OLS context-aware against the user's actual cluster rather than relying
+solely on general knowledge.
+
+## Behavioral Rules
+
+### MCP Server Configuration
+
+1. Each MCP server is defined with a unique name, URL, optional per-server
+   timeout, and optional authorization headers. Server names must be unique
+   within the configuration; duplicate names must be rejected at config load
+   time.
+
+2. Header values support three resolution modes:
+   - `"kubernetes"`: replaced at runtime with the user's Kubernetes bearer
+     token (formatted as `Bearer {token}`).
+   - `"client"`: replaced with a header value provided by the client in the
+     API request body, keyed by server name and header name.
+   - Any other value: treated as a literal (typically resolved from a file
+     path at config load time).
+
+3. If header resolution fails for a server (e.g., the user has no token for a
+   `"kubernetes"` header, or the client omitted a required `"client"` header),
+   that server must be silently skipped -- the request must not fail.
+
+4. The system must expose an API that tells clients which MCP servers require
+   client-provided headers and which header names are required, so clients can
+   supply them in requests. [PLANNED: OLS-2684 -- remove client MCP headers]
+
+5. When a certificate directory is configured, all MCP connections must use
+   the service's custom CA bundle for TLS verification.
+
+### Tool Gathering
+
+6. Tools must be collected from all configured MCP servers at query time.
+   Gathering is fault-isolated per server: if one MCP server is unreachable
+   or errors, tools from other servers must still be returned.
+
+7. Each gathered tool must carry metadata indicating which MCP server it came
+   from.
+
+8. Tool schemas must be normalized for LLM compatibility: object-type schemas
+   lacking a `properties` key must have an empty `properties` dict and empty
+   `required` list added.
+
+9. When the same tool name appears from multiple servers, the first
+   occurrence wins (deduplication). Duplicate tools from later servers must
+   be logged and dropped.
+
+### Tool Execution
+
+10. When the LLM requests multiple tool calls in a single round, all calls
+    must execute concurrently. Results are streamed as they complete from any
+    tool, not in request order. For how tool execution integrates with the
+    generation loop, see `what/query-processing.md` (stage 7).
+
+11. Transient errors (timeouts, connection resets, temporary failures) must be
+    retried up to 2 times (3 total attempts) with exponential backoff: base
+    delay 0.2 seconds, doubled on each retry.
+
+12. Rate-limit errors (HTTP 429, "too many requests") must use a longer base
+    delay of 1.0 second with the same exponential backoff and retry count.
+
+13. Non-transient errors must fail immediately without retry. On final
+    failure (retries exhausted or non-transient), the error message must be
+    passed to the LLM as a tool result with error status. Error messages in
+    tool results must be truncated to 220 characters.
+
+14. Each tool-call round (LLM generation + tool execution) is subject to a
+    per-round timeout (`TOOL_CALL_ROUND_TIMEOUT` = 300 seconds). For
+    iteration limits across rounds, see `what/agent-modes.md`.
+
+### Token Budget for Tool Results
+
+15. A configurable fraction of the model's context window is reserved for tool
+    traffic (definitions + execution results), controlled by
+    `model.parameters.tool_budget_ratio` (default 0.25, range 0.10--0.60).
+    This reserve is computed at startup as
+    `context_window_size * tool_budget_ratio` and set to zero when no MCP
+    servers are configured. For how the tool reserve integrates with the
+    overall token budget, see `what/query-processing.md` (token budget
+    system).
+
+16. When multiple tool calls execute in parallel within a round, the
+    remaining tool token budget must be split equally among the calls.
+
+17. Tool outputs must be truncated using a 3-tier strategy:
+    - **Tier 1 -- character estimate**: estimate token count at ~4 characters
+      per token. If the estimate is clearly under 90% of the remaining
+      budget, skip tokenization entirely.
+    - **Tier 2 -- precise tokenization**: if the character estimate is
+      ambiguous, tokenize each tool output to get exact counts. If the total
+      is within budget, return outputs unmodified.
+    - **Tier 3 -- proportional truncation**: if the longest output alone can
+      absorb the excess (its half is >= the excess), shrink only that output.
+      Otherwise, scale all outputs proportionally to fit the budget. All
+      truncation must cut at the last newline boundary to avoid mid-line
+      splits, and append a truncation warning.
+
+18. Before tokenization, a cheap character-level size guard
+    (`budget * 4 chars`) must be applied to raw tool output to prevent
+    the CPU cost of tokenizing arbitrarily large responses. Strings are cut
+    at the last newline boundary before the character limit.
+
+### Tool Filtering via Hybrid RAG
+
+19. When `ols_config.tool_filtering` is configured, the system must use
+    hybrid RAG (dense embeddings + sparse BM25) to select relevant tools
+    based on the user's query. For the underlying hybrid RAG mechanism, see
+    `what/rag.md`.
+
+20. Tools must be indexed by their name and description (concatenated as
+    search text). Retrieval uses reciprocal rank fusion (RRF) of dense
+    cosine similarity and BM25 sparse scores.
+
+21. The dense-vs-sparse weight is controlled by `tool_filtering.alpha`
+    (default 0.8; 1.0 = full dense, 0.0 = full sparse). Results below
+    `tool_filtering.threshold` (default 0.01) must be excluded.
+
+22. Results must be grouped by MCP server. When any tool from a server passes
+    the threshold, all selected tools from that server are gathered together.
+
+23. Default servers (those using kubernetes-token authentication) and any
+    client-auth servers with headers provided in the current request must
+    always be included in the search scope, regardless of RAG score.
+
+24. Kubernetes-auth server tools are populated into the RAG index once and
+    cached; client-auth server tools are populated per request when client
+    headers are provided.
+
+25. If tool filtering fails (RAG error), the system must fall back to
+    returning all tools from all servers rather than returning an empty set.
+
+26. If tool filtering is not configured, all tools from all servers must be
+    passed to the LLM without filtering.
+
+### Tool Approval Workflow
+
+27. Three approval strategies are supported, selected by
+    `tools_approval.strategy`:
+    - `never` (default): all tool calls execute immediately without approval.
+    - `always`: every tool call requires explicit user approval.
+    - `tool_annotations`: approval is required by default, but tools that
+      declare `readOnlyHint: true` in their MCP annotation metadata are
+      exempt.
+
+28. Approval is only supported for streaming requests. Non-streaming requests
+    must never trigger the approval flow, regardless of the configured
+    strategy.
+
+29. When approval is required for a tool call:
+    a. The system must emit an `approval_required` streaming event to the
+       client containing a unique approval ID, the tool name, description,
+       arguments, and annotation metadata.
+    b. The system must then block and wait for the client to submit an
+       approval or rejection via the `POST /tool-approvals/decision`
+       endpoint.
+    c. If approved, the tool executes normally through the retry policy.
+    d. If rejected, a non-retryable error result is returned to the LLM
+       with a message instructing it not to retry the call.
+    e. If the configured timeout expires (default 600 seconds, controlled by
+       `tools_approval.approval_timeout`), the call is treated as timed out
+       with a non-retryable error.
+
+30. Each approval request receives a unique ID. Approval state is stored in
+    memory per process and is not persisted across restarts. After a decision
+    is applied (or times out), the approval state must be cleaned up
+    immediately to prevent memory leaks.
+
+31. The approval decision endpoint must return HTTP 404 if no pending
+    approval exists for the given ID, and HTTP 409 if the approval was
+    already resolved. A decision for an already-resolved approval must not
+    change the outcome.
+
+### MCP Apps
+
+32. MCP servers can serve `ui://` URI resources containing HTML/JS/CSS for
+    rendering in the console UI as app iframes.
+
+33. The console can proxy tool calls to a specific MCP server outside the
+    normal LLM conversation flow for interactive app functionality.
+
+34. Both resource fetching and direct tool calls require the same
+    authentication and header resolution as normal MCP tool calls.
+
+35. Structured content returned by tool calls (e.g., rich data for UI
+    rendering) must be preserved in tool result metadata and forwarded to
+    the client.
+
+## Configuration Surface
+
+| Field Path | Type | Default | Purpose |
+|---|---|---|---|
+| `mcp_servers.servers[]` | list | [] | MCP server definitions |
+| `mcp_servers.servers[].name` | string | required | Unique server identifier |
+| `mcp_servers.servers[].url` | string | required | Server HTTP endpoint |
+| `mcp_servers.servers[].timeout` | int | 5 | Per-server request timeout in seconds |
+| `mcp_servers.servers[].headers` | map | {} | Authorization headers (values are file paths, `"kubernetes"`, or `"client"`) |
+| `model.parameters.tool_budget_ratio` | float | 0.25 | Fraction of context window reserved for tool traffic (0.10--0.60) |
+| `ols_config.tool_round_cap_fraction` | float | 0.6 | Fraction of remaining tool budget usable per round (0.3--0.8) |
+| `ols_config.tool_filtering` | object | none | Enables hybrid RAG tool filtering when present |
+| `ols_config.tool_filtering.embed_model_path` | string | none | Path to sentence transformer model for embeddings |
+| `ols_config.tool_filtering.alpha` | float | 0.8 | Dense vs sparse retrieval weight (0.0--1.0) |
+| `ols_config.tool_filtering.top_k` | int | 10 | Number of tools to retrieve (1--50) |
+| `ols_config.tool_filtering.threshold` | float | 0.01 | Minimum similarity score (0.0--1.0) |
+| `tools_approval.strategy` | enum | `never` | Approval strategy: `never`, `always`, or `tool_annotations` |
+| `tools_approval.approval_timeout` | int | 600 | Seconds to wait for user approval decision (>= 1) |
+
+## Constraints
+
+1. **Server names are unique.** Duplicate MCP server names in configuration
+   must be rejected at startup. Tool names are deduplicated at gathering time
+   (first-seen wins).
+
+2. **Fault isolation is mandatory.** A single unreachable MCP server must
+   never prevent tools from other servers from being gathered or executed.
+
+3. **Tool budget is separate from prompt budget.** Tool definitions and tool
+   execution traffic draw from the tool reserve, not the prompt budget.
+   See `what/query-processing.md` for the full budget partitioning.
+
+4. **Approval requires streaming.** The approval workflow is architecturally
+   dependent on the streaming protocol for client communication. Non-streaming
+   requests bypass approval entirely.
+
+5. **Approval state is ephemeral.** Pending approval state is in-memory per
+   process. A process restart clears all pending approvals; clients will
+   receive no response for approvals that were pending at restart time.
+
+6. **Truncation preserves line boundaries.** All truncation (both the
+   per-tool character guard and the aggregate budget enforcer) must cut at
+   newline boundaries to avoid delivering partial lines to the LLM.
+
+7. **Retry policy is fixed.** The retry count (2 retries), base delays
+   (0.2s transient, 1.0s rate-limit), and exponential backoff formula are
+   compile-time constants, not configurable. Only the tool budget ratio,
+   round cap fraction, and approval timeout are user-configurable.
+
+8. **RAG filtering is optional.** When `ols_config.tool_filtering` is absent,
+   all tools are passed to the LLM. When present but failing, the system
+   falls back to all tools. The system must never return an empty tool set
+   due to a filtering infrastructure failure.
+
+## Planned Changes
+
+| Jira Key | Summary |
+|---|---|
+| OLS-2685 | Previous tools in context -- carry tool results from prior conversation turns into the current prompt |
+| OLS-2715 | ocp-mcp additional toolsets -- expand the default MCP server set |
+| OLS-2684 | Remove client MCP headers -- eliminate the `"client"` header placeholder mechanism |
+| OLS-2491 | MCP client improvements -- transport and reliability enhancements |
+| OLS-1797 | Block sensitive tool args -- reject tool calls whose arguments match blocked patterns before execution |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,32 @@ Do not cross module or layer boundaries, even when it is the shorter path.
 ### Keep changes scoped
 Do not refactor, rename, or reformat outside the direct path of the task. Unrelated improvements belong in a separate PR.
 
+## Git and PR Workflow
+
+### Commit Messages
+- Start with the Jira ticket reference: `OLS-XXXX description`
+- Keep the first line under 72 characters
+- Use imperative mood
+
+### Pull Requests
+This repo uses a **fork-based workflow**:
+
+1. **Push to your fork**, not to `origin` (openshift/lightspeed-service)
+2. **Create the PR** against `origin/main` using your fork's branch:
+   ```bash
+   git push <your-fork-remote> <branch>
+   gh pr create --repo openshift/lightspeed-service --head <your-github-user>:<branch> --base main
+   ```
+3. **PR title** must start with the Jira reference: `OLS-XXXX description`
+4. **Squash commits** before pushing -- one logical commit per PR unless the PR explicitly tracks multiple independent changes
+
+### Branch Completion
+When finishing a development branch:
+1. Remove any process artifacts (design docs, plans in `docs/superpowers/`)
+2. Squash commits with the Jira-prefixed message
+3. Push to the contributor's fork remote (not `origin`)
+4. Create the PR against `origin/main` using `--head <user>:<branch>`
+
 ## Maintaining This Guide
 
 Update this file and the relevant `docs/ai/` reference when patterns, tooling, or conventions change, or after repeated mistakes. Only document what you would get wrong without being told — remove anything inferable from reading the code.


### PR DESCRIPTION
Create 14 OLS service spec files and add new ones, organized into two layers under .ai/spec/:

what/ (16 behavioral specs + README):
  Testable rules defining WHAT the system must do. Technology-neutral,
  with [PLANNED: OLS-XXXX] markers for open Jira work. Covers:
  system-overview, api, query-processing, agent-modes, conversation-history,
  llm-providers, rag, auth, tools, skills, quota, config, security,
  observability, prompts, mcp-apps.

how/ (6 architecture specs + README):
  HOW the current implementation is structured. Module maps, data flow,
  design patterns, extension guides. Covers: project-structure,
  query-pipeline, llm-providers, tools, config, cache.

Also updates .ai/jira-*.md files with current open/planned Jira items.

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [x] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
