### PR TITLE
e2e: extend wait for app-server pod after install

### DIFF
--- a/tests/e2e/utils/ols_installer.py
+++ b/tests/e2e/utils/ols_installer.py
@@ -15,6 +15,10 @@ from tests.e2e.utils.wait_for_ols import wait_for_ols
 OC_COMMAND_RETRY_COUNT = 120
 OC_COMMAND_RETRY_DELAY = 5
 
+# After the app-server Deployment exists, the Running pod can lag (pulls, scheduling).
+OLS_APP_SERVER_POD_RETRY_COUNT = 90
+OLS_APP_SERVER_POD_RETRY_DELAY = 10
+
 disconnected = os.getenv("DISCONNECTED", "")
 
 
@@ -453,9 +457,10 @@ def install_ols() -> tuple[str, str, str]:  # pylint: disable=R0915, R0912  # no
     # Ensure ols pod exists so it gets deleted during the scale down to zero, otherwise
     # there may be a race condition.
     retry_until_timeout_or_success(
-        OC_COMMAND_RETRY_COUNT,
-        OC_COMMAND_RETRY_DELAY,
+        OLS_APP_SERVER_POD_RETRY_COUNT,
+        OLS_APP_SERVER_POD_RETRY_DELAY,
         lambda: cluster_utils.get_pod_by_prefix(fail_not_found=False),
+        "Waiting for OLS app server pod (running)",
     )
 
     # get the name of the OLS image from CI so we can substitute it in


### PR DESCRIPTION

## Description

After install_ols() creates the lightspeed-app-server Deployment, the code waits for a Running pod before scaling the operator and app server down/up. That wait reused OC_COMMAND_RETRY_COUNT / OC_COMMAND_RETRY_DELAY (120 × 5s), which matches other install steps but can be tight when the image pull or scheduling is slow.

This change introduces dedicated OLS_APP_SERVER_POD_RETRY_COUNT / OLS_APP_SERVER_POD_RETRY_DELAY (90 × 10s), keeping roughly the same maximum wait (~15 minutes) while halving how often retry_until_timeout_or_success logs. A description string is passed so CI logs explicitly show “Waiting for OLS app server pod (running)”.

No change to other OC_COMMAND_RETRY_* call sites.



## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
