### PR TITLE
Prefix error messages with source to distinguish LLM backend and network errors

### DIFF
--- a/ols/utils/errors_parsing.py
+++ b/ols/utils/errors_parsing.py
@@ -3,9 +3,10 @@
 import json
 import logging
 
+import httpx
 from fastapi import status
 from ibm_watsonx_ai.wml_client_error import ApiRequestFailure
-from openai import BadRequestError
+from openai import APIConnectionError, APITimeoutError, BadRequestError
 
 from ols import config
 
@@ -15,18 +16,27 @@ logger = logging.getLogger(__name__)
 DEFAULT_ERROR_MESSAGE = "An error occurred during LLM invocation. Please contact your OpenShift Lightspeed administrator."  # noqa: E501
 DEFAULT_STATUS_CODE = status.HTTP_500_INTERNAL_SERVER_ERROR
 
-PROMPT_TOO_LONG_WITH_TOOLS_ERROR_MSG = (
-    "The request exceeds the allowed token limit, possibly due to tool "
-    "usage or misconfigured context window or maximum response tokens "
-    "settings. Please refine your prompt to be more specific, or verify "
-    "that the token-related configuration parameters are correctly set."
+_NETWORK_PREFIX = "[Network]"
+_LLM_BACKEND_PREFIX = "[LLM Backend]"
+
+NETWORK_ERROR_MSG = (
+    "Unable to reach the LLM backend. "
+    "Please verify network connectivity and provider URL configuration."
 )
 
-# The msg is user facing - note the config fields from OLS CRD
+PROMPT_TOO_LONG_WITH_TOOLS_ERROR_MSG = (
+    "The request exceeds the model's token limit, possibly due to tool "
+    "usage. This usually means the configured context_window_size is larger "
+    "than what the model actually supports. Please verify that "
+    "context_window_size matches the model's real context window, or "
+    "refine your prompt to be more specific."
+)
+
 PROMPT_TOO_LONG_ERROR_MSG = (
-    "The prompt exceeds the maximum token limit. Please shorten your "
-    "input or adjust the context window and maximum response tokens "
-    "settings in the configuration to allow for larger prompts."
+    "The prompt exceeds the model's token limit. This usually means "
+    "the configured context_window_size is larger than what the model "
+    "actually supports. Please verify that context_window_size in the "
+    "model configuration matches the model's real context window."
 )
 
 
@@ -57,25 +67,42 @@ def parse_watsonx_error(e: ApiRequestFailure) -> tuple[int, str, str]:
             raise ValueError
         response_text = errors[0]["message"]
     except (json.JSONDecodeError, KeyError, ValueError):
-        # fallback to response reason if message is not found
         response_text = e.response.reason
     return status_code, response_text, e.error_msg
 
 
 def parse_generic_llm_error(e: Exception) -> tuple[int, str, str]:
-    """Try to parse generic LLM error."""
+    """Parse LLM error and prefix the response with error source."""
     logger.error(
         "LLM error received: type=%s, message=%s",
         type(e).__name__,
         str(e)[:500],
     )
     match e:
+        case APIConnectionError() | APITimeoutError():
+            return (
+                status.HTTP_502_BAD_GATEWAY,
+                f"{_NETWORK_PREFIX} {NETWORK_ERROR_MSG}",
+                str(e),
+            )
+        case httpx.ConnectError() | httpx.ConnectTimeout():
+            return (
+                status.HTTP_502_BAD_GATEWAY,
+                f"{_NETWORK_PREFIX} {NETWORK_ERROR_MSG}",
+                str(e),
+            )
         case BadRequestError():
-            return parse_openai_error(e)
+            sc, resp, cause = parse_openai_error(e)
+            return sc, f"{_LLM_BACKEND_PREFIX} {resp}", cause
         case ApiRequestFailure():
-            return parse_watsonx_error(e)
+            sc, resp, cause = parse_watsonx_error(e)
+            return sc, f"{_LLM_BACKEND_PREFIX} {resp}", cause
         case _:
-            return DEFAULT_STATUS_CODE, DEFAULT_ERROR_MESSAGE, str(e)
+            return (
+                DEFAULT_STATUS_CODE,
+                f"{_LLM_BACKEND_PREFIX} {DEFAULT_ERROR_MESSAGE}",
+                str(e),
+            )
 
 
 def handle_known_errors(response: str, cause: str) -> tuple[str, str]:
@@ -88,9 +115,10 @@ def handle_known_errors(response: str, cause: str) -> tuple[str, str]:
         ]
     ):
         if config.mcp_servers.servers:
