### PR TITLE
OLS-3221 Add PostgreSQL resilience spec for auto-recovery after DB restart

### DIFF
--- a/.ai/spec/how/cache.md
+++ b/.ai/spec/how/cache.md
@@ -220,6 +220,25 @@ objects. Deserialization reads the `bytea` column as `memoryview`, converts to
   processes/pods.
 - **Connection decorator**: The `@connection` decorator on `PostgresBase`
   checks connection liveness and reconnects before each public method call.
+  It distinguishes connection errors (broken TCP, closed connection) from
+  operational errors (SQL failures on a live connection). On connection errors,
+  it attempts to re-establish via `connect()` before retrying the operation.
+  On operational errors, it wraps in `CacheError` and propagates immediately.
+  When a connection error is detected, it also immediately marks the shared
+  health status as unhealthy (dual-feed model, see `what/conversation-history.md`
+  Rule 23). [CHANGED: OLS-3221]
+- **Operation timeouts**: All PostgreSQL operations use `statement_timeout`
+  to prevent indefinite blocking on degraded databases. The `_tx_lock` mutex
+  uses bounded acquisition timeout to prevent application-level deadlocks
+  when a thread is stuck waiting on a hung PostgreSQL advisory lock.
+  [NEW: OLS-3221]
+- **Background health-check loop**: A background thread runs on a dedicated
+  connection (independent of the cache operation connection and `_tx_lock`)
+  to periodically verify PostgreSQL connectivity and attempt reconnection.
+  It is the sole component that restores health status to healthy after
+  confirming the database is reachable. The readiness and liveness probes
+  read this loop's status without performing their own DB queries.
+  [NEW: OLS-3221]
 
 ### Capacity Eviction (Postgres)
 

--- a/.ai/spec/what/api.md
+++ b/.ai/spec/what/api.md
@@ -43,8 +43,8 @@ The REST API is the only external interface to the OpenShift LightSpeed service.
 ### Infrastructure Endpoints
 
 22. `POST /authorized` validates the caller's credentials and authorization. The authentication check itself is the purpose of this endpoint. No `/v1` prefix.
-23. `GET /readiness` checks three subsystems: RAG index loaded (if configured), default LLM reachable, and conversation cache ready. All three must pass. The LLM readiness result is cached for a configurable duration. Returns 503 with cause if any subsystem fails.
-24. `GET /liveness` always returns `alive: true` if the process is running.
+23. `GET /readiness` checks three subsystems: RAG index loaded (if configured), default LLM reachable, and conversation cache health status. All three must pass. When the PostgreSQL cache backend is configured, cache health is read from the background health-check loop's last-known status (see `what/conversation-history.md`, Rules 22–23) rather than performing a direct database query. This ensures the readiness probe is non-blocking and immune to deadlocks in the cache operation path. The LLM readiness result is cached for a configurable duration. Returns 503 with cause if any subsystem fails. [CHANGED: OLS-3221]
+24. `GET /liveness` checks that the process is running and, when the PostgreSQL cache backend is configured, reads the database health status from the background health-check loop. If the loop has recorded N consecutive unhealthy readings (configurable via `liveness_db_failure_threshold`, default 3), the probe returns HTTP 503 with `{"alive": false, "reason": "database unreachable"}`. If no PostgreSQL backend is configured (in-memory cache), the probe always returns `{"alive": true}`. This ensures the liveness probe is non-blocking and only triggers a pod restart after sustained failure that the background loop could not self-heal. [CHANGED: OLS-3221]
 25. `GET /metrics` returns Prometheus metrics in exposition format. Requires `ols-metrics-access` scope. No version prefix.
 
 ---
@@ -495,7 +495,7 @@ None required.
 
 Kubernetes readiness probe. No authentication required. No version prefix.
 
-Checks three subsystems: RAG index loaded (if configured), default LLM reachable and responsive, and conversation cache backend ready. All three must pass. The LLM readiness result is cached; once confirmed ready, subsequent calls may return the cached result for a configurable duration (`expire_llm_is_ready_persistent_state`).
+Checks three subsystems: RAG index loaded (if configured), default LLM reachable and responsive, and conversation cache health status. When the PostgreSQL cache backend is configured, cache health is read from the background health-check loop's last-known status rather than performing a direct database query. This ensures the readiness probe is non-blocking and immune to deadlocks in the cache operation path. All three subsystems must pass. The LLM readiness result is cached; once confirmed ready, subsequent calls may return the cached result for a configurable duration (`expire_llm_is_ready_persistent_state`). [CHANGED: OLS-3221]
 
 #### Response 200 (ReadinessResponse)
 
