### PR TITLE
E2E: harden install and pod wait; disable introspection for MCP test

### DIFF
--- a/tests/config/operator_install/olsconfig.crd.openai_mcp.yaml
+++ b/tests/config/operator_install/olsconfig.crd.openai_mcp.yaml
@@ -24,6 +24,7 @@ spec:
       replicas: 1
     disableAuth: false
     logLevel: DEBUG
+    introspectionEnabled: false
     userDataCollection:
       feedbackDisabled: true
       transcriptsDisabled: true

--- a/tests/e2e/utils/adapt_ols_config.py
+++ b/tests/e2e/utils/adapt_ols_config.py
@@ -176,7 +176,7 @@ def wait_for_deployment() -> None:
     )
 
     print("Waiting for pods to be ready...")
-    cluster_utils.wait_for_running_pod()
+    cluster_utils.wait_for_running_pod(wait_http_ready=False)
 
 
 def setup_route() -> str:

--- a/tests/e2e/utils/cluster.py
+++ b/tests/e2e/utils/cluster.py
@@ -4,7 +4,10 @@ import json
 import os
 import subprocess
 
+import pytest
+
 from tests.e2e.utils.retry import retry_until_timeout_or_success
+from tests.e2e.utils.wait_for_ols import wait_for_ols
 
 OC_COMMAND_RETRY_COUNT = 120
 
@@ -355,9 +358,16 @@ def get_container_ready_status(pod: str, namespace: str = "openshift-lightspeed"
 
 
 def wait_for_running_pod(
-    name: str = "lightspeed-app-server-", namespace: str = "openshift-lightspeed"
+    name: str = "lightspeed-app-server-",
+    namespace: str = "openshift-lightspeed",
+    wait_http_ready: bool = True,
 ):
-    """Wait for the selected pod to be in running state."""
+    """Wait for the selected pod to be in running state.
+
+    After the pod's containers are ready, optionally poll ``/readiness`` on the
+    OLS route so callers do not hit ingress/HTML error pages before JSON is served
+    again (e.g. after scale + config changes).
+    """
     r = retry_until_timeout_or_success(
         3,
         2,
@@ -420,6 +430,23 @@ def wait_for_running_pod(
     )
     if not r:
         raise Exception("Timed out waiting for containers to become ready")
+
+    if not wait_http_ready:
+        return
+
+    # Standalone / local runs use OLS_URL with localhost; skip cluster route checks.
+    ols_url_env = os.getenv("OLS_URL", "")
+    if "localhost" in ols_url_env:
+        return
+
+    http_url = getattr(pytest, "ols_url", None) or ""
+    if not http_url.strip():
+        http_url = get_ols_url("ols")
+
+    if not wait_for_ols(http_url, timeout=300, interval=5):
+        raise Exception(
+            "Timed out waiting for OLS HTTP readiness after pod became ready"
+        )
 
 
 def get_certificate_secret_name(

--- a/tests/e2e/utils/ols_installer.py
+++ b/tests/e2e/utils/ols_installer.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess
+import time
 
 import yaml
 
@@ -15,6 +16,60 @@ OC_COMMAND_RETRY_COUNT = 120
 OC_COMMAND_RETRY_DELAY = 5
 
 disconnected = os.getenv("DISCONNECTED", "")
+
+
+def _app_server_deployment_exists() -> bool:
+    """Return True if the OLS API Deployment exists (``oc -o name`` shape varies by version)."""
+    name_line = cluster_utils.run_oc(
+        [
+            "get",
+            "deployment",
+            "lightspeed-app-server",
+            "--ignore-not-found",
+            "-o",
+            "name",
+        ]
+    ).stdout.strip()
+    return name_line in (
+        "deployment.apps/lightspeed-app-server",
+        "deployment/lightspeed-app-server",
+    )
+
+
+def _wait_for_operator_controller_ready() -> None:
+    """Wait until the operator manager pod exists and all containers are ready."""
+    r = retry_until_timeout_or_success(
+        60,
+        5,
+        lambda: (
+            pods := cluster_utils.get_pod_by_prefix(
+                prefix="lightspeed-operator-controller-manager", fail_not_found=False
+            )
+        )
+        and all(
+            status == "true"
+            for status in cluster_utils.get_container_ready_status(pods[0])
+        ),
+        "Waiting for operator controller to be ready",
+    )
+    if not r:
+        raise Exception(
+            "Timed out waiting for operator controller manager to become ready"
+        )
+
+
+def _dump_ols_install_debug() -> None:
+    """Print cluster state to logs when install waits fail (Konflux / Azure debugging)."""
+    for label, args in (
+        ("OLSConfig", ["get", "olsconfig", "cluster", "-o", "yaml"]),
+        ("deployments", ["get", "deployments", "-n", "openshift-lightspeed"]),
+        ("CSV", ["get", "csv", "-n", "openshift-lightspeed", "-o", "wide"]),
+    ):
+        try:
+            print(f"--- {label} (debug) ---")
+            print(cluster_utils.run_oc(args).stdout)
+        except Exception as e:
+            print(f"Could not get {label}: {e}")
 
 
 def create_and_config_sas() -> tuple[str, str]:
@@ -374,27 +429,24 @@ def install_ols() -> tuple[str, str, str]:  # pylint: disable=R0915, R0912  # no
             "1",
         ]
     )
+    _wait_for_operator_controller_ready()
+
+    print(
+        "Waiting for operator to reconcile OLSConfig before checking API deployment..."
+    )
+    time.sleep(30)
 
     # wait for the ols api server deployment to be created
     r = retry_until_timeout_or_success(
         OC_COMMAND_RETRY_COUNT,
         OC_COMMAND_RETRY_DELAY,
-        lambda: cluster_utils.run_oc(
-            [
-                "get",
-                "deployment",
-                "lightspeed-app-server",
-                "--ignore-not-found",
-                "-o",
-                "name",
-            ]
-        ).stdout
-        == "deployment.apps/lightspeed-app-server\n",
+        _app_server_deployment_exists,
         "Waiting for OLS API server deployment to be created",
     )
     if not r:
         msg = "Timed out waiting for OLS deployment to be created"
         print(msg)
+        _dump_ols_install_debug()
         raise Exception(msg)
     print("OLS deployment created")
 
@@ -445,7 +497,7 @@ def install_ols() -> tuple[str, str, str]:  # pylint: disable=R0915, R0912  # no
     )
     print("Deployment updated, waiting for new pod to be ready")
     # Wait for the pod to start being created and then wait for it to start running.
-    cluster_utils.wait_for_running_pod()
+    cluster_utils.wait_for_running_pod(wait_http_ready=False)
 
     print("-" * 50)
     print("OLS pod seems to be ready")


### PR DESCRIPTION
## Description

**Summary**
Improves reliability of on-cluster e2e setup and post-scale waits, and makes the OpenAI MCP operator install CR explicitly disable cluster introspection so operator-managed kube MCP does not overlap the mock mcpServers under test.

**Motivation**
After scaling or config changes, the API pod can be “ready” while ingress still returns non-API responses; polling /readiness avoids flaky tests.
install_ols could race the operator controller or mis-detect the app Deployment because oc -o name output differs across versions.
MCP e2e used olsconfig.crd.openai_mcp.yaml without introspectionEnabled: false, which could allow the operator to add introspection/kube MCP alongside the declared mock servers.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
https://redhat.atlassian.net/browse/OLS-2895
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
