### PR TITLE
feat: in-process LLM credential hot-reload

### DIFF
--- a/docs/credential-hot-reload.md
+++ b/docs/credential-hot-reload.md
@@ -1,0 +1,175 @@
+# RFE-9380: In-Process LLM Credential Hot-Reload
+
+## Problem
+
+When `credentialsSecretRef` is updated, the Lightspeed operator triggers a rolling
+restart of `lightspeed-app-server`. For customers using short-lived LLM tokens
+(e.g. 1-hour validity rotated by CronJob), this causes hourly pod restarts and
+temporary capacity loss.
+
+- **RFE:** [RFE-9380](https://redhat.atlassian.net/browse/RFE-9380)
+- **Customer environment:** OCP 4.21, pre-production
+- **Current workaround:** replicas >= 3 with manual PDB (minAvailable: 2)
+
+## Solution
+
+The service re-reads credential files from disk on every LLM request (Prometheus
+`credentials_file` pattern), so rotated secrets are picked up without a pod
+restart.
+
+### Why this matters
+
+The app-server pod contains the FAISS vector indexes (~100MB) and the
+SentenceTransformer embedding model (~400MB), all loaded into memory at startup.
+A rolling restart means:
+
+| Step | Time |
+|------|------|
+| FAISS index reload | ~5-15s |
+| Embedding model reload | ~3-5s |
+| Readiness probe pass | ~2-5s |
+| **Total cold start** | **~10-25s per pod** |
+
+With hourly rotation and 3 replicas, that is up to 24 restart cycles/day with
+degraded capacity during each one.
+
+### Cost comparison
+
+| Factor | Hot-Reload | 2+ Replicas workaround |
+|--------|-----------|------------------------|
+| CPU per request | 1 file read (~0.05ms) | Zero extra |
+| Memory | Zero extra | 2-3x pod memory |
+| Compute cost | Negligible | 2-3x vCPU reserved |
+| Availability during rotation | 100% | ~95-99% (brief capacity drop) |
+| Ops complexity | None | PDB + replica tuning + alert tuning |
+
+## Design
+
+Since `load_llm()` already creates a new `LLMProvider` per request, we add a
+`get_credentials()` method to `ProviderConfig` that re-reads the credential file
+each time it is called.
+
+```text
+Request → load_llm() → LLMProvider.__init__()
+                          → provider_config.get_credentials()
+                              → open(credentials_path) + read()
+                              → return fresh value
+```
+
+### Why re-read on every request (vs caching or fsnotify)
+
+- **Kubernetes symlink safety** — kubelet uses atomic symlink swaps (`..data`);
+  `os.stat()` mtime can be unreliable after swaps. Re-reading avoids edge cases.
+- **Proven pattern** — Prometheus `credentials_file` / `password_file` re-reads
+  on every scrape request.
+- **No new dependencies** — no watchdog, fsnotify, or background threads.
+- **Negligible overhead** — one `open()+read()` of a <100 byte file per LLM
+  request is trivial vs multi-second LLM call latency.
+- **Thread-safe by default** — each request reads independently.
+
+### Ecosystem alignment
+
+| Project | Pattern |
+|---------|---------|
+| Prometheus | `credentials_file` re-read on every scrape |
+| OpenShift library-go | `fileobserver` hash-based polling (Go operators) |
+| controller-runtime | `CertWatcher` fsnotify + periodic re-read |
+| kube-proxy | watches parent directory (PR #139204) |
+| Stakater Reloader | triggers rolling restart (what we are moving away from) |
+
+## Files Changed
+
+### Core
+
+- `ols/utils/checks.py` — added `read_secret_from_path()` helper
+- `ols/app/models/config.py` — added `_credentials_path` private attr and
+  `get_credentials()` method to `ProviderConfig`
+
+### Providers (7 files)
+
+All providers changed from `self.provider_config.credentials` to
+`self.provider_config.get_credentials()`:
+
+- `ols/src/llms/providers/openai.py`
+- `ols/src/llms/providers/azure_openai.py`
+- `ols/src/llms/providers/watsonx.py`
+- `ols/src/llms/providers/rhoai_vllm.py`
+- `ols/src/llms/providers/rhelai_vllm.py`
+- `ols/src/llms/providers/google_vertex.py` (both Gemini and Anthropic)
+- `ols/src/llms/providers/bedrock.py`
+
+### Tests (9 new tests)
+
+- `tests/unit/utils/test_checks.py` — 4 tests for `read_secret_from_path()`
+- `tests/unit/app/models/test_config.py` — 4 tests for `get_credentials()`
+- `tests/unit/llms/providers/test_openai.py` — 1 end-to-end rotation test
+
+## Testing on a Cluster
+
+### Local with Podman
+
+```bash
+# Build image with changes
+OLS_API_IMAGE=localhost/ols:hot-reload make images
+
+# Prepare config
+mkdir -p /tmp/ols-test/config
+cp examples/olsconfig.yaml /tmp/ols-test/config/olsconfig.yaml
+echo "your-api-key" > /tmp/ols-test/config/apikey.txt
+
+# Run
+podman run -it --rm \
+  -v /tmp/ols-test/config:/app-root/config:Z \
+  -e OLS_CONFIG_FILE=/app-root/config/olsconfig.yaml \
+  -p 8080:8080 localhost/ols:hot-reload
+
+# Query, then rotate, then query again
+curl -X POST http://localhost:8080/v1/query \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "what is a pod?"}'
+
+echo "new-rotated-key" > /tmp/ols-test/config/apikey.txt
+
+curl -X POST http://localhost:8080/v1/query \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "what is a deployment?"}'
+```
+
+### On OpenShift
+
+```bash
+# Build and push
+OLS_API_IMAGE=quay.io/<user>/lightspeed-service-api:hot-reload make images
+podman push quay.io/<user>/lightspeed-service-api:hot-reload
+
+# Patch existing deployment
+oc set image deployment/lightspeed-app-server \
+  lightspeed-app-server=quay.io/<user>/lightspeed-service-api:hot-reload \
+  -n openshift-lightspeed
+
+# Verify no restarts after secret rotation
+oc get pods -n openshift-lightspeed -w
+```
+
+### Validation checklist
+
+| Check | How to verify |
+|-------|---------------|
+| No pod restarts | `oc get pods` — restartCount stays 0 |
+| Credential picked up | Queries succeed after rotation |
+| No capacity loss | Service responds during rotation window |
+| No restart logs | No container start messages in logs |
+
+## Multi-Repo Contribution
+
+This feature spans two repositories:
+
+| PR | Repo | Purpose | Status |
+|----|------|---------|--------|
+| Service PR (first) | `openshift/lightspeed-service` | Add `get_credentials()` hot-reload | Ready |
+| Operator PR (second) | `openshift/lightspeed-operator` | Skip restart on credential-only secret changes | Future |
+
+The service PR is **backward compatible** — if the operator still restarts pods,
+nothing breaks. The operator PR depends on the service change being merged first.
+
+Both PRs reference RFE-9380 and cross-link each other.

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -396,14 +396,17 @@ class ProviderConfig(BaseModel):
     tls_security_profile: Optional[TLSSecurityProfile] = None
 
     _credentials_path: Optional[str] = PrivateAttr(default=None)
+    _credential_hot_reload: bool = PrivateAttr(default=False)
 
     def __init__(
         self,
         data: Optional[dict] = None,
         ignore_llm_secrets: bool = False,
+        credential_hot_reload: bool = False,
     ) -> None:
         """Initialize configuration and perform basic validation."""
         super().__init__()
+        self._credential_hot_reload = credential_hot_reload
         if data is None:
             return
         self.name = data.get("name", None)
@@ -621,15 +624,8 @@ class ProviderConfig(BaseModel):
             )
 
     def get_credentials(self) -> Optional[str]:
-        """Return current credentials, re-reading from disk when a path is configured.
-
-        When ``credentials_path`` was provided in the original configuration,
-        the credential file is re-read on every call so that secrets rotated
-        by Kubernetes (kubelet atomic symlink swap) or external CronJobs are
-        picked up without a pod restart.  Falls back to the cached value when
-        no path is available or the file cannot be read.
-        """
-        if self._credentials_path is not None:
+        """Return current credentials, re-reading from disk when hot-reload is enabled."""
+        if self._credential_hot_reload and self._credentials_path is not None:
             fresh = checks.read_secret_from_path(
                 self._credentials_path, constants.API_TOKEN_FILENAME
             )
@@ -637,6 +633,28 @@ class ProviderConfig(BaseModel):
                 self.credentials = fresh
                 return fresh
         return self.credentials
+
+    def get_aws_credentials(
+        self,
+    ) -> tuple[Optional[str], Optional[str], Optional[str]]:
+        """Return AWS IAM credentials, re-reading from disk when hot-reload is enabled."""
+        if self._credential_hot_reload and self._credentials_path is not None:
+            access_key = checks.read_secret_from_path(
+                self._credentials_path, constants.BEDROCK_ACCESS_KEY_ID_FILENAME
+            )
+            secret_key = checks.read_secret_from_path(
+                self._credentials_path, constants.BEDROCK_SECRET_ACCESS_KEY_FILENAME
+            )
+            role_arn = checks.read_secret_from_path(
+                self._credentials_path, constants.BEDROCK_ROLE_ARN_FILENAME
+            )
+            if access_key is not None:
+                self.aws_access_key_id = access_key
+            if secret_key is not None:
+                self.aws_secret_access_key = secret_key
+            if role_arn is not None:
+                self.role_arn = role_arn
+        return self.aws_access_key_id, self.aws_secret_access_key, self.role_arn
 
 
 class LLMProviders(BaseModel):
@@ -648,6 +666,7 @@ class LLMProviders(BaseModel):
         self,
         data: Optional[dict] = None,
         ignore_llm_secrets: bool = False,
+        credential_hot_reload: bool = False,
     ) -> None:
         """Initialize configuration and perform basic validation."""
         super().__init__()
