### PR TITLE
OLS-2460 fix uvicorn TLS profile handling

### DIFF
--- a/ols/runners/uvicorn.py
+++ b/ols/runners/uvicorn.py
@@ -4,7 +4,7 @@ import logging
 
 import uvicorn
 
-from ols.utils import ssl
+from ols.utils import ssl as ssl_utils
 from ols.utils.config import AppConfig
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ def start_uvicorn(config: AppConfig) -> None:
     )
     log_level = config.ols_config.logging_config.uvicorn_log_level
 
-    # The tls fields can be None, which means we will pass those values as None to uvicorn.run
+    # The tls fields can be None, which means we will pass those values through to Uvicorn.
     ssl_keyfile = config.ols_config.tls_config.tls_key_path
     ssl_certfile = config.ols_config.tls_config.tls_certificate_path
     ssl_keyfile_password = config.ols_config.tls_config.tls_key_password
@@ -34,10 +34,11 @@ def start_uvicorn(config: AppConfig) -> None:
     # when TLS security profile is not specified, default values will be used
     # that default values are based on default SSL package settings
     sec_profile = config.ols_config.tls_security_profile
-    ssl_version = ssl.get_ssl_version(sec_profile)
-    ssl_ciphers = ssl.get_ciphers(sec_profile)
+    ssl_version = ssl_utils.get_ssl_version(sec_profile)
+    min_tls_version = ssl_utils.get_min_tls_version(sec_profile)
+    ssl_ciphers = ssl_utils.get_ciphers(sec_profile)
 
