### PR TITLE
chore(deps): update own-app-lightspeed-rag-content to 7dd8fe3

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # vim: set filetype=dockerfile
-ARG LIGHTSPEED_RAG_CONTENT_IMAGE=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/own-app-lightspeed-rag-content@sha256:6a26cfb029969de645486ccc7736e4f2266e284826618075510333a06c387b43
+ARG LIGHTSPEED_RAG_CONTENT_IMAGE=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/own-app-lightspeed-rag-content@sha256:7dd8fe3cfc0ac65684332e678bc257bfc29144ab102a971e51e3acfdf7f1332e
 ARG BUILDER_BASE_IMAGE=registry.redhat.io/rhel9/python-312@sha256:46f883684d02cef2a7abb0c4124f18308ad920018d76c5c56f130dae02bfed05
 ARG RUNTIME_BASE_IMAGE=registry.redhat.io/rhel9/python-312-minimal@sha256:804b928fd278fa03c2edf0352378eca73c8efcf665c6e0180e074340b9f22a50
 FROM --platform=linux/amd64 ${LIGHTSPEED_RAG_CONTENT_IMAGE} AS lightspeed-rag-content


### PR DESCRIPTION
## Summary
- Updates the RAG content image digest from `6a26cfb` to `7dd8fe3`
- Image created from https://github.com/openshift/lightspeed-rag-content?rev=1e2753b5b3dc55b49a195395f456dc76842ad2a1
- Replaces PR #2897 which was stuck on a degraded CI cluster (`ci-op-qmmdf3gp`) — all retests landed on the same broken infrastructure

## Context
PR #2897 failed 4 times (2x e2e, 1x eval, and the merge-bot exhausted retests) due to infrastructure issues, not code problems. This PR applies the identical change from a fresh branch to get a new CI namespace allocation.

Made with [Cursor](https://cursor.com)