@@ -656,7 +675,9 @@ class LLMProviders(BaseModel):
         for p in data:
             if "name" not in p:
                 raise checks.InvalidConfigurationError("provider name is missing")
-            provider = ProviderConfig(p, ignore_llm_secrets)
+            provider = ProviderConfig(
+                p, ignore_llm_secrets, credential_hot_reload=credential_hot_reload
+            )
             self.providers[p["name"]] = provider
 
     def validate_yaml(self) -> None:
@@ -1282,6 +1303,8 @@ class OLSConfig(BaseModel):
 
     offload_storage_path: str = constants.DEFAULT_OFFLOAD_STORAGE_PATH
 
+    credential_hot_reload: bool = False
+
     def __init__(  # noqa: C901
         self, data: Optional[dict] = None, ignore_missing_certs: bool = False
     ) -> None:
@@ -1300,6 +1323,7 @@ class OLSConfig(BaseModel):
         self.default_model = data.get("default_model", None)
         self.max_iterations = data.get("max_iterations")
         self.history_compression_enabled = data.get("history_compression_enabled", True)
+        self.credential_hot_reload = data.get("credential_hot_reload", False)
         self.max_workers = data.get("max_workers", 1)
         self.expire_llm_is_ready_persistent_state = data.get(
             "expire_llm_is_ready_persistent_state", -1
@@ -1430,7 +1454,11 @@ class Config(BaseModel):
             raise checks.InvalidConfigurationError("no OLS config section found")
         v = data.get("llm_providers")
         if v is not None:
-            self.llm_providers = LLMProviders(v, ignore_llm_secrets)
+            self.llm_providers = LLMProviders(
+                v,
+                ignore_llm_secrets,
+                credential_hot_reload=self.ols_config.credential_hot_reload,
+            )
         else:
             raise checks.InvalidConfigurationError(
                 "no LLM providers config section found"

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -395,6 +395,8 @@ class ProviderConfig(BaseModel):
     fake_provider_config: Optional[FakeConfig] = None
     tls_security_profile: Optional[TLSSecurityProfile] = None
 
+    _credentials_path: Optional[str] = PrivateAttr(default=None)
+
     def __init__(
         self,
         data: Optional[dict] = None,
@@ -408,6 +410,7 @@ class ProviderConfig(BaseModel):
 
         self.set_provider_type(data)
         self.url = data.get("url", None)
+        self._credentials_path = data.get(constants.CREDENTIALS_PATH_SELECTOR)
         try:
             self.credentials = checks.read_secret(
                 data, constants.CREDENTIALS_PATH_SELECTOR, constants.API_TOKEN_FILENAME
@@ -616,6 +619,24 @@ class ProviderConfig(BaseModel):
             raise checks.InvalidConfigurationError(
                 "provider URL is invalid, only http:// and https:// URLs are supported"
             )
+
+    def get_credentials(self) -> Optional[str]:
+        """Return current credentials, re-reading from disk when a path is configured.
+
+        When ``credentials_path`` was provided in the original configuration,
+        the credential file is re-read on every call so that secrets rotated
+        by Kubernetes (kubelet atomic symlink swap) or external CronJobs are
+        picked up without a pod restart.  Falls back to the cached value when
+        no path is available or the file cannot be read.
+        """
+        if self._credentials_path is not None:
+            fresh = checks.read_secret_from_path(
+                self._credentials_path, constants.API_TOKEN_FILENAME
+            )
+            if fresh is not None:
+                self.credentials = fresh
+                return fresh
+        return self.credentials
 
 
 class LLMProviders(BaseModel):

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -645,15 +645,20 @@ class ProviderConfig(BaseModel):
             secret_key = checks.read_secret_from_path(
                 self._credentials_path, constants.BEDROCK_SECRET_ACCESS_KEY_FILENAME
             )
-            role_arn = checks.read_secret_from_path(
-                self._credentials_path, constants.BEDROCK_ROLE_ARN_FILENAME
-            )
             if access_key is not None:
                 self.aws_access_key_id = access_key
             if secret_key is not None:
                 self.aws_secret_access_key = secret_key
-            if role_arn is not None:
-                self.role_arn = role_arn
+            # role_arn is optional — only re-read when the file exists
+            role_arn_path = os.path.join(
+                self._credentials_path, constants.BEDROCK_ROLE_ARN_FILENAME
+            )
+            if os.path.isfile(role_arn_path):
+                role_arn = checks.read_secret_from_path(
+                    self._credentials_path, constants.BEDROCK_ROLE_ARN_FILENAME
+                )
+                if role_arn is not None:
+                    self.role_arn = role_arn
         return self.aws_access_key_id, self.aws_secret_access_key, self.role_arn
 
 

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -377,6 +377,8 @@ class ProviderConfig(BaseModel):
     fake_provider_config: Optional[FakeConfig] = None
     tls_security_profile: Optional[TLSSecurityProfile] = None
 
+    _credentials_path: Optional[str] = PrivateAttr(default=None)
+
     def __init__(
         self,
         data: Optional[dict] = None,
@@ -390,6 +392,7 @@ class ProviderConfig(BaseModel):
 
         self.set_provider_type(data)
         self.url = data.get("url", None)
+        self._credentials_path = data.get(constants.CREDENTIALS_PATH_SELECTOR)
         try:
             self.credentials = checks.read_secret(
                 data, constants.CREDENTIALS_PATH_SELECTOR, constants.API_TOKEN_FILENAME
@@ -598,6 +601,24 @@ class ProviderConfig(BaseModel):
             raise checks.InvalidConfigurationError(
                 "provider URL is invalid, only http:// and https:// URLs are supported"
             )
+
+    def get_credentials(self) -> Optional[str]:
+        """Return current credentials, re-reading from disk when a path is configured.
+
+        When ``credentials_path`` was provided in the original configuration,
+        the credential file is re-read on every call so that secrets rotated
+        by Kubernetes (kubelet atomic symlink swap) or external CronJobs are
+        picked up without a pod restart.  Falls back to the cached value when
+        no path is available or the file cannot be read.
+        """
+        if self._credentials_path is not None:
+            fresh = checks.read_secret_from_path(
+                self._credentials_path, constants.API_TOKEN_FILENAME
+            )
+            if fresh is not None:
+                self.credentials = fresh
+                return fresh
+        return self.credentials
 
 
 class LLMProviders(BaseModel):

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -378,14 +378,17 @@ class ProviderConfig(BaseModel):
     tls_security_profile: Optional[TLSSecurityProfile] = None
 
     _credentials_path: Optional[str] = PrivateAttr(default=None)
+    _credential_hot_reload: bool = PrivateAttr(default=False)
 
     def __init__(
         self,
         data: Optional[dict] = None,
         ignore_llm_secrets: bool = False,
+        credential_hot_reload: bool = False,
     ) -> None:
         """Initialize configuration and perform basic validation."""
         super().__init__()
+        self._credential_hot_reload = credential_hot_reload
         if data is None:
             return
         self.name = data.get("name", None)
@@ -603,15 +606,8 @@ class ProviderConfig(BaseModel):
             )
 
     def get_credentials(self) -> Optional[str]:
-        """Return current credentials, re-reading from disk when a path is configured.
-
-        When ``credentials_path`` was provided in the original configuration,
-        the credential file is re-read on every call so that secrets rotated
-        by Kubernetes (kubelet atomic symlink swap) or external CronJobs are
-        picked up without a pod restart.  Falls back to the cached value when
-        no path is available or the file cannot be read.
-        """
-        if self._credentials_path is not None:
+        """Return current credentials, re-reading from disk when hot-reload is enabled."""
+        if self._credential_hot_reload and self._credentials_path is not None:
             fresh = checks.read_secret_from_path(
                 self._credentials_path, constants.API_TOKEN_FILENAME
             )
@@ -619,6 +615,28 @@ class ProviderConfig(BaseModel):
                 self.credentials = fresh
                 return fresh
         return self.credentials
+
+    def get_aws_credentials(
+        self,
+    ) -> tuple[Optional[str], Optional[str], Optional[str]]:
+        """Return AWS IAM credentials, re-reading from disk when hot-reload is enabled."""
+        if self._credential_hot_reload and self._credentials_path is not None:
+            access_key = checks.read_secret_from_path(
+                self._credentials_path, constants.BEDROCK_ACCESS_KEY_ID_FILENAME
+            )
+            secret_key = checks.read_secret_from_path(
+                self._credentials_path, constants.BEDROCK_SECRET_ACCESS_KEY_FILENAME
+            )
+            role_arn = checks.read_secret_from_path(
+                self._credentials_path, constants.BEDROCK_ROLE_ARN_FILENAME
+            )
+            if access_key is not None:
+                self.aws_access_key_id = access_key
+            if secret_key is not None:
+                self.aws_secret_access_key = secret_key
+            if role_arn is not None:
+                self.role_arn = role_arn
+        return self.aws_access_key_id, self.aws_secret_access_key, self.role_arn
 
 
 class LLMProviders(BaseModel):
@@ -630,6 +648,7 @@ class LLMProviders(BaseModel):
         self,
         data: Optional[dict] = None,
         ignore_llm_secrets: bool = False,
+        credential_hot_reload: bool = False,
     ) -> None:
         """Initialize configuration and perform basic validation."""
         super().__init__()
@@ -638,7 +657,9 @@ class LLMProviders(BaseModel):
         for p in data:
             if "name" not in p:
                 raise checks.InvalidConfigurationError("provider name is missing")
-            provider = ProviderConfig(p, ignore_llm_secrets)
+            provider = ProviderConfig(
+                p, ignore_llm_secrets, credential_hot_reload=credential_hot_reload
+            )
             self.providers[p["name"]] = provider
 
     def validate_yaml(self) -> None:
@@ -1269,6 +1290,8 @@ class OLSConfig(BaseModel):
 
     offload_storage_path: str = constants.DEFAULT_OFFLOAD_STORAGE_PATH
 
+    credential_hot_reload: bool = False
+
     def __init__(  # noqa: C901
         self, data: Optional[dict] = None, ignore_missing_certs: bool = False
     ) -> None:
@@ -1287,6 +1310,7 @@ class OLSConfig(BaseModel):
         self.default_model = data.get("default_model", None)
         self.max_iterations = data.get("max_iterations")
         self.history_compression_enabled = data.get("history_compression_enabled", True)
+        self.credential_hot_reload = data.get("credential_hot_reload", False)
         self.max_workers = data.get("max_workers", 1)
         self.expire_llm_is_ready_persistent_state = data.get(
             "expire_llm_is_ready_persistent_state", -1
@@ -1417,7 +1441,11 @@ class Config(BaseModel):
             raise checks.InvalidConfigurationError("no OLS config section found")
         v = data.get("llm_providers")
         if v is not None:
-            self.llm_providers = LLMProviders(v, ignore_llm_secrets)
+            self.llm_providers = LLMProviders(
+                v,
+                ignore_llm_secrets,
+                credential_hot_reload=self.ols_config.credential_hot_reload,
+            )
         else:
             raise checks.InvalidConfigurationError(
                 "no LLM providers config section found"

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -627,15 +627,20 @@ class ProviderConfig(BaseModel):
             secret_key = checks.read_secret_from_path(
                 self._credentials_path, constants.BEDROCK_SECRET_ACCESS_KEY_FILENAME
             )
-            role_arn = checks.read_secret_from_path(
-                self._credentials_path, constants.BEDROCK_ROLE_ARN_FILENAME
-            )
             if access_key is not None:
                 self.aws_access_key_id = access_key
             if secret_key is not None:
                 self.aws_secret_access_key = secret_key
-            if role_arn is not None:
-                self.role_arn = role_arn
+            # role_arn is optional — only re-read when the file exists
+            role_arn_path = os.path.join(
+                self._credentials_path, constants.BEDROCK_ROLE_ARN_FILENAME
+            )
+            if os.path.isfile(role_arn_path):
+                role_arn = checks.read_secret_from_path(
+                    self._credentials_path, constants.BEDROCK_ROLE_ARN_FILENAME
+                )
+                if role_arn is not None:
+                    self.role_arn = role_arn
         return self.aws_access_key_id, self.aws_secret_access_key, self.role_arn
 
 

--- a/ols/src/llms/providers/azure_openai.py
+++ b/ols/src/llms/providers/azure_openai.py
@@ -52,7 +52,7 @@ class AzureOpenAI(LLMProvider):
     def default_params(self) -> dict[str, Any]:
         """Construct and return structure with default LLM params."""
         self.url = str(self.provider_config.url or self.url)
-        self.credentials = self.provider_config.credentials
+        self.credentials = self.provider_config.get_credentials()
         api_version = self.provider_config.api_version
         deployment_name = self.provider_config.deployment_name
         azure_config = self.provider_config.azure_config

--- a/ols/src/llms/providers/azure_openai.py
+++ b/ols/src/llms/providers/azure_openai.py
@@ -54,7 +54,7 @@ class AzureOpenAI(LLMProvider):
     def default_params(self) -> dict[str, Any]:
         """Construct and return structure with default LLM params."""
         self.url = str(self.provider_config.url or self.url)
-        self.credentials = self.provider_config.credentials
+        self.credentials = self.provider_config.get_credentials()
         api_version = self.provider_config.api_version
         deployment_name = self.provider_config.deployment_name
         azure_config = self.provider_config.azure_config

--- a/ols/src/llms/providers/bedrock.py
+++ b/ols/src/llms/providers/bedrock.py
@@ -34,7 +34,7 @@ class Bedrock(LLMProvider):
         """Construct and return default LLM params."""
         if self.provider_config.url is not None:
             self.url = str(self.provider_config.url).rstrip("/")
-        self.credentials = self.provider_config.credentials
+        self.credentials = self.provider_config.get_credentials()
 
         if not self.url:
             raise LLMConfigurationError(

--- a/ols/src/llms/providers/bedrock.py
+++ b/ols/src/llms/providers/bedrock.py
@@ -73,9 +73,15 @@ class Bedrock(LLMProvider):
             "expected format: https://bedrock-mantle.<region>.api.aws"
         )
 
-    def _build_boto3_session(self, region: str) -> boto3.Session:
+    def _build_boto3_session(
+        self,
+        region: str,
+        aws_creds: tuple[Optional[str], Optional[str], Optional[str]] | None = None,
+    ) -> boto3.Session:
         """Build a boto3 session from IAM credentials, with optional STS assume-role."""
-        access_key, secret_key, role_arn = self.provider_config.get_aws_credentials()
+        if aws_creds is None:
+            aws_creds = self.provider_config.get_aws_credentials()
+        access_key, secret_key, role_arn = aws_creds
         session = boto3.Session(
             aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,
@@ -83,9 +89,9 @@ class Bedrock(LLMProvider):
         )
         if role_arn:
             sts = session.client("sts")
-            assumed = sts.assume_role(
-                RoleArn=role_arn, RoleSessionName="ols-bedrock"
-            )["Credentials"]
+            assumed = sts.assume_role(RoleArn=role_arn, RoleSessionName="ols-bedrock")[
+                "Credentials"
+            ]
             session = boto3.Session(
                 aws_access_key_id=assumed["AccessKeyId"],
                 aws_secret_access_key=assumed["SecretAccessKey"],
@@ -94,9 +100,13 @@ class Bedrock(LLMProvider):
             )
         return session
 
-    def _build_sigv4_auth(self, region: str) -> AwsSigV4Auth:
+    def _build_sigv4_auth(
+        self,
+        region: str,
+        aws_creds: tuple[Optional[str], Optional[str], Optional[str]] | None = None,
+    ) -> AwsSigV4Auth:
         """Build a SigV4 auth handler from IAM credentials."""
-        session = self._build_boto3_session(region)
+        session = self._build_boto3_session(region, aws_creds)
         frozen = session.get_credentials().get_frozen_credentials()
         creds = AwsCredentials(
             access_key=frozen.access_key,
@@ -110,7 +120,8 @@ class Bedrock(LLMProvider):
         params = {**self.params}
         api_key = params.pop("api_key")
         model = params.pop("model")
-        use_iam = self._has_aws_credentials()
+        aws_creds = self.provider_config.get_aws_credentials()
+        use_iam = aws_creds[0] is not None and aws_creds[1] is not None
 
         if model.startswith(ANTHROPIC_MODEL_PREFIX):
             params.pop("max_completion_tokens", None)
@@ -119,7 +130,7 @@ class Bedrock(LLMProvider):
             model_id = f"{region_prefix}.{model}"
 
             if use_iam:
-                session = self._build_boto3_session(region)
+                session = self._build_boto3_session(region, aws_creds)
                 params["client"] = session.client("bedrock-runtime")
             else:
                 params["bedrock_api_key"] = api_key
@@ -145,7 +156,7 @@ class Bedrock(LLMProvider):
 
         if use_iam:
             region = self._region_from_url()
-            auth = self._build_sigv4_auth(region)
+            auth = self._build_sigv4_auth(region, aws_creds)
             params["openai_api_key"] = "unused"
             params["http_client"] = httpx.Client(auth=auth)
             params["http_async_client"] = httpx.AsyncClient(auth=auth)

--- a/ols/src/llms/providers/bedrock.py
+++ b/ols/src/llms/providers/bedrock.py
@@ -59,8 +59,8 @@ class Bedrock(LLMProvider):
 
     def _has_aws_credentials(self) -> bool:
         """Check whether IAM credentials are available."""
-        pc = self.provider_config
-        return pc.aws_access_key_id is not None and pc.aws_secret_access_key is not None
+        access_key, secret_key, _ = self.provider_config.get_aws_credentials()
+        return access_key is not None and secret_key is not None
 
     def _region_from_url(self) -> str:
         """Extract AWS region from the Mantle gateway URL."""
@@ -75,16 +75,16 @@ class Bedrock(LLMProvider):
 
     def _build_boto3_session(self, region: str) -> boto3.Session:
         """Build a boto3 session from IAM credentials, with optional STS assume-role."""
-        pc = self.provider_config
+        access_key, secret_key, role_arn = self.provider_config.get_aws_credentials()
         session = boto3.Session(
-            aws_access_key_id=pc.aws_access_key_id,
-            aws_secret_access_key=pc.aws_secret_access_key,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
             region_name=region,
         )
-        if pc.role_arn:
+        if role_arn:
             sts = session.client("sts")
             assumed = sts.assume_role(
-                RoleArn=pc.role_arn, RoleSessionName="ols-bedrock"
+                RoleArn=role_arn, RoleSessionName="ols-bedrock"
             )["Credentials"]
             session = boto3.Session(
                 aws_access_key_id=assumed["AccessKeyId"],

--- a/ols/src/llms/providers/bedrock.py
+++ b/ols/src/llms/providers/bedrock.py
@@ -75,9 +75,15 @@ class Bedrock(LLMProvider):
             "expected format: https://bedrock-mantle.<region>.api.aws"
         )
 
-    def _build_boto3_session(self, region: str) -> boto3.Session:
+    def _build_boto3_session(
+        self,
+        region: str,
+        aws_creds: tuple[Optional[str], Optional[str], Optional[str]] | None = None,
+    ) -> boto3.Session:
         """Build a boto3 session from IAM credentials, with optional STS assume-role."""
-        access_key, secret_key, role_arn = self.provider_config.get_aws_credentials()
+        if aws_creds is None:
+            aws_creds = self.provider_config.get_aws_credentials()
+        access_key, secret_key, role_arn = aws_creds
         session = boto3.Session(
             aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,
@@ -85,9 +91,9 @@ class Bedrock(LLMProvider):
         )
         if role_arn:
             sts = session.client("sts")
-            assumed = sts.assume_role(
-                RoleArn=role_arn, RoleSessionName="ols-bedrock"
-            )["Credentials"]
+            assumed = sts.assume_role(RoleArn=role_arn, RoleSessionName="ols-bedrock")[
+                "Credentials"
+            ]
             session = boto3.Session(
                 aws_access_key_id=assumed["AccessKeyId"],
                 aws_secret_access_key=assumed["SecretAccessKey"],
@@ -96,9 +102,13 @@ class Bedrock(LLMProvider):
             )
         return session
 
-    def _build_sigv4_auth(self, region: str) -> AwsSigV4Auth:
+    def _build_sigv4_auth(
+        self,
+        region: str,
+        aws_creds: tuple[Optional[str], Optional[str], Optional[str]] | None = None,
+    ) -> AwsSigV4Auth:
         """Build a SigV4 auth handler from IAM credentials."""
-        session = self._build_boto3_session(region)
+        session = self._build_boto3_session(region, aws_creds)
         frozen = session.get_credentials().get_frozen_credentials()
         creds = AwsCredentials(
             access_key=frozen.access_key,
@@ -160,7 +170,8 @@ class Bedrock(LLMProvider):
         params = {**self.params}
         api_key = params.pop("api_key")
         model = params.pop("model")
-        use_iam = self._has_aws_credentials()
+        aws_creds = self.provider_config.get_aws_credentials()
+        use_iam = aws_creds[0] is not None and aws_creds[1] is not None
 
         model_config = self.provider_config.models.get(self.model)
         model_params = getattr(model_config, "parameters", None) or ModelParameters()
@@ -172,7 +183,7 @@ class Bedrock(LLMProvider):
             model_id = f"{region_prefix}.{model}"
 
             if use_iam:
-                session = self._build_boto3_session(region)
+                session = self._build_boto3_session(region, aws_creds)
                 params["client"] = session.client("bedrock-runtime")
             else:
                 params["bedrock_api_key"] = api_key
@@ -202,7 +213,7 @@ class Bedrock(LLMProvider):
 
         if use_iam:
             region = self._region_from_url()
-            auth = self._build_sigv4_auth(region)
+            auth = self._build_sigv4_auth(region, aws_creds)
             params["openai_api_key"] = "unused"
             params["http_client"] = httpx.Client(auth=auth)
             params["http_async_client"] = httpx.AsyncClient(auth=auth)

--- a/ols/src/llms/providers/bedrock.py
+++ b/ols/src/llms/providers/bedrock.py
@@ -61,8 +61,8 @@ class Bedrock(LLMProvider):
 
     def _has_aws_credentials(self) -> bool:
         """Check whether IAM credentials are available."""
-        pc = self.provider_config
-        return pc.aws_access_key_id is not None and pc.aws_secret_access_key is not None
+        access_key, secret_key, _ = self.provider_config.get_aws_credentials()
+        return access_key is not None and secret_key is not None
 
     def _region_from_url(self) -> str:
         """Extract AWS region from the Mantle gateway URL."""
@@ -77,16 +77,16 @@ class Bedrock(LLMProvider):
 
     def _build_boto3_session(self, region: str) -> boto3.Session:
         """Build a boto3 session from IAM credentials, with optional STS assume-role."""
-        pc = self.provider_config
+        access_key, secret_key, role_arn = self.provider_config.get_aws_credentials()
         session = boto3.Session(
-            aws_access_key_id=pc.aws_access_key_id,
-            aws_secret_access_key=pc.aws_secret_access_key,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
             region_name=region,
         )
-        if pc.role_arn:
+        if role_arn:
             sts = session.client("sts")
             assumed = sts.assume_role(
-                RoleArn=pc.role_arn, RoleSessionName="ols-bedrock"
+                RoleArn=role_arn, RoleSessionName="ols-bedrock"
             )["Credentials"]
             session = boto3.Session(
                 aws_access_key_id=assumed["AccessKeyId"],

--- a/ols/src/llms/providers/bedrock.py
+++ b/ols/src/llms/providers/bedrock.py
@@ -36,7 +36,7 @@ class Bedrock(LLMProvider):
         """Construct and return default LLM params."""
         if self.provider_config.url is not None:
             self.url = str(self.provider_config.url).rstrip("/")
-        self.credentials = self.provider_config.credentials
+        self.credentials = self.provider_config.get_credentials()
 
         if not self.url:
             raise LLMConfigurationError(

--- a/ols/src/llms/providers/google_vertex.py
+++ b/ols/src/llms/providers/google_vertex.py
@@ -11,6 +11,7 @@ from ols import constants
 from ols.src.llms.providers.provider import LLMProvider
 from ols.src.llms.providers.registry import register_llm_provider_as
 from ols.src.llms.providers.utils import load_vertex_credentials
+from ols.utils.checks import InvalidConfigurationError
 
 if TYPE_CHECKING:
     from google.auth.credentials import Credentials as GoogleCredentials
@@ -32,9 +33,12 @@ class GoogleVertex(LLMProvider):
     def default_params(self) -> dict[str, Any]:
         """Construct and return structure with default LLM params."""
         self.project = self.provider_config.project_id
-        if self.provider_config.credentials is None:
-            raise ValueError("credentials are required for Google Vertex provider")
-        self.credentials = load_vertex_credentials(self.provider_config.credentials)
+        creds_value = self.provider_config.get_credentials()
+        if creds_value is None:
+            raise InvalidConfigurationError(
+                "credentials are required for Google Vertex provider"
+            )
+        self.credentials = load_vertex_credentials(creds_value)
         if self.provider_config.google_vertex_config is not None:
             vertex_config = self.provider_config.google_vertex_config
             self.project = vertex_config.project
@@ -70,11 +74,12 @@ class GoogleVertexAnthropic(LLMProvider):
     def default_params(self) -> dict[str, Any]:
         """Construct and return structure with default LLM params."""
         self.project = self.provider_config.project_id
-        if self.provider_config.credentials is None:
-            raise ValueError(
+        creds_value = self.provider_config.get_credentials()
+        if creds_value is None:
+            raise InvalidConfigurationError(
                 "credentials are required for Google Vertex Anthropic provider"
             )
-        self.credentials = load_vertex_credentials(self.provider_config.credentials)
+        self.credentials = load_vertex_credentials(creds_value)
         if self.provider_config.google_vertex_anthropic_config is not None:
             vertex_config = self.provider_config.google_vertex_anthropic_config
             self.project = vertex_config.project

--- a/ols/src/llms/providers/google_vertex.py
+++ b/ols/src/llms/providers/google_vertex.py
@@ -12,6 +12,7 @@ from ols.app.models.config import ModelParameters
 from ols.src.llms.providers.provider import LLMProvider
 from ols.src.llms.providers.registry import register_llm_provider_as
 from ols.src.llms.providers.utils import load_vertex_credentials
+from ols.utils.checks import InvalidConfigurationError
 
 if TYPE_CHECKING:
     from google.auth.credentials import Credentials as GoogleCredentials
@@ -33,9 +34,12 @@ class GoogleVertex(LLMProvider):
     def default_params(self) -> dict[str, Any]:
         """Construct and return structure with default LLM params."""
         self.project = self.provider_config.project_id
-        if self.provider_config.credentials is None:
-            raise ValueError("credentials are required for Google Vertex provider")
-        self.credentials = load_vertex_credentials(self.provider_config.credentials)
+        creds_value = self.provider_config.get_credentials()
+        if creds_value is None:
+            raise InvalidConfigurationError(
+                "credentials are required for Google Vertex provider"
+            )
+        self.credentials = load_vertex_credentials(creds_value)
         if self.provider_config.google_vertex_config is not None:
             vertex_config = self.provider_config.google_vertex_config
             self.project = vertex_config.project
@@ -85,11 +89,12 @@ class GoogleVertexAnthropic(LLMProvider):
     def default_params(self) -> dict[str, Any]:
         """Construct and return structure with default LLM params."""
         self.project = self.provider_config.project_id
-        if self.provider_config.credentials is None:
-            raise ValueError(
+        creds_value = self.provider_config.get_credentials()
+        if creds_value is None:
+            raise InvalidConfigurationError(
                 "credentials are required for Google Vertex Anthropic provider"
             )
-        self.credentials = load_vertex_credentials(self.provider_config.credentials)
+        self.credentials = load_vertex_credentials(creds_value)
         if self.provider_config.google_vertex_anthropic_config is not None:
             vertex_config = self.provider_config.google_vertex_anthropic_config
             self.project = vertex_config.project

--- a/ols/src/llms/providers/openai.py
+++ b/ols/src/llms/providers/openai.py
@@ -25,7 +25,7 @@ class OpenAI(LLMProvider):
     def default_params(self) -> dict[str, Any]:
         """Construct and return structure with default LLM params."""
         self.url = str(self.provider_config.url or self.url)
-        self.credentials = self.provider_config.credentials
+        self.credentials = self.provider_config.get_credentials()
         # provider-specific configuration has precendence over regular configuration
         if self.provider_config.openai_config is not None:
             openai_config = self.provider_config.openai_config

--- a/ols/src/llms/providers/openai.py
+++ b/ols/src/llms/providers/openai.py
@@ -26,7 +26,7 @@ class OpenAI(LLMProvider):
     def default_params(self) -> dict[str, Any]:
         """Construct and return structure with default LLM params."""
         self.url = str(self.provider_config.url or self.url)
-        self.credentials = self.provider_config.credentials
+        self.credentials = self.provider_config.get_credentials()
         # provider-specific configuration has precendence over regular configuration
         if self.provider_config.openai_config is not None:
             openai_config = self.provider_config.openai_config

--- a/ols/src/llms/providers/rhelai_vllm.py
+++ b/ols/src/llms/providers/rhelai_vllm.py
@@ -25,7 +25,7 @@ class RHELAIVLLM(LLMProvider):
     def default_params(self) -> dict[str, Any]:
         """Construct and return structure with default LLM params."""
         self.url = str(self.provider_config.url or self.url)
-        self.credentials = self.provider_config.credentials
+        self.credentials = self.provider_config.get_credentials()
         # provider-specific configuration has precendence over regular configuration
         if self.provider_config.rhelai_vllm_config is not None:
             rhelai_vllm_config = self.provider_config.rhelai_vllm_config

--- a/ols/src/llms/providers/rhelai_vllm.py
+++ b/ols/src/llms/providers/rhelai_vllm.py
@@ -28,7 +28,7 @@ class RHELAIVLLM(LLMProvider):
     def default_params(self) -> dict[str, Any]:
         """Construct and return structure with default LLM params."""
         self.url = str(self.provider_config.url or self.url)
-        self.credentials = self.provider_config.credentials
+        self.credentials = self.provider_config.get_credentials()
         # provider-specific configuration has precendence over regular configuration
         if self.provider_config.rhelai_vllm_config is not None:
             rhelai_vllm_config = self.provider_config.rhelai_vllm_config

--- a/ols/src/llms/providers/rhoai_vllm.py
+++ b/ols/src/llms/providers/rhoai_vllm.py
@@ -25,7 +25,7 @@ class RHOAIVLLM(LLMProvider):
     def default_params(self) -> dict[str, Any]:
         """Construct and return structure with default LLM params."""
         self.url = str(self.provider_config.url or self.url)
-        self.credentials = self.provider_config.credentials
+        self.credentials = self.provider_config.get_credentials()
         # provider-specific configuration has precendence over regular configuration
         if self.provider_config.rhoai_vllm_config is not None:
             rhoai_vllm_config = self.provider_config.rhoai_vllm_config

--- a/ols/src/llms/providers/rhoai_vllm.py
+++ b/ols/src/llms/providers/rhoai_vllm.py
@@ -28,7 +28,7 @@ class RHOAIVLLM(LLMProvider):
     def default_params(self) -> dict[str, Any]:
         """Construct and return structure with default LLM params."""
         self.url = str(self.provider_config.url or self.url)
-        self.credentials = self.provider_config.credentials
+        self.credentials = self.provider_config.get_credentials()
         # provider-specific configuration has precendence over regular configuration
         if self.provider_config.rhoai_vllm_config is not None:
             rhoai_vllm_config = self.provider_config.rhoai_vllm_config

--- a/ols/src/llms/providers/watsonx.py
+++ b/ols/src/llms/providers/watsonx.py
@@ -42,7 +42,7 @@ class Watsonx(LLMProvider):
     def load(self) -> BaseChatModel:
         """Load LLM."""
         self.url = str(self.provider_config.url or self.url)
-        self.credentials = self.provider_config.credentials
+        self.credentials = self.provider_config.get_credentials()
         self.project_id = self.provider_config.project_id
 
         # provider-specific configuration has precendence over regular configuration

--- a/ols/utils/checks.py
+++ b/ols/utils/checks.py
@@ -68,6 +68,38 @@ def read_secret(
         return None
 
 
+def read_secret_from_path(
+    path: str,
+    default_filename: str,
+) -> Optional[str]:
+    """Re-read a secret from a file path, resolving directories.
+
+    Unlike ``read_secret`` this function takes a concrete path string
+    (not a dict lookup) and is designed to be called on every LLM
+    request so that credential files rotated by Kubernetes (atomic
+    symlink swap) are picked up without a pod restart.
+
+    Args:
+        path: File path or directory containing the secret.
+        default_filename: Filename to append when *path* is a directory.
+
+    Returns:
+        The secret value with trailing whitespace stripped, or ``None``
+        when the file cannot be read.
+    """
+    filename = path
+    if os.path.isdir(path):
+        filename = os.path.join(path, default_filename)
+
+    try:
+        with open(filename, encoding="utf-8") as f:
+            return f.read().rstrip()
+    except OSError:
+        logger = logging.getLogger(__name__)
+        logger.warning("Failed to re-read credential from %s", filename)
+        return None
+
+
 def dir_check(path: FilePath, desc: str) -> None:
     """Check that path is a readable directory."""
     if not os.path.exists(path):

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -4,6 +4,7 @@ import copy
 import errno
 import logging
 import os
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -4336,3 +4337,96 @@ def test_skills_config_validation():
         SkillsConfig(alpha=-0.1)
     with pytest.raises(ValidationError, match="less than or equal to 1"):
         SkillsConfig(alpha=1.1)
+
+
+def test_provider_config_get_credentials_returns_cached_when_no_path() -> None:
+    """Test get_credentials() returns cached value when no path is configured."""
+    provider_config = ProviderConfig()
+    provider_config.credentials = "cached-key"
+    assert provider_config.get_credentials() == "cached-key"
+
+
+def test_provider_config_get_credentials_rereads_from_disk(tmp_path: Path) -> None:
+    """Test get_credentials() re-reads credential file on every call."""
+    secret_file = tmp_path / "apitoken"
+    secret_file.write_text("original-key")
+
+    provider_config = ProviderConfig(
+        {
+            "name": "test_provider",
+            "type": "openai",
+            "url": "http://test.url",
+            "credentials_path": str(secret_file),
+            "models": [
+                {
+                    "name": "test_model",
+                    "url": "http://test.url/",
+                    "credentials_path": str(secret_file),
+                }
+            ],
+        }
+    )
+
+    assert provider_config.get_credentials() == "original-key"
+
+    secret_file.write_text("rotated-key")
+    assert provider_config.get_credentials() == "rotated-key"
+
+
+def test_provider_config_get_credentials_falls_back_on_read_failure(
+    tmp_path: Path,
+) -> None:
+    """Test get_credentials() falls back to cached value when file disappears."""
+    secret_file = tmp_path / "apitoken"
+    secret_file.write_text("original-key")
+
+    provider_config = ProviderConfig(
+        {
+            "name": "test_provider",
+            "type": "openai",
+            "url": "http://test.url",
+            "credentials_path": str(secret_file),
+            "models": [
+                {
+                    "name": "test_model",
+                    "url": "http://test.url/",
+                    "credentials_path": str(secret_file),
+                }
+            ],
+        }
+    )
+
+    assert provider_config.get_credentials() == "original-key"
+
+    secret_file.write_text("rotated-key")
+    assert provider_config.get_credentials() == "rotated-key"
+
+    secret_file.unlink()
+    assert provider_config.get_credentials() == "rotated-key"
+
+
+def test_provider_config_get_credentials_with_directory(tmp_path: Path) -> None:
+    """Test get_credentials() when credentials_path is a directory."""
+    secret_file = tmp_path / "apitoken"
+    secret_file.write_text("dir-key")
+
+    provider_config = ProviderConfig(
+        {
+            "name": "test_provider",
+            "type": "openai",
+            "url": "http://test.url",
+            "credentials_path": str(tmp_path),
+            "models": [
+                {
+                    "name": "test_model",
+                    "url": "http://test.url/",
+                    "credentials_path": str(secret_file),
+                }
+            ],
+        }
+    )
+
+    assert provider_config.get_credentials() == "dir-key"
+
+    secret_file.write_text("new-dir-key")
+    assert provider_config.get_credentials() == "new-dir-key"

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -4347,7 +4347,7 @@ def test_provider_config_get_credentials_returns_cached_when_no_path() -> None:
 
 
 def test_provider_config_get_credentials_rereads_from_disk(tmp_path: Path) -> None:
-    """Test get_credentials() re-reads credential file on every call."""
+    """Test get_credentials() re-reads credential file when hot-reload is enabled."""
     secret_file = tmp_path / "apitoken"
     secret_file.write_text("original-key")
 
@@ -4364,7 +4364,8 @@ def test_provider_config_get_credentials_rereads_from_disk(tmp_path: Path) -> No
                     "credentials_path": str(secret_file),
                 }
             ],
-        }
+        },
+        credential_hot_reload=True,
     )
 
     assert provider_config.get_credentials() == "original-key"
@@ -4393,7 +4394,8 @@ def test_provider_config_get_credentials_falls_back_on_read_failure(
                     "credentials_path": str(secret_file),
                 }
             ],
-        }
+        },
+        credential_hot_reload=True,
     )
 
     assert provider_config.get_credentials() == "original-key"
@@ -4423,7 +4425,8 @@ def test_provider_config_get_credentials_with_directory(tmp_path: Path) -> None:
                     "credentials_path": str(secret_file),
                 }
             ],
-        }
+        },
+        credential_hot_reload=True,
     )
 
     assert provider_config.get_credentials() == "dir-key"

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -4342,7 +4342,7 @@ def test_provider_config_get_credentials_returns_cached_when_no_path() -> None:
 
 
 def test_provider_config_get_credentials_rereads_from_disk(tmp_path: Path) -> None:
