### PR TITLE
Improve MCP E2E observability for Konflux debugging

### DIFF
--- a/tests/config/operator_install/olsconfig.crd.openai_mcp.yaml
+++ b/tests/config/operator_install/olsconfig.crd.openai_mcp.yaml
@@ -32,8 +32,8 @@ spec:
       approvalType: tool_annotations
       approvalTimeout: 5
     toolFilteringConfig:
-      alpha: 0.5
-      topK: 5
+      alpha: 0.8
+      topK: 10
       threshold: 0.01
   mcpServers:
     - name: mock-file-auth

--- a/tests/e2e/test_mcp.py
+++ b/tests/e2e/test_mcp.py
@@ -10,14 +10,34 @@ Locally: start the mock server manually (python tests/e2e/mcp/server/server.py 3
 # pyright: reportAttributeAccessIssue=false
 
 import json
+import os
 import threading
 from typing import Optional
 
 import pytest
 
 from tests.e2e.utils.constants import LLM_REST_API_TIMEOUT
+from tests.e2e.utils.mcp_setup import log_effective_mcp_debug_info
 
 pytestmark = pytest.mark.mcp
+
+
+def _ols_base_url() -> str:
+    return str(getattr(pytest, "ols_url", os.getenv("OLS_URL", ""))).lower()
+
+
+def _running_against_remote_ols() -> bool:
+    u = _ols_base_url()
+    return bool(u) and "localhost" not in u and "127.0.0.1" not in u
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _log_cluster_mcp_effective_config() -> None:
+    """Log effective ``mcp_servers`` from the ``olsconfig`` ConfigMap (remote OLS only)."""
+    if not _running_against_remote_ols():
+        return
+    log_effective_mcp_debug_info()
+
 
 CLIENT_HEADERS = {"mock-client-auth": {"Authorization": "Bearer my-client-token-456"}}
 

--- a/tests/e2e/utils/mcp_setup.py
+++ b/tests/e2e/utils/mcp_setup.py
@@ -8,6 +8,9 @@ The OLS configmap is NOT patched here -- MCP config lives in the OLSConfig CR
 
 from pathlib import Path
 
+import yaml
+
+from ols.constants import DEFAULT_CONFIGURATION_FILE
 from tests.e2e.utils import cluster as cluster_utils
 from tests.e2e.utils.retry import retry_until_timeout_or_success
 
@@ -93,6 +96,77 @@ def setup_mcp_on_cluster() -> None:
     _create_token_secret()
     _deploy_mock_server()
     print("MCP pre-setup complete (secret + mock server)")
+
+
+def log_effective_mcp_debug_info() -> None:
+    """Print MCP-related effective config from the cluster (best-effort).
+
+    Logs ``spec.ols.introspectionEnabled`` from the OLSConfig CR and each entry in
+    ``mcp_servers`` from the ``olsconfig`` ConfigMap (embedded ``olsconfig.yaml``).
+    Intended for CI logs when debugging wrong tool selection (e.g. ``pods_log`` on
+    ``openshift`` vs mock ``openshift_pod_logs``). Skips quietly when ``oc`` or
+    resources are unavailable (e.g. local pytest against localhost).
+    """
+    print("\n--- MCP e2e debug: cluster MCP configuration (best-effort) ---")
+    try:
+        out = cluster_utils.run_oc(
+            [
+                "get",
+                "olsconfig",
+                "cluster",
+                "-o",
+                "jsonpath={.spec.ols.introspectionEnabled}",
+            ]
+        ).stdout.strip()
+        print(f"OLSConfig spec.ols.introspectionEnabled: {out!r}")
+    except Exception as e:
+        print(f"Could not read OLSConfig introspectionEnabled: {e}")
+
+    try:
+        raw = cluster_utils.run_oc(
+            [
+                "get",
+                "cm",
+                "olsconfig",
+                "-n",
+                NAMESPACE,
+                "-o",
+                "yaml",
+            ]
+        ).stdout
+        cm = yaml.safe_load(raw)
+        data = cm.get("data") or {}
+        if DEFAULT_CONFIGURATION_FILE not in data:
+            print(
+                "ConfigMap olsconfig: missing embedded file "
+                f"{DEFAULT_CONFIGURATION_FILE!r}; data keys={list(data)}"
+            )
+            print("--- end MCP e2e debug ---\n")
+            return
+        cfg = yaml.safe_load(data[DEFAULT_CONFIGURATION_FILE])
+        servers = cfg.get("mcp_servers") or []
+        print(
+            f"ConfigMap olsconfig data[{DEFAULT_CONFIGURATION_FILE!r}]: "
+            f"{len(servers)} mcp_server(s)"
+        )
+        for i, s in enumerate(servers):
+            if not isinstance(s, dict):
+                print(f"  [{i}] (non-dict entry): {s!r}")
+                continue
+            name = s.get("name", "?")
+            url = s.get("url", "")
+            print(f"  [{i}] name={name!r} url={url!r}")
+        names = [s.get("name") for s in servers if isinstance(s, dict)]
+        if "openshift" in names:
+            print(
+                "WARNING: built-in server name 'openshift' is present in mcp_servers. "
+                "The model may call pods_log against the real cluster. For mock-only "
+                "MCP e2e, set spec.ols.introspectionEnabled: false on OLSConfig so the "
+                "operator does not inject the OpenShift MCP server."
+            )
+    except Exception as e:
+        print(f"Could not read ConfigMap olsconfig / mcp_servers: {e}")
+    print("--- end MCP e2e debug ---\n")
 
 
 def teardown_mcp_on_cluster() -> None:


### PR DESCRIPTION
## Description

Description:

This change makes MCP end-to-end runs easier to debug on real clusters and adjusts the operator-install OLSConfig used for OpenAI MCP tests.

What changed

tests/e2e/utils/mcp_setup.py: Added log_effective_mcp_debug_info(), which (best effort) prints spec.ols.introspectionEnabled from the OLSConfig CR and lists mcp_servers entries (name and URL) from the olsconfig ConfigMap’s embedded olsconfig.yaml. If a server named openshift is present, it logs a warning that the model may call real-cluster tools and suggests disabling introspection for mock-only MCP scenarios.
tests/e2e/test_mcp.py: Module-scoped autouse fixture runs that logging only when pytest.ols_url / OLS_URL is set and does not look like localhost or 127.0.0.1, so local runs against a local OLS instance are not spammed with oc calls.
tests/config/operator_install/olsconfig.crd.openai_mcp.yaml: toolFilteringConfig updates: alpha 0.5 → 0.8, topK 5 → 10 (tighter relevance / broader candidate set for tool selection in MCP tests).
Why

Cluster MCP failures (e.g. wrong tool such as real pods_log vs mock tools) are hard to infer from pytest output alone. Dumping effective operator-rendered MCP configuration to CI logs speeds triage. The CRD tweak aligns install-test config with desired filtering behavior for MCP E2E; adjust the numbers here if product defaults differ.

How to verify

Run MCP-marked E2E against a remote OLS instance and confirm the new “MCP e2e debug” block appears in logs when the base URL is not local.
Run the same suite against localhost and confirm that block is skipped.
Confirm operator-install / MCP job that consumes olsconfig.crd.openai_mcp.yaml still passes.


## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
