### PR TITLE
OLS-2920 - Pre-warm tiktoken caching for non-runtime installs for disconnected env.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -50,10 +50,16 @@ RUN if [ -f /cachi2/cachi2.env ]; then \
 # Add executables from .venv to system PATH
 ENV PATH="/app-root/.venv/bin:$PATH"
 
+# Pre-warm tiktoken encoding cache to a stable, version-agnostic location.
+RUN src=$(find .venv/lib -path "*/llama_index/core/_static/tiktoken_cache" -type d) && \
+    mkdir -p /app-root/.tiktoken_cache && \
+    cp "$src"/[0-9a-f]* /app-root/.tiktoken_cache/
+
 # Verify all dependencies are installed correctly
 RUN echo "Verifying dependencies installation..." && \
     pip check && \
     python -c "import yaml, fastapi, langchain, llama_index, uvicorn, pydantic" && \
+    TIKTOKEN_CACHE_DIR=/app-root/.tiktoken_cache python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')" && \
     echo "All dependencies installed and verified successfully!"
 
 FROM ${RUNTIME_BASE_IMAGE}
@@ -70,9 +76,11 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUTF8=1 \
     PYTHONIOENCODING=UTF-8 \
     LANG=en_US.UTF-8 \
-    LLAMA_INDEX_CACHE_DIR=/tmp/llama_index
+    LLAMA_INDEX_CACHE_DIR=/tmp/llama_index \
+    TIKTOKEN_CACHE_DIR=/app-root/.tiktoken_cache
 
 COPY --from=builder /app-root/.venv .venv
+COPY --from=builder /app-root/.tiktoken_cache .tiktoken_cache
 COPY ols ./ols
 COPY runner.py /app-root/runner.py
 COPY --from=lightspeed-rag-content /rag/vector_db/ocp_product_docs ./vector_db/ocp_product_docs


### PR DESCRIPTION
## Description

Fix tiktoken encoding download failure on disconnected clusters. Starting in operator 1.0.11, the lightspeed-app-server pod crashed at startup with:                                                     
                  
```
  requests.exceptions.ConnectTimeout: HTTPSConnectionPool(host='openaipublic.blob.core.windows.net', port=443):
  Max retries exceeded with url: /encodings/cl100k_base.tiktoken
```

` tools.py `introduced a module-level TokenHandler() call that triggers tiktoken.get_encoding("cl100k_base") at import time. Without a cached encoding file, tiktoken attempted a network download — which
  times out in disconnected environments.

 Fix: Pre-warm the tiktoken encoding cache during the image build (when internet access is available) and point TIKTOKEN_CACHE_DIR at the pre-warmed location. llama_index ships cl100k_base and  o200k_base as package data, so no download is needed at build time either — the files are copied out to a stable, version-agnostic path (/app-root/.tiktoken_cache) that is baked into the runtime image.  The build-time verification step is extended to validate that get_encoding('cl100k_base') resolves from the cache, failing the build early if the cache is missing rather than producing a broken image.


## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