-    """Test get_credentials() re-reads credential file on every call."""
+    """Test get_credentials() re-reads credential file when hot-reload is enabled."""
     secret_file = tmp_path / "apitoken"
     secret_file.write_text("original-key")
 
@@ -4359,7 +4359,8 @@ def test_provider_config_get_credentials_rereads_from_disk(tmp_path: Path) -> No
                     "credentials_path": str(secret_file),
                 }
             ],
-        }
+        },
+        credential_hot_reload=True,
     )
 
     assert provider_config.get_credentials() == "original-key"
@@ -4388,7 +4389,8 @@ def test_provider_config_get_credentials_falls_back_on_read_failure(
                     "credentials_path": str(secret_file),
                 }
             ],
-        }
+        },
+        credential_hot_reload=True,
     )
 
     assert provider_config.get_credentials() == "original-key"
@@ -4418,7 +4420,8 @@ def test_provider_config_get_credentials_with_directory(tmp_path: Path) -> None:
                     "credentials_path": str(secret_file),
                 }
             ],
-        }
+        },
+        credential_hot_reload=True,
     )
 
     assert provider_config.get_credentials() == "dir-key"

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -4,6 +4,7 @@ import copy
 import errno
 import logging
 import os
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -4331,3 +4332,96 @@ def test_skills_config_validation():
         SkillsConfig(alpha=-0.1)
     with pytest.raises(ValidationError, match="less than or equal to 1"):
         SkillsConfig(alpha=1.1)
