### PR TITLE
NETOBSERV-2230 Add netobserv scenarios and skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ logs/*
 # Evaluation artifacts
 eval/venv/
 eval/results*/
+eval/netobserv/results*/
+eval/netobserv/.lseval-venv/
 eval/.deepeval/
 */*/eval_result*/*
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -71,5 +71,12 @@ Results are saved in output directories:
 - `graphs/` - Visualization charts
 
 
+## Live-cluster eval packages
+
+- **`troubleshooting/`** — Kubernetes troubleshooting scenarios (CrashLoop, NetworkPolicy, OOM, etc.)
+- **`netobserv/`** — NetObserv network observability scenarios (DNS, packet drops, TLS, RTT)
+
+Each package has its own `Makefile`, `system.yaml`, `scenario_evals.yaml`, and `scenarios/`.
+
 ## Data & Eval system setup
 Refer [Lightspeed Evaluation tool](https://github.com/lightspeed-core/lightspeed-evaluation#readme)

--- a/eval/netobserv/Makefile
+++ b/eval/netobserv/Makefile
@@ -1,0 +1,68 @@
+# Usage:
+#   make all                        # Run all NetObserv evals
+#   make dns_nxdomain               # Run a single eval by tag
+#
+# Prerequisites:
+#   make setup-lseval               # once — isolated venv (see below)
+#   oc login ...                    # OpenShift cluster with NetObserv FlowCollector Ready
+#   OPENAI_API_KEY or openai_api_key.txt at repo root — judge LLM
+#   OLS running with obs-mcp (default api_base http://localhost:8080)
+#
+# setup-lseval uses a dedicated .lseval-venv: the repo's lseval extra (v0.4.0) does not
+# support api.extra_request_params (mode: troubleshooting), and newer lseval pins conflict
+# with OLS langchain deps — so eval CLI is installed separately.
+
+EVAL_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+REPO_ROOT := $(abspath $(EVAL_DIR)../..)
+LSEVAL_VENV := $(EVAL_DIR).lseval-venv
+LSEVAL := $(LSEVAL_VENV)/bin/lightspeed-eval
+LSEVAL_GIT := git+https://github.com/lightspeed-core/lightspeed-evaluation.git@32c80e1c9555ccc3f3573bc073cd5a4c6595c414
+OPENAI_KEY_FILE ?= $(REPO_ROOT)/openai_api_key.txt
+
+.PHONY: all setup-lseval check-lseval \
+        dns_latency dns_nxdomain packet_drops_kernel packet_drops_policy \
+        tls_issues tcp_rtt
+
+check-lseval:
+	@test -x "$(LSEVAL)" || (echo "Run: make setup-lseval" >&2; exit 1)
+
+ifneq ($(MAKECMDGOALS),)
+$(filter-out setup-lseval check-lseval,$(MAKECMDGOALS)): check-lseval
+endif
+
+setup-lseval:
+	@command -v uv >/dev/null || (echo "Install uv: https://docs.astral.sh/uv/" >&2; exit 1)
+	uv venv --python 3.12 "$(LSEVAL_VENV)"
+	uv pip install --python "$(LSEVAL_VENV)/bin/python" -U pip "$(LSEVAL_GIT)" 'langchain-community<0.4'
+
+EVAL_CMD = @set -e; \
+	if [ -z "$$OPENAI_API_KEY" ] && [ -f "$(OPENAI_KEY_FILE)" ]; then \
+		export OPENAI_API_KEY=$$(tr -d '\n' < "$(OPENAI_KEY_FILE)"); \
+	fi; \
+	if [ -z "$$OPENAI_API_KEY" ]; then \
+		echo "Set OPENAI_API_KEY or create $(OPENAI_KEY_FILE)" >&2; exit 1; \
+	fi; \
+	API_KEY=$$(oc whoami -t) "$(LSEVAL)" \
+		--system-config system.yaml \
+		--eval-data scenario_evals.yaml \
+		--output-dir results
+
+all: dns_latency dns_nxdomain packet_drops_kernel packet_drops_policy tls_issues tcp_rtt
+
+dns_latency:
+	$(EVAL_CMD) --tag dns_latency
+
+dns_nxdomain:
+	$(EVAL_CMD) --tag dns_nxdomain
+
+packet_drops_kernel:
+	$(EVAL_CMD) --tag packet_drops_kernel
+
+packet_drops_policy:
+	$(EVAL_CMD) --tag packet_drops_policy
+
+tls_issues:
+	$(EVAL_CMD) --tag tls_issues
+
+tcp_rtt:
+	$(EVAL_CMD) --tag tcp_rtt

--- a/eval/netobserv/Makefile
+++ b/eval/netobserv/Makefile
@@ -47,22 +47,24 @@ EVAL_CMD = @set -e; \
 		--eval-data scenario_evals.yaml \
 		--output-dir results
 
-all: dns_latency dns_nxdomain packet_drops_kernel packet_drops_policy tls_issues tcp_rtt
+# One lightspeed-eval run → single evaluation_*_detailed.csv / *_summary.json
+all:
+	$(EVAL_CMD)
 
 dns_latency:
-	$(EVAL_CMD) --tag dns_latency
+	$(EVAL_CMD) --tags dns_latency
 
 dns_nxdomain:
-	$(EVAL_CMD) --tag dns_nxdomain
+	$(EVAL_CMD) --tags dns_nxdomain
 
 packet_drops_kernel:
-	$(EVAL_CMD) --tag packet_drops_kernel
+	$(EVAL_CMD) --tags packet_drops_kernel
 
 packet_drops_policy:
-	$(EVAL_CMD) --tag packet_drops_policy
+	$(EVAL_CMD) --tags packet_drops_policy
 
 tls_issues:
-	$(EVAL_CMD) --tag tls_issues
+	$(EVAL_CMD) --tags tls_issues
 
 tcp_rtt:
-	$(EVAL_CMD) --tag tcp_rtt
+	$(EVAL_CMD) --tags tcp_rtt

--- a/eval/netobserv/Makefile
+++ b/eval/netobserv/Makefile
@@ -42,7 +42,11 @@ EVAL_CMD = @set -e; \
 	if [ -z "$$OPENAI_API_KEY" ]; then \
 		echo "Set OPENAI_API_KEY or create $(OPENAI_KEY_FILE)" >&2; exit 1; \
 	fi; \
-	API_KEY=$$(oc whoami -t) "$(LSEVAL)" \
+	TOKEN=$$(oc whoami -t 2>/dev/null || true); \
+	if [ -z "$$TOKEN" ]; then \
+		echo "Not logged in to OpenShift; run 'oc login'" >&2; exit 1; \
+	fi; \
+	API_KEY="$$TOKEN" "$(LSEVAL)" \
 		--system-config system.yaml \
 		--eval-data scenario_evals.yaml \
 		--output-dir results

--- a/eval/netobserv/README.md
+++ b/eval/netobserv/README.md
@@ -1,0 +1,106 @@
+# OLS NetObserv Evals
+
+Evaluation scenarios for network observability troubleshooting with NetObserv. Each scenario deploys synthetic traffic on a live OpenShift cluster, asks the agent to investigate using NetObserv metrics and/or flow logs, and scores the response with LLM-based metrics.
+
+## Prerequisites
+
+- OLS dev environment per [main README](../../README.md#installation) (`make install-deps`; Python 3.12 via `uv`)
+- Eval CLI: `make setup-lseval` in this directory (isolated `.lseval-venv`; repo `lseval` extra is v0.4.0 and cannot pass `mode: troubleshooting`)
+- OpenShift cluster with **NetObserv** installed (`FlowCollector` named `cluster`, Ready)
+- Relevant eBPF features enabled per scenario (DNSTracking, PacketDrop, NetworkEvents, FlowRTT, etc.)
+- OLS running with **obs-mcp** (and optionally kubernetes-mcp-server `netobserv` tools)
+- `oc login` to the cluster
+
+## Scenarios
+
+| Tag | Category | Description |
+|-----|----------|-------------|
+| `dns_latency` | DNS | Slow DNS lookups — `netobserv_namespace_dns_latency_seconds`, `DnsLatencyMs` |
+| `dns_nxdomain` | DNS | DNS failures / NXDOMAIN — `DNSErrors`, `DNSNxDomain`, flow DNS fields |
+| `packet_drops_kernel` | Drops | Kernel packet drops — `PacketDropsByKernel`, `PktDrop*` fields |
+| `packet_drops_policy` | Drops | NetworkPolicy denials — `NetpolDenied`, `network_policy_events` |
+| `tls_issues` | Ingress/TLS | HTTPS/TLS errors — `Ingress5xxErrors`, `IPsecErrors` |
+| `tcp_rtt` | Latency | Slow TCP RTT — `LatencyHighTrend`, `netobserv_namespace_rtt_seconds` |
+
+Each scenario has `scenarios/<tag>/setup.sh` (deploy workloads), `cleanup.sh` (teardown), and `fixtures/manifest.yaml`. Allow a few minutes after setup for NetObserv to export metrics and flows.
+
+Skills for the agent live at repo root: `skills/netobserv-metrics/` and `skills/netobserv-flow-logs/`.
+
+## Running
+
+```bash
+cd eval/netobserv
+make setup-lseval   # once
+oc login ...
+# Judge + agent: OpenAI — export OPENAI_API_KEY or ../../openai_api_key.txt at repo root
+```
+
+Start **obs-mcp** (separate terminal, from the obs-mcp repo):
+
+```bash
+oc login …
+TOOLSETS=metrics,logs LOKI_URL=http://127.0.0.1:8080 make run   # after Loki port-forward if needed
+```
+
+Start **OLS** (provider must match `api.provider` in `system.yaml`):
+
+```bash
+OLS_CONFIG_FILE=eval/netobserv/olsconfig/olsconfig-openai.yaml uv run make run
+```
+
+Run evals (`lightspeed-eval` runs each scenario's `setup_script` before calling OLS — no separate setup step):
+
+```bash
+cd eval/netobserv
+
+# Single scenario
+make dns_nxdomain
+
+# All NetObserv scenarios
+make all
+```
+
+Debug a failing setup script (prints rollout/log wait errors):
+
+```bash
+./scenarios/dns_nxdomain/setup.sh
+oc logs -n netobserv-eval-dns-nxdomain -l app=dns-nxdomain-prober --tail=30
+
+# DNS latency — delete stale namespace if the prober image changed (ubi → busybox)
+oc delete namespace netobserv-eval-dns-latency --ignore-not-found --wait=false
+./scenarios/dns_latency/setup.sh
+
+# TLS — requires openssl on the host; setup.sh generates a self-signed cert (not in git)
+oc delete namespace netobserv-eval-tls --ignore-not-found --wait=false
+./scenarios/tls_issues/setup.sh
+```
+
+## Metrics
+
+Each turn is scored with:
+
+- `custom:answer_correctness` — alignment with the expected investigation outcome
+- `geval:generic_troubleshooting_experience` — evidence-based NetObserv investigation (see `system.yaml`)
+
+## OLS configs
+
+Example OLS configs for eval runs are under `olsconfig/`:
+
+- `olsconfig-openai.yaml` — OpenAI `gpt-4o-mini`; default for `system.yaml`
+- `olsconfig-watsonx.yaml` — WatsonX Granite
+- `olsconfig-rhoai-vllm.yaml` — RHOAI vLLM endpoint (set `url` to your serving endpoint)
+
+## Troubleshooting
+
+### `500` / `incomplete chunked read` from the LLM backend
+
+Some OpenAI-compatible gateways drop long streaming responses during MCP tool-calling (large tool schemas). Mitigations:
+
+1. **Run obs-mcp** with NetObserv-relevant toolsets only, e.g. `metrics,logs` — avoid loading every MCP tool on the same OLS instance.
+2. **Raise MCP timeout** in your olsconfig (e.g. `timeout: 120` on `mcp_servers`) and lower `tool_budget_ratio` if the provider supports it.
+3. **Check OLS logs** (`app_log_level: debug` temporarily) for the failing LLM round.
+4. **Fallback providers** — `olsconfig-watsonx.yaml` or `olsconfig-openai.yaml` often handle large tool contexts more reliably; update `api.provider` / `api.model` in `system.yaml` to match.
+
+### `422` / provider not valid
+
+`api.provider` in `system.yaml` must match `llm_providers[].name` in the active olsconfig (e.g. `openai`, `watsonx`).

--- a/eval/netobserv/README.md
+++ b/eval/netobserv/README.md
@@ -56,7 +56,7 @@ cd eval/netobserv
 # Single scenario
 make dns_nxdomain
 
-# All NetObserv scenarios
+# All scenarios (one run → single evaluation_*_detailed.csv in results/)
 make all
 ```
 
@@ -104,3 +104,7 @@ Some OpenAI-compatible gateways drop long streaming responses during MCP tool-ca
 ### `422` / provider not valid
 
 `api.provider` in `system.yaml` must match `llm_providers[].name` in the active olsconfig (e.g. `openai`, `watsonx`).
+
+### `[Confident AI Metric Data Log] Invalid API key`
+
+Harmless noise from DeepEval’s optional Confident AI telemetry upload — not the OpenAI judge key. GEval still runs if you see progress like `GEval Turn Metric` and `5/6`. `system.yaml` sets `CONFIDENT_METRIC_LOGGING_ENABLED=0` to silence it. If the judge itself fails, you get LiteLLM/OpenAI auth errors instead; ensure `OPENAI_API_KEY` or `openai_api_key.txt` is set and `unset OPENAI_API_BASE` when using the public OpenAI API.

--- a/eval/netobserv/README.md
+++ b/eval/netobserv/README.md
@@ -5,11 +5,12 @@ Evaluation scenarios for network observability troubleshooting with NetObserv. E
 ## Prerequisites
 
 - OLS dev environment per [main README](../../README.md#installation) (`make install-deps`; Python 3.12 via `uv`)
-- Eval CLI: `make setup-lseval` in this directory (isolated `.lseval-venv`; repo `lseval` extra is v0.4.0 and cannot pass `mode: troubleshooting`)
+- Eval CLI: `make setup-lseval` in this directory (isolated `.lseval-venv`; installs `lightspeed-evaluation` from the Makefile-pinned git commit `32c80e1`, not the repo `lseval` extra v0.4.0)
 - OpenShift cluster with **NetObserv** installed (`FlowCollector` named `cluster`, Ready)
 - Relevant eBPF features enabled per scenario (DNSTracking, PacketDrop, NetworkEvents, FlowRTT, etc.)
 - OLS running with **obs-mcp** (and optionally kubernetes-mcp-server `netobserv` tools)
 - `oc login` to the cluster
+- OLS started from **repo root** with an olsconfig that enables **`ols_config.skills`** (all files under `eval/netobserv/olsconfig/` include this). Without skills, the agent will not load the NetObserv investigation workflow.
 
 ## Scenarios
 
@@ -22,9 +23,9 @@ Evaluation scenarios for network observability troubleshooting with NetObserv. E
 | `tls_issues` | Ingress/TLS | HTTPS/TLS errors — `Ingress5xxErrors`, `IPsecErrors` |
 | `tcp_rtt` | Latency | Slow TCP RTT — `LatencyHighTrend`, `netobserv_namespace_rtt_seconds` |
 
-Each scenario has `scenarios/<tag>/setup.sh` (deploy workloads), `cleanup.sh` (teardown), and `fixtures/manifest.yaml`. Allow a few minutes after setup for NetObserv to export metrics and flows.
+Each scenario has `scenarios/<tag>/setup.sh` (deploy workloads), `cleanup.sh` (teardown), and `fixtures/manifest.yaml`. Setup waits for workload traffic, then **`wait_for_netobserv_warmup`** (default **120s**) so flows/metrics reach Prometheus/Loki before OLS is queried. Override with `NETOBSERV_WARMUP_SECS=180` if your cluster is slow.
 
-Skills for the agent live at repo root: `skills/netobserv-metrics/` and `skills/netobserv-flow-logs/`.
+Skills for the agent live at repo root: `skills/netobserv-metrics/` and `skills/netobserv-flow-logs/`. They are injected via skills RAG only when `ols_config.skills` is present in the active olsconfig — **restart OLS** after skill or olsconfig changes.
 
 ## Running
 
@@ -66,21 +67,37 @@ Debug a failing setup script (prints rollout/log wait errors):
 ./scenarios/dns_nxdomain/setup.sh
 oc logs -n netobserv-eval-dns-nxdomain -l app=dns-nxdomain-prober --tail=30
 
-# DNS latency — delete stale namespace if the prober image changed (ubi → busybox)
-oc delete namespace netobserv-eval-dns-latency --ignore-not-found --wait=false
-./scenarios/dns_latency/setup.sh
+# Stale namespace after manifest changes — setup recreates by default; or delete manually:
+oc delete namespace netobserv-eval-dns-nxdomain --ignore-not-found --wait=false
+./scenarios/dns_nxdomain/setup.sh
 
-# TLS — requires openssl on the host; setup.sh generates a self-signed cert (not in git)
-oc delete namespace netobserv-eval-tls --ignore-not-found --wait=false
-./scenarios/tls_issues/setup.sh
+# OpenShift restricted SCC: busybox/iperf/python UIDs are patched from the namespace
+# openshift.io/sa.scc.uid-range after apply. Set NETOBSERV_EVAL_RECREATE_NS=false to skip
+# namespace delete on re-run.
 ```
 
 ## Metrics
 
 Each turn is scored with:
 
-- `custom:answer_correctness` — alignment with the expected investigation outcome
+- `custom:answer_correctness` — alignment with `expected_response` in `scenario_evals.yaml` (stricter than GEval)
 - `geval:generic_troubleshooting_experience` — evidence-based NetObserv investigation (see `system.yaml`)
+
+`contexts` in `scenario_evals.yaml` are **judge-only** rubrics for GEval; they are not sent to OLS. Investigation recipes and PromQL belong in `skills/`; ground truth for answer correctness stays in `expected_response`.
+
+### Improving `answer_correctness`
+
+GEval often scores higher because it rewards any real NetObserv data. **Answer correctness** compares against `expected_response` in `scenario_evals.yaml` and penalizes incomplete investigations.
+
+| Common gap | Fix |
+|------------|-----|
+| Stops after alerts or one generic metric | Run the 3-layer workflow in `skills/netobserv-metrics` §7: alerts → domain metrics → flow logs |
+| Wrong namespace in PromQL | Always use the namespace from the user query (e.g. `netobserv-eval-drops-kernel`, not `netobserv`) |
+| Policy scenario uses `drop_packets_total` only | Use `network_policy_events_total{action="drop"}` + flows with `packetLoss=dropped`; cite **`OVS_DROP_EXPLICIT`** on OpenShift |
+| DNS NXDOMAIN with “no metrics” | Enable `ols_config.skills` and restart OLS; NXDOMAIN is **return traffic** — use `DstK8S_Namespace="…"` (not `SrcK8S_Namespace` first); not `{namespace="…"}`; then Loki flows with `DnsName~netobserv-eval.invalid` |
+| TCP RTT without metric names | Cite `netobserv_namespace_rtt_seconds` + `histogram_quantile`; use `TimeFlowRttNs` in flows |
+
+After updating skills, restart OLS so the skills RAG index reloads, then re-run `make all`.
 
 ## OLS configs
 

--- a/eval/netobserv/olsconfig/olsconfig-azure-openai.yaml
+++ b/eval/netobserv/olsconfig/olsconfig-azure-openai.yaml
@@ -1,0 +1,55 @@
+---
+# OLS configuration for troubleshooting evals — Azure OpenAI provider
+#
+# Prerequisites:
+#   1. Store your Azure OpenAI API key in a file:
+#        echo "$AZURE_OPENAI_API_KEY" > azure_openai_api_key.txt
+#   2. Fill in your Azure deployment URL and deployment name below
+#   3. Start port-forwards (see TROUBLESHOOTING_EVALS_SETUP.md)
+#   4. Run OLS:
+#        OLS_CONFIG_FILE=eval/troubleshooting/olsconfig/olsconfig-azure-openai.yaml uv run make run
+#
+# Eval system config: eval/troubleshooting/system_azure_openai.yaml
+
+llm_providers:
+  - name: azure_openai
+    type: azure_openai
+    url: "https://<your-deployment>.openai.azure.com/"  # replace with your Azure endpoint
+    credentials_path: azure_openai_api_key.txt
+    api_version: "2024-02-15-preview"
+    deployment_name: <your-deployment-name>  # replace with your deployment name
+    models:
+      - name: gpt-4.1-mini
+
+mcp_servers:
+  - name: obs-mcp
+    url: "http://127.0.0.1:9100/mcp"
+    headers:
+      kubernetes-authorization: kubernetes
+    timeout: 5
+  - name: openshift-mcp-server
+    url: "http://127.0.0.1:8089/mcp"
+    timeout: 5
+
+ols_config:
+  conversation_cache:
+    type: memory
+    memory:
+      max_entries: 1000
+  logging_config:
+    app_log_level: info
+    lib_log_level: warning
+    uvicorn_log_level: info
+  default_provider: azure_openai
+  default_model: gpt-4.1-mini
+  authentication_config:
+    module: "noop-with-token"
+  user_data_collection:
+    feedback_disabled: true
+    transcripts_disabled: true
+
+dev_config:
+  enable_dev_ui: true
+  disable_tls: true
+  enable_system_prompt_override: true
+  uvicorn_port_number: 8080

--- a/eval/netobserv/olsconfig/olsconfig-azure-openai.yaml
+++ b/eval/netobserv/olsconfig/olsconfig-azure-openai.yaml
@@ -1,15 +1,15 @@
 ---
-# OLS configuration for troubleshooting evals — Azure OpenAI provider
+# OLS configuration for NetObserv evals — Azure OpenAI provider
 #
 # Prerequisites:
 #   1. Store your Azure OpenAI API key in a file:
 #        echo "$AZURE_OPENAI_API_KEY" > azure_openai_api_key.txt
 #   2. Fill in your Azure deployment URL and deployment name below
-#   3. Start port-forwards (see TROUBLESHOOTING_EVALS_SETUP.md)
+#   3. Start obs-mcp (see eval/netobserv/README.md)
 #   4. Run OLS:
-#        OLS_CONFIG_FILE=eval/troubleshooting/olsconfig/olsconfig-azure-openai.yaml uv run make run
+#        OLS_CONFIG_FILE=eval/netobserv/olsconfig/olsconfig-azure-openai.yaml uv run make run
 #
-# Eval system config: eval/troubleshooting/system_azure_openai.yaml
+# Eval system config: eval/netobserv/system.yaml — set api.provider: azure_openai, api.model: gpt-4o-mini
 
 llm_providers:
   - name: azure_openai
@@ -17,16 +17,16 @@ llm_providers:
     url: "https://<your-deployment>.openai.azure.com/"  # replace with your Azure endpoint
     credentials_path: azure_openai_api_key.txt
     api_version: "2024-02-15-preview"
-    deployment_name: <your-deployment-name>  # replace with your deployment name
+    deployment_name: <your-deployment-name>  # replace with your Azure deployment name (must match models[].name)
     models:
-      - name: gpt-4.1-mini
+      - name: gpt-4o-mini
 
 mcp_servers:
   - name: obs-mcp
     url: "http://127.0.0.1:9100/mcp"
     headers:
       kubernetes-authorization: kubernetes
-    timeout: 5
+    timeout: 120
   - name: openshift-mcp-server
     url: "http://127.0.0.1:8089/mcp"
     timeout: 5
@@ -41,12 +41,16 @@ ols_config:
     lib_log_level: warning
     uvicorn_log_level: info
   default_provider: azure_openai
-  default_model: gpt-4.1-mini
+  default_model: gpt-4o-mini
   authentication_config:
     module: "noop-with-token"
   user_data_collection:
     feedback_disabled: true
     transcripts_disabled: true
+  skills:
+    skills_dir: skills
+    embed_model_path: sentence-transformers/all-MiniLM-L6-v2
+    threshold: 0.30
 
 dev_config:
   enable_dev_ui: true

--- a/eval/netobserv/olsconfig/olsconfig-openai.yaml
+++ b/eval/netobserv/olsconfig/olsconfig-openai.yaml
@@ -1,0 +1,49 @@
+---
+# OLS configuration for NetObserv evals — OpenAI provider
+#
+# Prerequisites:
+#   1. Store your OpenAI API key at repo root (path is relative to lightspeed-service/):
+#        echo "$OPENAI_API_KEY" > openai_api_key.txt && chmod 600 openai_api_key.txt
+#   2. Start obs-mcp with metrics+logs (see eval/netobserv/README.md)
+#   3. Run OLS:
+#        OLS_CONFIG_FILE=eval/netobserv/olsconfig/olsconfig-openai.yaml uv run make run
+#
+# Eval system config: eval/netobserv/system.yaml — set api.provider: openai, api.model: gpt-4o-mini
+
+llm_providers:
+  - name: openai
+    type: openai
+    url: "https://api.openai.com/v1"
+    credentials_path: openai_api_key.txt
+    models:
+      - name: gpt-4o-mini
+
+mcp_servers:
+  - name: obs-mcp
+    url: "http://127.0.0.1:9100/mcp"
+    headers:
+      kubernetes-authorization: kubernetes
+    timeout: 120
+
+ols_config:
+  conversation_cache:
+    type: memory
+    memory:
+      max_entries: 1000
+  logging_config:
+    app_log_level: info
+    lib_log_level: warning
+    uvicorn_log_level: info
+  default_provider: openai
+  default_model: gpt-4o-mini
+  authentication_config:
+    module: "noop-with-token"
+  user_data_collection:
+    feedback_disabled: true
+    transcripts_disabled: true
+
+dev_config:
+  enable_dev_ui: true
+  disable_tls: true
+  enable_system_prompt_override: true
+  uvicorn_port_number: 8080

--- a/eval/netobserv/olsconfig/olsconfig-openai.yaml
+++ b/eval/netobserv/olsconfig/olsconfig-openai.yaml
@@ -41,6 +41,10 @@ ols_config:
   user_data_collection:
     feedback_disabled: true
     transcripts_disabled: true
+  skills:
+    skills_dir: skills
+    embed_model_path: sentence-transformers/all-MiniLM-L6-v2
+    threshold: 0.30
 
 dev_config:
   enable_dev_ui: true

--- a/eval/netobserv/olsconfig/olsconfig-rhelai-vllm.yaml
+++ b/eval/netobserv/olsconfig/olsconfig-rhelai-vllm.yaml
@@ -1,0 +1,54 @@
+---
+# OLS configuration for troubleshooting evals — RHEL AI vLLM provider
+#
+# Prerequisites:
+#   1. Store your vLLM API token in a file:
+#        echo "$RHELAI_API_TOKEN" > rhelai_api_key.txt
+#   2. Set your vLLM inference endpoint URL and model name below
+#   3. Start port-forwards (see TROUBLESHOOTING_EVALS_SETUP.md)
+#   4. Run OLS:
+#        OLS_CONFIG_FILE=eval/troubleshooting/olsconfig/olsconfig-rhelai-vllm.yaml uv run make run
+#
+# Eval system config: eval/troubleshooting/system_rhelai_vllm.yaml
+# The model name must match the alias registered in your vLLM deployment.
+
+llm_providers:
+  - name: rhelai_vllm
+    type: rhelai_vllm
+    url: "https://<your-vllm-endpoint>/v1"  # replace with your RHEL AI vLLM endpoint
+    credentials_path: rhelai_api_key.txt
+    models:
+      - name: granite-3.1-8b-instruct  # replace with your deployed model name
+
+mcp_servers:
+  - name: obs-mcp
+    url: "http://127.0.0.1:9100/mcp"
+    headers:
+      kubernetes-authorization: kubernetes
+    timeout: 5
+  - name: openshift-mcp-server
+    url: "http://127.0.0.1:8089/mcp"
+    timeout: 5
+
+ols_config:
+  conversation_cache:
+    type: memory
+    memory:
+      max_entries: 1000
+  logging_config:
+    app_log_level: info
+    lib_log_level: warning
+    uvicorn_log_level: info
+  default_provider: rhelai_vllm
+  default_model: granite-3.1-8b-instruct  # must match model name above
+  authentication_config:
+    module: "noop-with-token"
+  user_data_collection:
+    feedback_disabled: true
+    transcripts_disabled: true
+
+dev_config:
+  enable_dev_ui: true
+  disable_tls: true
+  enable_system_prompt_override: true
+  uvicorn_port_number: 8080

--- a/eval/netobserv/olsconfig/olsconfig-rhelai-vllm.yaml
+++ b/eval/netobserv/olsconfig/olsconfig-rhelai-vllm.yaml
@@ -1,15 +1,15 @@
 ---
-# OLS configuration for troubleshooting evals — RHEL AI vLLM provider
+# OLS configuration for NetObserv evals — RHEL AI vLLM provider
 #
 # Prerequisites:
 #   1. Store your vLLM API token in a file:
 #        echo "$RHELAI_API_TOKEN" > rhelai_api_key.txt
 #   2. Set your vLLM inference endpoint URL and model name below
-#   3. Start port-forwards (see TROUBLESHOOTING_EVALS_SETUP.md)
+#   3. Start obs-mcp (see eval/netobserv/README.md)
 #   4. Run OLS:
-#        OLS_CONFIG_FILE=eval/troubleshooting/olsconfig/olsconfig-rhelai-vllm.yaml uv run make run
+#        OLS_CONFIG_FILE=eval/netobserv/olsconfig/olsconfig-rhelai-vllm.yaml uv run make run
 #
-# Eval system config: eval/troubleshooting/system_rhelai_vllm.yaml
+# Eval system config: eval/netobserv/system.yaml
 # The model name must match the alias registered in your vLLM deployment.
 
 llm_providers:
@@ -46,6 +46,10 @@ ols_config:
   user_data_collection:
     feedback_disabled: true
     transcripts_disabled: true
+  skills:
+    skills_dir: skills
+    embed_model_path: sentence-transformers/all-MiniLM-L6-v2
+    threshold: 0.30
 
 dev_config:
   enable_dev_ui: true

--- a/eval/netobserv/olsconfig/olsconfig-rhoai-vllm.yaml
+++ b/eval/netobserv/olsconfig/olsconfig-rhoai-vllm.yaml
@@ -46,6 +46,10 @@ ols_config:
   user_data_collection:
     feedback_disabled: true
     transcripts_disabled: true
+  skills:
+    skills_dir: skills
+    embed_model_path: sentence-transformers/all-MiniLM-L6-v2
+    threshold: 0.30
 
 dev_config:
   enable_dev_ui: true

--- a/eval/netobserv/olsconfig/olsconfig-rhoai-vllm.yaml
+++ b/eval/netobserv/olsconfig/olsconfig-rhoai-vllm.yaml
@@ -1,0 +1,54 @@
+---
+# OLS configuration for NetObserv evals — RHOAI vLLM provider
+#
+# Prerequisites:
+#   1. Store your RHOAI bearer token in a file:
+#        oc whoami --show-token > rhoai_api_key.txt
+#   2. Set your RHOAI model serving endpoint URL and model name below
+#   3. Start port-forwards for obs-mcp and openshift-mcp-server
+#   4. Run OLS:
+#        OLS_CONFIG_FILE=eval/netobserv/olsconfig/olsconfig-rhoai-vllm.yaml uv run make run
+#
+# Eval system config: eval/netobserv/system.yaml
+# The model name must match the alias registered in your RHOAI serving runtime.
+
+llm_providers:
+  - name: rhoai_vllm
+    type: rhoai_vllm
+    url: "https://<your-rhoai-serving-endpoint>/v1"  # replace with your RHOAI model serving URL
+    credentials_path: rhoai_api_key.txt
+    models:
+      - name: granite-3.1-8b-instruct  # replace with your deployed model name
+
+mcp_servers:
+  - name: obs-mcp
+    url: "http://127.0.0.1:9100/mcp"
+    headers:
+      kubernetes-authorization: kubernetes
+    timeout: 5
+  - name: openshift-mcp-server
+    url: "http://127.0.0.1:8089/mcp"
+    timeout: 5
+
+ols_config:
+  conversation_cache:
+    type: memory
+    memory:
+      max_entries: 1000
+  logging_config:
+    app_log_level: info
+    lib_log_level: warning
+    uvicorn_log_level: info
+  default_provider: rhoai_vllm
+  default_model: granite-3.1-8b-instruct  # must match model name above
+  authentication_config:
+    module: "noop-with-token"
+  user_data_collection:
+    feedback_disabled: true
+    transcripts_disabled: true
+
+dev_config:
+  enable_dev_ui: true
+  disable_tls: true
+  enable_system_prompt_override: true
+  uvicorn_port_number: 8080

--- a/eval/netobserv/olsconfig/olsconfig-watsonx.yaml
+++ b/eval/netobserv/olsconfig/olsconfig-watsonx.yaml
@@ -1,0 +1,54 @@
+---
+# OLS configuration for NetObserv evals — WatsonX provider
+#
+# Prerequisites:
+#   1. Store your WatsonX API key in a file:
+#        echo "$WATSONX_APIKEY" > watsonx_api_key.txt
+#   2. Set your WatsonX project ID below (project_id field)
+#   3. Start port-forwards for obs-mcp and openshift-mcp-server
+#   4. Run OLS:
+#        OLS_CONFIG_FILE=eval/netobserv/olsconfig/olsconfig-watsonx.yaml uv run make run
+#
+# Eval system config: eval/netobserv/system.yaml (set llm.provider to watsonx for judge)
+
+llm_providers:
+  - name: watsonx
+    type: watsonx
+    url: "https://us-south.ml.cloud.ibm.com"
+    credentials_path: watsonx_api_key.txt
+    project_id: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX  # replace with your project ID
+    models:
+      - name: ibm/granite-4-h-small
+
+mcp_servers:
+  - name: obs-mcp
+    url: "http://127.0.0.1:9100/mcp"
+    headers:
+      kubernetes-authorization: kubernetes
+    timeout: 5
+  - name: openshift-mcp-server
+    url: "http://127.0.0.1:8089/mcp"
+    timeout: 5
+
+ols_config:
+  conversation_cache:
+    type: memory
+    memory:
+      max_entries: 1000
+  logging_config:
+    app_log_level: info
+    lib_log_level: warning
+    uvicorn_log_level: info
+  default_provider: watsonx
+  default_model: ibm/granite-4-h-small
+  authentication_config:
+    module: "noop-with-token"
+  user_data_collection:
+    feedback_disabled: true
+    transcripts_disabled: true
+
+dev_config:
+  enable_dev_ui: true
+  disable_tls: true
+  enable_system_prompt_override: true
+  uvicorn_port_number: 8080

--- a/eval/netobserv/olsconfig/olsconfig-watsonx.yaml
+++ b/eval/netobserv/olsconfig/olsconfig-watsonx.yaml
@@ -46,6 +46,10 @@ ols_config:
   user_data_collection:
     feedback_disabled: true
     transcripts_disabled: true
+  skills:
+    skills_dir: skills
+    embed_model_path: sentence-transformers/all-MiniLM-L6-v2
+    threshold: 0.30
 
 dev_config:
   enable_dev_ui: true

--- a/eval/netobserv/scenario_evals.yaml
+++ b/eval/netobserv/scenario_evals.yaml
@@ -1,4 +1,6 @@
 # NetObserv evaluation scenarios — requires live cluster + NetObserv + obs-mcp
+#
+# contexts: judge-only rubric for geval (not sent to OLS). Agent guidance lives in skills/.
 
 # --- DNS latency (DNSTracking) ---
 - conversation_group_id: dns_latency
@@ -11,11 +13,6 @@
         Applications in namespace netobserv-eval-dns-latency report slow DNS lookups over
         the last hour. Use NetObserv network observability data to investigate DNS latency
         and identify which workloads or queries are affected.
-      contexts:
-        - "Agent should use Prometheus netobserv_* metrics (e.g. netobserv_namespace_dns_latency_seconds) and/or Loki flow logs with DnsLatencyMs when DNSTracking is enabled."
-        - "DNSTracking must be enabled in FlowCollector spec.agent.ebpf.features for DNS latency metrics."
-        - "For Loki flow logs use SrcK8S_Namespace/DstK8S_Namespace and tenant network on OpenShift — not kubernetes_namespace_name."
-        - "If no data is present, state that clearly and mention required NetObserv features or export configuration."
       expected_response: >
         Evidence-based investigation using NetObserv: queries netobserv_namespace_dns_latency_seconds
         or related DNS metrics, or Loki flow fields (DnsLatencyMs, DnsName). Identifies namespaces
@@ -23,7 +20,6 @@
         DNSTracking or missing metrics if data is unavailable.
       turn_metrics:
         - custom:answer_correctness
-        - geval:generic_troubleshooting_experience
 
   setup_script: scenarios/dns_latency/setup.sh
   cleanup_script: scenarios/dns_latency/cleanup.sh
@@ -36,21 +32,18 @@
   turns:
     - turn_id: dns_nxdomain
       query: >
-        Namespace netobserv-eval-dns-nxdomain has DNS resolution failures. Check NetObserv
-        for DNS-related errors such as NXDOMAIN or elevated DNS error rates in the last hour
-        and tell me what is failing.
-      contexts:
-        - "NetObserv health rules include DNSErrors and DNSNxDomain when DNSTracking is enabled."
-        - "Flow log fields include DnsErrno, DnsFlagsResponseCode, DnsName — use Loki with correct indexed labels."
-        - "Should check firing alerts (DNSErrors, DNSNxDomain) via Prometheus/Alertmanager when available."
+        Namespace netobserv-eval-dns-nxdomain has DNS resolution failures. Query NetObserv
+        Prometheus DNS metrics and Loki flow logs for the last hour to find NXDOMAIN responses
+        or failing query names. Report what is failing with numeric evidence — do not rely on
+        alerts alone.
       expected_response: >
-        Uses NetObserv data to find DNS failures: alerts (DNSErrors/DNSNxDomain), metrics, or
-        flow logs showing error response codes / errno. Names affected DNS names or namespaces,
-        provides evidence from tool output, and suggests whether the issue is misconfiguration,
-        upstream DNS, or missing records.
+        Uses NetObserv DNS metrics with DstK8S_Namespace (return traffic — primary for RCODE) and
+        DnsFlagsResponseCode=NXDomain on netobserv_namespace_dns_latency_seconds_count, or flow logs
+        showing NXDOMAIN / failing DnsName (e.g. does-not-exist-*.netobserv-eval.invalid). Names the
+        target namespace, cites numeric NXDOMAIN rate or sample failing names, and explains if alerts
+        are absent despite metric evidence.
       turn_metrics:
         - custom:answer_correctness
-        - geval:generic_troubleshooting_experience
 
   setup_script: scenarios/dns_nxdomain/setup.sh
   cleanup_script: scenarios/dns_nxdomain/cleanup.sh
@@ -66,10 +59,6 @@
         Network traffic in namespace netobserv-eval-drops-kernel shows packet loss. Investigate
         kernel-level packet drops using NetObserv metrics and flow logs. Which nodes or workloads
         are affected and what drop causes appear?
-      contexts:
-        - "PacketDrop eBPF feature must be enabled for drop metrics and PktDrop* flow fields."
-        - "Metrics include netobserv_namespace_drop_packets_total, netobserv_node_drop_packets_total; health rule PacketDropsByKernel."
-        - "Flow logs may show PktDropLatestDropCause, PktDropPackets, PktDropLatestState."
       expected_response: >
         Investigates kernel packet drops with NetObserv: PacketDropsByKernel alert or
         netobserv_*_drop_* metrics, optionally Loki flows with drop fields. Identifies nodes,
@@ -77,7 +66,6 @@
         and distinguishes kernel drops from policy drops.
       turn_metrics:
         - custom:answer_correctness
-        - geval:generic_troubleshooting_experience
 
   setup_script: scenarios/packet_drops_kernel/setup.sh
   cleanup_script: scenarios/packet_drops_kernel/cleanup.sh
@@ -93,18 +81,13 @@
         In namespace netobserv-eval-drops-policy, pods cannot reach each other and we suspect
         NetworkPolicy is blocking traffic. Use NetObserv to find network policy related drops
         or denials in the last hour.
-      contexts:
-        - "NetObserv health rule NetpolDenied and metric netobserv_namespace_network_policy_events_total require NetworkEvents feature."
-        - "Flow logs may include NetworkEvents with action drop and policy feature acl."
-        - "Distinguish policy drops from kernel buffer drops (PacketDropsByKernel)."
       expected_response: >
-        Uses NetObserv to identify policy-related denials: NetpolDenied alert, network policy
-        event metrics, or flow log NetworkEvents showing drop actions. Names source/destination
-        namespaces and policies involved when visible in data, and recommends NetworkPolicy
-        review rather than only kernel tuning.
+        Identifies NetworkPolicy-related denials in netobserv-eval-drops-policy: netobserv_namespace_network_policy_events_total
+        with action=drop, and/or flow evidence (OVS_DROP_EXPLICIT, packetLoss=dropped) between policy-frontend and policy-backend.
+        Names the restrictive policy (deny-frontend-to-backend) or src/dst workloads, cites metric or log values, and recommends
+        NetworkPolicy review — not "no drops detected" from an incomplete drop_packets_total query.
       turn_metrics:
         - custom:answer_correctness
-        - geval:generic_troubleshooting_experience
 
   setup_script: scenarios/packet_drops_policy/setup.sh
   cleanup_script: scenarios/packet_drops_policy/cleanup.sh
@@ -120,10 +103,6 @@
         Namespace netobserv-eval-tls has HTTPS and TLS connection problems between workloads
         over the last hour. Use NetObserv metrics and flows to investigate failed connections,
         TLS errors, or related ingress/IPsec issues.
-      contexts:
-        - "Ingress5xxErrors health rule relates to ingress HTTP errors; check netobserv metrics and alerts."
-        - "IPsecErrors health rule applies when IPSec eBPF feature is enabled (netobserv_node_ipsec_flows_total)."
-        - "May combine flow logs (Proto=6, DstPort=443) with metrics; cite evidence from tools."
       expected_response: >
         Investigates TLS/HTTPS/connectivity using NetObserv: Ingress5xxErrors or related alerts,
         elevated error rates on ingress paths, IPsecErrors if applicable, and flow evidence for
@@ -131,7 +110,6 @@
         termination, backend unreachable, or IPsec misconfiguration based on available data.
       turn_metrics:
         - custom:answer_correctness
-        - geval:generic_troubleshooting_experience
 
   setup_script: scenarios/tls_issues/setup.sh
   cleanup_script: scenarios/tls_issues/cleanup.sh
@@ -147,10 +125,6 @@
         Application teams report slow TCP connections and high network latency between
         services in namespace netobserv-eval-tcp-rtt. Use NetObserv to analyze TCP round-trip
         time trends in the last hour.
-      contexts:
-        - "FlowRTT feature enables netobserv_namespace_rtt_seconds and TimeFlowRttNs in flows."
-        - "Health rule LatencyHighTrend flags rising RTT; use histogram_quantile on RTT metrics when present."
-        - "Prefer namespace-level metrics before high-cardinality workload series."
       expected_response: >
         Analyzes TCP RTT using NetObserv: netobserv_namespace_rtt_seconds or LatencyHighTrend
         alert, with PromQL such as histogram_quantile on RTT histograms when applicable.
@@ -158,7 +132,6 @@
         if FlowRTT is disabled when metrics are missing.
       turn_metrics:
         - custom:answer_correctness
-        - geval:generic_troubleshooting_experience
 
   setup_script: scenarios/tcp_rtt/setup.sh
   cleanup_script: scenarios/tcp_rtt/cleanup.sh

--- a/eval/netobserv/scenario_evals.yaml
+++ b/eval/netobserv/scenario_evals.yaml
@@ -1,0 +1,164 @@
+# NetObserv evaluation scenarios — requires live cluster + NetObserv + obs-mcp
+
+# --- DNS latency (DNSTracking) ---
+- conversation_group_id: dns_latency
+  tag: dns_latency
+  description: "NetObserv DNS latency — investigate slow DNS using netobserv metrics or flow logs"
+
+  turns:
+    - turn_id: dns_latency
+      query: >
+        Applications in namespace netobserv-eval-dns-latency report slow DNS lookups over
+        the last hour. Use NetObserv network observability data to investigate DNS latency
+        and identify which workloads or queries are affected.
+      contexts:
+        - "Agent should use Prometheus netobserv_* metrics (e.g. netobserv_namespace_dns_latency_seconds) and/or Loki flow logs with DnsLatencyMs when DNSTracking is enabled."
+        - "DNSTracking must be enabled in FlowCollector spec.agent.ebpf.features for DNS latency metrics."
+        - "For Loki flow logs use SrcK8S_Namespace/DstK8S_Namespace and tenant network on OpenShift — not kubernetes_namespace_name."
+        - "If no data is present, state that clearly and mention required NetObserv features or export configuration."
+      expected_response: >
+        Evidence-based investigation using NetObserv: queries netobserv_namespace_dns_latency_seconds
+        or related DNS metrics, or Loki flow fields (DnsLatencyMs, DnsName). Identifies namespaces
+        or workloads with elevated latency, cites concrete metric values or log patterns, and mentions
+        DNSTracking or missing metrics if data is unavailable.
+      turn_metrics:
+        - custom:answer_correctness
+        - geval:generic_troubleshooting_experience
+
+  setup_script: scenarios/dns_latency/setup.sh
+  cleanup_script: scenarios/dns_latency/cleanup.sh
+
+# --- DNS NXDOMAIN / DNS errors ---
+- conversation_group_id: dns_nxdomain
+  tag: dns_nxdomain
+  description: "NetObserv DNS errors — NXDOMAIN and DNS failure investigation"
+
+  turns:
+    - turn_id: dns_nxdomain
+      query: >
+        Namespace netobserv-eval-dns-nxdomain has DNS resolution failures. Check NetObserv
+        for DNS-related errors such as NXDOMAIN or elevated DNS error rates in the last hour
+        and tell me what is failing.
+      contexts:
+        - "NetObserv health rules include DNSErrors and DNSNxDomain when DNSTracking is enabled."
+        - "Flow log fields include DnsErrno, DnsFlagsResponseCode, DnsName — use Loki with correct indexed labels."
+        - "Should check firing alerts (DNSErrors, DNSNxDomain) via Prometheus/Alertmanager when available."
+      expected_response: >
+        Uses NetObserv data to find DNS failures: alerts (DNSErrors/DNSNxDomain), metrics, or
+        flow logs showing error response codes / errno. Names affected DNS names or namespaces,
+        provides evidence from tool output, and suggests whether the issue is misconfiguration,
+        upstream DNS, or missing records.
+      turn_metrics:
+        - custom:answer_correctness
+        - geval:generic_troubleshooting_experience
+
+  setup_script: scenarios/dns_nxdomain/setup.sh
+  cleanup_script: scenarios/dns_nxdomain/cleanup.sh
+
+# --- Kernel packet drops ---
+- conversation_group_id: packet_drops_kernel
+  tag: packet_drops_kernel
+  description: "NetObserv packet drops — kernel-level drops (PacketDropsByKernel)"
+
+  turns:
+    - turn_id: packet_drops_kernel
+      query: >
+        Network traffic in namespace netobserv-eval-drops-kernel shows packet loss. Investigate
+        kernel-level packet drops using NetObserv metrics and flow logs. Which nodes or workloads
+        are affected and what drop causes appear?
+      contexts:
+        - "PacketDrop eBPF feature must be enabled for drop metrics and PktDrop* flow fields."
+        - "Metrics include netobserv_namespace_drop_packets_total, netobserv_node_drop_packets_total; health rule PacketDropsByKernel."
+        - "Flow logs may show PktDropLatestDropCause, PktDropPackets, PktDropLatestState."
+      expected_response: >
+        Investigates kernel packet drops with NetObserv: PacketDropsByKernel alert or
+        netobserv_*_drop_* metrics, optionally Loki flows with drop fields. Identifies nodes,
+        namespaces, or interfaces with drops, cites drop causes from flow data when available,
+        and distinguishes kernel drops from policy drops.
+      turn_metrics:
+        - custom:answer_correctness
+        - geval:generic_troubleshooting_experience
+
+  setup_script: scenarios/packet_drops_kernel/setup.sh
+  cleanup_script: scenarios/packet_drops_kernel/cleanup.sh
+
+# --- Network policy packet drops ---
+- conversation_group_id: packet_drops_policy
+  tag: packet_drops_policy
+  description: "NetObserv packet drops — network policy denials (NetpolDenied)"
+
+  turns:
+    - turn_id: packet_drops_policy
+      query: >
+        In namespace netobserv-eval-drops-policy, pods cannot reach each other and we suspect
+        NetworkPolicy is blocking traffic. Use NetObserv to find network policy related drops
+        or denials in the last hour.
+      contexts:
+        - "NetObserv health rule NetpolDenied and metric netobserv_namespace_network_policy_events_total require NetworkEvents feature."
+        - "Flow logs may include NetworkEvents with action drop and policy feature acl."
+        - "Distinguish policy drops from kernel buffer drops (PacketDropsByKernel)."
+      expected_response: >
+        Uses NetObserv to identify policy-related denials: NetpolDenied alert, network policy
+        event metrics, or flow log NetworkEvents showing drop actions. Names source/destination
+        namespaces and policies involved when visible in data, and recommends NetworkPolicy
+        review rather than only kernel tuning.
+      turn_metrics:
+        - custom:answer_correctness
+        - geval:generic_troubleshooting_experience
+
+  setup_script: scenarios/packet_drops_policy/setup.sh
+  cleanup_script: scenarios/packet_drops_policy/cleanup.sh
+
+# --- TLS / HTTPS / ingress connectivity ---
+- conversation_group_id: tls_issues
+  tag: tls_issues
+  description: "NetObserv TLS and ingress errors — HTTPS failures and IPsec issues"
+
+  turns:
+    - turn_id: tls_issues
+      query: >
+        Namespace netobserv-eval-tls has HTTPS and TLS connection problems between workloads
+        over the last hour. Use NetObserv metrics and flows to investigate failed connections,
+        TLS errors, or related ingress/IPsec issues.
+      contexts:
+        - "Ingress5xxErrors health rule relates to ingress HTTP errors; check netobserv metrics and alerts."
+        - "IPsecErrors health rule applies when IPSec eBPF feature is enabled (netobserv_node_ipsec_flows_total)."
+        - "May combine flow logs (Proto=6, DstPort=443) with metrics; cite evidence from tools."
+      expected_response: >
+        Investigates TLS/HTTPS/connectivity using NetObserv: Ingress5xxErrors or related alerts,
+        elevated error rates on ingress paths, IPsecErrors if applicable, and flow evidence for
+        TCP:443 or failed connections. Explains whether the issue appears to be ingress/TLS
+        termination, backend unreachable, or IPsec misconfiguration based on available data.
+      turn_metrics:
+        - custom:answer_correctness
+        - geval:generic_troubleshooting_experience
+
+  setup_script: scenarios/tls_issues/setup.sh
+  cleanup_script: scenarios/tls_issues/cleanup.sh
+
+# --- Slow TCP RTT ---
+- conversation_group_id: tcp_rtt
+  tag: tcp_rtt
+  description: "NetObserv TCP RTT — high round-trip latency (FlowRTT)"
+
+  turns:
+    - turn_id: tcp_rtt
+      query: >
+        Application teams report slow TCP connections and high network latency between
+        services in namespace netobserv-eval-tcp-rtt. Use NetObserv to analyze TCP round-trip
+        time trends in the last hour.
+      contexts:
+        - "FlowRTT feature enables netobserv_namespace_rtt_seconds and TimeFlowRttNs in flows."
+        - "Health rule LatencyHighTrend flags rising RTT; use histogram_quantile on RTT metrics when present."
+        - "Prefer namespace-level metrics before high-cardinality workload series."
+      expected_response: >
+        Analyzes TCP RTT using NetObserv: netobserv_namespace_rtt_seconds or LatencyHighTrend
+        alert, with PromQL such as histogram_quantile on RTT histograms when applicable.
+        Identifies namespaces or paths with elevated RTT, cites numeric evidence, and notes
+        if FlowRTT is disabled when metrics are missing.
+      turn_metrics:
+        - custom:answer_correctness
+        - geval:generic_troubleshooting_experience
+
+  setup_script: scenarios/tcp_rtt/setup.sh
+  cleanup_script: scenarios/tcp_rtt/cleanup.sh

--- a/eval/netobserv/scenarios/common/check_prereqs.sh
+++ b/eval/netobserv/scenarios/common/check_prereqs.sh
@@ -45,10 +45,9 @@ check_netobserv_prereqs() {
   fi
 
   FC_NAME="$(echo "${FC_JSON}" | jq -r '.items[0].metadata.name')"
-  FC_NS="$(echo "${FC_JSON}" | jq -r '.items[0].metadata.namespace')"
   FC_READY="$(echo "${FC_JSON}" | jq -r '.items[0].status.conditions[]? | select(.type=="Ready") | .status' | head -n1)"
 
-  echo "FlowCollector: ${FC_NS}/${FC_NAME} (Ready=${FC_READY:-unknown})"
+  echo "FlowCollector: ${FC_NAME} (Ready=${FC_READY:-unknown})"
 
   if [[ "${FC_READY}" != "True" ]]; then
     echo "WARN: FlowCollector is not Ready — NetObserv metrics/logs may be incomplete"
@@ -68,10 +67,89 @@ check_netobserv_prereqs() {
   echo "OLS must have MCP access to Prometheus/Thanos (obs-mcp) and optionally NetObserv console or Loki tools."
 }
 
+# OpenShift restricted SCC requires runAsUser inside the namespace UID allocation.
+openshift_namespace_uid_min() {
+  local ns="$1"
+  local uid_range
+  uid_range="$(oc get namespace "${ns}" -o jsonpath='{.metadata.annotations.openshift\.io/sa\.scc\.uid-range}' 2>/dev/null || true)"
+  if [[ -z "${uid_range}" || "${uid_range}" != */* ]]; then
+    return 1
+  fi
+  echo "${uid_range%%/*}"
+}
+
+# Patch busybox/python/iperf containers to the namespace min UID; skip images with a fixed non-root USER.
+patch_openshift_deployments() {
+  local ns="$1"
+  local uid_min
+  if ! uid_min="$(openshift_namespace_uid_min "${ns}")"; then
+    echo "No OpenShift UID range on ${ns} — using manifest runAsUser values"
+    return 0
+  fi
+
+  echo "OpenShift: patching deployments in ${ns} to runAsUser=${uid_min}"
+  local deploy
+  for deploy in $(oc get deploy -n "${ns}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+    [[ -z "${deploy}" ]] && continue
+    local json container_count i
+    json="$(oc get deploy "${deploy}" -n "${ns}" -o json)"
+    container_count="$(echo "${json}" | jq '.spec.template.spec.containers | length')"
+    i=0
+    while [[ "${i}" -lt "${container_count}" ]]; do
+      local image
+      image="$(echo "${json}" | jq -r ".spec.template.spec.containers[${i}].image")"
+      case "${image}" in
+        *nginx-unprivileged* | *curlimages/curl*)
+          i=$((i + 1))
+          continue
+          ;;
+      esac
+      oc patch deploy "${deploy}" -n "${ns}" --type=json \
+        -p="[{\"op\":\"add\",\"path\":\"/spec/template/spec/containers/${i}/securityContext/runAsUser\",\"value\":${uid_min}}]" \
+        2>/dev/null \
+        || oc patch deploy "${deploy}" -n "${ns}" --type=json \
+          -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/${i}/securityContext/runAsUser\",\"value\":${uid_min}}]"
+      i=$((i + 1))
+    done
+  done
+}
+
+wait_for_namespace_gone() {
+  local ns="$1"
+  local max_attempts="${2:-90}"
+  local attempt
+  for attempt in $(seq 1 "${max_attempts}"); do
+    if ! oc get namespace "${ns}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "WARN: namespace ${ns} still terminating after $((max_attempts * 2))s"
+  return 1
+}
+
 deploy_netobserv_fixture() {
   local fixture_dir="$1"
   local ns="$2"
+  local recreate="${NETOBSERV_EVAL_RECREATE_NS:-true}"
+
+  if [[ "${recreate}" == "true" ]] && oc get namespace "${ns}" >/dev/null 2>&1; then
+    echo "Recreating eval namespace ${ns} for a clean fixture deploy…"
+    oc delete namespace "${ns}" --ignore-not-found --wait=false
+    wait_for_namespace_gone "${ns}" || true
+  fi
+
   oc apply -f "${fixture_dir}/manifest.yaml"
+
+  local attempt
+  for attempt in $(seq 1 15); do
+    if openshift_namespace_uid_min "${ns}" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+  done
+  patch_openshift_deployments "${ns}"
+
   echo "Deployed fixture in namespace ${ns}"
 }
 

--- a/eval/netobserv/scenarios/common/check_prereqs.sh
+++ b/eval/netobserv/scenarios/common/check_prereqs.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Shared prerequisites and helpers for NetObserv troubleshooting eval scenarios.
+# Requires NetObserv (FlowCollector) and observability MCP tools (obs-mcp, optional kubernetes-mcp-server netobserv).
+
+set -euo pipefail
+
+NETOBSERV_NS="${NETOBSERV_NS:-netobserv}"
+TARGET_NS="${TARGET_NS:-netobserv}"
+
+# Optional space-separated FlowCollector eBPF features (e.g. "DNSTracking PacketDrop").
+REQUIRED_NETOBSERV_FEATURES="${REQUIRED_NETOBSERV_FEATURES:-}"
+
+check_netobserv_feature() {
+  local feature="$1"
+  local fc_json="$2"
+  if echo "${fc_json}" | jq -e --arg f "${feature}" '
+    [.items[0].spec.agent.ebpf.features[]? | if type == "string" then . else .name end] | index($f)
+  ' >/dev/null; then
+    return 0
+  fi
+  echo "WARN: FlowCollector does not list eBPF feature '${feature}' — NetObserv may not export related metrics/flows"
+  return 1
+}
+
+check_netobserv_prereqs() {
+  if ! command -v oc >/dev/null 2>&1; then
+    echo "ERROR: oc is required for NetObserv scenarios"
+    exit 1
+  fi
+
+  if ! oc whoami >/dev/null 2>&1; then
+    echo "ERROR: not logged in to OpenShift (oc whoami failed)"
+    exit 1
+  fi
+
+  if ! oc api-resources --api-group=flows.netobserv.io 2>/dev/null | grep -q flowcollectors; then
+    echo "ERROR: FlowCollector CRD (flows.netobserv.io) not found — install NetObserv operator first"
+    exit 1
+  fi
+
+  FC_JSON="$(oc get flowcollector -A -o json 2>/dev/null || true)"
+  if [[ -z "${FC_JSON}" || "$(echo "${FC_JSON}" | jq '.items | length')" == "0" ]]; then
+    echo "ERROR: no FlowCollector resource found in the cluster"
+    exit 1
+  fi
+
+  FC_NAME="$(echo "${FC_JSON}" | jq -r '.items[0].metadata.name')"
+  FC_NS="$(echo "${FC_JSON}" | jq -r '.items[0].metadata.namespace')"
+  FC_READY="$(echo "${FC_JSON}" | jq -r '.items[0].status.conditions[]? | select(.type=="Ready") | .status' | head -n1)"
+
+  echo "FlowCollector: ${FC_NS}/${FC_NAME} (Ready=${FC_READY:-unknown})"
+
+  if [[ "${FC_READY}" != "True" ]]; then
+    echo "WARN: FlowCollector is not Ready — NetObserv metrics/logs may be incomplete"
+  fi
+
+  if ! oc get namespace "${TARGET_NS}" >/dev/null 2>&1; then
+    echo "WARN: target namespace '${TARGET_NS}' does not exist — agent may still answer cluster-wide"
+  fi
+
+  if [[ -n "${REQUIRED_NETOBSERV_FEATURES}" ]]; then
+    for feat in ${REQUIRED_NETOBSERV_FEATURES}; do
+      check_netobserv_feature "${feat}" "${FC_JSON}" || true
+    done
+  fi
+
+  echo "NetObserv prerequisites OK (TARGET_NS=${TARGET_NS}, NETOBSERV_NS=${NETOBSERV_NS})"
+  echo "OLS must have MCP access to Prometheus/Thanos (obs-mcp) and optionally NetObserv console or Loki tools."
+}
+
+deploy_netobserv_fixture() {
+  local fixture_dir="$1"
+  local ns="$2"
+  oc apply -f "${fixture_dir}/manifest.yaml"
+  echo "Deployed fixture in namespace ${ns}"
+}
+
+cleanup_netobserv_fixture() {
+  local ns="$1"
+  if oc get namespace "${ns}" >/dev/null 2>&1; then
+    oc delete namespace "${ns}" --ignore-not-found --wait=false
+    echo "Deleted namespace ${ns}"
+  else
+    echo "Namespace ${ns} not present — nothing to clean up"
+  fi
+}

--- a/eval/netobserv/scenarios/common/wait_for.sh
+++ b/eval/netobserv/scenarios/common/wait_for.sh
@@ -5,7 +5,18 @@ wait_for_rollout() {
   local ns="$1"
   local deployment="$2"
   local timeout="${3:-120s}"
-  oc wait --for=condition=available "deployment/${deployment}" -n "$ns" --timeout="$timeout"
+  if oc wait --for=condition=available "deployment/${deployment}" -n "$ns" --timeout="$timeout"; then
+    return 0
+  fi
+  echo "ERROR: deployment/${deployment} not available in ${ns} within ${timeout}"
+  oc get pods -n "$ns" -l "app=${deployment}" -o wide 2>/dev/null \
+    || oc get pods -n "$ns" -o wide 2>/dev/null || true
+  local pod
+  for pod in $(oc get pods -n "$ns" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+    echo "--- oc describe pod/${pod} -n ${ns} (last events) ---"
+    oc describe pod "${pod}" -n "$ns" 2>/dev/null | tail -25 || true
+  done
+  return 1
 }
 
 wait_for_log_pattern() {
@@ -28,4 +39,37 @@ wait_for_log_pattern() {
   oc get pods -n "$ns" -l "$selector" 2>/dev/null || true
   oc logs -n "$ns" -l "$selector" --tail=20 2>/dev/null || true
   return 1
+}
+
+# Require at least min_count log lines matching pattern (sustained traffic before NetObserv export).
+wait_for_min_log_matches() {
+  local ns="$1"
+  local selector="$2"
+  local pattern="$3"
+  local min_count="${4:-3}"
+  local max_attempts="${5:-50}"
+  local sleep_secs="${6:-3}"
+
+  local attempt count
+  for attempt in $(seq 1 "$max_attempts"); do
+    count="$(oc logs -n "$ns" -l "$selector" --tail=80 2>/dev/null | grep -cE "$pattern" || true)"
+    if [[ "${count}" -ge "${min_count}" ]]; then
+      echo "Log pattern matched ${count} times (need >= ${min_count}, attempt ${attempt}/${max_attempts})"
+      return 0
+    fi
+    echo "  attempt ${attempt}/${max_attempts}: ${count}/${min_count} log lines matching /${pattern}/ …"
+    sleep "$sleep_secs"
+  done
+  echo "ERROR: fewer than ${min_count} log lines matched /${pattern}/ within timeout"
+  oc logs -n "$ns" -l "$selector" --tail=30 2>/dev/null || true
+  return 1
+}
+
+# NetObserv eBPF → flowlogs-pipeline → Prometheus/Loki needs time after traffic starts.
+# Override with NETOBSERV_WARMUP_SECS (default 120).
+wait_for_netobserv_warmup() {
+  local secs="${NETOBSERV_WARMUP_SECS:-120}"
+  echo "Waiting ${secs}s for NetObserv to export flows/metrics (NETOBSERV_WARMUP_SECS)…"
+  sleep "$secs"
+  echo "NetObserv warmup complete"
 }

--- a/eval/netobserv/scenarios/common/wait_for.sh
+++ b/eval/netobserv/scenarios/common/wait_for.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Wait helpers for NetObserv eval scenarios.
+
+wait_for_rollout() {
+  local ns="$1"
+  local deployment="$2"
+  local timeout="${3:-120s}"
+  oc wait --for=condition=available "deployment/${deployment}" -n "$ns" --timeout="$timeout"
+}
+
+wait_for_log_pattern() {
+  local ns="$1"
+  local selector="$2"
+  local pattern="$3"
+  local max_attempts="${4:-40}"
+  local sleep_secs="${5:-3}"
+
+  local attempt
+  for attempt in $(seq 1 "$max_attempts"); do
+    if oc logs -n "$ns" -l "$selector" --tail=30 2>/dev/null | grep -qE "$pattern"; then
+      echo "Log pattern matched (attempt ${attempt}/${max_attempts})"
+      return 0
+    fi
+    echo "  attempt ${attempt}/${max_attempts}: waiting for log /${pattern}/ …"
+    sleep "$sleep_secs"
+  done
+  echo "ERROR: log pattern not found within timeout"
+  oc get pods -n "$ns" -l "$selector" 2>/dev/null || true
+  oc logs -n "$ns" -l "$selector" --tail=20 2>/dev/null || true
+  return 1
+}

--- a/eval/netobserv/scenarios/dns_latency/cleanup.sh
+++ b/eval/netobserv/scenarios/dns_latency/cleanup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../common/check_prereqs.sh
+source "${SCRIPT_DIR}/../common/check_prereqs.sh"
+cleanup_netobserv_fixture "netobserv-eval-dns-latency"

--- a/eval/netobserv/scenarios/dns_latency/fixtures/manifest.yaml
+++ b/eval/netobserv/scenarios/dns_latency/fixtures/manifest.yaml
@@ -1,0 +1,48 @@
+# Generates DNS traffic to cluster DNS and external resolvers (DNSTracking).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netobserv-eval-dns-latency
+  labels:
+    purpose: netobserv-eval
+    netobserv.openshift.io/eval-scenario: dns-latency
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dns-latency-prober
+  namespace: netobserv-eval-dns-latency
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dns-latency-prober
+  template:
+    metadata:
+      labels:
+        app: dns-latency-prober
+        netobserv.openshift.io/eval-scenario: dns-latency
+    spec:
+      containers:
+        - name: prober
+          # busybox includes nslookup — ubi-minimal needs a runtime microdnf install that often
+          # fails or exceeds the eval setup timeout before DNS lines appear in pod logs.
+          image: busybox:1.36.1
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "DNS latency prober: querying cluster DNS and external resolvers"
+              i=0
+              while true; do
+                nslookup kubernetes.default.svc.cluster.local 2>&1 || true
+                nslookup "slow-probe-${i}.netobserv-eval.example.com" 2>&1 || true
+                nslookup google.com 8.8.8.8 2>&1 || true
+                i=$((i + 1))
+                sleep 2
+              done
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 128Mi

--- a/eval/netobserv/scenarios/dns_latency/fixtures/manifest.yaml
+++ b/eval/netobserv/scenarios/dns_latency/fixtures/manifest.yaml
@@ -23,11 +23,20 @@ spec:
         app: dns-latency-prober
         netobserv.openshift.io/eval-scenario: dns-latency
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: prober
           # busybox includes nslookup — ubi-minimal needs a runtime microdnf install that often
           # fails or exceeds the eval setup timeout before DNS lines appear in pod logs.
-          image: busybox:1.36.1
+          image: busybox:1.36.1@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: ["ALL"]
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/eval/netobserv/scenarios/dns_latency/setup.sh
+++ b/eval/netobserv/scenarios/dns_latency/setup.sh
@@ -17,4 +17,5 @@ deploy_netobserv_fixture "${SCRIPT_DIR}/fixtures" "${TARGET_NS}"
 wait_for_rollout "${TARGET_NS}" "dns-latency-prober" "180s"
 echo "Waiting for DNS prober traffic (NetObserv export may take a few minutes)…"
 wait_for_log_pattern "${TARGET_NS}" "app=dns-latency-prober" "kubernetes\\.default|Name:|Address" 30 3
+wait_for_netobserv_warmup
 echo "Scenario dns_latency ready (TARGET_NS=${TARGET_NS})"

--- a/eval/netobserv/scenarios/dns_latency/setup.sh
+++ b/eval/netobserv/scenarios/dns_latency/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET_NS="netobserv-eval-dns-latency"
+export TARGET_NS
+export REQUIRED_NETOBSERV_FEATURES="DNSTracking"
+
+# shellcheck source=../common/check_prereqs.sh
+source "${SCRIPT_DIR}/../common/check_prereqs.sh"
+# shellcheck source=../common/wait_for.sh
+source "${SCRIPT_DIR}/../common/wait_for.sh"
+
+check_netobserv_prereqs
+deploy_netobserv_fixture "${SCRIPT_DIR}/fixtures" "${TARGET_NS}"
+
+wait_for_rollout "${TARGET_NS}" "dns-latency-prober" "180s"
+echo "Waiting for DNS prober traffic (NetObserv export may take a few minutes)…"
+wait_for_log_pattern "${TARGET_NS}" "app=dns-latency-prober" "kubernetes\\.default|Name:|Address" 30 3
+echo "Scenario dns_latency ready (TARGET_NS=${TARGET_NS})"

--- a/eval/netobserv/scenarios/dns_nxdomain/cleanup.sh
+++ b/eval/netobserv/scenarios/dns_nxdomain/cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/../common/check_prereqs.sh"
+cleanup_netobserv_fixture "netobserv-eval-dns-nxdomain"

--- a/eval/netobserv/scenarios/dns_nxdomain/fixtures/manifest.yaml
+++ b/eval/netobserv/scenarios/dns_nxdomain/fixtures/manifest.yaml
@@ -23,11 +23,20 @@ spec:
         app: dns-nxdomain-prober
         netobserv.openshift.io/eval-scenario: dns-nxdomain
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: prober
           # busybox includes nslookup — ubi-minimal needs a runtime microdnf install that often
           # fails or exceeds the eval setup timeout before NXDOMAIN lines appear in pod logs.
-          image: busybox:1.36.1
+          image: busybox:1.36.1@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: ["ALL"]
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/eval/netobserv/scenarios/dns_nxdomain/fixtures/manifest.yaml
+++ b/eval/netobserv/scenarios/dns_nxdomain/fixtures/manifest.yaml
@@ -1,0 +1,47 @@
+# Generates NXDOMAIN and DNS error responses (DNSTracking).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netobserv-eval-dns-nxdomain
+  labels:
+    purpose: netobserv-eval
+    netobserv.openshift.io/eval-scenario: dns-nxdomain
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dns-nxdomain-prober
+  namespace: netobserv-eval-dns-nxdomain
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dns-nxdomain-prober
+  template:
+    metadata:
+      labels:
+        app: dns-nxdomain-prober
+        netobserv.openshift.io/eval-scenario: dns-nxdomain
+    spec:
+      containers:
+        - name: prober
+          # busybox includes nslookup — ubi-minimal needs a runtime microdnf install that often
+          # fails or exceeds the eval setup timeout before NXDOMAIN lines appear in pod logs.
+          image: busybox:1.36.1
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "NXDOMAIN prober: resolving non-existent names"
+              i=0
+              while true; do
+                nslookup "does-not-exist-${i}.netobserv-eval.invalid" 2>&1 || true
+                nslookup "nxdomain-${i}.netobserv-eval.invalid" 2>&1 || true
+                i=$((i + 1))
+                sleep 1
+              done
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 128Mi

--- a/eval/netobserv/scenarios/dns_nxdomain/setup.sh
+++ b/eval/netobserv/scenarios/dns_nxdomain/setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET_NS="netobserv-eval-dns-nxdomain"
+export TARGET_NS
+export REQUIRED_NETOBSERV_FEATURES="DNSTracking"
+
+source "${SCRIPT_DIR}/../common/check_prereqs.sh"
+source "${SCRIPT_DIR}/../common/wait_for.sh"
+
+check_netobserv_prereqs
+deploy_netobserv_fixture "${SCRIPT_DIR}/fixtures" "${TARGET_NS}"
+
+wait_for_rollout "${TARGET_NS}" "dns-nxdomain-prober" "180s"
+wait_for_log_pattern "${TARGET_NS}" "app=dns-nxdomain-prober" "NXDOMAIN|can't find|can't resolve|SERVFAIL|not found" 40 3
+echo "Scenario dns_nxdomain ready (TARGET_NS=${TARGET_NS})"

--- a/eval/netobserv/scenarios/dns_nxdomain/setup.sh
+++ b/eval/netobserv/scenarios/dns_nxdomain/setup.sh
@@ -13,5 +13,6 @@ check_netobserv_prereqs
 deploy_netobserv_fixture "${SCRIPT_DIR}/fixtures" "${TARGET_NS}"
 
 wait_for_rollout "${TARGET_NS}" "dns-nxdomain-prober" "180s"
-wait_for_log_pattern "${TARGET_NS}" "app=dns-nxdomain-prober" "NXDOMAIN|can't find|can't resolve|SERVFAIL|not found" 40 3
+wait_for_log_pattern "${TARGET_NS}" "app=dns-nxdomain-prober" "NXDOMAIN|can't find|can't resolve|server can't find|SERVFAIL|not found" 40 3
+wait_for_netobserv_warmup
 echo "Scenario dns_nxdomain ready (TARGET_NS=${TARGET_NS})"

--- a/eval/netobserv/scenarios/packet_drops_kernel/cleanup.sh
+++ b/eval/netobserv/scenarios/packet_drops_kernel/cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/../common/check_prereqs.sh"
+cleanup_netobserv_fixture "netobserv-eval-drops-kernel"

--- a/eval/netobserv/scenarios/packet_drops_kernel/fixtures/manifest.yaml
+++ b/eval/netobserv/scenarios/packet_drops_kernel/fixtures/manifest.yaml
@@ -23,9 +23,18 @@ spec:
         app: iperf-server
         netobserv.openshift.io/eval-scenario: drops-kernel
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: iperf
-          image: networkstatic/iperf3:latest
+          image: networkstatic/iperf3:latest@sha256:07dcca91c0e47d82d83d91de8c3d46b840eef4180499456b4fa8d6dadb46b6c8
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: ["ALL"]
           args: ["-s"]
           ports:
             - containerPort: 5201
@@ -48,6 +57,11 @@ spec:
   selector:
     app: iperf-server
   ports:
+    # iperf3 uses TCP 5201 for session setup even during UDP tests.
+    - name: tcp
+      port: 5201
+      protocol: TCP
+      targetPort: 5201
     - name: udp
       port: 5201
       protocol: UDP
@@ -69,14 +83,32 @@ spec:
         app: iperf-udp-flood
         netobserv.openshift.io/eval-scenario: drops-kernel
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: flood
-          image: networkstatic/iperf3:latest
+          image: networkstatic/iperf3:latest@sha256:07dcca91c0e47d82d83d91de8c3d46b840eef4180499456b4fa8d6dadb46b6c8
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: ["ALL"]
           command: ["/bin/sh", "-c"]
           args:
             - |
               echo "Starting sustained UDP load to iperf-server (may cause kernel drops)"
-              exec iperf3 -c iperf-server -p 5201 -u -b 80M -l 1400 -t 86400 --get-server-output
+              # Brief TCP probe — UDP tests still require the TCP control channel on 5201.
+              for i in $(seq 1 60); do
+                if iperf3 -c iperf-server -p 5201 -t 1 2>&1 | grep -qE 'Connecting to host|connected'; then
+                  echo "iperf-server reachable (attempt ${i})"
+                  break
+                fi
+                echo "waiting for iperf-server TCP control channel (attempt ${i}/60)…"
+                sleep 2
+              done
+              exec iperf3 -c iperf-server -p 5201 -u -b 80M -l 1400 -i 1 -t 86400 --get-server-output
           resources:
             requests:
               cpu: 100m

--- a/eval/netobserv/scenarios/packet_drops_kernel/fixtures/manifest.yaml
+++ b/eval/netobserv/scenarios/packet_drops_kernel/fixtures/manifest.yaml
@@ -1,0 +1,85 @@
+# High-rate UDP between pods to encourage kernel-level packet loss (PacketDrop feature).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netobserv-eval-drops-kernel
+  labels:
+    purpose: netobserv-eval
+    netobserv.openshift.io/eval-scenario: drops-kernel
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iperf-server
+  namespace: netobserv-eval-drops-kernel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: iperf-server
+  template:
+    metadata:
+      labels:
+        app: iperf-server
+        netobserv.openshift.io/eval-scenario: drops-kernel
+    spec:
+      containers:
+        - name: iperf
+          image: networkstatic/iperf3:latest
+          args: ["-s"]
+          ports:
+            - containerPort: 5201
+              protocol: UDP
+            - containerPort: 5201
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: iperf-server
+  namespace: netobserv-eval-drops-kernel
+spec:
+  selector:
+    app: iperf-server
+  ports:
+    - name: udp
+      port: 5201
+      protocol: UDP
+      targetPort: 5201
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iperf-udp-flood
+  namespace: netobserv-eval-drops-kernel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: iperf-udp-flood
+  template:
+    metadata:
+      labels:
+        app: iperf-udp-flood
+        netobserv.openshift.io/eval-scenario: drops-kernel
+    spec:
+      containers:
+        - name: flood
+          image: networkstatic/iperf3:latest
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "Starting sustained UDP load to iperf-server (may cause kernel drops)"
+              exec iperf3 -c iperf-server -p 5201 -u -b 80M -l 1400 -t 86400 --get-server-output
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              memory: 128Mi

--- a/eval/netobserv/scenarios/packet_drops_kernel/setup.sh
+++ b/eval/netobserv/scenarios/packet_drops_kernel/setup.sh
@@ -14,5 +14,6 @@ deploy_netobserv_fixture "${SCRIPT_DIR}/fixtures" "${TARGET_NS}"
 
 wait_for_rollout "${TARGET_NS}" "iperf-server" "180s"
 wait_for_rollout "${TARGET_NS}" "iperf-udp-flood" "180s"
-wait_for_log_pattern "${TARGET_NS}" "app=iperf-udp-flood" "iperf|UDP|lost" 40 5
+wait_for_log_pattern "${TARGET_NS}" "app=iperf-udp-flood" 'Connecting to host|Mbits/sec|Lost/Total Datagrams|[0-9]+/[0-9]+ \([0-9.]+%\)' 40 5
+wait_for_netobserv_warmup
 echo "Scenario packet_drops_kernel ready (TARGET_NS=${TARGET_NS})"

--- a/eval/netobserv/scenarios/packet_drops_kernel/setup.sh
+++ b/eval/netobserv/scenarios/packet_drops_kernel/setup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET_NS="netobserv-eval-drops-kernel"
+export TARGET_NS
+export REQUIRED_NETOBSERV_FEATURES="PacketDrop"
+
+source "${SCRIPT_DIR}/../common/check_prereqs.sh"
+source "${SCRIPT_DIR}/../common/wait_for.sh"
+
+check_netobserv_prereqs
+deploy_netobserv_fixture "${SCRIPT_DIR}/fixtures" "${TARGET_NS}"
+
+wait_for_rollout "${TARGET_NS}" "iperf-server" "180s"
+wait_for_rollout "${TARGET_NS}" "iperf-udp-flood" "180s"
+wait_for_log_pattern "${TARGET_NS}" "app=iperf-udp-flood" "iperf|UDP|lost" 40 5
+echo "Scenario packet_drops_kernel ready (TARGET_NS=${TARGET_NS})"

--- a/eval/netobserv/scenarios/packet_drops_policy/cleanup.sh
+++ b/eval/netobserv/scenarios/packet_drops_policy/cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/../common/check_prereqs.sh"
+cleanup_netobserv_fixture "netobserv-eval-drops-policy"

--- a/eval/netobserv/scenarios/packet_drops_policy/fixtures/manifest.yaml
+++ b/eval/netobserv/scenarios/packet_drops_policy/fixtures/manifest.yaml
@@ -24,9 +24,13 @@ spec:
         tier: backend
         netobserv.openshift.io/eval-scenario: drops-policy
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: backend
-          image: nginxinc/nginx-unprivileged:latest
+          # Image USER 101 — do not set runAsUser (OpenShift SCC rejects UID 101 outside project range).
+          image: nginxinc/nginx-unprivileged:1.27-alpine@sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0
           ports:
             - containerPort: 8080
           resources:
@@ -65,9 +69,18 @@ spec:
         tier: frontend
         netobserv.openshift.io/eval-scenario: drops-policy
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: frontend
-          image: busybox:1.36
+          image: busybox:1.36.1@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: ["ALL"]
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -78,7 +91,7 @@ spec:
                 else
                   echo "ERROR: connection blocked or timed out (expected — NetworkPolicy)"
                 fi
-                sleep 10
+                sleep 5
               done
           resources:
             requests:

--- a/eval/netobserv/scenarios/packet_drops_policy/fixtures/manifest.yaml
+++ b/eval/netobserv/scenarios/packet_drops_policy/fixtures/manifest.yaml
@@ -1,0 +1,108 @@
+# Frontend cannot reach backend due to restrictive NetworkPolicy (NetworkEvents / NetpolDenied).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netobserv-eval-drops-policy
+  labels:
+    purpose: netobserv-eval
+    netobserv.openshift.io/eval-scenario: drops-policy
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-backend
+  namespace: netobserv-eval-drops-policy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: policy-backend
+  template:
+    metadata:
+      labels:
+        app: policy-backend
+        tier: backend
+        netobserv.openshift.io/eval-scenario: drops-policy
+    spec:
+      containers:
+        - name: backend
+          image: nginxinc/nginx-unprivileged:latest
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 64Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: policy-backend
+  namespace: netobserv-eval-drops-policy
+spec:
+  selector:
+    app: policy-backend
+  ports:
+    - port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-frontend
+  namespace: netobserv-eval-drops-policy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: policy-frontend
+  template:
+    metadata:
+      labels:
+        app: policy-frontend
+        tier: frontend
+        netobserv.openshift.io/eval-scenario: drops-policy
+    spec:
+      containers:
+        - name: frontend
+          image: busybox:1.36
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              while true; do
+                echo "Probing policy-backend:8080 …"
+                if wget -q -O- -T 3 http://policy-backend:8080/; then
+                  echo "unexpected success"
+                else
+                  echo "ERROR: connection blocked or timed out (expected — NetworkPolicy)"
+                fi
+                sleep 10
+              done
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-frontend-to-backend
+  namespace: netobserv-eval-drops-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: policy-backend
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              tier: backend
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/eval/netobserv/scenarios/packet_drops_policy/setup.sh
+++ b/eval/netobserv/scenarios/packet_drops_policy/setup.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TARGET_NS="netobserv-eval-drops-policy"
 export TARGET_NS
-export REQUIRED_NETOBSERV_FEATURES="NetworkEvents"
+# OVS_DROP_EXPLICIT in flows needs PacketDrop; NetpolDenied metric needs NetworkEvents.
+export REQUIRED_NETOBSERV_FEATURES="NetworkEvents PacketDrop"
 
 source "${SCRIPT_DIR}/../common/check_prereqs.sh"
 source "${SCRIPT_DIR}/../common/wait_for.sh"
@@ -14,5 +15,7 @@ deploy_netobserv_fixture "${SCRIPT_DIR}/fixtures" "${TARGET_NS}"
 
 wait_for_rollout "${TARGET_NS}" "policy-backend" "120s"
 wait_for_rollout "${TARGET_NS}" "policy-frontend" "120s"
-wait_for_log_pattern "${TARGET_NS}" "app=policy-frontend" "connection blocked|timed out" 40 3
+# Probe every ~5s — need several blocked attempts before NetObserv/Loki show OVS drops.
+wait_for_min_log_matches "${TARGET_NS}" "app=policy-frontend" "connection blocked|timed out" 5 60 5
+wait_for_netobserv_warmup
 echo "Scenario packet_drops_policy ready (TARGET_NS=${TARGET_NS})"

--- a/eval/netobserv/scenarios/packet_drops_policy/setup.sh
+++ b/eval/netobserv/scenarios/packet_drops_policy/setup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET_NS="netobserv-eval-drops-policy"
+export TARGET_NS
+export REQUIRED_NETOBSERV_FEATURES="NetworkEvents"
+
+source "${SCRIPT_DIR}/../common/check_prereqs.sh"
+source "${SCRIPT_DIR}/../common/wait_for.sh"
+
+check_netobserv_prereqs
+deploy_netobserv_fixture "${SCRIPT_DIR}/fixtures" "${TARGET_NS}"
+
+wait_for_rollout "${TARGET_NS}" "policy-backend" "120s"
+wait_for_rollout "${TARGET_NS}" "policy-frontend" "120s"
+wait_for_log_pattern "${TARGET_NS}" "app=policy-frontend" "connection blocked|timed out" 40 3
+echo "Scenario packet_drops_policy ready (TARGET_NS=${TARGET_NS})"

--- a/eval/netobserv/scenarios/tcp_rtt/cleanup.sh
+++ b/eval/netobserv/scenarios/tcp_rtt/cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/../common/check_prereqs.sh"
+cleanup_netobserv_fixture "netobserv-eval-tcp-rtt"

--- a/eval/netobserv/scenarios/tcp_rtt/fixtures/manifest.yaml
+++ b/eval/netobserv/scenarios/tcp_rtt/fixtures/manifest.yaml
@@ -1,0 +1,103 @@
+# HTTP server with artificial delay on responses (FlowRTT); client polls continuously.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netobserv-eval-tcp-rtt
+  labels:
+    purpose: netobserv-eval
+    netobserv.openshift.io/eval-scenario: tcp-rtt
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slow-http-server
+  namespace: netobserv-eval-tcp-rtt
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: slow-http-server
+  template:
+    metadata:
+      labels:
+        app: slow-http-server
+        netobserv.openshift.io/eval-scenario: tcp-rtt
+    spec:
+      containers:
+        - name: server
+          image: python:3.12-alpine
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              cat >/tmp/server.py <<'PY'
+              import time
+              from http.server import BaseHTTPRequestHandler, HTTPServer
+              class H(BaseHTTPRequestHandler):
+                  def do_GET(self):
+                      time.sleep(0.35)
+                      self.send_response(200)
+                      self.end_headers()
+                      self.wfile.write(b"slow\n")
+                  def log_message(self, *a): pass
+              HTTPServer(("0.0.0.0", 8080), H).serve_forever()
+              PY
+              exec python /tmp/server.py
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: slow-http-server
+  namespace: netobserv-eval-tcp-rtt
+spec:
+  selector:
+    app: slow-http-server
+  ports:
+    - port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rtt-client
+  namespace: netobserv-eval-tcp-rtt
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rtt-client
+  template:
+    metadata:
+      labels:
+        app: rtt-client
+        netobserv.openshift.io/eval-scenario: tcp-rtt
+    spec:
+      containers:
+        - name: client
+          image: busybox:1.36
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              while true; do
+                start=$(date +%s)
+                if wget -q -O- -T 10 http://slow-http-server:8080/; then
+                  end=$(date +%s)
+                  echo "OK round-trip $((end - start))s (expect elevated RTT)"
+                else
+                  echo "ERROR: request failed"
+                fi
+                sleep 3
+              done
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi

--- a/eval/netobserv/scenarios/tcp_rtt/fixtures/manifest.yaml
+++ b/eval/netobserv/scenarios/tcp_rtt/fixtures/manifest.yaml
@@ -23,9 +23,18 @@ spec:
         app: slow-http-server
         netobserv.openshift.io/eval-scenario: tcp-rtt
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: server
           image: python:3.12-alpine
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: ["ALL"]
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -79,9 +88,18 @@ spec:
         app: rtt-client
         netobserv.openshift.io/eval-scenario: tcp-rtt
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: client
-          image: busybox:1.36
+          image: busybox:1.36.1@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: ["ALL"]
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/eval/netobserv/scenarios/tcp_rtt/setup.sh
+++ b/eval/netobserv/scenarios/tcp_rtt/setup.sh
@@ -15,4 +15,5 @@ deploy_netobserv_fixture "${SCRIPT_DIR}/fixtures" "${TARGET_NS}"
 wait_for_rollout "${TARGET_NS}" "slow-http-server" "120s"
 wait_for_rollout "${TARGET_NS}" "rtt-client" "120s"
 wait_for_log_pattern "${TARGET_NS}" "app=rtt-client" "OK round-trip|elevated RTT" 40 3
+wait_for_netobserv_warmup
 echo "Scenario tcp_rtt ready (TARGET_NS=${TARGET_NS})"

--- a/eval/netobserv/scenarios/tcp_rtt/setup.sh
+++ b/eval/netobserv/scenarios/tcp_rtt/setup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET_NS="netobserv-eval-tcp-rtt"
+export TARGET_NS
+export REQUIRED_NETOBSERV_FEATURES="FlowRTT"
+
+source "${SCRIPT_DIR}/../common/check_prereqs.sh"
+source "${SCRIPT_DIR}/../common/wait_for.sh"
+
+check_netobserv_prereqs
+deploy_netobserv_fixture "${SCRIPT_DIR}/fixtures" "${TARGET_NS}"
+
+wait_for_rollout "${TARGET_NS}" "slow-http-server" "120s"
+wait_for_rollout "${TARGET_NS}" "rtt-client" "120s"
+wait_for_log_pattern "${TARGET_NS}" "app=rtt-client" "OK round-trip|elevated RTT" 40 3
+echo "Scenario tcp_rtt ready (TARGET_NS=${TARGET_NS})"

--- a/eval/netobserv/scenarios/tls_issues/cleanup.sh
+++ b/eval/netobserv/scenarios/tls_issues/cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/../common/check_prereqs.sh"
+cleanup_netobserv_fixture "netobserv-eval-tls"

--- a/eval/netobserv/scenarios/tls_issues/fixtures/manifest.yaml
+++ b/eval/netobserv/scenarios/tls_issues/fixtures/manifest.yaml
@@ -1,0 +1,122 @@
+# TLS server with self-signed cert; client performs HTTPS handshakes (TLS/connection errors on mismatch).
+# tls-server-cert Secret is created by setup.sh (openssl) — not stored in git.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netobserv-eval-tls
+  labels:
+    purpose: netobserv-eval
+    netobserv.openshift.io/eval-scenario: tls
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tls-nginx-config
+  namespace: netobserv-eval-tls
+data:
+  nginx.conf: |
+    # Required for nginx-unprivileged on OpenShift (non-root cannot write /run/nginx.pid).
+    pid /tmp/nginx.pid;
+    worker_processes 1;
+    error_log /dev/stderr warn;
+    events { worker_connections 1024; }
+    http {
+      access_log /dev/stdout;
+      server {
+        listen 8443 ssl;
+        ssl_certificate     /etc/tls/tls.crt;
+        ssl_certificate_key /etc/tls/tls.key;
+        location / { return 200 "ok\n"; }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tls-server
+  namespace: netobserv-eval-tls
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tls-server
+  template:
+    metadata:
+      labels:
+        app: tls-server
+        netobserv.openshift.io/eval-scenario: tls
+    spec:
+      containers:
+        - name: nginx
+          image: nginxinc/nginx-unprivileged:1.27-alpine
+          ports:
+            - containerPort: 8443
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/tls
+              readOnly: true
+            - name: config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: tls
+          secret:
+            secretName: tls-server-cert
+        - name: config
+          configMap:
+            name: tls-nginx-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tls-server
+  namespace: netobserv-eval-tls
+spec:
+  selector:
+    app: tls-server
+  ports:
+    - name: https
+      port: 8443
+      targetPort: 8443
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tls-client
+  namespace: netobserv-eval-tls
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tls-client
+  template:
+    metadata:
+      labels:
+        app: tls-client
+        netobserv.openshift.io/eval-scenario: tls
+    spec:
+      containers:
+        - name: client
+          image: curlimages/curl:8.11.0
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              while true; do
+                echo "HTTPS with verify (may fail on self-signed)…"
+                curl -fsS --max-time 5 "https://tls-server:8443/" 2>&1 || true
+                echo "Plain HTTP to TLS port (protocol mismatch)…"
+                curl -v --max-time 5 "http://tls-server:8443/" 2>&1 || true
+                sleep 8
+              done
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 128Mi

--- a/eval/netobserv/scenarios/tls_issues/setup.sh
+++ b/eval/netobserv/scenarios/tls_issues/setup.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET_NS="netobserv-eval-tls"
+TLS_SECRET_NAME="tls-server-cert"
+TLS_CN="tls-server.netobserv-eval-tls.svc.cluster.local"
+export TARGET_NS
+
+source "${SCRIPT_DIR}/../common/check_prereqs.sh"
+source "${SCRIPT_DIR}/../common/wait_for.sh"
+
+check_netobserv_prereqs
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "ERROR: openssl is required to generate the eval TLS certificate"
+  exit 1
+fi
+
+deploy_netobserv_fixture "${SCRIPT_DIR}/fixtures" "${TARGET_NS}"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
+  -keyout "${TMPDIR}/tls.key" -out "${TMPDIR}/tls.crt" \
+  -subj "/CN=${TLS_CN}"
+
+oc create secret tls "${TLS_SECRET_NAME}" \
+  --cert="${TMPDIR}/tls.crt" --key="${TMPDIR}/tls.key" \
+  -n "${TARGET_NS}" --dry-run=client -o yaml | oc apply -f -
+
+if ! wait_for_rollout "${TARGET_NS}" "tls-server" "180s"; then
+  echo "tls-server rollout failed — pod status:"
+  oc get pods -n "${TARGET_NS}" -l app=tls-server
+  oc logs -n "${TARGET_NS}" -l app=tls-server -c nginx --tail=30 2>/dev/null || true
+  oc describe pod -n "${TARGET_NS}" -l app=tls-server | tail -40
+  exit 1
+fi
+wait_for_rollout "${TARGET_NS}" "tls-client" "120s"
+wait_for_log_pattern "${TARGET_NS}" "app=tls-client" "certificate|SSL|ERROR|failed|unable|refused" 30 3
+echo "Scenario tls_issues ready (TARGET_NS=${TARGET_NS})"

--- a/eval/netobserv/scenarios/tls_issues/setup.sh
+++ b/eval/netobserv/scenarios/tls_issues/setup.sh
@@ -39,4 +39,5 @@ if ! wait_for_rollout "${TARGET_NS}" "tls-server" "180s"; then
 fi
 wait_for_rollout "${TARGET_NS}" "tls-client" "120s"
 wait_for_log_pattern "${TARGET_NS}" "app=tls-client" "certificate|SSL|ERROR|failed|unable|refused" 30 3
+wait_for_netobserv_warmup
 echo "Scenario tls_issues ready (TARGET_NS=${TARGET_NS})"

--- a/eval/netobserv/system.yaml
+++ b/eval/netobserv/system.yaml
@@ -96,6 +96,9 @@ visualization:
 environment:
   DEEPEVAL_TELEMETRY_OPT_OUT: "YES"
   DEEPEVAL_DISABLE_PROGRESS_BAR: "YES"
+  # DeepEval tries to upload GEval scores to Confident AI unless disabled (needs CONFIDENT_API_KEY).
+  CONFIDENT_METRIC_LOGGING_ENABLED: "0"
+  CONFIDENT_METRIC_LOGGING_VERBOSE: "0"
   LITELLM_LOG: ERROR
 
 logging:

--- a/eval/netobserv/system.yaml
+++ b/eval/netobserv/system.yaml
@@ -1,0 +1,113 @@
+# LightSpeed Evaluation Framework Configuration — NetObserv Evals
+# OLS backend (api): model sent to OLS /query — must match olsconfig default_model.
+# Judge (llm): OpenAI scores responses (same key as OLS when using olsconfig-openai.yaml).
+#
+# Credentials: export OPENAI_API_KEY, or create ../../openai_api_key.txt (repo root).
+
+core:
+  max_threads: 5
+
+llm:
+  provider: "openai"
+  model: "gpt-4o-mini"
+  temperature: 0.0
+  max_tokens: 5000
+  timeout: 300
+  num_retries: 3
+  cache_enabled: false
+
+api:
+  enabled: true
+  api_base: http://localhost:8080
+  endpoint_type: query
+  timeout: 600
+  # Must match llm_providers[].name in the active olsconfig (e.g. openai).
+  provider: "openai"
+  model: "gpt-4o-mini"
+  no_tools: null
+  system_prompt: null
+  cache_enabled: false
+  extra_request_params:
+    mode: troubleshooting
+
+embedding:
+  cache_enabled: false
+
+metrics_metadata:
+  turn_level:
+    "custom:answer_correctness":
+      description: "Correctness vs expected answer using custom LLM evaluation"
+      default: false
+
+    "geval:generic_troubleshooting_experience":
+      description: "Evidence-based NetObserv investigation using real cluster data from tools"
+      criteria: |
+        The agent is investigating a network observability problem with NetObserv (Prometheus
+        netobserv_* metrics, Loki flow logs, alerts). Evaluate:
+          - The response must use real data from tool calls (metrics, flows, alerts), not generic advice
+          - Evidence should reference NetObserv-specific signals (metric names, flow fields, namespaces)
+          - Generic Kubernetes troubleshooting without NetObserv data must be penalized
+          - If data is missing, the agent should state that clearly and mention required FlowCollector features
+      evaluation_params:
+        - query
+        - response
+        - contexts
+      evaluation_steps:
+        - "Step 1: Check if the response cites real NetObserv tool output (metrics, flows, alerts) or only generic suggestions."
+        - "Step 2: Check if the analysis addresses the network observability symptom in the query."
+        - "Step 3: Check if namespaces, workloads, or metric/log values from the cluster are named in the response."
+        - "Step 4: If data is absent, check whether the agent explains missing NetObserv features or export config."
+
+  conversation_level:
+    "deepeval:conversation_completeness":
+      default: false
+
+    "deepeval:conversation_relevancy":
+      default: false
+
+    "deepeval:knowledge_retention":
+      default: false
+
+output:
+  output_dir: "./eval_output"
+  base_filename: "evaluation"
+  enabled_outputs:
+    - csv
+    - json
+  csv_columns:
+    - "conversation_group_id"
+    - "turn_id"
+    - "metric_identifier"
+    - "score"
+    - "threshold"
+    - "result"
+    - "reason"
+    - "query"
+    - "response"
+    - "execution_time"
+
+visualization:
+  figsize: [12, 8]
+  dpi: 300
+  enabled_graphs:
+    - "score_distribution"
+    - "status_breakdown"
+
+environment:
+  DEEPEVAL_TELEMETRY_OPT_OUT: "YES"
+  DEEPEVAL_DISABLE_PROGRESS_BAR: "YES"
+  LITELLM_LOG: ERROR
+
+logging:
+  source_level: INFO
+  package_level: ERROR
+  log_format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+  show_timestamps: true
+  package_overrides:
+    httpx: ERROR
+    urllib3: ERROR
+    requests: ERROR
+    matplotlib: ERROR
+    LiteLLM: WARNING
+    DeepEval: WARNING
+    ragas: WARNING

--- a/eval/scripts/update_eval_trends.py
+++ b/eval/scripts/update_eval_trends.py
@@ -16,6 +16,8 @@ Usage::
         --summary-json /logs/artifacts/troubleshooting/scenarios/evaluation_YYYYMMDD_summary.json \
         --suite lseval_troubleshooting_mcp \
         --summary-json /logs/artifacts/troubleshooting/mcp/evaluation_YYYYMMDD_summary.json \
+        --suite lseval_netobserv \
+        --summary-json /logs/artifacts/netobserv/evaluation_YYYYMMDD_summary.json \
         --history-csv eval/score_history.csv \
         --output-dir /logs/artifacts \
         [--date 2026-04-30]
@@ -50,6 +52,7 @@ _SUITE_LABELS: dict[str, str] = {
     "lseval_periodic": "Periodic QnA (797 questions)",
     "lseval_troubleshooting_scenarios": "Troubleshooting Scenarios",
     "lseval_troubleshooting_mcp": "Troubleshooting MCP",
+    "lseval_netobserv": "NetObserv Scenarios",
 }
 
 _METRIC_LABELS: dict[str, str] = {

--- a/eval/troubleshooting/README.md
+++ b/eval/troubleshooting/README.md
@@ -20,9 +20,13 @@ Scenarios require `oc` access to a running OpenShift cluster. Each one has a `se
 | `oom` | OOMKill | Pod in CrashLoopBackOff due to a deliberate memory leak exceeding its 60Mi limit |
 | `wrong_networkpolicy` | NetworkPolicy (multi-turn) | Three-turn conversation: diagnose frontend-backend connectivity, identify the blocking NetworkPolicy, and propose a fix |
 
+NetObserv network observability scenarios live in [`eval/netobserv/`](../netobserv/README.md).
+
 ## Running
 
 ```bash
+cd eval/troubleshooting
+
 # Single scenario
 make oom
 

--- a/skills/netobserv-flow-logs/reference.md
+++ b/skills/netobserv-flow-logs/reference.md
@@ -1,0 +1,92 @@
+# NetObserv flow fields — Loki and filters reference
+
+Source: [Network flows format reference](https://github.com/netobserv/network-observability-operator/blob/main/docs/flows-format.adoc) (`docs/flows-format.adoc`).
+
+Flow records are used for Kafka export, Prometheus `FlowMetric` labels, and **Loki storage**. The **Loki label** column indicates whether a field can be used in LogQL **stream selectors** `{label="value"}`.
+
+The **Filter ID** column is the name used in NetObserv console **Quick Filters** (`FlowCollector` `spec.consolePlugin.quickFilters`).
+
+## Loki-indexed labels (stream selectors)
+
+Use these in `{...}` matchers when confirmed by `loki_label_names`:
+
+| Field | Filter ID | Description |
+|-------|-----------|-------------|
+| `SrcK8S_Namespace` | `src_namespace` | Source namespace |
+| `DstK8S_Namespace` | `dst_namespace` | Destination namespace |
+| `SrcK8S_OwnerName` | `src_owner_name` | Source owner (Deployment, StatefulSet, …) |
+| `DstK8S_OwnerName` | `dst_owner_name` | Destination owner |
+| `SrcK8S_Type` | `src_kind` | Source K8s kind (Pod, Service, Node, …) |
+| `DstK8S_Type` | `dst_kind` | Destination K8s kind |
+| `SrcK8S_Zone` | `src_zone` | Source availability zone |
+| `DstK8S_Zone` | `dst_zone` | Destination availability zone |
+| `K8S_ClusterName` | `cluster_name` | Cluster name |
+| `K8S_FlowLayer` | `flow_layer` | `app` or `infra` |
+| `FlowDirection` | `node_direction` | `0` Ingress, `1` Egress, `2` Inner (node observation point) |
+| `_RecordType` | `type` | `flowLog`, `newConnection`, `heartbeat`, `endConnection` |
+
+## Common fields — not Loki labels (use console filters or line JSON)
+
+These appear in the flow format but **Loki label = no**. Do not assume they work in `{...}` without checking `loki_label_names`:
+
+| Field | Filter ID | Notes |
+|-------|-----------|-------|
+| `SrcK8S_Name` | `src_name` | Pod, Service, or Node name — careful cardinality |
+| `DstK8S_Name` | `dst_name` | Same for destination |
+| `Proto` | `protocol` | IANA L4 protocol (`6` TCP, `17` UDP) |
+| `SrcPort` | `src_port` | |
+| `DstPort` | `dst_port` | |
+| `SrcAddr` | `src_address` | IP address |
+| `DstAddr` | `dst_address` | IP address |
+| `Bytes` | n/a | Byte count for the flow |
+| `Packets` | n/a | Packet count |
+| `DnsName` | `dns_name` | Requires DNSTracking feature |
+| `DnsLatencyMs` | `dns_latency` | Requires DNSTracking |
+| `PktDropPackets` | n/a | Requires PacketDrop feature |
+| `PktDropLatestDropCause` | `pkt_drop_cause` | Requires PacketDrop |
+| `TimeFlowRttNs` | `time_flow_rtt` | RTT in nanoseconds — requires FlowRTT |
+
+## LogQL examples
+
+```logql
+# Namespace scope (most common)
+{SrcK8S_Namespace="netobserv"} or {DstK8S_Namespace="netobserv"}
+
+# Application flows only
+{K8S_FlowLayer="app"}
+
+# Exclude connection-tracking control messages
+{_RecordType="flowLog"}
+
+# Owner + namespace
+{SrcK8S_Namespace="default", SrcK8S_OwnerName="my-deployment"}
+```
+
+## OpenShift LokiStack notes
+
+- Flow logs for NetObserv on OpenShift often use Loki tenant **`network`**.
+- Gateway paths may be under `/api/logs/v1/<tenant>/...` when using openshift-network mode.
+- Empty streams with no error often indicate **RBAC** (user cannot view pods in the namespace used in the query) or **wrong tenant/labels**.
+
+## Labels to avoid for NetObserv flows
+
+| Label | Why |
+|-------|-----|
+| `kubernetes_namespace_name` | Container/application log schema, not flow logs |
+| `namespace` (generic) | Unless confirmed on the Loki stack, prefer `SrcK8S_Namespace` / `DstK8S_Namespace` |
+
+## Cardinality (FlowMetrics / labels)
+
+From the flows format **Cardinality** column:
+
+- **fine** — safer as metric or filter labels
+- **careful** — narrow with filters before using as labels
+- **avoid** — high cardinality (IPs, byte counts, timestamps)
+
+Mixing `SrcK8S_Name` and `DstK8S_Name` in the same metric label set can multiply cardinality severely.
+
+## Further reading
+
+- [Metrics.md](https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md) — Prometheus `netobserv_*` metrics from the same flow data
+- [HealthRules.md](https://github.com/netobserv/network-observability-operator/blob/main/docs/HealthRules.md) — alerts built on NetObserv metrics
+- Full field table: [flows-format.adoc](https://github.com/netobserv/network-observability-operator/blob/main/docs/flows-format.adoc)

--- a/skills/netobserv-flow-logs/reference.md
+++ b/skills/netobserv-flow-logs/reference.md
@@ -85,6 +85,38 @@ From the flows format **Cardinality** column:
 
 Mixing `SrcK8S_Name` and `DstK8S_Name` in the same metric label set can multiply cardinality severely.
 
+## DNS and error fields (DNSTracking)
+
+| Field | Meaning |
+|-------|---------|
+| `DnsName` | Queried name |
+| `DnsLatencyMs` | DNS lookup latency |
+| `DnsErrno` | Resolver errno when lookup fails |
+| `DnsFlagsResponseCode` | DNS RCODE — **3 = NXDOMAIN**; Prometheus metric label value is **`NXDomain`** |
+
+Console / MCP filter examples for namespace `NS`:
+
+- NXDOMAIN: `DstK8S_Namespace=NS&DnsFlagsResponseCode=3` (response path; client is destination)
+- Any DNS in NS: `SrcK8S_Namespace=NS|DstK8S_Namespace=NS` with DNS fields in results
+
+## Packet drop vs policy fields
+
+| Field / metric | Feature | Notes |
+|----------------|---------|-------|
+| `PktDropPackets`, `PktDropLatestDropCause` | PacketDrop | Kernel drops; on OpenShift **`OVS_DROP_EXPLICIT`** = NetworkPolicy/OVS deny |
+| `NetworkEvents` (action drop, feature acl) | NetworkEvents | Policy correlation in flow JSON |
+| `netobserv_namespace_network_policy_events_total{action="drop"}` | NetworkEvents | Primary policy **metric** — not the same as `drop_packets_total` |
+
+When the user suspects NetworkPolicy: query **`network_policy_events_total` with `action="drop"`** and flow logs with **`packetLoss=dropped`**. Do not conclude “policy is not blocking” from zero unscoped `drop_packets_total` alone.
+
+## RTT fields (FlowRTT)
+
+| Field | Notes |
+|-------|-------|
+| `TimeFlowRttNs` | Per-flow RTT in nanoseconds — cite in answers; convert to ms for readability |
+
+Prometheus counterpart: `netobserv_namespace_rtt_seconds` histogram — prefer both when investigating latency.
+
 ## Further reading
 
 - [Metrics.md](https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md) — Prometheus `netobserv_*` metrics from the same flow data

--- a/skills/netobserv-flow-logs/skill.md
+++ b/skills/netobserv-flow-logs/skill.md
@@ -100,6 +100,36 @@ Report which case applies using evidence (label list, error message, FlowCollect
 
 Use both: metrics for "how much" and "trend", flow logs for "which flows" and "exact endpoints".
 
+## 8. Symptom Playbooks (Required After Metrics)
+
+After checking alerts and Prometheus metrics, query flow logs scoped to the **user's target namespace** (`SrcK8S_Namespace` or `DstK8S_Namespace`). Cite filter/LogQL used and sample field values from results.
+
+| Symptom | Flow investigation | Key fields to cite |
+|---------|-------------------|-------------------|
+| DNS failures / NXDOMAIN | Flows where client NS is **destination** (DNS response path) | `DnsName`, `DnsErrno`, `DnsFlagsResponseCode` — filter **`DstK8S_Namespace=TARGET_NS`** first |
+| Slow DNS | Same namespace, sort/filter by latency | `DnsLatencyMs`, `DnsName`, workload names from `SrcK8S_OwnerName` |
+| Kernel packet drops | `{_RecordType="flowLog"}` + namespace scope | `PktDropPackets`, `PktDropLatestDropCause`, `PktDropLatestState` |
+| NetworkPolicy blocks | `packetLoss=dropped` + namespace scope; check `NetworkEvents` and OVS causes | **`PktDropLatestDropCause=OVS_DROP_EXPLICIT`** (OpenShift); `NetworkEvents` action=drop, feature=acl |
+| TLS / HTTPS issues | TCP flows to port 443 in target NS | `Proto=6`, `DstPort=443`; pair with ingress error metrics |
+| High TCP RTT | Flows in target NS with RTT feature enabled | `TimeFlowRttNs` (nanoseconds) — do not confuse with unrelated pod metrics |
+
+**LogQL starting point** (tenant `network` on OpenShift):
+
+```logql
+{SrcK8S_Namespace="TARGET_NS", _RecordType="flowLog"} or {DstK8S_Namespace="TARGET_NS", _RecordType="flowLog"}
+```
+
+For non-indexed filters (`DnsName`, `DstPort`, `DnsErrno`), use NetObserv console filter syntax or `netobserv_list_flows` when available, for example:
+
+- DNS NXDOMAIN in **Prometheus**: `netobserv_namespace_dns_latency_seconds_count{DnsFlagsResponseCode="NXDomain",DstK8S_Namespace=TARGET_NS}` — return traffic; try `SrcK8S_Namespace` only if empty (see `netobserv-metrics` skill)
+- DNS NXDOMAIN in **flows**: `DstK8S_Namespace=TARGET_NS&DnsFlagsResponseCode=3` or `DstK8S_Namespace=TARGET_NS&DnsName~netobserv-eval.invalid`
+- **NetworkPolicy / OVS drops** in **flows**: `SrcK8S_Namespace=TARGET_NS&packetLoss=dropped` — cite `PktDropLatestDropCause=OVS_DROP_EXPLICIT` when present; also check `NetworkEvents` (action drop) in flow JSON
+- **NetworkPolicy** in **Prometheus**: `netobserv_namespace_network_policy_events_total{action="drop",SrcK8S_Namespace=TARGET_NS}` (see `netobserv-metrics` skill)
+- HTTPS: `SrcK8S_Namespace=TARGET_NS&Proto=6&DstPort=443`
+- Kernel drops: `SrcK8S_Namespace=TARGET_NS&packetLoss=dropped` with causes other than OVS (e.g. `SKB_DROP`)
+
+If alerts and metrics are empty but the user reports an active problem, **still run flow queries** — DNS errors and policy denials often appear in logs before alert thresholds fire.
+
 ## Quality Standards
 
 - Prefer `SrcK8S_Namespace` / `DstK8S_Namespace` over generic Kubernetes logging labels.

--- a/skills/netobserv-flow-logs/skill.md
+++ b/skills/netobserv-flow-logs/skill.md
@@ -1,0 +1,108 @@
+---
+name: netobserv-flow-logs
+description: Query NetObserv network flow logs in Loki using LogQL and flow field labels (SrcK8S_Namespace, DstK8S_Namespace, K8S_FlowLayer). Use for per-flow investigation, conversation records, packet drops in logs, DNS flows, or when Prometheus netobserv_* metrics are not enough.
+---
+
+# NetObserv Flow Logs (Loki)
+
+NetObserv stores **enriched network flow records** in Loki. Each log line represents aggregated or conversation-tracked flow data with Kubernetes, network, and optional DNS/drop fields.
+
+Use this skill when the user needs **individual flows**, conversation history, or label combinations that Prometheus `netobserv_*` metrics cannot express. For bandwidth totals and rates, prefer the `netobserv-metrics` skill first.
+
+## 1. Choose the Right Tooling
+
+| Need | Approach |
+|------|----------|
+| Filtered flow table in NetObserv UI semantics | NetObserv console plugin or `netobserv_*` MCP tools (kubernetes-mcp-server) when available |
+| Raw LogQL, label discovery, LokiStack on OpenShift | `loki_list_instances` → `loki_label_names` / `loki_label_values` → `loki_query_range` (obs-mcp) |
+
+On OpenShift with LokiStack **openshift-network** mode:
+
+- Use tenant **`network`** (`X-Scope-OrgID`) when querying through the gateway.
+- Do **not** use `kubernetes_namespace_name` — that label is for container/application logs, not NetObserv flows.
+
+## 2. Discover Labels Before Writing LogQL
+
+1. Confirm `FlowCollector` has Loki enabled (`spec.loki` configured).
+2. List Loki labels for a short time window — only use **indexed** fields as stream selectors (see `reference.md`).
+3. Start with low-cardinality matchers: `SrcK8S_Namespace`, `DstK8S_Namespace`, `K8S_FlowLayer`, `_RecordType`.
+4. Add `SrcK8S_OwnerName` / `DstK8S_OwnerName` or `SrcK8S_Type` / `DstK8S_Type` when narrowing to a workload.
+
+Load `reference.md` for the full Loki-indexed label list and field semantics from the flows format specification.
+
+## 3. Common LogQL Patterns
+
+**Flows involving a namespace (source or destination):**
+
+```logql
+{SrcK8S_Namespace="my-app"} or {DstK8S_Namespace="my-app"}
+```
+
+**Application-layer flows only:**
+
+```logql
+{K8S_FlowLayer="app"}
+```
+
+**Regular flow logs (exclude connection tracking control records):**
+
+```logql
+{_RecordType="flowLog"}
+```
+
+**Combine namespace + layer:**
+
+```logql
+{SrcK8S_Namespace="netobserv", K8S_FlowLayer="app"} or {DstK8S_Namespace="netobserv", K8S_FlowLayer="app"}
+```
+
+Use a **short time range** and **low limit** first, then widen. Broad queries without label matchers are expensive.
+
+## 4. Fields That Are Not Loki Labels
+
+Many flow fields exist in the JSON payload but are **not** indexed as Loki stream labels (for example `SrcK8S_Name`, `DstK8S_Name`, `Proto`, `SrcPort`, `DstPort`, `Bytes`, `DnsName`).
+
+- Do not put non-indexed field names in the stream selector `{...}` unless `loki_label_names` confirms they exist.
+- For console-style filters on those fields, use NetObserv plugin filter syntax or `netobserv_list_flows` when available.
+- If log line parsing is required, use LogQL pipeline stages only after confirming the deployment exposes those fields in the line format.
+
+## 5. Map Questions to Fields
+
+| User intent | Indexed labels / fields |
+|-------------|-------------------------|
+| Traffic to/from a namespace | `SrcK8S_Namespace`, `DstK8S_Namespace` |
+| Pod / Service / Node name | `SrcK8S_Name`, `DstK8S_Name` (not indexed — use plugin filters or metrics) |
+| Deployment / StatefulSet | `SrcK8S_OwnerName`, `DstK8S_OwnerName` |
+| Pod vs Service vs Node | `SrcK8S_Type`, `DstK8S_Type` |
+| Ingress / egress at node | `FlowDirection` (`0` Ingress, `1` Egress, `2` Inner) |
+| App vs infrastructure flows | `K8S_FlowLayer` (`app` or `infra`) |
+| TCP vs UDP | `Proto` (`6` = TCP, `17` = UDP) — verify via label discovery |
+| Packet drops in logs | `PktDropPackets`, `PktDropLatestDropCause` (typically in line JSON; PacketDrop feature required) |
+| DNS | `DnsName`, `DnsLatencyMs` (DNSTracking feature required) |
+| Connection tracking | `_RecordType`: `flowLog`, `newConnection`, `heartbeat`, `endConnection` |
+
+## 6. Empty Results
+
+If LogQL returns no streams:
+
+1. **Wrong labels** — `kubernetes_namespace_name` or container log labels will not match flow logs.
+2. **Wrong tenant** — OpenShift network flows use tenant `network`.
+3. **RBAC** — Loki gateway may enforce OpenShift authorization; the user must be allowed to view pods in filtered namespaces.
+4. **No export** — FlowCollector not writing to this LokiStack, or time range has no data.
+5. **Feature disabled** — DNS or drop fields require eBPF features in `FlowCollector`.
+
+Report which case applies using evidence (label list, error message, FlowCollector status).
+
+## 7. Relation to Metrics
+
+- **Metrics** (`netobserv_*` in Prometheus): aggregates, dashboards, alerts.
+- **Flow logs** (Loki): drill-down, arbitrary label combinations, conversation records.
+
+Use both: metrics for "how much" and "trend", flow logs for "which flows" and "exact endpoints".
+
+## Quality Standards
+
+- Prefer `SrcK8S_Namespace` / `DstK8S_Namespace` over generic Kubernetes logging labels.
+- Always confirm labels with discovery tools before assuming a field is indexed.
+- Cite the LogQL selector used and the time range.
+- Do not fabricate flow records when queries return zero streams — explain likely causes.

--- a/skills/netobserv-metrics/reference.md
+++ b/skills/netobserv-metrics/reference.md
@@ -7,6 +7,19 @@ Source: [NetObserv operator Metrics documentation](https://github.com/netobserv/
 - Configure in `FlowCollector` `spec.processor.metrics.includeList` using the **short name** (no prefix).
 - Prometheus exposes `netobserv_<short_name>` (for example `namespace_egress_packets_total` → `netobserv_namespace_egress_packets_total`).
 
+## Prometheus labels (not `namespace`)
+
+Namespace-scoped metrics use **Src/Dst flow labels**, matching Loki flow logs:
+
+| Label | Typical use |
+|-------|-------------|
+| `SrcK8S_Namespace`, `DstK8S_Namespace` | Scope to a Kubernetes namespace (use both sides with `or` when unsure) |
+| `K8S_FlowLayer` | `infra` for DNS/node traffic; `app` for pod/service traffic |
+| `DnsFlagsResponseCode` | On `*_dns_latency_seconds_*` — `NoError`, `NXDomain`, etc. **Response RCODE** (NXDOMAIN) labels the client on **`DstK8S_Namespace`**. |
+| `SrcK8S_OwnerName`, `DstK8S_OwnerName` | Workload / controller name (workload metrics) |
+
+Alert descriptions may show `namespace={{ $labels.namespace }}` after recording-rule `label_replace`; ad-hoc PromQL must still filter on `SrcK8S_Namespace` / `DstK8S_Namespace`.
+
 ## Predefined metrics
 
 `*` = enabled by default. `**` = also enabled by default when Loki is disabled (workload metrics may replace namespace counterparts).
@@ -79,19 +92,37 @@ Source: [NetObserv operator Metrics documentation](https://github.com/netobserv/
 **Counter rate (bandwidth or QPS):**
 
 ```promql
-sum(rate(netobserv_namespace_ingress_bytes_total{namespace="TARGET"}[2m]))
+sum(rate(netobserv_namespace_ingress_bytes_total{SrcK8S_Namespace="TARGET"}[2m]))
 ```
 
-**Top-N by namespace:**
+**Network policy drop rate (namespace TARGET):**
 
 ```promql
-topk(10, sum(rate(netobserv_namespace_egress_packets_total[5m])) by (namespace))
+sum(rate(netobserv_namespace_network_policy_events_total{action="drop",SrcK8S_Namespace="TARGET"}[2m])) by (type,direction,SrcK8S_Namespace,DstK8S_Namespace)
 ```
 
-**Histogram p99 (custom or RTT metrics with `_bucket`):**
+**Packet drops per namespace pair (app-layer pod traffic):**
 
 ```promql
-histogram_quantile(0.99, sum(rate(netobserv_namespace_rtt_seconds_bucket[2m])) by (le))
+sum(rate(netobserv_namespace_drop_packets_total{K8S_FlowLayer="app",SrcK8S_Namespace="TARGET"}[2m])) by (SrcK8S_Namespace,DstK8S_Namespace)
+```
+
+**DNS NXDOMAIN rate (namespace TARGET — RCODE on return traffic, use DstK8S_Namespace first):**
+
+```promql
+sum(rate(netobserv_namespace_dns_latency_seconds_count{DnsFlagsResponseCode="NXDomain",K8S_FlowLayer="infra",DstK8S_Namespace="TARGET"}[2m])) by (SrcK8S_Namespace,DstK8S_Namespace)
+```
+
+**Top-N by source namespace:**
+
+```promql
+topk(10, sum(rate(netobserv_namespace_egress_packets_total{SrcK8S_Namespace!=""}[5m])) by (SrcK8S_Namespace))
+```
+
+**Histogram p99 (RTT or DNS):**
+
+```promql
+histogram_quantile(0.99, sum(rate(netobserv_namespace_rtt_seconds_bucket{SrcK8S_Namespace="TARGET"}[2m])) by (le))
 ```
 
 **Histogram average:**
@@ -133,3 +164,19 @@ Prometheus name: `netobserv_cluster_external_ingress_bytes_total`
 
 - More metrics in `includeList` increase Prometheus load.
 - Prefer namespace metrics for cluster-wide questions; enable `workload_*` only when needed.
+
+## NetObserv health rules (alerts)
+
+Recording/alert rules shipped with NetObserv (names may appear as `alertname` in Prometheus). Pair with domain metrics — do not rely on alerts alone.
+
+| Rule | Feature / metric basis | Typical use |
+|------|------------------------|-------------|
+| `PacketDropsByKernel` | PacketDrop | Kernel buffer / NIC drops |
+| `NetpolDenied` | NetworkEvents | NetworkPolicy deny events |
+| `DNSErrors` | DNSTracking | Elevated DNS error rate |
+| `DNSNxDomain` | DNSTracking | NXDOMAIN responses |
+| `LatencyHighTrend` | FlowRTT | Rising TCP RTT |
+| `Ingress5xxErrors` | Ingress metrics | HTTP 5xx on ingress paths |
+| `IPsecErrors` | IPSec | IPsec flow errors |
+
+Policy denials: query `netobserv_namespace_network_policy_events_total{action="drop",SrcK8S_Namespace="…"}`, not only `drop_packets_total`. OpenShift policy blocks often show **`OVS_DROP_EXPLICIT`** in flow `PktDropLatestDropCause`.

--- a/skills/netobserv-metrics/reference.md
+++ b/skills/netobserv-metrics/reference.md
@@ -1,0 +1,135 @@
+# NetObserv predefined metrics reference
+
+Source: [NetObserv operator Metrics documentation](https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md).
+
+## Naming
+
+- Configure in `FlowCollector` `spec.processor.metrics.includeList` using the **short name** (no prefix).
+- Prometheus exposes `netobserv_<short_name>` (for example `namespace_egress_packets_total` → `netobserv_namespace_egress_packets_total`).
+
+## Predefined metrics
+
+`*` = enabled by default. `**` = also enabled by default when Loki is disabled (workload metrics may replace namespace counterparts).
+
+### Core traffic
+
+| Short name | Default | Notes |
+|------------|---------|-------|
+| `namespace_egress_bytes_total` | | |
+| `namespace_egress_packets_total` | | |
+| `namespace_ingress_bytes_total` | | |
+| `namespace_ingress_packets_total` | * | |
+| `namespace_flows_total` | * | |
+| `node_egress_bytes_total` | * | |
+| `node_egress_packets_total` | | |
+| `node_ingress_bytes_total` | * | |
+| `node_ingress_packets_total` | * | |
+| `node_flows_total` | | |
+| `workload_egress_bytes_total` | * | High cardinality |
+| `workload_egress_packets_total` | ** | High cardinality |
+| `workload_ingress_bytes_total` | * | High cardinality |
+| `workload_ingress_packets_total` | ** | High cardinality |
+| `workload_flows_total` | ** | High cardinality |
+| `workload_sampling` | | |
+| `node_to_node_ingress_flows_total` | * | |
+
+### Feature `PacketDrop` (`spec.agent.ebpf.features`, privileged)
+
+| Short name | Default |
+|------------|---------|
+| `namespace_drop_bytes_total` | |
+| `namespace_drop_packets_total` | * |
+| `node_drop_bytes_total` | |
+| `node_drop_packets_total` | * |
+| `workload_drop_bytes_total` | ** |
+| `workload_drop_packets_total` | ** |
+
+### Feature `FlowRTT`
+
+| Short name | Default |
+|------------|---------|
+| `namespace_rtt_seconds` | * |
+| `node_rtt_seconds` | |
+| `workload_rtt_seconds` | ** |
+
+### Feature `DNSTracking`
+
+| Short name | Default |
+|------------|---------|
+| `namespace_dns_latency_seconds` | * |
+| `node_dns_latency_seconds` | |
+| `workload_dns_latency_seconds` | ** |
+
+### Feature `NetworkEvents`
+
+| Short name | Default |
+|------------|---------|
+| `namespace_network_policy_events_total` | * |
+| `node_network_policy_events_total` | |
+| `workload_network_policy_events_total` | |
+
+### Feature `IPSec`
+
+| Short name | Default |
+|------------|---------|
+| `node_ipsec_flows_total` | * |
+
+## PromQL patterns
+
+**Counter rate (bandwidth or QPS):**
+
+```promql
+sum(rate(netobserv_namespace_ingress_bytes_total{namespace="TARGET"}[2m]))
+```
+
+**Top-N by namespace:**
+
+```promql
+topk(10, sum(rate(netobserv_namespace_egress_packets_total[5m])) by (namespace))
+```
+
+**Histogram p99 (custom or RTT metrics with `_bucket`):**
+
+```promql
+histogram_quantile(0.99, sum(rate(netobserv_namespace_rtt_seconds_bucket[2m])) by (le))
+```
+
+**Histogram average:**
+
+```promql
+sum(rate(METRIC_sum[2m])) / sum(rate(METRIC_count[2m]))
+```
+
+## FlowMetric CR (custom metrics)
+
+- API: `flows.netobserv.io/v1alpha1`, kind `FlowMetric`
+- Create in FlowCollector namespace (default `netobserv`)
+- Types: `Counter`, `Histogram`
+- Use `labels`, `filters`, `valueField`, `direction` per [FlowMetric spec](https://github.com/netobserv/network-observability-operator/blob/main/docs/FlowMetric.md)
+- Flow field catalog: [flows-format.adoc](https://github.com/netobserv/network-observability-operator/blob/main/docs/flows-format.adoc) — respect cardinality (`fine` vs `careful` fields)
+- Samples: https://github.com/netobserv/netobserv-operator/tree/main/config/samples/flowmetrics
+
+### Example counter (external ingress bytes)
+
+```yaml
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowMetric
+metadata:
+  name: flowmetric-cluster-external-ingress-traffic
+spec:
+  metricName: cluster_external_ingress_bytes_total
+  type: Counter
+  valueField: Bytes
+  direction: Ingress
+  labels: [DstK8S_HostName, DstK8S_Namespace, DstK8S_OwnerName, DstK8S_OwnerType]
+  filters:
+  - field: SrcSubnetLabel
+    matchType: Absence
+```
+
+Prometheus name: `netobserv_cluster_external_ingress_bytes_total`
+
+## Operational impact
+
+- More metrics in `includeList` increase Prometheus load.
+- Prefer namespace metrics for cluster-wide questions; enable `workload_*` only when needed.

--- a/skills/netobserv-metrics/skill.md
+++ b/skills/netobserv-metrics/skill.md
@@ -1,13 +1,21 @@
 ---
 name: netobserv-metrics
-description: Query and interpret NetObserv network flow metrics in Prometheus (netobserv_*). Use for namespace or workload traffic, packet drops, RTT latency, DNS latency, network policy events, or missing NetObserv metrics on OpenShift.
+description: Query and interpret NetObserv network flow metrics in Prometheus (netobserv_*). Use for namespace traffic, packet drops, RTT, DNS latency, DNS NXDOMAIN errors, network policy events, or missing NetObserv metrics on OpenShift. Do not conclude no DNS failures from absent alerts alone.
 ---
 
 # NetObserv Metrics
 
 NetObserv exports **Prometheus metrics** derived from network flow records. They are scraped by cluster monitoring (not shipped by the NetObserv operator itself). Metric names in Prometheus are prefixed with `netobserv_`.
 
-Use this skill when the user asks about network bandwidth, flow counts, packet drops, latency, DNS performance, or whether NetObserv metrics exist.
+Use this skill when the user asks about network bandwidth, flow counts, packet drops, latency, DNS performance, DNS NXDOMAIN, or whether NetObserv metrics exist.
+
+## Critical rules
+
+1. **Do not stop after alerts.** For DNS, drops, RTT, or policy symptoms, absent firing alerts does **not** mean no problem — run domain metrics and flow logs (§7).
+2. **Do not use `{namespace="..."}`** on `netobserv_*` series. Scope with `SrcK8S_Namespace` and/or `DstK8S_Namespace`.
+3. **DNS NXDOMAIN:** query `netobserv_namespace_dns_latency_seconds_count` with `DnsFlagsResponseCode="NXDomain"` (exact casing) before reporting no DNS errors.
+4. **DNS RCODE is return traffic:** NXDOMAIN and other response codes label the **client namespace on `DstK8S_Namespace`**, not `SrcK8S_Namespace`. Always query `DstK8S_Namespace="NS"` first for DNS failures; use `SrcK8S_Namespace` only as a fallback.
+5. **Empty Prometheus → query Loki:** If DNS metrics return no data after both Src/Dst filters, run flow-log queries (`netobserv-flow-logs` skill) before concluding there is no traffic.
 
 ## 1. Discover What Exists
 
@@ -38,22 +46,36 @@ Load `reference.md` in this skill directory for the full predefined metric list 
 
 ## 3. Write PromQL
 
-**Counters** (names ending in `_total`): always use `rate()` or `increase()` over a range window (for example `[5m]`).
+### Label model (critical)
+
+`netobserv_namespace_*` and `netobserv_workload_*` series use **flow field labels**, not a generic `namespace` label:
+
+| Label | Use |
+|-------|-----|
+| `SrcK8S_Namespace` | Source Kubernetes namespace |
+| `DstK8S_Namespace` | Destination Kubernetes namespace |
+| `K8S_FlowLayer` | `infra` (DNS, node traffic) or `app` (workload traffic) |
+| `DnsFlagsResponseCode` | DNS RCODE on DNS latency metrics — `NoError`, **`NXDomain`**, etc. On **response** flows the client namespace is usually **`DstK8S_Namespace`**. |
+
+**Do not** query `{namespace="my-app"}` on NetObserv flow metrics — it returns empty and looks like “no data”. Scope with `SrcK8S_Namespace` and/or `DstK8S_Namespace`. Health alert templates may show `{{ $labels.namespace }}` after `label_replace`; raw metrics still use `SrcK8S_Namespace`.
+
+**Counters** (names ending in `_total` or histogram `_count`): use `rate()` or `increase()` over a range window (for example `[2m]` or `[5m]`).
 
 Examples:
 
 ```promql
-# Namespace ingress bandwidth (bytes/s)
-sum(rate(netobserv_namespace_ingress_bytes_total{namespace="my-app"}[5m]))
+# Namespace ingress bandwidth (bytes/s) — source side
+sum(rate(netobserv_namespace_ingress_bytes_total{SrcK8S_Namespace="my-app"}[5m]))
 
 # Top namespaces by egress packets
-topk(10, sum(rate(netobserv_namespace_egress_packets_total[5m])) by (namespace))
+topk(10, sum(rate(netobserv_namespace_egress_packets_total{SrcK8S_Namespace!=""}[5m])) by (SrcK8S_Namespace))
 
-# Packet drops in a namespace (if metric exists)
-sum(rate(netobserv_namespace_drop_packets_total{namespace="my-app"}[5m]))
+# Packet drops involving a namespace (either direction)
+sum(rate(netobserv_namespace_drop_packets_total{SrcK8S_Namespace="my-app"}[5m]))
+  or sum(rate(netobserv_namespace_drop_packets_total{DstK8S_Namespace="my-app"}[5m]))
 ```
 
-**Histograms** (RTT, DNS latency): use `histogram_quantile` on `_bucket` series, or average via `_sum` / `_count` as documented for custom FlowMetrics.
+**Histograms** (RTT, DNS latency): use `histogram_quantile` on `_bucket` series, or `rate()` on `_count` / `_sum`.
 
 Prefer **namespace-level** metrics unless the user needs pod/workload detail. `workload_*` metrics multiply cardinality and can stress Prometheus when many are enabled.
 
@@ -77,6 +99,118 @@ For FlowMetric examples and console chart PromQL, load `reference.md`.
 
 - **Per-flow records and LogQL** use Loki flow logs (different labels such as `SrcK8S_Namespace`) — not the same as `netobserv_*` metrics. Use the `netobserv-flow-logs` skill, NetObserv console, or Loki MCP tools for flow-level investigation.
 - **Network health alerts** (packet drops by device, DNS errors, external traffic trends) are built from these metrics — see OpenShift Network Health or `PrometheusRule` resources from NetObserv.
+
+## 7. Investigation Workflow (Required for Troubleshooting)
+
+For every NetObserv investigation, run **all applicable layers** before concluding. Do not stop after alerts or a single generic metric.
+
+1. **Alerts** — list firing or recent NetObserv health rules for the target namespace (see table below).
+2. **Domain metrics** — query the symptom-specific `netobserv_*` series scoped with **`SrcK8S_Namespace` / `DstK8S_Namespace`** (not a generic `namespace` label).
+3. **Flow logs** — cross-check with Loki or NetObserv flow tools (`netobserv-flow-logs` skill) for names, error codes, drop causes, or RTT fields metrics cannot show.
+
+Always filter Prometheus queries to the **namespace the user named**. Health recording rules use names like `netobserv:health:*:namespace:*` — still scope by the user's namespace label when present.
+
+### Health rules (Prometheus alerts)
+
+| Symptom | Alert / rule name | Primary metrics |
+|---------|-------------------|-----------------|
+| DNS resolution failures | `DNSErrors`, `DNSNxDomain` | `netobserv_namespace_dns_latency_seconds_*` (if latency also suspected) |
+| Slow DNS | (trend from DNS latency histogram) | `netobserv_namespace_dns_latency_seconds_bucket`, `_count`, `_sum` |
+| Kernel packet drops | `PacketDropsByKernel` | `netobserv_namespace_drop_packets_total`, `netobserv_node_drop_packets_total` |
+| NetworkPolicy denials | `NetpolDenied` | `netobserv_namespace_network_policy_events_total` (not `drop_packets_total` alone) |
+| High TCP RTT | `LatencyHighTrend` | `netobserv_namespace_rtt_seconds` — use `histogram_quantile` on `_bucket` |
+| Ingress / HTTPS errors | `Ingress5xxErrors` | `netobserv:health:ingress_5xx_errors:namespace:*` |
+| IPsec issues | `IPsecErrors` | `netobserv_node_ipsec_flows_total` |
+
+**Policy vs kernel drops:** `netobserv_namespace_drop_packets_total` counts **kernel/OVS packet drops** (PacketDrop feature). On OpenShift, NetworkPolicy denials often appear as **`PktDropLatestDropCause="OVS_DROP_EXPLICIT"`** in flow logs — that is policy-related even though the field is under PacketDrop.
+
+For policy investigation, always query **both**:
+
+1. `netobserv_namespace_network_policy_events_total{action="drop",…}` (NetworkEvents feature)
+2. Flow logs with `packetLoss=dropped` or `PktDropLatestDropCause~OVS_DROP`
+
+**Zero `drop_packets_total` with a wrong or missing namespace label does not rule out NetworkPolicy blocks.** Scope with `SrcK8S_Namespace` / `DstK8S_Namespace` and try `K8S_FlowLayer="app"` (pod-to-pod) and `"infra"`.
+
+### Symptom → required PromQL patterns
+
+Use `NS` as the target namespace from the user query. DNS traffic is usually `K8S_FlowLayer="infra"`.
+
+**DNS NXDOMAIN / DNS errors** (namespace `NS`) — RCODE is on **DNS response (return) traffic**; filter **`DstK8S_Namespace="NS"` first**. Use `_count` with `DnsFlagsResponseCode`; value is **`NXDomain`** (exact casing):
+
+```promql
+# Primary — client namespace on return path (matches NetObserv DNSNxDomain alert)
+topk(10,
+  sum(rate(netobserv_namespace_dns_latency_seconds_count{
+    DnsFlagsResponseCode="NXDomain",
+    K8S_FlowLayer="infra",
+    DstK8S_Namespace="NS"
+  }[2m])) by (DnsFlagsResponseCode, SrcK8S_Namespace, DstK8S_Namespace)
+)
+
+# Fallback — try source side or drop K8S_FlowLayer if still empty
+sum(rate(netobserv_namespace_dns_latency_seconds_count{
+  DnsFlagsResponseCode="NXDomain",
+  SrcK8S_Namespace="NS"
+}[2m])) by (DnsFlagsResponseCode, SrcK8S_Namespace, DstK8S_Namespace)
+```
+
+Discover which label holds the namespace when unsure:
+
+```promql
+topk(10, sum(rate(netobserv_namespace_dns_latency_seconds_count{DnsFlagsResponseCode="NXDomain"}[5m])) by (SrcK8S_Namespace, DstK8S_Namespace))
+```
+
+All non-success DNS codes (return traffic — prefer `DstK8S_Namespace`):
+
+```promql
+sum(rate(netobserv_namespace_dns_latency_seconds_count{DnsFlagsResponseCode!="NoError",K8S_FlowLayer="infra",DstK8S_Namespace="NS"}[2m])) by (DnsFlagsResponseCode, SrcK8S_Namespace, DstK8S_Namespace)
+```
+
+**No firing `DNSNxDomain` alert does not mean no NXDOMAIN** — the alert fires on a percentage threshold; direct metric queries can still show NXDOMAIN rate.
+
+**DNS latency** (namespace `NS`):
+
+```promql
+histogram_quantile(0.99, sum(rate(netobserv_namespace_dns_latency_seconds_bucket{SrcK8S_Namespace="NS",K8S_FlowLayer="infra"}[2m])) by (le))
+sum(rate(netobserv_namespace_dns_latency_seconds_count{SrcK8S_Namespace="NS",K8S_FlowLayer="infra"}[2m]))
+```
+
+**TCP RTT** (namespace `NS`):
+
+```promql
+histogram_quantile(0.99, sum(rate(netobserv_namespace_rtt_seconds_bucket{SrcK8S_Namespace="NS"}[2m])) by (le))
+sum(rate(netobserv_namespace_rtt_seconds_sum{SrcK8S_Namespace="NS"}[2m])) / sum(rate(netobserv_namespace_rtt_seconds_count{SrcK8S_Namespace="NS"}[2m]))
+```
+
+**Network policy denials** (namespace `NS`) — **`action="drop"`** is required on the events metric:
+
+```promql
+sum(rate(netobserv_namespace_network_policy_events_total{
+  action="drop",
+  SrcK8S_Namespace="NS"
+}[2m])) by (type, direction, SrcK8S_Namespace, DstK8S_Namespace)
+or sum(rate(netobserv_namespace_network_policy_events_total{
+  action="drop",
+  DstK8S_Namespace="NS"
+}[2m])) by (type, direction, SrcK8S_Namespace, DstK8S_Namespace)
+```
+
+**Packet drops involving a namespace** (kernel or OVS — pair with policy flows above):
+
+```promql
+sum(rate(netobserv_namespace_drop_packets_total{
+  K8S_FlowLayer="app",
+  SrcK8S_Namespace="NS"
+}[2m])) by (SrcK8S_Namespace, DstK8S_Namespace)
+or sum(rate(netobserv_namespace_drop_packets_total{
+  K8S_FlowLayer="app",
+  DstK8S_Namespace="NS"
+}[2m])) by (SrcK8S_Namespace, DstK8S_Namespace)
+```
+
+On OpenShift, policy-blocked pod traffic may show **`OVS_DROP_EXPLICIT`** in flow `PktDropLatestDropCause` while a naïve `drop_packets_total` query returns empty — check flow logs and `network_policy_events_total` before concluding “no drops”.
+
+Cite the **exact metric name**, **label selectors** (`DstK8S_Namespace` for DNS RCODE, `SrcK8S_Namespace` for egress/app traffic, `DnsFlagsResponseCode`, …), and **numeric result** in the final answer. If a query returns empty, retry with `DstK8S_Namespace` (DNS responses) then `SrcK8S_Namespace`, then drop `K8S_FlowLayer`, then query Loki flow logs — before concluding data is missing.
 
 ## Quality Standards
 

--- a/skills/netobserv-metrics/skill.md
+++ b/skills/netobserv-metrics/skill.md
@@ -1,0 +1,87 @@
+---
+name: netobserv-metrics
+description: Query and interpret NetObserv network flow metrics in Prometheus (netobserv_*). Use for namespace or workload traffic, packet drops, RTT latency, DNS latency, network policy events, or missing NetObserv metrics on OpenShift.
+---
+
+# NetObserv Metrics
+
+NetObserv exports **Prometheus metrics** derived from network flow records. They are scraped by cluster monitoring (not shipped by the NetObserv operator itself). Metric names in Prometheus are prefixed with `netobserv_`.
+
+Use this skill when the user asks about network bandwidth, flow counts, packet drops, latency, DNS performance, or whether NetObserv metrics exist.
+
+## 1. Discover What Exists
+
+Before writing PromQL:
+
+1. Confirm **NetObserv is installed** — look for a `FlowCollector` in the NetObserv namespace (default `netobserv`).
+2. List metrics with a `netobserv` filter (for example `list_metrics` with regex `netobserv_.*` when observability MCP tools are available).
+3. If no `netobserv_*` series appear, metrics may be disabled in `FlowCollector` `spec.processor.metrics.includeList` or not yet scraped — check configuration before inventing metric names.
+
+Do not guess metric names. Names in configuration omit the `netobserv_` prefix; in Prometheus they appear as `netobserv_<name>` (for example `netobserv_namespace_ingress_packets_total`).
+
+## 2. Map the Question to a Metric Family
+
+| User intent | Typical metric (Prometheus name) | Notes |
+|-------------|----------------------------------|-------|
+| Bytes in/out per namespace | `netobserv_namespace_ingress_bytes_total`, `netobserv_namespace_egress_bytes_total` | Use `rate()` over a range |
+| Packets in/out per namespace | `netobserv_namespace_ingress_packets_total`, `netobserv_namespace_egress_packets_total` | Ingress packets enabled by default |
+| Flow count per namespace | `netobserv_namespace_flows_total` | Enabled by default |
+| Per-workload traffic | `netobserv_workload_*` | Higher cardinality — prefer aggregation |
+| Node-level traffic | `netobserv_node_*` | Node ingress/egress bytes and packets |
+| Packet drops | `netobserv_namespace_drop_packets_total`, `netobserv_workload_drop_packets_total` | Requires `PacketDrop` eBPF feature |
+| TCP RTT / latency | `netobserv_namespace_rtt_seconds`, `netobserv_workload_rtt_seconds` | Requires `FlowRTT` feature |
+| DNS latency | `netobserv_namespace_dns_latency_seconds` | Requires `DNSTracking` feature |
+| Network policy denials | `netobserv_namespace_network_policy_events_total` | Requires `NetworkEvents` feature |
+| IPSec flows | `netobserv_node_ipsec_flows_total` | Requires `IPSec` feature |
+
+Load `reference.md` in this skill directory for the full predefined metric list and feature gates.
+
+## 3. Write PromQL
+
+**Counters** (names ending in `_total`): always use `rate()` or `increase()` over a range window (for example `[5m]`).
+
+Examples:
+
+```promql
+# Namespace ingress bandwidth (bytes/s)
+sum(rate(netobserv_namespace_ingress_bytes_total{namespace="my-app"}[5m]))
+
+# Top namespaces by egress packets
+topk(10, sum(rate(netobserv_namespace_egress_packets_total[5m])) by (namespace))
+
+# Packet drops in a namespace (if metric exists)
+sum(rate(netobserv_namespace_drop_packets_total{namespace="my-app"}[5m]))
+```
+
+**Histograms** (RTT, DNS latency): use `histogram_quantile` on `_bucket` series, or average via `_sum` / `_count` as documented for custom FlowMetrics.
+
+Prefer **namespace-level** metrics unless the user needs pod/workload detail. `workload_*` metrics multiply cardinality and can stress Prometheus when many are enabled.
+
+## 4. When Metrics Are Missing
+
+If the user expects a metric but it is absent:
+
+1. Check `FlowCollector` `spec.processor.metrics.includeList` — only listed metrics are generated (names without `netobserv_` prefix).
+2. Check required **eBPF features** in `spec.agent.ebpf.features` (for example `PacketDrop`, `FlowRTT`, `DNSTracking`, `NetworkEvents`, `IPSec`).
+3. Note default metrics: several `namespace_*` and `workload_*` counters are on by default; workload variants may replace namespace defaults when Loki is disabled (see reference).
+
+Report the specific gap (metric name + feature or includeList entry) rather than a generic “NetObserv broken” conclusion.
+
+## 5. Custom Metrics (FlowMetric)
+
+Users can define counters or histograms via the `FlowMetric` CR (`flows.netobserv.io/v1alpha1`) in the FlowCollector namespace. Warn about **label cardinality** — avoid combining high-cardinality Src and Dst labels without filters.
+
+For FlowMetric examples and console chart PromQL, load `reference.md`.
+
+## 6. Related Data (Not Prometheus)
+
+- **Per-flow records and LogQL** use Loki flow logs (different labels such as `SrcK8S_Namespace`) — not the same as `netobserv_*` metrics. Use the `netobserv-flow-logs` skill, NetObserv console, or Loki MCP tools for flow-level investigation.
+- **Network health alerts** (packet drops by device, DNS errors, external traffic trends) are built from these metrics — see OpenShift Network Health or `PrometheusRule` resources from NetObserv.
+
+## Quality Standards
+
+- Cite the exact `netobserv_*` metric name returned by discovery or the FlowCollector config.
+- Show PromQL with an explicit range window for counters.
+- Warn before recommending many `workload_*` metrics or custom FlowMetric labels with high cardinality.
+- Distinguish “metric not enabled” from “no traffic” — zero `rate()` can be legitimate.
+- If tools cannot query Prometheus, tell the user which metric and query to run rather than fabricating numbers.

--- a/tests/integration/test_skills_rag.py
+++ b/tests/integration/test_skills_rag.py
@@ -66,6 +66,26 @@ def _sample_skills() -> list[Skill]:
             ),
             source_path="skills/namespace-troubleshooting",
         ),
+        Skill(
+            name="netobserv-metrics",
+            description=(
+                "Query and interpret NetObserv network flow metrics in Prometheus "
+                "(netobserv_*). Use for namespace or workload traffic, packet drops, "
+                "RTT latency, DNS latency, network policy events, or missing NetObserv "
+                "metrics on OpenShift."
+            ),
+            source_path="skills/netobserv-metrics",
+        ),
+        Skill(
+            name="netobserv-flow-logs",
+            description=(
+                "Query NetObserv network flow logs in Loki using LogQL and flow field "
+                "labels (SrcK8S_Namespace, DstK8S_Namespace, K8S_FlowLayer). Use for "
+                "per-flow investigation, conversation records, packet drops in logs, "
+                "DNS flows, or when Prometheus netobserv_* metrics are not enough."
+            ),
+            source_path="skills/netobserv-flow-logs",
+        ),
     ]
 
 
@@ -116,6 +136,30 @@ class TestSkillSelection:
             (
                 "permission denied forbidden error in namespace",
                 "namespace-troubleshooting",
+            ),
+            (
+                "which namespace has the most network egress traffic",
+                "netobserv-metrics",
+            ),
+            (
+                "show netobserv packet drops in prometheus",
+                "netobserv-metrics",
+            ),
+            (
+                "netobserv namespace ingress bytes metric",
+                "netobserv-metrics",
+            ),
+            (
+                "query netobserv flow logs in loki for namespace netobserv",
+                "netobserv-flow-logs",
+            ),
+            (
+                "logql SrcK8S_Namespace network flows",
+                "netobserv-flow-logs",
+            ),
+            (
+                "investigate per-flow packet drops in loki not prometheus",
+                "netobserv-flow-logs",
             ),
         ],
     )


### PR DESCRIPTION
## Description

Add netobserv scenarios and skills

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [X] Optimization
- [X] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue https://redhat.atlassian.net/browse/NETOBSERV-2230
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Six NetObserv live-cluster troubleshooting scenarios (DNS latency/NXDOMAIN, kernel/policy packet drops, TLS issues, TCP RTT) with run/debug targets and eval CLI support.
  * Multiple runtime/provider configurations for evaluation UI/backends and a results-output workflow.

* **Documentation**
  * Comprehensive NetObserv eval guide, scenario catalogs, metrics/flow-log references, and skill how‑tos.

* **Bug Fixes / Chores**
  * Updated ignore rules to exclude evaluation artifacts.

* **Tests**
  * Integration tests extended to include NetObserv skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->