### PR TITLE
OLS-1680: Add AWS Bedrock provider to LLM provider specs

### DIFF
--- a/.ai/spec/how/llm-providers.md
+++ b/.ai/spec/how/llm-providers.md
@@ -21,8 +21,8 @@ The LLM provider subsystem translates a (provider name, model name) pair from co
 - `LLMProvider(AbstractLLMProvider)` -- Concrete base. Constructor pipeline: `default_params` -> `_override_params` (merge caller params, then dev-config overrides) -> `_remap_to_llm_params` (generic-to-provider name translation) -> `_validate_parameters` (drop params not in the provider's allowed set).
 - `_construct_httpx_client(use_custom_certificate_store, use_async)` -- Builds `httpx.Client` or `httpx.AsyncClient` with proxy, TLS security profile, and custom certificate store support. Used by OpenAI-compatible providers.
 - `ProviderParameter(name, _type)` -- Frozen dataclass. The allowed-parameter sets use both name and type for validation (a parameter with the wrong type is rejected).
-- Parameter sets: `AzureOpenAIParameters`, `OpenAIParameters`, `RHOAIVLLMParameters`, `RHELAIVLLMParameters`, `WatsonxParameters`, `FakeProviderParameters`, `GoogleVertexAnthropicParameters`, `GoogleVertexParameters`. Collected in `available_provider_parameters` dict keyed by provider type string.
-- Generic-to-LLM mapping dicts: `AzureOpenAIParametersMapping`, `OpenAIParametersMapping`, `WatsonxParametersMapping`, etc. Collected in `generic_to_llm_parameters`.
+- Parameter sets: `AzureOpenAIParameters`, `OpenAIParameters`, `RHOAIVLLMParameters`, `RHELAIVLLMParameters`, `WatsonxParameters`, `BedrockParameters`, `FakeProviderParameters`, `GoogleVertexAnthropicParameters`, `GoogleVertexParameters`. Collected in `available_provider_parameters` dict keyed by provider type string.
+- Generic-to-LLM mapping dicts: `AzureOpenAIParametersMapping`, `OpenAIParametersMapping`, `WatsonxParametersMapping`, `BedrockParametersMapping`, etc. Collected in `generic_to_llm_parameters`.
 
 ### Provider implementations
 
@@ -35,6 +35,7 @@ The LLM provider subsystem translates a (provider name, model name) pair from co
 | `rhelai_vllm.py` | `RHELAIVLLM` | `"rhelai_vllm"` | `ChatOpenAI` | OpenAI-compatible, no default URL |
 | `google_vertex.py` | `GoogleVertex` | `"google_vertex"` | `ChatGoogleGenerativeAI` | Gemini / publisher models; credentials via `load_vertex_credentials` |
 | `google_vertex.py` | `GoogleVertexAnthropic` | `"google_vertex_anthropic"` | `ChatAnthropicVertex` | Claude on Vertex Model Garden; same module |
+| `bedrock.py` | `Bedrock` | `"bedrock"` | `ChatAnthropic` / `ChatOpenAI` | Model-prefix routing to 3 Mantle API paths; see below |
 | `fake_provider.py` | `FakeProvider` | `"fake_provider"` | `FakeListLLM` / `FakeStreamingListLLM` | Testing only; monkey-patches `bind_tools` |
 
 ### `ols/src/llms/providers/utils.py` -- Shared utilities
@@ -126,7 +127,7 @@ Each provider follows the same pattern: read generic fields from `ProviderConfig
 
 ### Constants
 
-- Provider type strings: `PROVIDER_OPENAI`, `PROVIDER_AZURE_OPENAI`, `PROVIDER_WATSONX`, `PROVIDER_RHOAI_VLLM`, `PROVIDER_RHELAI_VLLM`, `PROVIDER_FAKE`, `PROVIDER_GOOGLE_VERTEX`, `PROVIDER_GOOGLE_VERTEX_ANTHROPIC` in `ols/constants.py`.
+- Provider type strings: `PROVIDER_OPENAI`, `PROVIDER_AZURE_OPENAI`, `PROVIDER_WATSONX`, `PROVIDER_RHOAI_VLLM`, `PROVIDER_RHELAI_VLLM`, `PROVIDER_BEDROCK`, `PROVIDER_FAKE`, `PROVIDER_GOOGLE_VERTEX`, `PROVIDER_GOOGLE_VERTEX_ANTHROPIC` in `ols/constants.py`.
 - `SUPPORTED_PROVIDER_TYPES` frozenset is checked during config validation (not by the registry).
 
 ### TLS and proxy
@@ -161,6 +162,20 @@ WatsonX uses IBM's `GenTextParamsMetaNames` constants for parameter keys instead
 | `temperature` | `TEMPERATURE` |
 
 WatsonX also passes `params=self.params` to `ChatWatsonx` (as a nested dict), unlike OpenAI-compatible providers that spread params as `**self.params`.
+
+### Bedrock model-prefix routing
+
+`bedrock.py` serves multiple model families behind the Bedrock Mantle gateway. `load()` inspects `self.model` to select the LangChain class and construct the correct Mantle endpoint URL:
+
+| Model prefix | LangChain class | Base URL suffix | Extra params |
+|---|---|---|---|
+| `anthropic.*` | `ChatAnthropic` | `/anthropic` | `anthropic_api_key` |
+| `openai.*` | `ChatOpenAI` | `/openai/v1` | `use_responses_api=True`, `openai_api_key` |
+| Everything else | `ChatOpenAI` | `/v1` | `openai_api_key` |
+
+`BedrockParameters` is a single union set covering kwargs from both `ChatAnthropic` and `ChatOpenAI`. `BedrockParametersMapping` maps `max_tokens_for_response` to `max_completion_tokens` (the OpenAI name). For the Anthropic branch, `load()` pops `max_completion_tokens` from params and passes `max_tokens` instead.
+
+Auth follows the Azure dual-auth pattern: `default_params` checks `self.credentials` (Bearer token). If present, it is used directly. If absent, the `else` branch raises an error (placeholder for future STS implementation).
 
 ### OpenAI reasoning model handling
 

--- a/.ai/spec/what/llm-providers.md
+++ b/.ai/spec/what/llm-providers.md
@@ -111,6 +111,21 @@ The following sections describe only what differs from the standard contract abo
 
 38. Does not use httpx clients or custom certificate stores. `max_tokens_for_response` maps to `max_output_tokens`.
 
+### AWS Bedrock (`bedrock`)
+
+42. Uses the Bedrock Mantle gateway — a single endpoint exposing multiple model families (Anthropic Claude, OpenAI GPT, DeepSeek, etc.) via their native APIs. The base URL must be configured explicitly (region-specific, e.g., `https://bedrock-mantle.us-east-1.api.aws`). No default URL; the system must reject a Bedrock provider with no URL at configuration time.
+
+43. Must route to the correct LangChain class and Mantle API path based on model name prefix:
+    - `anthropic.*` → `ChatAnthropic` from `langchain-anthropic`, with base URL suffix `/anthropic`
+    - `openai.*` → `ChatOpenAI` from `langchain-openai`, with base URL suffix `/openai/v1` and `use_responses_api=True`
+    - All other models → `ChatOpenAI` from `langchain-openai`, with base URL suffix `/v1` (standard Chat Completions)
+
+44. Authentication: Bearer token read from `credentials_path` using the standard `apitoken` file pattern (identical to OpenAI). If no Bearer token is found and no STS configuration is present, the provider must raise a clear error. [PLANNED] STS/IAM role authentication following the Azure AD dual-auth pattern (absence of `apitoken` triggers the STS path, using `role_arn` and `region` from `bedrock_config`).
+
+45. Uses a single `BedrockParameters` set — the union of `ChatAnthropic` and `ChatOpenAI` kwargs. `max_tokens_for_response` maps to `max_completion_tokens` in the generic parameter mapping; `load()` remaps to `max_tokens` for the Anthropic branch.
+
+46. Uses custom certificate store and httpx clients (same pattern as OpenAI). Supports TLS security profiles and proxy configuration.
+
 ### Fake Provider (`fake_provider`)
 
 39. Returns static preconfigured responses for testing. Supports a streaming mode that splits the response into chunks with a configurable sleep interval, and a non-streaming mode that returns the full response at once.
@@ -122,7 +137,7 @@ The following sections describe only what differs from the standard contract abo
 ## Configuration Surface
 
 - `llm_providers[].name` -- Provider instance name (used as the lookup key).
-- `llm_providers[].type` -- Provider type string (must match a registered type: `openai`, `azure_openai`, `watsonx`, `rhoai_vllm`, `rhelai_vllm`, `google_vertex`, `google_vertex_anthropic`, `fake_provider`). Defaults to the provider name if not specified.
+- `llm_providers[].type` -- Provider type string (must match a registered type: `openai`, `azure_openai`, `watsonx`, `rhoai_vllm`, `rhelai_vllm`, `google_vertex`, `google_vertex_anthropic`, `bedrock`, `fake_provider`). Defaults to the provider name if not specified.
 - `llm_providers[].url` -- Base URL for the LLM API endpoint.
 - `llm_providers[].credentials_path` -- Path to file or directory containing the API key/token.
 - `llm_providers[].project_id` -- Required for WatsonX; project identifier.
@@ -146,6 +161,7 @@ The following sections describe only what differs from the standard contract abo
 - `llm_providers[].rhelai_vllm_config` -- Provider-specific: `url`, `credentials_path`.
 - `llm_providers[].google_vertex_config` -- Provider-specific: `project`, `location`.
 - `llm_providers[].google_vertex_anthropic_config` -- Provider-specific: `project`, `location`.
+- `llm_providers[].bedrock_config` -- Provider-specific: `url`, `credentials_path`. [PLANNED] STS fields: `role_arn`, `region`.
 - `llm_providers[].fake_provider_config` -- Testing: `stream`, `mcp_tool_call`, `response`, `chunks`, `sleep`.
 - `dev_config.llm_params` -- Admin/developer override parameters applied at highest precedence.
 - `ols_config.proxy_config.proxy_url` -- HTTP/HTTPS proxy URL for LLM traffic.
@@ -174,7 +190,7 @@ The following sections describe only what differs from the standard contract abo
 
 ## Planned Changes
 
-- [PLANNED: OLS-1680] Support AWS Bedrock as an LLM provider, enabling models hosted on Amazon's managed inference service.
+- [PLANNED: OLS-1680] STS/IAM role authentication for the AWS Bedrock provider, following the Azure AD dual-auth pattern.
 - [PLANNED: OLS-2776] Support Anthropic as a direct LLM provider (not via Google Vertex), communicating with the Anthropic API natively. Anthropic models are currently available through the Google Vertex Anthropic provider.
 - [PLANNED: OLS-1320] Support short-lived (rotating) tokens for all providers, replacing static API keys with tokens that are refreshed periodically.
 - [PLANNED: OLS-1999] Support IBM WatsonX short-lived token authentication, enabling token-based auth that refreshes automatically rather than using a static API key.

--- a/docs/superpowers/bedrock-provider-findings.md
+++ b/docs/superpowers/bedrock-provider-findings.md
@@ -1,0 +1,166 @@
+# OLS-1680: AWS Bedrock Provider — Research Findings
+
+## Summary
+
+AWS Bedrock can be integrated into OLS using existing LangChain classes
+(`ChatAnthropic`, `ChatOpenAI`) pointed at the `bedrock-mantle` endpoint.
+No new LangChain provider package (`langchain-aws`) or `boto3` is required.
+
+## Authentication
+
+Bedrock API key — a simple Bearer token generated in the AWS Bedrock
+console. Same key works for all models. Set via environment variable
+or credentials file.
+
+- 30-day long-term keys for dev (generated in console)
+- Short-term keys via `aws-bedrock-token-generator` for production
+- Environment variable: `AWS_BEARER_TOKEN_BEDROCK`
+
+## Tested Models and LangChain Classes
+
+All tested on 2026-06-18 with `bedrock-mantle.us-east-1.api.aws`.
+
+### Claude (Anthropic Messages API)
+
+```python
+from langchain_anthropic import ChatAnthropic
+
+llm = ChatAnthropic(
+    model="anthropic.claude-opus-4-7",
+    base_url="https://bedrock-mantle.{region}.api.aws/anthropic",
+    api_key=BEDROCK_KEY,
+)
+```
+
+- Endpoint: `/anthropic/v1/messages`
+- Streaming: works
+- Does NOT support Chat Completions or Responses API on Mantle
+
+### OpenAI GPT-5.x (Responses API)
+
+```python
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(
+    model="openai.gpt-5.4",
+    base_url="https://bedrock-mantle.{region}.api.aws/openai/v1",
+    api_key=BEDROCK_KEY,
+    use_responses_api=True,
+)
+```
+
+- Endpoint: `/openai/v1/responses`
+- Streaming: works
+- Does NOT support Chat Completions (`/v1/chat/completions`)
+- `use_responses_api=True` is required
+- `max_output_tokens` minimum is 16
+
+### DeepSeek (Chat Completions API)
+
+```python
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(
+    model="deepseek.v3.1",
+    base_url="https://bedrock-mantle.{region}.api.aws/v1",
+    api_key=BEDROCK_KEY,
+)
+```
+
+- Endpoint: `/v1/chat/completions`
+- Standard OpenAI-compatible, no special flags needed
+
+## Endpoint Matrix
+
+| Model family | LangChain class | Base URL path | Extra params |
+|---|---|---|---|
+| Claude | `ChatAnthropic` | `/anthropic` | — |
+| OpenAI GPT-5.x | `ChatOpenAI` | `/openai/v1` | `use_responses_api=True` |
+| DeepSeek, others | `ChatOpenAI` | `/v1` | — |
+
+## Available Models (in test account, us-east-1)
+
+- `anthropic.claude-opus-4-7`
+- `openai.gpt-5.4`
+- `openai.gpt-5.5` (listed, not tested)
+- `deepseek.v3.1`
+
+Model list is account-specific. Use:
+```bash
+curl -s "https://bedrock-mantle.us-east-1.api.aws/v1/models" \
+  -H "Authorization: Bearer $BEDROCK_KEY"
+```
+
+## What Did NOT Work
+
+- `ChatOpenAI` without `use_responses_api=True` for GPT-5.x → 400 error
+- `ChatOpenAI` for Claude (neither Chat Completions nor Responses) → 400
+- `ChatBedrockConverse` for GPT-5.x → invalid model ID (Converse API
+  doesn't support OpenAI models)
+- `ChatBedrockConverse` for Claude without `us.` prefix → needs
+  inference profile ID (`us.anthropic.claude-opus-4-7`)
+- Converse API (`bedrock-runtime`) → requires different model IDs,
+  different auth patterns; unnecessary when using `bedrock-mantle`
+
+## Implementation Plan for OLS
+
+### Dependencies to add
+
+- `langchain-anthropic` — explicit dependency (currently only transitive)
+
+### No new dependencies needed
+
+- `langchain-openai` — already in project
+- `anthropic` — already in project
+- `langchain-aws` / `boto3` — NOT needed
+
+### Provider design
+
+Two approaches, recommend **option A**:
+
+**A. Single `bedrock` provider with model-based routing**
+
+One provider type in `olsconfig.yaml`. The provider detects the model
+prefix and picks the right LangChain class:
+
+- `anthropic.*` → `ChatAnthropic`
+- `openai.*` → `ChatOpenAI` with `use_responses_api=True`
+- Everything else → `ChatOpenAI` (Chat Completions)
+
+**B. Separate providers per API**
+
+- `bedrock_anthropic` → `ChatAnthropic`
+- `bedrock_openai` → `ChatOpenAI`
+
+Option A is simpler for users (one provider type, one set of credentials).
+
+### Config shape
+
+```yaml
+llm_providers:
+  - name: my-bedrock
+    type: bedrock
+    url: https://bedrock-mantle.us-east-1.api.aws
+    credentials_path: /path/to/bedrock_api_key
+    models:
+      - name: anthropic.claude-opus-4-7
+      - name: openai.gpt-5.4
+      - name: deepseek.v3.1
+```
+
+### Files to create/modify
+
+| Step | File | Action |
+|---|---|---|
+| 1 | `ols/constants.py` | Add `PROVIDER_BEDROCK = "bedrock"` |
+| 2 | `ols/src/llms/providers/bedrock.py` | New provider class |
+| 3 | `ols/src/llms/providers/provider.py` | Add parameter sets |
+| 4 | `ols/app/models/config.py` | Add `BedrockConfig` (region) |
+| 5 | `pyproject.toml` | Add `langchain-anthropic` |
+| 6 | `tests/unit/llms/providers/test_bedrock.py` | Unit tests |
+| 7 | `tests/unit/llms/providers/test_providers.py` | Registration test |
+
+### Jira stories
+
+- **OLS-1895** — OLS service support for AWS Bedrock (this repo)
+- **OLS-2605** — OLSConfig CR support for Bedrock (operator repo)


### PR DESCRIPTION
## Summary

- Adds behavioral rules (42-46) for the new `bedrock` provider type to `.ai/spec/what/llm-providers.md`
- Adds architecture documentation (model-prefix routing, parameter set, auth pattern) to `.ai/spec/how/llm-providers.md`
- Bedrock uses the Mantle gateway with model-prefix routing to `ChatAnthropic`/`ChatOpenAI`
- Bearer token auth initially; STS/IAM role auth marked as `[PLANNED]`
- Design spec: `docs/superpowers/specs/2026-06-19-bedrock-provider-design.md` (in parent workspace)

## Related

- Epic: [OLS-1680](https://redhat.atlassian.net/browse/OLS-1680)
- Service story: [OLS-1895](https://redhat.atlassian.net/browse/OLS-1895)
- Operator story: [OLS-2605](https://redhat.atlassian.net/browse/OLS-2605)

## Test plan

- [ ] Spec review — verify behavioral rules are consistent with existing provider patterns
- [ ] Verify `how/` architecture doc matches actual codebase structure

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AWS Bedrock LLM provider specifications with configuration requirements for endpoint URLs and credential management.
  * Included details on model routing across supported backends and parameter mapping behavior.
  * Documented authentication flow and outlined planned future enhancements for credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->