### PR TITLE
Azure Entra secret for multi-provider PROVIDER

### DIFF
--- a/tests/e2e/utils/ols_installer.py
+++ b/tests/e2e/utils/ols_installer.py
@@ -222,16 +222,29 @@ def replace_ols_image(ols_image: str) -> None:
     )
 
 
+_AZURE_ENTRA_ENV_KEYS: tuple[str, ...] = (
+    "AZUREOPENAI_ENTRA_ID_TENANT_ID",
+    "AZUREOPENAI_ENTRA_ID_CLIENT_ID",
+    "AZUREOPENAI_ENTRA_ID_CLIENT_SECRET",
+)
+
+
 def ensure_azure_entra_id_secret() -> None:
-    """Create openshift-lightspeed/azure-entra-id when using Azure OpenAI with Entra ID."""
-    try:
-        tenant_id = os.environ["AZUREOPENAI_ENTRA_ID_TENANT_ID"]
-        client_id = os.environ["AZUREOPENAI_ENTRA_ID_CLIENT_ID"]
-        client_secret = os.environ["AZUREOPENAI_ENTRA_ID_CLIENT_SECRET"]
-    except KeyError as e:
-        raise RuntimeError(
-            f"Missing required Azure Entra environment variable: {e.args[0]}"
-        ) from e
+    """Create openshift-lightspeed/azure-entra-id when Entra credentials are available."""
+    values = {k: os.getenv(k) for k in _AZURE_ENTRA_ENV_KEYS}
+    missing = [k for k in _AZURE_ENTRA_ENV_KEYS if not values[k]]
+    if missing:
+        print(
+            "Skipping azure-entra-id secret creation (unset or empty): "
+            f"{', '.join(missing)}. "
+            "Azure OpenAI via Entra will not work until these CI/Vault/Prow env vars "
+            "are set."
+        )
+        return
+
+    tenant_id = values["AZUREOPENAI_ENTRA_ID_TENANT_ID"]
+    client_id = values["AZUREOPENAI_ENTRA_ID_CLIENT_ID"]
+    client_secret = values["AZUREOPENAI_ENTRA_ID_CLIENT_SECRET"]
 
     print("Ensuring azure-entra-id secret exists...")
     cluster_utils.run_oc(
@@ -249,9 +262,10 @@ def ensure_azure_entra_id_secret() -> None:
 
 
 def create_secrets(provider_name: str, creds: str, provider_size: int) -> None:
-    """Create Kubernetes secrets needed for an LLM provider (API creds plus extras).
+    """Create Kubernetes secrets needed for an LLM provider (API creds).
 
-    For ``azure_openai``, also ensures the ``azure-entra-id`` secret exists.
+    Azure Entra ID secret ``azure-entra-id`` is ensured separately when the provider
+    list includes ``azure_openai`` (see ``install_ols`` and ``adapt_ols_config``).
 
     Args:
         provider_name (str): the name of the provider.
@@ -304,9 +318,6 @@ def create_secrets(provider_name: str, creds: str, provider_size: int) -> None:
             ],
             ignore_existing_resource=True,
         )
-
-    if provider_name == "azure_openai":
-        ensure_azure_entra_id_secret()
 
 
 def install_ols() -> tuple[str, str, str]:  # pylint: disable=R0915, R0912  # noqa: C901
@@ -400,6 +411,9 @@ def install_ols() -> tuple[str, str, str]:  # pylint: disable=R0915, R0912  # no
     creds_list = creds.split()
     for i, prov in enumerate(provider_list):
         create_secrets(prov, creds_list[i], len(provider_list))
+
+    if "azure_openai" in provider_list:
+        ensure_azure_entra_id_secret()
 
     # create the olsconfig operand
     try:


### PR DESCRIPTION
## Description

This updates OpenShift Lightspeed e2e harness behavior around the azure-entra-id secret used for Azure OpenAI with Entra ID.

Previously, install_ols() only created that secret when PROVIDER equaled the single token azure_openai. For evaluation-style PROVIDER values with multiple space-separated providers (for example openai azure_openai watsonx), the Entra secret was never created, so CI never needed AZUREOPENAI_ENTRA_ID_* environment variables during install.

After ensuring the secret whenever azure_openai appears in the parsed provider list, ols-evaluation and similar jobs began failing at install time because those variables are not wired in Prow for that lane.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