+
+
+def test_provider_config_get_credentials_returns_cached_when_no_path() -> None:
+    """Test get_credentials() returns cached value when no path is configured."""
+    provider_config = ProviderConfig()
+    provider_config.credentials = "cached-key"
+    assert provider_config.get_credentials() == "cached-key"
+
+
+def test_provider_config_get_credentials_rereads_from_disk(tmp_path: Path) -> None:
+    """Test get_credentials() re-reads credential file on every call."""
+    secret_file = tmp_path / "apitoken"
+    secret_file.write_text("original-key")
+
+    provider_config = ProviderConfig(
+        {
+            "name": "test_provider",
+            "type": "openai",
+            "url": "http://test.url",
+            "credentials_path": str(secret_file),
+            "models": [
+                {
+                    "name": "test_model",
+                    "url": "http://test.url/",
+                    "credentials_path": str(secret_file),
+                }
+            ],
+        }
+    )
+
+    assert provider_config.get_credentials() == "original-key"
+
+    secret_file.write_text("rotated-key")
+    assert provider_config.get_credentials() == "rotated-key"
+
+
+def test_provider_config_get_credentials_falls_back_on_read_failure(
+    tmp_path: Path,
+) -> None:
+    """Test get_credentials() falls back to cached value when file disappears."""
+    secret_file = tmp_path / "apitoken"
+    secret_file.write_text("original-key")
+
+    provider_config = ProviderConfig(
+        {
+            "name": "test_provider",
+            "type": "openai",
+            "url": "http://test.url",
+            "credentials_path": str(secret_file),
+            "models": [
+                {
+                    "name": "test_model",
+                    "url": "http://test.url/",
+                    "credentials_path": str(secret_file),
+                }
+            ],
+        }
+    )
+
+    assert provider_config.get_credentials() == "original-key"
+
+    secret_file.write_text("rotated-key")
+    assert provider_config.get_credentials() == "rotated-key"
+
+    secret_file.unlink()
+    assert provider_config.get_credentials() == "rotated-key"
+
+
+def test_provider_config_get_credentials_with_directory(tmp_path: Path) -> None:
+    """Test get_credentials() when credentials_path is a directory."""
+    secret_file = tmp_path / "apitoken"
+    secret_file.write_text("dir-key")
+
+    provider_config = ProviderConfig(
+        {
+            "name": "test_provider",
+            "type": "openai",
+            "url": "http://test.url",
+            "credentials_path": str(tmp_path),
+            "models": [
+                {
+                    "name": "test_model",
+                    "url": "http://test.url/",
+                    "credentials_path": str(secret_file),
+                }
+            ],
+        }
+    )
+
+    assert provider_config.get_credentials() == "dir-key"
+
+    secret_file.write_text("new-dir-key")
+    assert provider_config.get_credentials() == "new-dir-key"