-            # tool calls are too long
-            return PROMPT_TOO_LONG_WITH_TOOLS_ERROR_MSG, cause
-        # models with context smaller than our default
-        return PROMPT_TOO_LONG_ERROR_MSG, cause
+            return (
+                f"{_LLM_BACKEND_PREFIX} {PROMPT_TOO_LONG_WITH_TOOLS_ERROR_MSG}",
+                cause,
+            )
+        return f"{_LLM_BACKEND_PREFIX} {PROMPT_TOO_LONG_ERROR_MSG}", cause
 
     return response, cause

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -20,7 +20,11 @@ from ols.app.models.config import (
     QueryFilter,
 )
 from ols.utils import suid
-from ols.utils.errors_parsing import DEFAULT_ERROR_MESSAGE, DEFAULT_STATUS_CODE
+from ols.utils.errors_parsing import (
+    _LLM_BACKEND_PREFIX,
+    DEFAULT_ERROR_MESSAGE,
+    DEFAULT_STATUS_CODE,
+)
 from ols.utils.logging_configurator import configure_logging
 from ols.utils.token_handler import PromptTooLongError
 from tests.mock_classes.mock_langchain_interface import mock_langchain_interface
@@ -104,7 +108,7 @@ def test_post_question_on_generic_response_type_summarize_error(_setup, endpoint
         assert response.status_code == DEFAULT_STATUS_CODE
         expected_json = {
             "detail": {
-                "response": DEFAULT_ERROR_MESSAGE,
+                "response": f"{_LLM_BACKEND_PREFIX} {DEFAULT_ERROR_MESSAGE}",
                 "cause": "summarizer error",
             }
         }

--- a/tests/unit/app/endpoints/test_streaming_ols.py
+++ b/tests/unit/app/endpoints/test_streaming_ols.py
@@ -26,7 +26,10 @@ from ols.app.endpoints.streaming_ols import (  # noqa:E402
 )
 from ols.app.models.models import RagChunk, StreamChunkType, TokenCounter  # noqa:E402
 from ols.utils import suid  # noqa:E402
-from ols.utils.errors_parsing import DEFAULT_ERROR_MESSAGE  # noqa:E402
+from ols.utils.errors_parsing import (  # noqa:E402
+    _LLM_BACKEND_PREFIX,
+    DEFAULT_ERROR_MESSAGE,
+)
 
 conversation_id = suid.get_suid()
 
@@ -177,16 +180,17 @@ def test_prompt_too_long_error():
 
 def test_generic_llm_error():
     """Test generic_llm_error."""
+    prefixed_msg = f"{_LLM_BACKEND_PREFIX} {DEFAULT_ERROR_MESSAGE}"
     assert (
         generic_llm_error("error", constants.MEDIA_TYPE_TEXT)
-        == f"{DEFAULT_ERROR_MESSAGE}: error"
+        == f"{prefixed_msg}: error"
     )
 
     assert generic_llm_error("error", constants.MEDIA_TYPE_JSON) == format_stream_data(
         {
             "event": "error",
             "data": {
-                "response": DEFAULT_ERROR_MESSAGE,
+                "response": prefixed_msg,
                 "cause": "error",
             },
         }

--- a/tests/unit/utils/test_errors_parsing.py
+++ b/tests/unit/utils/test_errors_parsing.py
@@ -2,8 +2,9 @@
 
 from unittest.mock import patch
 
+import httpx
 from httpx import Request, Response
-from openai import BadRequestError
+from openai import APIConnectionError, APITimeoutError, BadRequestError
 
 from ols.utils import errors_parsing
 
@@ -24,7 +25,7 @@ def test_parse_generic_llm_error_on_bad_request_error_without_info():
 
     # check the parsed error
     assert status_code == expected_status_code
-    assert error_message == "Exception"
+    assert error_message == f"{errors_parsing._LLM_BACKEND_PREFIX} Exception"
     assert cause == "Exception"
 
 
@@ -43,7 +44,7 @@ def test_parse_generic_llm_error_on_bad_request_error_with_info():
 
     # check the parsed error
     assert status_code == expected_status_code
-    assert error_message == message
+    assert error_message == f"{errors_parsing._LLM_BACKEND_PREFIX} {message}"
     assert cause == "Exception"
 
 
@@ -57,7 +58,10 @@ def test_parse_generic_llm_error_on_unknown_exception():
 
     # check the parsed error
     assert status_code == errors_parsing.DEFAULT_STATUS_CODE
-    assert error_message == errors_parsing.DEFAULT_ERROR_MESSAGE
+    assert (
+        error_message
+        == f"{errors_parsing._LLM_BACKEND_PREFIX} {errors_parsing.DEFAULT_ERROR_MESSAGE}"
+    )
     assert cause == "Exception"
 
 
@@ -71,7 +75,10 @@ def test_parse_generic_llm_error_on_unknown_exception_without_message():
 
     # check the parsed error
     assert status_code == errors_parsing.DEFAULT_STATUS_CODE
-    assert error_message == errors_parsing.DEFAULT_ERROR_MESSAGE
+    assert (
+        error_message
+        == f"{errors_parsing._LLM_BACKEND_PREFIX} {errors_parsing.DEFAULT_ERROR_MESSAGE}"
+    )
     assert cause == ""
 
 
@@ -82,11 +89,14 @@ def test_handle_known_errors():
     unknown_response = "This is unknown response"
     cause = "cause"
 
-    # known error - prompt too
+    # known error - prompt too long
     handled_response, handled_cause = errors_parsing.handle_known_errors(
         known_response, cause
     )
-    assert handled_response == errors_parsing.PROMPT_TOO_LONG_ERROR_MSG
+    assert (
+        handled_response
+        == f"{errors_parsing._LLM_BACKEND_PREFIX} {errors_parsing.PROMPT_TOO_LONG_ERROR_MSG}"
+    )
     assert handled_cause == "cause"
 
     # known error - prompt too long with tools
@@ -94,7 +104,11 @@ def test_handle_known_errors():
         handled_response, handled_cause = errors_parsing.handle_known_errors(
             known_response, cause
         )
-    assert handled_response == errors_parsing.PROMPT_TOO_LONG_WITH_TOOLS_ERROR_MSG
+    expected = (
+        f"{errors_parsing._LLM_BACKEND_PREFIX}"
+        f" {errors_parsing.PROMPT_TOO_LONG_WITH_TOOLS_ERROR_MSG}"
+    )
+    assert handled_response == expected
     assert handled_cause == "cause"
 
     # unknown error
@@ -103,3 +117,47 @@ def test_handle_known_errors():
     )
     assert handled_response == unknown_response
     assert handled_cause == cause
+
+
+def test_parse_generic_llm_error_on_api_connection_error():
+    """Test network error prefix for OpenAI APIConnectionError."""
+    error = APIConnectionError(request=Request(method="POST", url="http://llm.svc"))
+
+    status_code, error_message, _cause = errors_parsing.parse_generic_llm_error(error)
+
+    assert status_code == 502
+    assert error_message.startswith(errors_parsing._NETWORK_PREFIX)
+    assert errors_parsing.NETWORK_ERROR_MSG in error_message
+
+
+def test_parse_generic_llm_error_on_api_timeout_error():
+    """Test network error prefix for OpenAI APITimeoutError."""
+    error = APITimeoutError(request=Request(method="POST", url="http://llm.svc"))
+
+    status_code, error_message, _cause = errors_parsing.parse_generic_llm_error(error)
+
+    assert status_code == 502
+    assert error_message.startswith(errors_parsing._NETWORK_PREFIX)
+    assert errors_parsing.NETWORK_ERROR_MSG in error_message
+
+
+def test_parse_generic_llm_error_on_httpx_connect_error():
+    """Test network error prefix for httpx ConnectError."""
+    error = httpx.ConnectError("Connection refused")
+
+    status_code, error_message, cause = errors_parsing.parse_generic_llm_error(error)
+
+    assert status_code == 502
+    assert error_message.startswith(errors_parsing._NETWORK_PREFIX)
+    assert "Connection refused" in cause
+
+
+def test_parse_generic_llm_error_on_httpx_connect_timeout():
+    """Test network error prefix for httpx ConnectTimeout."""
+    error = httpx.ConnectTimeout("Timed out")
+
+    status_code, error_message, cause = errors_parsing.parse_generic_llm_error(error)
+
+    assert status_code == 502
+    assert error_message.startswith(errors_parsing._NETWORK_PREFIX)
+    assert "Timed out" in cause


### PR DESCRIPTION
## Description

When a backend model rejects a request (e.g. token limit exceeded on a model with a small context window), the error message displayed in the UI is indistinguishable from an OLS internal error. This makes troubleshooting difficult for customers and administrators.

This PR prefixes all errors that originate outside OLS processing with a source tag:

[Network] — connection/timeout failures reaching the LLM provider
[LLM Backend] — errors returned by the model server (token limits, bad requests, rate limits, etc.)
OLS's own errors (e.g. PromptTooLongError from internal budget checks) remain unprefixed.

Additionally, the token-limit error messages now explicitly name context_window_size as the likely misconfiguration, giving admins a direct pointer to the fix.



</div></div></div>

## Type of change

- [ ] Refactor
- [ ] New feature
- [ x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
https://redhat.atlassian.net/browse/OLS-3071
- Closes #
https://redhat.atlassian.net/browse/OLS-3071

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