-    uvicorn.run(
+    uvicorn_config = uvicorn.Config(
         "ols.app.main:app",
         host=host,
         port=port,
@@ -50,3 +51,9 @@ def start_uvicorn(config: AppConfig) -> None:
         ssl_ciphers=ssl_ciphers,
         access_log=log_level < logging.INFO,
     )
+    uvicorn_config.load()
+    if uvicorn_config.ssl is not None and min_tls_version is not None:
+        uvicorn_config.ssl.minimum_version = min_tls_version
+
+    server = uvicorn.Server(uvicorn_config)
+    server.run()

--- a/ols/utils/ssl.py
+++ b/ols/utils/ssl.py
@@ -1,4 +1,4 @@
-"""Utility function for retrieving SSL version and list of ciphers for TLS secutiry profile."""
+"""Utility function for retrieving SSL version and list of ciphers for TLS security profile."""
 
 import logging
 import ssl

--- a/ols/utils/ssl.py
+++ b/ols/utils/ssl.py
@@ -1,6 +1,7 @@
 """Utility function for retrieving SSL version and list of ciphers for TLS secutiry profile."""
 
 import logging
+import ssl
 from typing import Optional
 
 from ols import constants
@@ -10,23 +11,27 @@ from ols.utils import tls
 logger = logging.getLogger(__name__)
 
 
-def get_ssl_version(sec_profile: Optional[TLSSecurityProfile]) -> str:
-    """Get SSL version to be used. It can be configured in tls_security_profile section."""
-    # if security profile is not set, use default SSL version
-    # as specified in SSL library
-    if sec_profile is None or sec_profile.profile_type is None:
-        logger.info("Using default SSL version: %s", constants.DEFAULT_SSL_VERSION)
-        return constants.DEFAULT_SSL_VERSION
+def get_ssl_version(sec_profile: Optional[TLSSecurityProfile]) -> int:
+    """Get SSL protocol constant for TLS context creation."""
+    logger.info("Using SSL protocol version: %s", ssl.PROTOCOL_TLS_SERVER)
+    return ssl.PROTOCOL_TLS_SERVER
 
-    # security profile is set -> we need to retrieve SSL version and list of allowed ciphers
+
+def get_min_tls_version(
+    sec_profile: Optional[TLSSecurityProfile],
+) -> Optional[ssl.TLSVersion]:
+    """Get minimum TLS version to enforce on the SSL context."""
+    if sec_profile is None or sec_profile.profile_type is None:
+        return None
+
     min_tls_version = tls.min_tls_version(
         sec_profile.min_tls_version, sec_profile.profile_type
     )
     logger.info("min TLS version: %s", min_tls_version)
 
-    ssl_version = tls.ssl_tls_version(min_tls_version)
-    logger.info("Using SSL version: %s", ssl_version)
-    return ssl_version
+    resolved_min_tls_version = tls.ssl_tls_version(min_tls_version)
+    logger.info("Using minimum TLS version: %s", resolved_min_tls_version)
+    return resolved_min_tls_version
 
 
 def get_ciphers(sec_profile: Optional[TLSSecurityProfile]) -> str:

--- a/tests/integration/test_runners.py
+++ b/tests/integration/test_runners.py
@@ -1,7 +1,8 @@
 """Integration tests for runners."""
 
 import ssl
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -16,47 +17,84 @@ QUOTA_LIMITERS_CONFIG_FILE = (
 )
 
 
+def _run_start_uvicorn_and_assert(
+    *,
+    host: str,
+    port: int,
+    ssl_keyfile,
+    ssl_certfile,
+    ssl_keyfile_password,
+    ssl_ciphers: str,
+    min_tls_version,
+    access_log: bool,
+) -> None:
+    """Call start_uvicorn with mocked uvicorn internals and assert expectations."""
+    fake_uvicorn_config = SimpleNamespace(
+        ssl=SimpleNamespace(minimum_version=None),
+        loaded=False,
+    )
+    fake_uvicorn_config.load = Mock(
+        side_effect=lambda: setattr(fake_uvicorn_config, "loaded", True)
+    )
+    fake_server = SimpleNamespace(run=Mock())
+
+    with (
+        patch("ols.runners.uvicorn.uvicorn.Config") as mocked_config,
+        patch("ols.runners.uvicorn.uvicorn.Server") as mocked_server,
+    ):
+        mocked_config.return_value = fake_uvicorn_config
+        mocked_server.return_value = fake_server
+        start_uvicorn(config)
+
+        mocked_config.assert_called_once_with(
+            "ols.app.main:app",
+            host=host,
+            port=port,
+            workers=1,
+            log_level=30,
+            ssl_keyfile=ssl_keyfile,
+            ssl_certfile=ssl_certfile,
+            ssl_keyfile_password=ssl_keyfile_password,
+            ssl_version=ssl.PROTOCOL_TLS_SERVER,
+            ssl_ciphers=ssl_ciphers,
+            access_log=access_log,
+        )
+        assert fake_uvicorn_config.loaded is True
+        assert fake_uvicorn_config.ssl.minimum_version == min_tls_version
+        mocked_server.assert_called_once_with(fake_uvicorn_config)
+        fake_server.run.assert_called_once_with()
+
+
 def test_start_uvicorn_minimal_setup():
     """Test the function to start Uvicorn server."""
     config.reload_from_yaml_file(MINIMAL_CONFIG_FILE)
 
-    # don't start the real Uvicorn server
-    with patch("uvicorn.run") as mocked_runner:
-        start_uvicorn(config)
-        mocked_runner.assert_called_once_with(
-            "ols.app.main:app",
-            host="0.0.0.0",  # noqa: S104
-            port=8080,
-            workers=1,
-            log_level=30,
-            ssl_keyfile=None,
-            ssl_certfile=None,
-            ssl_keyfile_password=None,
-            ssl_version=ssl.PROTOCOL_TLS_SERVER,
-            ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
-            access_log=False,
-        )
+    _run_start_uvicorn_and_assert(
+        host="0.0.0.0",  # noqa: S104
+        port=8080,
+        ssl_keyfile=None,
+        ssl_certfile=None,
+        ssl_keyfile_password=None,
+        ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
+        min_tls_version=None,
+        access_log=False,
+    )
 
 
 def test_start_uvicorn_full_setup():
     """Test the function to start Uvicorn server."""
     config.reload_from_yaml_file(CORRECT_CONFIG_FILE)
-    # don't start the real Uvicorn server
-    with patch("uvicorn.run") as mocked_runner:
-        start_uvicorn(config)
-        mocked_runner.assert_called_once_with(
-            "ols.app.main:app",
-            host="0.0.0.0",  # noqa: S104
-            port=8080,
-            workers=1,
-            log_level=30,
-            ssl_keyfile="tests/config/key",
-            ssl_certfile="tests/config/empty_cert.crt",
-            ssl_keyfile_password="* this is password *",  # noqa: S106
-            ssl_version=ssl.TLSVersion.TLSv1_3,
-            ssl_ciphers="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",  # noqa: E501
-            access_log=False,
-        )
+
+    _run_start_uvicorn_and_assert(
+        host="0.0.0.0",  # noqa: S104
+        port=8080,
+        ssl_keyfile="tests/config/key",
+        ssl_certfile="tests/config/empty_cert.crt",
+        ssl_keyfile_password="* this is password *",  # noqa: S106
+        ssl_ciphers="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",  # noqa: E501
+        min_tls_version=ssl.TLSVersion.TLSv1_3,
+        access_log=False,
+    )
 
 
 @pytest.mark.filterwarnings("ignore")

--- a/tests/integration/test_runners.py
+++ b/tests/integration/test_runners.py
@@ -91,7 +91,7 @@ def test_start_uvicorn_full_setup():
         ssl_keyfile="tests/config/key",
         ssl_certfile="tests/config/empty_cert.crt",
         ssl_keyfile_password="* this is password *",  # noqa: S106
-        ssl_ciphers="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",  # noqa: E501
+        ssl_ciphers="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
         min_tls_version=ssl.TLSVersion.TLSv1_3,
         access_log=False,
     )