--- a/tests/unit/llms/providers/test_bedrock.py
+++ b/tests/unit/llms/providers/test_bedrock.py
@@ -495,7 +495,7 @@ def test_build_sigv4_auth_with_role(
 
 
 def test_bedrock_picks_up_rotated_credentials(tmp_path: Path) -> None:
-    """Test that Bedrock provider re-reads credentials on each default_params access."""
+    """Test that Bedrock provider re-reads credentials when hot-reload is enabled."""
     secret_file = tmp_path / "apitoken"
     secret_file.write_text("initial-key")
 
@@ -506,7 +506,8 @@ def test_bedrock_picks_up_rotated_credentials(tmp_path: Path) -> None:
             "url": "https://bedrock-mantle.us-east-1.api.aws",
             "credentials_path": str(secret_file),
             "models": [{"name": "anthropic.claude-opus-4-7"}],
-        }
+        },
+        credential_hot_reload=True,
     )
 
     bedrock_1 = Bedrock(
@@ -520,3 +521,33 @@ def test_bedrock_picks_up_rotated_credentials(tmp_path: Path) -> None:
         model="anthropic.claude-opus-4-7", params={}, provider_config=config
     )
     assert bedrock_2.default_params["api_key"] == "rotated-key"
+
+
+def test_bedrock_iam_picks_up_rotated_credentials(tmp_path: Path) -> None:
+    """Test that Bedrock IAM credentials are re-read when hot-reload is enabled."""
+    creds_dir = tmp_path / "aws_creds"
+    creds_dir.mkdir()
+    (creds_dir / "aws_access_key_id").write_text("original_access")
+    (creds_dir / "aws_secret_access_key").write_text("original_secret")
+
+    config = ProviderConfig(
+        {
+            "name": "test_provider",
+            "type": "bedrock",
+            "url": "https://bedrock-mantle.us-east-1.api.aws",
+            "credentials_path": str(creds_dir),
+            "models": [{"name": "anthropic.claude-opus-4-7"}],
+        },
+        credential_hot_reload=True,
+    )
+
+    access_key, secret_key, _ = config.get_aws_credentials()
+    assert access_key == "original_access"
+    assert secret_key == "original_secret"
+
+    (creds_dir / "aws_access_key_id").write_text("rotated_access")
+    (creds_dir / "aws_secret_access_key").write_text("rotated_secret")
+
+    access_key, secret_key, _ = config.get_aws_credentials()
+    assert access_key == "rotated_access"
+    assert secret_key == "rotated_secret"