@@ -512,13 +512,20 @@ Structured error with cause indicating which subsystem is not ready: `"Index is 
 
 ### GET /liveness
 
-Kubernetes liveness probe. No authentication required. No version prefix. Always succeeds if the process is running.
+Kubernetes liveness probe. No authentication required. No version prefix. When the PostgreSQL cache backend is configured, reads the database health status from the background health-check loop's last-known status. Returns HTTP 503 after sustained database unavailability (configurable consecutive failure threshold). When no PostgreSQL backend is configured (in-memory cache), always succeeds if the process is running. [CHANGED: OLS-3221]
 
 #### Response 200 (LivenessResponse)
 
 | Field | Type    | Description |
 |-------|---------|-------------|
-| alive | boolean | Always `true` |
+| alive | boolean | `true` when process is running and DB health threshold is not exceeded |
+
+#### Response 503 (LivenessResponse)
+
+| Field  | Type    | Description |
+|--------|---------|-------------|
+| alive  | boolean | `false` |
+| reason | string  | `"database unreachable"` |
 
 ---
 
@@ -748,6 +755,8 @@ The service applies the following cross-cutting behaviors to all requests:
 - `ols_config.user_data_collection.transcripts_storage` -- filesystem path for transcript JSON files.
 - `ols_config.logging_config.suppress_metrics_in_log` -- suppress debug logging for `/metrics` requests.
 - `ols_config.expire_llm_is_ready_persistent_state` -- duration (seconds) to cache the LLM readiness check result. Negative or unset means cache indefinitely once ready.
+- `ols_config.liveness_db_failure_threshold` -- number of consecutive unhealthy readings from the background health-check loop before the liveness probe fails (default: 3). [NEW: OLS-3221]
+- `ols_config.cache_health_check_interval` -- interval in seconds for the background PostgreSQL health-check loop (default: 30). [NEW: OLS-3221]
 - `ols_config.reference_content` -- when set, the readiness probe checks that the RAG index is loaded.
 - `dev_config.disable_tls` -- disables TLS; affects whether HSTS header is added.
 - `dev_config.enable_dev_ui` -- mounts an embedded Gradio UI at the application root.
@@ -776,3 +785,4 @@ The service applies the following cross-cutting behaviors to all requests:
 - [PLANNED: OLS-2682] Remove `/v1/query` endpoint. The streaming endpoint becomes the sole query interface.
 - [PLANNED: OLS-2680] Add OpenAI `/responses` API compatibility layer.
 - [PLANNED: OLS-2684] Remove client MCP headers (`mcp_headers` field).
+- [PLANNED: OLS-3221] PostgreSQL resilience — liveness probe DB check via background health-check loop status, readiness probe reads loop status instead of direct DB query. See Rules 23–24.

--- a/.ai/spec/what/conversation-history.md
+++ b/.ai/spec/what/conversation-history.md
@@ -40,6 +40,18 @@ The conversation history subsystem preserves prior exchanges within a conversati
 
 18. The in-memory cache must be a singleton: all threads within a process share one cache instance.
 
+### PostgreSQL Resilience [NEW: OLS-3221]
+
+19. Cache operations must distinguish between *connection errors* (broken TCP, connection refused, closed connection) and *operational errors* (SQL failures on a live connection such as constraint violations, disk full, or query syntax errors). Connection errors trigger the reconnection path via the `@connection` decorator. Operational errors are wrapped in `CacheError` and propagated immediately — reconnection would not resolve them.
+
+20. When a PostgreSQL cache operation fails due to a connection error, the `@connection` decorator must attempt to re-establish the connection transparently before retrying the operation. The decorator must detect closed or broken connections (via `psycopg2` connection status checks) and call `connect()` to obtain a fresh connection. If reconnection itself fails, the operation must raise a `CacheError` with the original cause preserved. Connection re-establishment must be idempotent and thread-safe; the existing `_tx_lock` mutex serializes reconnection attempts.
+
+21. All PostgreSQL operations (queries, advisory lock acquisitions) must have a statement-level timeout (`statement_timeout`). If an operation exceeds the timeout, it must be cancelled, the transaction rolled back, and a `CacheError` raised. This prevents indefinite blocking when PostgreSQL is degraded (e.g., hung transactions, slow I/O). The Python-level `_tx_lock` must use a bounded acquisition timeout. If the lock cannot be acquired within the timeout, the operation must raise a `CacheError` rather than blocking indefinitely.
+
+22. When the PostgreSQL cache backend is configured, the system must run a background health-check loop that periodically verifies database connectivity and attempts reconnection when the connection is lost. The loop runs every `cache_health_check_interval` seconds (default: 30). The loop must use a dedicated lightweight connection, independent of the connection and `_tx_lock` used by cache operations. This ensures the health-check loop remains responsive even when the cache operation path is blocked or deadlocked. When the connection is healthy, the loop records a healthy status and is otherwise a no-op. When the connection is broken, the loop attempts reconnection and logs the result.
+
+23. The health status maintained by the background health-check loop is the single source of truth for database health consumed by the readiness and liveness probes. Neither probe performs its own database query or acquires `_tx_lock`. The health status is an in-memory flag updated by two sources: (a) the background loop on each iteration, and (b) cache operations that encounter connection errors, which immediately mark the status as unhealthy (dual-feed model). Only the background loop may restore the status to healthy after successfully reconnecting on its independent connection. This ensures near-instant detection (first failed user query flips to unhealthy) and controlled recovery (background loop confirms before restoring healthy).
+
 ## Configuration Surface
 
 | Field path | Description |
@@ -55,6 +67,9 @@ The conversation history subsystem preserves prior exchanges within a conversati
 | `ols_config.conversation_cache.postgres.ca_cert_path` | Path to CA certificate for PostgreSQL TLS |
 | `ols_config.conversation_cache.postgres.max_entries` | Maximum total message entries for PostgreSQL cache |
 | `ols_config.history_compression_enabled` | Whether to use LLM-based history compression (default: true) |
+| `ols_config.cache_health_check_interval` | Interval in seconds for the background PostgreSQL health-check loop (default: 30) [NEW: OLS-3221] |
+| `ols_config.conversation_cache.postgres.statement_timeout` | Statement-level timeout in milliseconds for PostgreSQL operations (default: 5000) [NEW: OLS-3221] |
+| `ols_config.conversation_cache.postgres.lock_timeout` | Timeout in seconds for Python-level `_tx_lock` acquisition (default: 10) [NEW: OLS-3221] |
 
 ## Constraints
 
@@ -74,6 +89,7 @@ The conversation history subsystem preserves prior exchanges within a conversati
 
 ## Planned Changes
 
+- [PLANNED: OLS-3221] PostgreSQL resilience — auto-reconnection, background health-check loop, dual-feed health status, operation timeouts, and liveness probe DB check. See Rules 19–23.
 - [PLANNED: OLS-2713] Persistent chat -- UI-side conversation persistence, enabling users to resume conversations across browser sessions.
 - [PLANNED: OLS-141] Encrypting conversation state cache data, on disk and in memory.
 - [PLANNED: OLS-251] Scale Postgres Conversation Cache Backend for high-availability and multi-instance production deployments.


### PR DESCRIPTION
## Summary

- Spec-only changes (no code) for [OLS-3221](https://redhat.atlassian.net/browse/OLS-3221): app server pods do not auto-recover after PostgreSQL restart
- Adds layered defense: auto-reconnection, background health-check loop, dual-feed health status, operation timeouts, and liveness probe DB check
- Updates three spec files: `what/api.md` (probe behavior), `what/conversation-history.md` (resilience rules 19-23), `how/cache.md` (architecture docs)

### Key design decisions

1. **Background health-check loop** with dedicated independent connection is the single source of truth for DB health - both readiness and liveness probes read its status without direct DB queries or `_tx_lock` contention
2. **Dual-feed model**: cache operation connection errors immediately flip status to unhealthy (near-instant detection), but only the background loop can restore healthy status (controlled recovery)
3. **Operation timeouts** (`statement_timeout` + bounded `_tx_lock` acquisition) prevent deadlocks when PostgreSQL is degraded
4. **Liveness probe** fails after configurable consecutive unhealthy readings -> Kubernetes restarts pod as last resort (CrashLoopBackOff with backoff is acceptable)

## Test plan

- [ ] Review spec rules 19-23 in `what/conversation-history.md` for completeness and consistency
- [ ] Verify `what/api.md` rules 23-24 and endpoint reference sections are internally consistent
- [ ] Confirm `how/cache.md` architecture docs match the behavioral rules
- [ ] Validate new config surface entries have sensible defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API specification for readiness and liveness probes to use background health-check monitoring instead of direct database checks.
  * Added PostgreSQL resilience specification detailing improved error handling and automatic recovery.
  * Documented new configuration options: `liveness_db_failure_threshold` and `cache_health_check_interval`.
  * Readiness endpoint now returns 503 with cause details when subsystems fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->