--- a/tests/unit/runners/test_uvicorn_runner.py
+++ b/tests/unit/runners/test_uvicorn_runner.py
@@ -56,9 +56,10 @@ def _assert_start_uvicorn(
     )
     fake_server = SimpleNamespace(run=Mock())
 
-    with patch("ols.runners.uvicorn.uvicorn.Config") as mocked_config, patch(
-        "ols.runners.uvicorn.uvicorn.Server"
-    ) as mocked_server:
+    with (
+        patch("ols.runners.uvicorn.uvicorn.Config") as mocked_config,
+        patch("ols.runners.uvicorn.uvicorn.Server") as mocked_server,
+    ):
         mocked_config.return_value = fake_uvicorn_config
         mocked_server.return_value = fake_server
         start_uvicorn(config)
@@ -86,7 +87,7 @@ def test_start_uvicorn(default_config):
     """Test the function to start Uvicorn server."""
     _assert_start_uvicorn(
         default_config,
-        host="0.0.0.0",
+        host="0.0.0.0",  # noqa: S104
         port=8080,
         min_tls_version=None,
         ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
@@ -98,7 +99,7 @@ def test_start_uvicorn_with_tls(default_config):
     default_config.dev_config.disable_tls = False
     _assert_start_uvicorn(
         default_config,
-        host="0.0.0.0",
+        host="0.0.0.0",  # noqa: S104
         port=8443,
         min_tls_version=None,
         ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
@@ -122,7 +123,7 @@ def test_start_uvicorn_on_non_default_port(default_config):
     default_config.dev_config.uvicorn_port_number = 8081
     _assert_start_uvicorn(
         default_config,
-        host="0.0.0.0",
+        host="0.0.0.0",  # noqa: S104
         port=8081,
         min_tls_version=None,
         ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
@@ -136,7 +137,9 @@ def test_start_uvicorn_on_non_default_port(default_config):
         ("ModernType", stdlib_ssl.TLSVersion.TLSv1_3),
     ],
 )
-def test_start_uvicorn_applies_min_tls_version(default_config, profile_type, min_tls_version):
+def test_start_uvicorn_applies_min_tls_version(
+    default_config, profile_type, min_tls_version
+):
     """Test the function to start Uvicorn server with a TLS security profile."""
     default_config.dev_config.disable_tls = False
     default_config.ols_config.tls_security_profile = TLSSecurityProfile(
@@ -144,7 +147,7 @@ def test_start_uvicorn_applies_min_tls_version(default_config, profile_type, min
     )
     _assert_start_uvicorn(
         default_config,
-        host="0.0.0.0",
+        host="0.0.0.0",  # noqa: S104
         port=8443,
         min_tls_version=min_tls_version,
         ssl_ciphers=tls.ciphers_for_tls_profile(profile_type),

--- a/tests/unit/runners/test_uvicorn_runner.py
+++ b/tests/unit/runners/test_uvicorn_runner.py
@@ -1,12 +1,15 @@
 """Unit tests for runners."""
 
-from unittest.mock import patch
+import ssl as stdlib_ssl
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
 
 from ols import constants
-from ols.app.models.config import Config
+from ols.app.models.config import Config, TLSSecurityProfile
 from ols.runners.uvicorn import start_uvicorn
+from ols.utils import tls
 
 
 @pytest.fixture
@@ -35,84 +38,114 @@ def default_config():
     )
 
 
-def test_start_uvicorn(default_config):
-    """Test the function to start Uvicorn server."""
-    # don't start real Uvicorn server
-    with patch("uvicorn.run") as mocked_run:
-        start_uvicorn(default_config)
-        mocked_run.assert_called_once_with(
+def _assert_start_uvicorn(
+    config: Config,
+    *,
+    host: str,
+    port: int,
+    min_tls_version,
+    ssl_ciphers,
+) -> None:
+    """Assert the Uvicorn runner configures and starts the server."""
+    fake_uvicorn_config = SimpleNamespace(
+        ssl=SimpleNamespace(minimum_version=None),
+        loaded=False,
+    )
+    fake_uvicorn_config.load = Mock(
+        side_effect=lambda: setattr(fake_uvicorn_config, "loaded", True)
+    )
+    fake_server = SimpleNamespace(run=Mock())
+
+    with patch("ols.runners.uvicorn.uvicorn.Config") as mocked_config, patch(
+        "ols.runners.uvicorn.uvicorn.Server"
+    ) as mocked_server:
+        mocked_config.return_value = fake_uvicorn_config
+        mocked_server.return_value = fake_server
+        start_uvicorn(config)
+
+        mocked_config.assert_called_once_with(
             "ols.app.main:app",
-            host="0.0.0.0",  # noqa: S104
-            port=8080,
+            host=host,
+            port=port,
             workers=1,
             log_level=30,
             ssl_keyfile=None,
             ssl_certfile=None,
             ssl_keyfile_password=None,
-            ssl_version=17,
-            ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
+            ssl_version=constants.DEFAULT_SSL_VERSION,
+            ssl_ciphers=ssl_ciphers,
             access_log=False,
         )
+        assert fake_uvicorn_config.loaded is True
+        assert fake_uvicorn_config.ssl.minimum_version == min_tls_version
+        mocked_server.assert_called_once_with(fake_uvicorn_config)
+        fake_server.run.assert_called_once_with()
+
+
+def test_start_uvicorn(default_config):
+    """Test the function to start Uvicorn server."""
+    _assert_start_uvicorn(
+        default_config,
+        host="0.0.0.0",
+        port=8080,
+        min_tls_version=None,
+        ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
+    )
 
 
 def test_start_uvicorn_with_tls(default_config):
-    """Test the function to start Uvicorn server."""
+    """Test the function to start Uvicorn server with TLS enabled."""
     default_config.dev_config.disable_tls = False
-    # don't start real Uvicorn server
-    with patch("uvicorn.run") as mocked_run:
-        start_uvicorn(default_config)
-        mocked_run.assert_called_once_with(
-            "ols.app.main:app",
-            host="0.0.0.0",  # noqa: S104
-            port=8443,
-            workers=1,
-            log_level=30,
-            ssl_keyfile=None,
-            ssl_certfile=None,
-            ssl_keyfile_password=None,
-            ssl_version=17,
-            ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
-            access_log=False,
-        )
+    _assert_start_uvicorn(
+        default_config,
+        host="0.0.0.0",
+        port=8443,
+        min_tls_version=None,
+        ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
+    )
 
 
 def test_start_uvicorn_on_localhost(default_config):
     """Test the function to start Uvicorn server."""
     default_config.dev_config.run_on_localhost = True
-    # don't start real Uvicorn server
-    with patch("uvicorn.run") as mocked_run:
-        start_uvicorn(default_config)
-        mocked_run.assert_called_once_with(
-            "ols.app.main:app",
-            host="localhost",
-            port=8080,
-            workers=1,
-            log_level=30,
-            ssl_keyfile=None,
-            ssl_certfile=None,
-            ssl_keyfile_password=None,
-            ssl_version=17,
-            ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
-            access_log=False,
-        )
+    _assert_start_uvicorn(
+        default_config,
+        host="localhost",
+        port=8080,
+        min_tls_version=None,
+        ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
+    )
 
 
 def test_start_uvicorn_on_non_default_port(default_config):
     """Test the function to start Uvicorn server on a non-default port."""
     default_config.dev_config.uvicorn_port_number = 8081
-    # don't start real Uvicorn server
-    with patch("uvicorn.run") as mocked_run:
-        start_uvicorn(default_config)
-        mocked_run.assert_called_once_with(
-            "ols.app.main:app",
-            host="0.0.0.0",  # noqa: S104
-            port=8081,
-            workers=1,
-            log_level=30,
-            ssl_keyfile=None,
-            ssl_certfile=None,
-            ssl_keyfile_password=None,
-            ssl_version=17,
-            ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
-            access_log=False,
-        )
+    _assert_start_uvicorn(
+        default_config,
+        host="0.0.0.0",
+        port=8081,
+        min_tls_version=None,
+        ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
+    )
+
+
+@pytest.mark.parametrize(
+    "profile_type,min_tls_version",
+    [
+        ("IntermediateType", stdlib_ssl.TLSVersion.TLSv1_2),
+        ("ModernType", stdlib_ssl.TLSVersion.TLSv1_3),
+    ],
+)
+def test_start_uvicorn_applies_min_tls_version(default_config, profile_type, min_tls_version):
+    """Test the function to start Uvicorn server with a TLS security profile."""
+    default_config.dev_config.disable_tls = False
+    default_config.ols_config.tls_security_profile = TLSSecurityProfile(
+        {"type": profile_type}
+    )
+    _assert_start_uvicorn(
+        default_config,
+        host="0.0.0.0",
+        port=8443,
+        min_tls_version=min_tls_version,
+        ssl_ciphers=tls.ciphers_for_tls_profile(profile_type),
+    )

--- a/tests/unit/utils/test_pyroscope.py
+++ b/tests/unit/utils/test_pyroscope.py
@@ -38,7 +38,8 @@ def test_pyroscope_server_reachable(mock_config, mock_logger):
     """Test that Pyroscope starts when the server is reachable."""
     with (
         patch("ols.utils.pyroscope.requests.get") as mock_get,
-        patch("ols.runners.uvicorn.uvicorn.run") as mock_run,
+        patch("ols.runners.uvicorn.uvicorn.Config") as mock_uvicorn_config_cls,
+        patch("ols.runners.uvicorn.uvicorn.Server") as mock_uvicorn_server_cls,
         patch("ols.utils.pyroscope.threading.Thread") as mock_thread,
         patch.dict("sys.modules", {"pyroscope": MagicMock()}) as mock_pyroscope_module,
     ):
@@ -53,7 +54,8 @@ def test_pyroscope_server_reachable(mock_config, mock_logger):
             "Pyroscope server is reachable at %s", mock_config.dev_config.pyroscope_url
         )
         mock_pyroscope.configure.assert_called_once()
-        mock_run.assert_called_once()
+        mock_uvicorn_config_cls.assert_called_once()
+        mock_uvicorn_server_cls.return_value.run.assert_called_once_with()
         mock_thread.assert_called_once_with(target=mock_config.rag_index)
 
 

--- a/tests/unit/utils/test_ssl.py
+++ b/tests/unit/utils/test_ssl.py
@@ -1,51 +1,57 @@
 """Unit tests for TLS security profiles manipulation."""
 
+import ssl as stdlib_ssl
+
 import pytest
 
 from ols import constants
 from ols.app.models.config import TLSSecurityProfile
-from ols.utils import ssl, tls
+from ols.utils import ssl as ssl_utils, tls
 
 
-def test_get_ssl_version_no_security_profile():
-    """Check the function to get SSL version when security profile is not provided."""
-    assert ssl.get_ssl_version(None) == constants.DEFAULT_SSL_VERSION
+def test_get_ssl_version_returns_protocol_constant():
+    """Check the function to get SSL version."""
+    assert ssl_utils.get_ssl_version(None) == constants.DEFAULT_SSL_VERSION
 
 
-def test_get_ssl_version_no_security_profile_type():
-    """Check the function to get SSL version when security profile type is not provided."""
+def test_get_min_tls_version_no_security_profile():
+    """Check the function to get minimum TLS version when profile is absent."""
+    assert ssl_utils.get_min_tls_version(None) is None
+
+
+def test_get_min_tls_version_no_security_profile_type():
+    """Check the function to get minimum TLS version when profile type is absent."""
     security_profile = TLSSecurityProfile()
     security_profile.profile_type = None
-    assert ssl.get_ssl_version(security_profile) == constants.DEFAULT_SSL_VERSION
+    assert ssl_utils.get_min_tls_version(security_profile) is None
 
 
 tls_profile_to_min_version = (
-    ("OldType", "VersionTLS10"),
-    ("IntermediateType", "VersionTLS12"),
-    ("ModernType", "VersionTLS13"),
+    ("OldType", stdlib_ssl.TLSVersion.TLSv1),
+    ("IntermediateType", stdlib_ssl.TLSVersion.TLSv1_2),
+    ("ModernType", stdlib_ssl.TLSVersion.TLSv1_3),
 )
 
 
 @pytest.mark.parametrize("tls_profile_to_min_version", tls_profile_to_min_version)
-def test_get_ssl_version_with_proper_security_profile(tls_profile_to_min_version):
-    """Check the function to get SSL version when security profile type is provided."""
+def test_get_min_tls_version_with_proper_security_profile(tls_profile_to_min_version):
+    """Check the function to get minimum TLS version for each security profile."""
     security_profile = TLSSecurityProfile()
     security_profile.profile_type = tls_profile_to_min_version[0]
-    ssl_version = ssl.get_ssl_version(security_profile)
-    assert ssl_version is not None
-    assert ssl_version == tls.ssl_tls_version(tls_profile_to_min_version[1])
+    ssl_version = ssl_utils.get_min_tls_version(security_profile)
+    assert ssl_version == tls_profile_to_min_version[1]
 
 
 def test_get_ciphers_no_security_profile():
     """Check the function to get SSL ciphers when security profile is not provided."""
-    assert ssl.get_ciphers(None) == constants.DEFAULT_SSL_CIPHERS
+    assert ssl_utils.get_ciphers(None) == constants.DEFAULT_SSL_CIPHERS
 
 
 def test_get_ciphers_no_security_profile_type():
     """Check the function to get SSL ciphers when security profile type is not provided."""
     security_profile = TLSSecurityProfile()
     security_profile.profile_type = None
-    assert ssl.get_ciphers(security_profile) == constants.DEFAULT_SSL_CIPHERS
+    assert ssl_utils.get_ciphers(security_profile) == constants.DEFAULT_SSL_CIPHERS
 
 
 tls_profile_names = (
@@ -61,6 +67,6 @@ def test_get_ciphers_with_proper_security_profile(tls_profile_name):
     security_profile = TLSSecurityProfile()
     security_profile.profile_type = tls_profile_name
     security_profile.ciphers = None
-    allowed_ciphers = ssl.get_ciphers(security_profile)
+    allowed_ciphers = ssl_utils.get_ciphers(security_profile)
     assert allowed_ciphers is not None
     assert allowed_ciphers == tls.ciphers_for_tls_profile(tls_profile_name)

--- a/tests/unit/utils/test_ssl.py
+++ b/tests/unit/utils/test_ssl.py
@@ -6,7 +6,8 @@ import pytest
 
 from ols import constants
 from ols.app.models.config import TLSSecurityProfile
-from ols.utils import ssl as ssl_utils, tls
+from ols.utils import ssl as ssl_utils
+from ols.utils import tls
 
 
 def test_get_ssl_version_returns_protocol_constant():


### PR DESCRIPTION
## Description

Fix a startup crash in the OLS service when `tlsSecurityProfile` is set in the generated `olsconfig.yaml`.

### Problem

The operator PR [openshift/lightspeed-operator#1430](https://github.com/openshift/lightspeed-operator/pull/1430) wires the TLS security profile from the CR into the generated `olsconfig.yaml`. This is the first time the `tlsSecurityProfile` field is actually populated at the `ols_config` level, which activated a code path in the service that had never been exercised.

The uvicorn runner received an `ssl.TLSVersion` enum value (e.g. `TLSv1_2 = 771`) from the TLS profile resolution code and passed it as `ssl_version=771` to `uvicorn.run()`. Uvicorn feeds that directly into `ssl.SSLContext(771)`, which only accepts `ssl.PROTOCOL_*` constants (e.g. `ssl.PROTOCOL_TLS_SERVER = 17`), not raw TLS version numbers.

Result: `ValueError: invalid or unsupported protocol version 771` → the service CrashLoops and the operator e2e CI (`bundle-e2e-4-21`) fails on every run.

The operator sends correct data — the bug was in how the service consumed it.

### Fix

Separate two concerns that were conflated in `get_ssl_version()`:

1. **Protocol constant** for `ssl.SSLContext()` construction — always `ssl.PROTOCOL_TLS_SERVER`
2. **Minimum TLS version** to enforce — set via `context.minimum_version` after the context is created

The runner now uses `uvicorn.Config` + `uvicorn.Server` instead of `uvicorn.run()` so it can call `config.load()`, set `config.ssl.minimum_version` from the resolved profile, and then `server.run()`. Uvicorn guards against double-load (`assert not self.loaded` / `if not config.loaded`), so pre-loading is safe.

The provider-level TLS code (`ols/src/llms/providers/provider.py`) already handles this correctly — builds `ssl.create_default_context()` and sets `context.minimum_version`. This PR aligns the uvicorn runner with the same pattern.

Unblocks https://github.com/openshift/lightspeed-operator/pull/1430

## Type of change

- Bug fix

## Related Tickets & Documents

- Related Issue #[OLS-2460](https://redhat.atlassian.net/browse/OLS-2460)
- Closes #[OLS-2460](https://redhat.atlassian.net/browse/OLS-2460)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- `uv run pytest tests/unit/utils/test_ssl.py tests/unit/runners/test_uvicorn_runner.py`
- Result: 17 passed

Made with Cursor