--- a/tests/unit/llms/providers/test_bedrock.py
+++ b/tests/unit/llms/providers/test_bedrock.py
@@ -492,3 +492,31 @@ def test_build_sigv4_auth_with_role(
         RoleArn="arn:aws:iam::123456789012:role/TestRole",
         RoleSessionName="ols-bedrock",
     )
+
+
+def test_bedrock_picks_up_rotated_credentials(tmp_path: Path) -> None:
+    """Test that Bedrock provider re-reads credentials on each default_params access."""
+    secret_file = tmp_path / "apitoken"
+    secret_file.write_text("initial-key")
+
+    config = ProviderConfig(
+        {
+            "name": "test_provider",
+            "type": "bedrock",
+            "url": "https://bedrock-mantle.us-east-1.api.aws",
+            "credentials_path": str(secret_file),
+            "models": [{"name": "anthropic.claude-opus-4-7"}],
+        }
+    )
+
+    bedrock_1 = Bedrock(
+        model="anthropic.claude-opus-4-7", params={}, provider_config=config
+    )
+    assert bedrock_1.default_params["api_key"] == "initial-key"
+
+    secret_file.write_text("rotated-key")
+
+    bedrock_2 = Bedrock(
+        model="anthropic.claude-opus-4-7", params={}, provider_config=config
+    )
+    assert bedrock_2.default_params["api_key"] == "rotated-key"

--- a/tests/unit/llms/providers/test_bedrock.py
+++ b/tests/unit/llms/providers/test_bedrock.py
@@ -1,7 +1,7 @@
 """Unit tests for AWS Bedrock provider."""
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -355,7 +355,7 @@ def test_load_anthropic_model_iam(
     assert call_kwargs["region_name"] == "us-east-1"
     assert call_kwargs["client"] is mock_client
     assert "bedrock_api_key" not in call_kwargs
-    mock_build_session.assert_called_once_with("us-east-1")
+    mock_build_session.assert_called_once_with("us-east-1", ANY)
     mock_build_session.return_value.client.assert_called_once_with("bedrock-runtime")
 
 
@@ -384,7 +384,7 @@ def test_load_openai_model_iam(
     assert call_kwargs["use_responses_api"] is True
     assert "http_client" in call_kwargs
     assert "http_async_client" in call_kwargs
-    _mock_sigv4.assert_called_once_with("us-east-1")
+    _mock_sigv4.assert_called_once_with("us-east-1", ANY)
 
 
 @patch(
@@ -543,11 +543,11 @@ def test_bedrock_iam_picks_up_rotated_credentials(tmp_path: Path) -> None:
 
     access_key, secret_key, _ = config.get_aws_credentials()
     assert access_key == "original_access"
-    assert secret_key == "original_secret"
+    assert secret_key == "original_secret"  # noqa: S105
 
     (creds_dir / "aws_access_key_id").write_text("rotated_access")
     (creds_dir / "aws_secret_access_key").write_text("rotated_secret")
 
     access_key, secret_key, _ = config.get_aws_credentials()
     assert access_key == "rotated_access"
-    assert secret_key == "rotated_secret"
+    assert secret_key == "rotated_secret"  # noqa: S105

--- a/tests/unit/llms/providers/test_bedrock.py
+++ b/tests/unit/llms/providers/test_bedrock.py
@@ -776,7 +776,7 @@ def test_anthropic_no_thinking_config() -> None:
 
 
 def test_bedrock_picks_up_rotated_credentials(tmp_path: Path) -> None:
-    """Test that Bedrock provider re-reads credentials on each default_params access."""
+    """Test that Bedrock provider re-reads credentials when hot-reload is enabled."""
     secret_file = tmp_path / "apitoken"
     secret_file.write_text("initial-key")
 
@@ -787,7 +787,8 @@ def test_bedrock_picks_up_rotated_credentials(tmp_path: Path) -> None:
             "url": "https://bedrock-mantle.us-east-1.api.aws",
             "credentials_path": str(secret_file),
             "models": [{"name": "anthropic.claude-opus-4-7"}],
-        }
+        },
+        credential_hot_reload=True,
     )
 
     bedrock_1 = Bedrock(
@@ -801,3 +802,33 @@ def test_bedrock_picks_up_rotated_credentials(tmp_path: Path) -> None:
         model="anthropic.claude-opus-4-7", params={}, provider_config=config
     )
     assert bedrock_2.default_params["api_key"] == "rotated-key"
