### PR TITLE
Add risk level rubric to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,37 +155,7 @@ When finishing a development branch:
 
 ## Risk Levels
 
-When creating Jira tickets for this repo, assign a risk level in the description.
-
-| Level | Customer Impact | Review Requirements | Automation |
-|-------|----------------|---------------------|------------|
-| Risk 1 | Very little impact if change goes wrong | No human code review required | Fully automated implementation |
-| Risk 2 | Medium impact if change causes problems | 1 human reviewer required | Automated implementation with human review gate |
-| Risk 3 | Major impact — risk of losing customers if a bug is introduced | 2+ human reviewers required | Human-driven implementation |
-
-### Classification Examples
-
-| Change Type | Risk Level |
-|-------------|------------|
-| Dependency version bump | 1 |
-| Doc/comment updates, test-only changes | 1 |
-| Internal refactor with no API change | 2 |
-| New provider adapter | 2 |
-| RAG pipeline changes | 2 |
-| API contract changes (endpoints, request/response schemas) | 3 |
-| Authentication/authorization changes | 3 |
-| LLM prompt template changes affecting user-facing responses | 3 |
-
-### Jira Description Format
-
-Include this section in every ticket description:
-
-```
-## Risk Level
-
-Risk {1|2|3} — {one-line impact summary}
-Rationale: {why this classification, referencing the rubric}
-```
+Risk levels are enforced via a PreToolUse hook before every Jira create/edit call. The rubric and classification examples live in [lightspeed-team-harness/hooks/risk-rubric.md](https://github.com/openshift/lightspeed-team-harness/blob/main/hooks/risk-rubric.md).
 
 ## Maintaining This Guide
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,40 @@ When finishing a development branch:
 3. Push to the contributor's fork remote (not `origin`)
 4. Create the PR against `origin/main` using `--head <user>:<branch>`
 
+## Risk Levels
+
+When creating Jira tickets for this repo, assign a risk level in the description.
+
+| Level | Customer Impact | Review Requirements | Automation |
+|-------|----------------|---------------------|------------|
+| Risk 1 | Very little impact if change goes wrong | No human code review required | Fully automated implementation |
+| Risk 2 | Medium impact if change causes problems | 1 human reviewer required | Automated implementation with human review gate |
+| Risk 3 | Major impact — risk of losing customers if a bug is introduced | 2+ human reviewers required | Human-driven implementation |
+
+### Classification Examples
+
+| Change Type | Risk Level |
+|-------------|------------|
+| Dependency version bump | 1 |
+| Doc/comment updates, test-only changes | 1 |
+| Internal refactor with no API change | 2 |
+| New provider adapter | 2 |
+| RAG pipeline changes | 2 |
+| API contract changes (endpoints, request/response schemas) | 3 |
+| Authentication/authorization changes | 3 |
+| LLM prompt template changes affecting user-facing responses | 3 |
+
+### Jira Description Format
+
+Include this section in every ticket description:
+
+```
+## Risk Level
+
+Risk {1|2|3} — {one-line impact summary}
+Rationale: {why this classification, referencing the rubric}
+```
+
 ## Maintaining This Guide
 
 Update this file and the relevant `docs/ai/` reference when patterns, tooling, or conventions change, or after repeated mistakes. Only document what you would get wrong without being told — remove anything inferable from reading the code.


### PR DESCRIPTION
Adds a Risk Levels section to AGENTS.md defining risk 1/2/3 classification with repo-specific examples and Jira description format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Risk Levels" section describing how risk levels are applied before change actions and linking to an external risk-rubric for classification examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->