+
+
+def test_bedrock_iam_picks_up_rotated_credentials(tmp_path: Path) -> None:
+    """Test that Bedrock IAM credentials are re-read when hot-reload is enabled."""
+    creds_dir = tmp_path / "aws_creds"
+    creds_dir.mkdir()
+    (creds_dir / "aws_access_key_id").write_text("original_access")
+    (creds_dir / "aws_secret_access_key").write_text("original_secret")
+
+    config = ProviderConfig(
+        {
+            "name": "test_provider",
+            "type": "bedrock",
+            "url": "https://bedrock-mantle.us-east-1.api.aws",
+            "credentials_path": str(creds_dir),
+            "models": [{"name": "anthropic.claude-opus-4-7"}],
+        },
+        credential_hot_reload=True,
+    )
+
+    access_key, secret_key, _ = config.get_aws_credentials()
+    assert access_key == "original_access"
+    assert secret_key == "original_secret"
+
+    (creds_dir / "aws_access_key_id").write_text("rotated_access")
+    (creds_dir / "aws_secret_access_key").write_text("rotated_secret")
+
+    access_key, secret_key, _ = config.get_aws_credentials()
+    assert access_key == "rotated_access"
+    assert secret_key == "rotated_secret"

--- a/tests/unit/llms/providers/test_bedrock.py
+++ b/tests/unit/llms/providers/test_bedrock.py
@@ -773,3 +773,31 @@ def test_anthropic_no_thinking_config() -> None:
 
     # Should return early without setting anything
     assert "additional_model_request_fields" not in params
+
+
+def test_bedrock_picks_up_rotated_credentials(tmp_path: Path) -> None:
+    """Test that Bedrock provider re-reads credentials on each default_params access."""
+    secret_file = tmp_path / "apitoken"
+    secret_file.write_text("initial-key")
+
+    config = ProviderConfig(
+        {
+            "name": "test_provider",
+            "type": "bedrock",
+            "url": "https://bedrock-mantle.us-east-1.api.aws",
+            "credentials_path": str(secret_file),
+            "models": [{"name": "anthropic.claude-opus-4-7"}],
+        }
+    )
+
+    bedrock_1 = Bedrock(
+        model="anthropic.claude-opus-4-7", params={}, provider_config=config
+    )
+    assert bedrock_1.default_params["api_key"] == "initial-key"
+
+    secret_file.write_text("rotated-key")
+
+    bedrock_2 = Bedrock(
+        model="anthropic.claude-opus-4-7", params={}, provider_config=config
+    )
+    assert bedrock_2.default_params["api_key"] == "rotated-key"

--- a/tests/unit/llms/providers/test_bedrock.py
+++ b/tests/unit/llms/providers/test_bedrock.py
@@ -1,7 +1,7 @@
 """Unit tests for AWS Bedrock provider."""
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -478,7 +478,7 @@ def test_load_anthropic_model_iam(
     assert call_kwargs["region_name"] == "us-east-1"
     assert call_kwargs["client"] is mock_client
     assert "bedrock_api_key" not in call_kwargs
-    mock_build_session.assert_called_once_with("us-east-1")
+    mock_build_session.assert_called_once_with("us-east-1", ANY)
     mock_build_session.return_value.client.assert_called_once_with("bedrock-runtime")
 
 
@@ -507,7 +507,7 @@ def test_load_openai_model_iam(
     assert call_kwargs["use_responses_api"] is True
     assert "http_client" in call_kwargs
     assert "http_async_client" in call_kwargs
-    _mock_sigv4.assert_called_once_with("us-east-1")
+    _mock_sigv4.assert_called_once_with("us-east-1", ANY)
 
 
 @patch(
@@ -824,11 +824,11 @@ def test_bedrock_iam_picks_up_rotated_credentials(tmp_path: Path) -> None:
 
     access_key, secret_key, _ = config.get_aws_credentials()
     assert access_key == "original_access"
-    assert secret_key == "original_secret"
+    assert secret_key == "original_secret"  # noqa: S105
 
     (creds_dir / "aws_access_key_id").write_text("rotated_access")
     (creds_dir / "aws_secret_access_key").write_text("rotated_secret")
 
     access_key, secret_key, _ = config.get_aws_credentials()
     assert access_key == "rotated_access"
-    assert secret_key == "rotated_secret"
+    assert secret_key == "rotated_secret"  # noqa: S105

--- a/tests/unit/llms/providers/test_openai.py
+++ b/tests/unit/llms/providers/test_openai.py
@@ -1,5 +1,8 @@
 """Unit tests for OpenAI provider."""
 
+import os
+from pathlib import Path
+
 import httpx
 import pytest
 from langchain_openai.chat_models.base import ChatOpenAI
@@ -249,3 +252,35 @@ def test_gpt5_and_o_series_models_parameter_exclusion(
     assert "model" in openai.default_params
     assert "max_completion_tokens" in openai.default_params
     assert openai.default_params["model"] == model_name
+
+
+def test_openai_picks_up_rotated_credentials(
+    tmp_path: Path, fake_certifi_store: str
+) -> None:
+    """Test that OpenAI provider re-reads credentials on each load."""
+    secret_file = tmp_path / "apitoken"
+    secret_file.write_text("initial-key")
+
+    config = ProviderConfig(
+        {
+            "name": "test_provider",
+            "type": "openai",
+            "url": "http://test.url",
+            "credentials_path": str(secret_file),
+            "models": [
+                {
+                    "name": "test_model",
+                    "url": "http://test.url/",
+                    "credentials_path": str(secret_file),
+                }
+            ],
+        }
+    )
+
+    openai_1 = OpenAI(model="test_model", provider_config=config)
+    assert openai_1.default_params["openai_api_key"] == "initial-key"
+
+    secret_file.write_text("rotated-key")
+
+    openai_2 = OpenAI(model="test_model", provider_config=config)
+    assert openai_2.default_params["openai_api_key"] == "rotated-key"

--- a/tests/unit/llms/providers/test_openai.py
+++ b/tests/unit/llms/providers/test_openai.py
@@ -257,7 +257,7 @@ def test_gpt5_and_o_series_models_parameter_exclusion(
 def test_openai_picks_up_rotated_credentials(
     tmp_path: Path, fake_certifi_store: str
 ) -> None:
-    """Test that OpenAI provider re-reads credentials on each load."""
+    """Test that OpenAI provider re-reads credentials when hot-reload is enabled."""
     secret_file = tmp_path / "apitoken"
     secret_file.write_text("initial-key")
 
@@ -274,7 +274,8 @@ def test_openai_picks_up_rotated_credentials(
                     "credentials_path": str(secret_file),
                 }
             ],
-        }
+        },
+        credential_hot_reload=True,
     )
 
     openai_1 = OpenAI(model="test_model", provider_config=config)
@@ -284,3 +285,36 @@ def test_openai_picks_up_rotated_credentials(
 
     openai_2 = OpenAI(model="test_model", provider_config=config)
     assert openai_2.default_params["openai_api_key"] == "rotated-key"
+
+
+def test_openai_returns_cached_credentials_when_hot_reload_disabled(
+    tmp_path: Path, fake_certifi_store: str
+) -> None:
+    """Test that credentials are cached (not re-read) when hot-reload is disabled."""
+    secret_file = tmp_path / "apitoken"
+    secret_file.write_text("initial-key")
+
+    config = ProviderConfig(
+        {
+            "name": "test_provider",
+            "type": "openai",
+            "url": "http://test.url",
+            "credentials_path": str(secret_file),
+            "models": [
+                {
+                    "name": "test_model",
+                    "url": "http://test.url/",
+                    "credentials_path": str(secret_file),
+                }
+            ],
+        },
+        credential_hot_reload=False,
+    )
+
+    openai_1 = OpenAI(model="test_model", provider_config=config)
+    assert openai_1.default_params["openai_api_key"] == "initial-key"
+
+    secret_file.write_text("rotated-key")
+
+    openai_2 = OpenAI(model="test_model", provider_config=config)
+    assert openai_2.default_params["openai_api_key"] == "initial-key"

--- a/tests/unit/llms/providers/test_openai.py
+++ b/tests/unit/llms/providers/test_openai.py
@@ -1,6 +1,5 @@
 """Unit tests for OpenAI provider."""
 
-import os
 from pathlib import Path
 
 import httpx
@@ -255,7 +254,7 @@ def test_gpt5_and_o_series_models_parameter_exclusion(
 
 
 def test_openai_picks_up_rotated_credentials(
-    tmp_path: Path, fake_certifi_store: str
+    tmp_path: Path,
 ) -> None:
     """Test that OpenAI provider re-reads credentials when hot-reload is enabled."""
     secret_file = tmp_path / "apitoken"
@@ -288,7 +287,7 @@ def test_openai_picks_up_rotated_credentials(
 
 
 def test_openai_returns_cached_credentials_when_hot_reload_disabled(
-    tmp_path: Path, fake_certifi_store: str
+    tmp_path: Path,
 ) -> None:
     """Test that credentials are cached (not re-read) when hot-reload is disabled."""
     secret_file = tmp_path / "apitoken"

--- a/tests/unit/llms/providers/test_openai.py
+++ b/tests/unit/llms/providers/test_openai.py
@@ -243,7 +243,7 @@ def test_models_do_not_get_sampling_defaults_without_reasoning_config(
 def test_openai_picks_up_rotated_credentials(
     tmp_path: Path, fake_certifi_store: str
 ) -> None:
-    """Test that OpenAI provider re-reads credentials on each load."""
+    """Test that OpenAI provider re-reads credentials when hot-reload is enabled."""
     secret_file = tmp_path / "apitoken"
     secret_file.write_text("initial-key")
 
@@ -260,7 +260,8 @@ def test_openai_picks_up_rotated_credentials(
                     "credentials_path": str(secret_file),
                 }
             ],
-        }
+        },
+        credential_hot_reload=True,
     )
 
     openai_1 = OpenAI(model="test_model", provider_config=config)
@@ -270,3 +271,36 @@ def test_openai_picks_up_rotated_credentials(
 
     openai_2 = OpenAI(model="test_model", provider_config=config)
     assert openai_2.default_params["openai_api_key"] == "rotated-key"
+
+
+def test_openai_returns_cached_credentials_when_hot_reload_disabled(
+    tmp_path: Path, fake_certifi_store: str
+) -> None:
+    """Test that credentials are cached (not re-read) when hot-reload is disabled."""
+    secret_file = tmp_path / "apitoken"
+    secret_file.write_text("initial-key")
+
+    config = ProviderConfig(
+        {
+            "name": "test_provider",
+            "type": "openai",
+            "url": "http://test.url",
+            "credentials_path": str(secret_file),
+            "models": [
+                {
+                    "name": "test_model",
+                    "url": "http://test.url/",
+                    "credentials_path": str(secret_file),
+                }
+            ],
+        },
+        credential_hot_reload=False,
+    )
+
+    openai_1 = OpenAI(model="test_model", provider_config=config)
+    assert openai_1.default_params["openai_api_key"] == "initial-key"
+
+    secret_file.write_text("rotated-key")
+
+    openai_2 = OpenAI(model="test_model", provider_config=config)
+    assert openai_2.default_params["openai_api_key"] == "initial-key"

--- a/tests/unit/llms/providers/test_openai.py
+++ b/tests/unit/llms/providers/test_openai.py
@@ -1,5 +1,8 @@
 """Unit tests for OpenAI provider."""
 
+import os
+from pathlib import Path
+
 import httpx
 import pytest
 from langchain_openai.chat_models.base import ChatOpenAI
@@ -235,3 +238,35 @@ def test_models_do_not_get_sampling_defaults_without_reasoning_config(
     assert "model" in openai.default_params
     assert "max_completion_tokens" in openai.default_params
     assert openai.default_params["model"] == model_name
+
+
+def test_openai_picks_up_rotated_credentials(
+    tmp_path: Path, fake_certifi_store: str
+) -> None:
+    """Test that OpenAI provider re-reads credentials on each load."""
+    secret_file = tmp_path / "apitoken"
+    secret_file.write_text("initial-key")
+
+    config = ProviderConfig(
+        {
+            "name": "test_provider",
+            "type": "openai",
+            "url": "http://test.url",
+            "credentials_path": str(secret_file),
+            "models": [
+                {
+                    "name": "test_model",
+                    "url": "http://test.url/",
+                    "credentials_path": str(secret_file),
+                }
+            ],
+        }
+    )
+
+    openai_1 = OpenAI(model="test_model", provider_config=config)
+    assert openai_1.default_params["openai_api_key"] == "initial-key"
+
+    secret_file.write_text("rotated-key")
+
+    openai_2 = OpenAI(model="test_model", provider_config=config)
+    assert openai_2.default_params["openai_api_key"] == "rotated-key"

--- a/tests/unit/llms/providers/test_openai.py
+++ b/tests/unit/llms/providers/test_openai.py
@@ -1,6 +1,5 @@
 """Unit tests for OpenAI provider."""
 
-import os
 from pathlib import Path
 
 import httpx
@@ -241,7 +240,7 @@ def test_models_do_not_get_sampling_defaults_without_reasoning_config(
 
 
 def test_openai_picks_up_rotated_credentials(
-    tmp_path: Path, fake_certifi_store: str
+    tmp_path: Path,
 ) -> None:
     """Test that OpenAI provider re-reads credentials when hot-reload is enabled."""
     secret_file = tmp_path / "apitoken"
@@ -274,7 +273,7 @@ def test_openai_picks_up_rotated_credentials(
 
 
 def test_openai_returns_cached_credentials_when_hot_reload_disabled(
-    tmp_path: Path, fake_certifi_store: str
+    tmp_path: Path,
 ) -> None:
     """Test that credentials are cached (not re-read) when hot-reload is disabled."""
     secret_file = tmp_path / "apitoken"

--- a/tests/unit/utils/test_checks.py
+++ b/tests/unit/utils/test_checks.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 from ols.constants import NOOP_WITH_TOKEN_AUTHENTICATION_MODULE
-from ols.utils.checks import resolve_headers
+from ols.utils.checks import read_secret_from_path, resolve_headers
 
 
 def test_resolve_headers_empty() -> None:
@@ -152,3 +152,38 @@ def test_resolve_headers_kubernetes_with_no_auth_module(caplog) -> None:
     assert result == {}
     assert "kubernetes" in caplog.text.lower()
     assert "skipped" in caplog.text.lower()
+
+
+def test_read_secret_from_path_file(tmp_path: Path) -> None:
+    """Test reading a secret from a file path."""
+    secret_file = tmp_path / "apitoken"
+    secret_file.write_text("my-api-key\n")
+
+    result = read_secret_from_path(str(secret_file), "apitoken")
+    assert result == "my-api-key"
+
+
+def test_read_secret_from_path_directory(tmp_path: Path) -> None:
+    """Test reading a secret when path is a directory."""
+    secret_file = tmp_path / "apitoken"
+    secret_file.write_text("dir-api-key")
+
+    result = read_secret_from_path(str(tmp_path), "apitoken")
+    assert result == "dir-api-key"
+
+
+def test_read_secret_from_path_nonexistent() -> None:
+    """Test reading from a nonexistent path returns None."""
+    result = read_secret_from_path("/nonexistent/path", "apitoken")
+    assert result is None
+
+
+def test_read_secret_from_path_picks_up_rotation(tmp_path: Path) -> None:
+    """Test that re-reading picks up rotated credential values."""
+    secret_file = tmp_path / "apitoken"
+    secret_file.write_text("original-key")
+
+    assert read_secret_from_path(str(secret_file), "apitoken") == "original-key"
+
+    secret_file.write_text("rotated-key")
+    assert read_secret_from_path(str(secret_file), "apitoken") == "rotated-key"


### PR DESCRIPTION
## Summary

When `credentialsSecretRef` is updated by a CronJob or external rotation, the lightspeed-operator triggers a rolling restart of `lightspeed-app-server`. For customers using short-lived LLM tokens (1-hour validity), this causes **hourly pod restarts and temporary capacity loss** — including reloading RAG vector indexes and embedding models.

This PR makes `ProviderConfig` re-read the credential file on every LLM request via a new `get_credentials()` method, so rotated secrets are picked up without a pod restart. This follows the Prometheus `credentials_file` pattern: *re-read on every request, no caching, no edge cases with K8s symlink swaps*.

## Changes

- **`ols/utils/checks.py`** — New `read_secret_from_path()` helper for repeated file reads
- **`ols/app/models/config.py`** — Store `_credentials_path` in `ProviderConfig.__init__()`, add `get_credentials()` method that re-reads the file when a path is configured
- **All LLM providers** (`openai`, `azure_openai`, `watsonx`, `rhoai_vllm`, `rhelai_vllm`, `google_vertex`) — Use `get_credentials()` instead of `.credentials`
- **Unit tests** — Tests for the helper, `ProviderConfig.get_credentials()` (cached, re-read, fallback, directory), and OpenAI provider credential rotation
- **`docs/credential-hot-reload.md`** — Design rationale and test plan

## Why this approach

| Concern | Answer |
|---|---|
| K8s symlink safety | `kubelet` uses atomic symlink swaps (`..data`); `os.stat()` mtime can be unreliable after swaps. Re-reading avoids the edge case. |
| Precedent | Prometheus `credentials_file`, Envoy, controller-runtime `CertWatcher`, kube-proxy all re-read files. |
| Dependencies | None — no watchdog, fsnotify, or background threads. |
| Performance | One `open()+read()` of a <100 byte file per LLM request is negligible vs LLM call latency (seconds). |
| Thread safety | Each request reads independently; no shared mutable state. |

## Scope

Hot-reload applies to **top-level `credentials_path`**, which is the path used by operator-managed deployments (`credentialsSecretRef`). Provider-specific config blocks (`openai_config.credentials_path`, `azure_openai_config.credentials_path`, etc.) continue to cache credentials at startup — this matches the existing operator behavior, which does not generate these blocks.

Azure AD credentials (`tenant_id`, `client_id`, `client_secret`) are also read once at startup. These can be addressed in a follow-up if needed.

## Test plan

- [x] `read_secret_from_path()` — file, directory, nonexistent, rotation
- [x] `ProviderConfig.get_credentials()` — cached fallback, disk re-read, read failure fallback, directory path
- [x] OpenAI provider — verifies rotated credential is picked up across two `load_llm()` calls
- [x] Full suite: 1067 tests pass, `ruff check` clean, `mypy` clean

## Ref

- [RFE-9380](https://issues.redhat.com/browse/RFE-9380)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional credential hot-reload (`credential_hot_reload`, default off).
  * When enabled, providers re-read token/secret values from the configured path (including directory paths) to pick up rotated credentials without restarts.
* **Bug Fixes**
  * If credentials can’t be re-read temporarily, the last successfully loaded values are used.
  * Improved error handling for missing credentials in supported providers.
* **Documentation**
  * Added a credential hot-reload validation guide with rollout/checklist steps.
* **Tests**
  * Added unit tests covering token rotation, caching behavior, and path/directory secret reading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->