### PR TITLE
OLS-3221 Add PostgreSQL auto-recovery after DB restart

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -944,6 +944,16 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Service is not alive",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/LivenessResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1711,6 +1721,17 @@
                     "alive": {
                         "type": "boolean",
                         "title": "Alive"
+                    },
+                    "reason": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Reason"
                     }
                 },
                 "type": "object",
@@ -1718,7 +1739,7 @@
                     "alive"
                 ],
                 "title": "LivenessResponse",
-                "description": "Model representing a response to a liveness request.\n\nAttributes:\n    alive: If app is alive.\n\nExample:\n    ```python\n    liveness_response = LivenessResponse(alive=True)\n    ```",
+                "description": "Model representing a response to a liveness request.\n\nAttributes:\n    alive: If app is alive.\n    reason: Optional reason when not alive.\n\nExample:\n    ```python\n    liveness_response = LivenessResponse(alive=True)\n    ```",
                 "examples": [
                     {
                         "alive": true

--- a/ols/app/endpoints/health.py
+++ b/ols/app/endpoints/health.py
@@ -10,7 +10,7 @@ import logging
 import time
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Response, status
 from langchain_core.messages.ai import AIMessage
 
 from ols import config
@@ -19,6 +19,7 @@ from ols.app.models.models import (
     NotAvailableResponse,
     ReadinessResponse,
 )
+from ols.src.cache.postgres_cache import PostgresCache
 from ols.src.llms.llm_loader import load_llm
 
 router = APIRouter(tags=["health"])
@@ -133,10 +134,31 @@ get_liveness_responses: dict[int | str, dict[str, Any]] = {
         "description": "Service is alive",
         "model": LivenessResponse,
     },
+    503: {
+        "description": "Service is not alive",
+        "model": LivenessResponse,
+    },
 }
 
 
-@router.get("/liveness", responses=get_liveness_responses)
-def liveness_probe_get_method() -> LivenessResponse:
+def _get_postgres_cache() -> PostgresCache | None:
+    """Return the conversation cache if it is a PostgresCache, None otherwise."""
+    try:
+        cache = config.conversation_cache
+        return cache if isinstance(cache, PostgresCache) else None
+    except Exception:
+        return None
+
+
+@router.get(
+    "/liveness", responses=get_liveness_responses, response_model_exclude_none=True
+)
+def liveness_probe_get_method(response: Response) -> LivenessResponse:
     """Live status of service."""
+    cache = _get_postgres_cache()
+    if cache is not None:
+        threshold = config.ols_config.liveness_db_failure_threshold
+        if cache.consecutive_failures >= threshold:
+            response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+            return LivenessResponse(alive=False, reason="database unreachable")
     return LivenessResponse(alive=True)

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -53,6 +53,21 @@ def validate_tool_round_cap_fraction_config(v: float) -> float:
     return v
 
 
+def validate_liveness_db_failure_threshold(raw_value: Any) -> int:
+    """Validate ``liveness_db_failure_threshold`` for ``OLSConfig``."""
+    try:
+        threshold = int(raw_value)
+    except (TypeError, ValueError) as e:
+        raise checks.InvalidConfigurationError(
+            f"liveness_db_failure_threshold must be a positive integer, got {raw_value!r}"
+        ) from e
+    if threshold < 1:
+        raise checks.InvalidConfigurationError(
+            f"liveness_db_failure_threshold must be at least 1, got {threshold}"
+        )
+    return threshold
+
+
 class ModelParameters(BaseModel):
     """Model parameters."""
 
@@ -807,6 +822,12 @@ class PostgresConfig(BaseModel):
     gss_encmode: str = constants.POSTGRES_CACHE_GSSENCMODE
     ca_cert_path: Optional[FilePath] = None
     max_entries: PositiveInt = constants.POSTGRES_CACHE_MAX_ENTRIES
+    statement_timeout: PositiveInt = constants.POSTGRES_STATEMENT_TIMEOUT
+    lock_timeout: PositiveInt = constants.POSTGRES_LOCK_TIMEOUT
+    health_check_interval: PositiveInt = constants.CACHE_HEALTH_CHECK_INTERVAL
+    health_check_connect_timeout: PositiveInt = (
+        constants.CACHE_HEALTH_CHECK_CONNECT_TIMEOUT
+    )
     tls_security_profile: Optional["TLSSecurityProfile"] = None
 
     def __init__(self, **data: Any) -> None:
@@ -1261,7 +1282,9 @@ class OLSConfig(BaseModel):
 
     offload_storage_path: str = constants.DEFAULT_OFFLOAD_STORAGE_PATH
 
-    def __init__(  # noqa: C901
+    liveness_db_failure_threshold: int = constants.LIVENESS_DB_FAILURE_THRESHOLD
+
+    def __init__(
         self, data: Optional[dict] = None, ignore_missing_certs: bool = False
     ) -> None:
         """Initialize configuration and perform basic validation."""
@@ -1309,6 +1332,10 @@ class OLSConfig(BaseModel):
         self.quota_handlers = QuotaHandlersConfig(data.get("quota_handlers", None))
         self._propagate_tls_profile()
         self.proxy_config = ProxyConfig(data.get("proxy_config"))
+        self._init_optional_sections(data)
+
+    def _init_optional_sections(self, data: dict) -> None:
+        """Initialize optional config sections to keep __init__ complexity low."""
         if data.get("tool_filtering", None) is not None:
             self.tool_filtering = ToolFilteringConfig(**data.get("tool_filtering"))
         if data.get("tools_approval", None) is not None:
@@ -1333,6 +1360,12 @@ class OLSConfig(BaseModel):
 
         self.offload_storage_path = data.get(
             "offload_storage_path", constants.DEFAULT_OFFLOAD_STORAGE_PATH
+        )
+
+        self.liveness_db_failure_threshold = validate_liveness_db_failure_threshold(
+            data.get(
+                "liveness_db_failure_threshold", constants.LIVENESS_DB_FAILURE_THRESHOLD
+            )
         )
 
     def _propagate_tls_profile(self) -> None:

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -476,6 +476,7 @@ class LivenessResponse(BaseModel):
 
     Attributes:
         alive: If app is alive.
+        reason: Optional reason when not alive.
 
     Example:
         ```python
@@ -484,6 +485,7 @@ class LivenessResponse(BaseModel):
     """
 
     alive: bool
+    reason: Optional[str] = None
 
     # provides examples for /docs endpoint
     model_config = {

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -137,6 +137,8 @@ POSTGRES_CACHE_PORT = 5432
 POSTGRES_CACHE_DBNAME = "cache"
 POSTGRES_CACHE_USER = "postgres"
 POSTGRES_CACHE_MAX_ENTRIES = 1000
+POSTGRES_STATEMENT_TIMEOUT = 5000
+POSTGRES_LOCK_TIMEOUT = 10
 
 # look at https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLMODE
 # for all possible options
@@ -145,6 +147,10 @@ POSTGRES_CACHE_SSL_MODE = "require"
 # look at https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-GSSENCMODE
 # for all possible options
 POSTGRES_CACHE_GSSENCMODE = "prefer"
+
+CACHE_HEALTH_CHECK_INTERVAL = 30
+CACHE_HEALTH_CHECK_CONNECT_TIMEOUT = 10
+LIVENESS_DB_FAILURE_THRESHOLD = 3
 
 
 # default indentity for local testing and deployment

--- a/ols/src/cache/postgres_cache.py
+++ b/ols/src/cache/postgres_cache.py
@@ -17,6 +17,7 @@ from ols.app.models.models import (
 from ols.src.cache.cache import Cache
 from ols.src.cache.cache_error import CacheError
 from ols.utils.postgres import PostgresBase, connection
+from ols.utils.ssl import libpq_tls_params
 
 logger = logging.getLogger(__name__)
 
@@ -154,8 +155,23 @@ class PostgresCache(Cache, PostgresBase):
     def __init__(self, config: PostgresConfig) -> None:
         """Create a new instance of Postgres cache."""
         self._tx_lock = threading.Lock()
+        self._lock_timeout = config.lock_timeout
         self.capacity = config.max_entries
+
+        self._health_status = True
+        self._consecutive_failures = 0
+        self._health_lock = threading.Lock()
+        self._health_check_interval = config.health_check_interval
+        self._health_check_connect_timeout = config.health_check_connect_timeout
+        self._health_connection: Any = None
+        self._shutdown_event = threading.Event()
+
         super().__init__(config)
+
+        self._health_thread = threading.Thread(
+            target=self._health_check_loop, daemon=True
+        )
+        self._health_thread.start()
 
     @property
     def _ddl_statements(self) -> list[str]:
@@ -165,6 +181,125 @@ class PostgresCache(Cache, PostgresBase):
             self.CREATE_CONVERSATIONS_TABLE,
             self.CREATE_INDEX,
         ]
+
+    def _mark_unhealthy(self) -> None:
+        """Mark health status as unhealthy (dual-feed from cache operations)."""
+        with self._health_lock:
+            self._consecutive_failures += 1
+            self._health_status = False
+
+    def _mark_healthy(self) -> None:
+        """Mark health status as healthy after a successful reconnect."""
+        with self._health_lock:
+            if not self._health_status:
+                logger.info("Database connection recovered via cache operation")
+            self._health_status = True
+            self._consecutive_failures = 0
+
+    def _connect_health(self) -> None:
+        """Establish a dedicated lightweight connection for health checks."""
+        if self._health_connection is not None:
+            try:
+                self._health_connection.close()
+            except Exception as close_err:
+                logger.debug("Failed to close old health connection: %s", close_err)
+            self._health_connection = None
+        config = self.connection_config
+        connect_kwargs: dict[str, Any] = {
+            "host": config.host,
+            "port": config.port,
+            "user": config.user,
+            "password": config.password,
+            "dbname": config.dbname,
+            "sslmode": config.ssl_mode,
+            "sslrootcert": config.ca_cert_path,
+            "gssencmode": config.gss_encmode,
+            "connect_timeout": self._health_check_connect_timeout,
+            **libpq_tls_params(config.tls_security_profile),
+        }
+        self._health_connection = psycopg2.connect(**connect_kwargs)
+        self._health_connection.autocommit = True
+        with self._health_connection.cursor() as cursor:
+            cursor.execute(
+                "SET statement_timeout = %s", (str(config.statement_timeout),)
+            )
+
+    def shutdown(self) -> None:
+        """Stop the health-check thread and close its connection."""
+        self._shutdown_event.set()
+        self._health_thread.join(timeout=self._health_check_connect_timeout)
+
+    def _health_check_loop(self) -> None:
+        """Background loop that periodically checks DB connectivity."""
+        first_check = True
+        try:
+            while not self._shutdown_event.is_set():
+                try:
+                    if (
+                        self._health_connection is None
+                        or self._health_connection.closed
+                    ):
+                        self._connect_health()
+                    with self._health_connection.cursor() as cursor:
+                        cursor.execute("SELECT 1")
+                    with self._health_lock:
+                        if not self._health_status:
+                            logger.info("Database connection recovered")
+                        self._health_status = True
+                        self._consecutive_failures = 0
+                except Exception as e:
+                    with self._health_lock:
+                        self._consecutive_failures += 1
+                        self._health_status = False
+                        failures = self._consecutive_failures
+                    if first_check:
+                        logger.info("Initial health check failed, will retry: %s", e)
+                    else:
+                        logger.warning(
+                            "Health check failed (consecutive=%d): %s",
+                            failures,
+                            e,
+                        )
+                    try:
+                        self._connect_health()
+                    except Exception as reconnect_err:
+                        logger.debug(
+                            "Health reconnect attempt failed: %s", reconnect_err
+                        )
+                first_check = False
+                self._shutdown_event.wait(self._health_check_interval)
+        finally:
+            if self._health_connection is not None:
+                try:
+                    self._health_connection.close()
+                except Exception as close_err:
+                    logger.debug("Failed to close health connection: %s", close_err)
+                self._health_connection = None
+
+    def _safe_rollback(self) -> None:
+        """Rollback the current transaction, ignoring errors on dead connections."""
+        try:
+            self.connection.rollback()
+        except Exception as e:
+            logger.debug("Rollback failed on dead connection: %s", e)
+
+    def _safe_set_autocommit(self) -> None:
+        """Restore autocommit, ignoring errors on dead connections."""
+        try:
+            if (
+                self.connection.get_transaction_status()
+                != psycopg2.extensions.TRANSACTION_STATUS_IDLE
+            ):
+                self.connection.rollback()
+            self.connection.autocommit = True
+        except Exception as e:
+            logger.debug("Failed to restore autocommit: %s", e)
+
+    def _acquire_lock(self) -> None:
+        """Acquire _tx_lock with bounded timeout."""
+        # pylint: disable-next=consider-using-with
+        if not self._tx_lock.acquire(timeout=self._lock_timeout):
+            raise CacheError("lock acquisition timeout")
 
     @connection
     def get(
@@ -183,7 +318,8 @@ class PostgresCache(Cache, PostgresBase):
         # just check if user_id and conversation_id are UUIDs
         super().construct_key(user_id, conversation_id, skip_user_id_check)
 
-        with self._tx_lock:
+        self._acquire_lock()
+        try:
             with self.connection.cursor() as cursor:
                 try:
                     value = PostgresCache._select(cursor, user_id, conversation_id)
@@ -191,9 +327,13 @@ class PostgresCache(Cache, PostgresBase):
                         return []
                     history = [CacheEntry.from_dict(ce) for ce in value]
                     return history
+                except (psycopg2.OperationalError, psycopg2.InterfaceError):
+                    raise
                 except psycopg2.DatabaseError as e:
                     logger.error("PostgresCache.get %s", e)
                     raise CacheError("PostgresCache.get", e) from e
+        finally:
+            self._tx_lock.release()
 
     @connection
     def insert_or_append(
@@ -217,13 +357,8 @@ class PostgresCache(Cache, PostgresBase):
         # pg_advisory_xact_lock would be released immediately after the first
         # execute.  Disable autocommit for a real multi-statement transaction.
         # The lock serialises concurrent callers that share this connection.
-        with self._tx_lock:
-            # This transaction status check is required for evaluation tests that use
-            # multi-turn conversations. Without it, rapid cache writes (appending each
-            # turn's messages) can leave an active transaction when autocommit=True is
-            # set in the finally block, causing psycopg2 to raise "set_session cannot
-            # be used inside a transaction". Rollback any active transaction to ensure
-            # clean autocommit mode transition.
+        self._acquire_lock()
+        try:
             if (
                 self.connection.get_transaction_status()
                 != psycopg2.extensions.TRANSACTION_STATUS_IDLE
@@ -257,20 +392,23 @@ class PostgresCache(Cache, PostgresBase):
                         (user_id, conversation_id),
                     )
                     PostgresCache._cleanup(cursor, self.capacity)
-                    self.connection.commit()
+                    try:
+                        self.connection.commit()
+                    except (psycopg2.OperationalError, psycopg2.InterfaceError) as e:
+                        raise CacheError(
+                            "PostgresCache.insert_or_append: ambiguous commit", e
+                        ) from e
+                except (psycopg2.OperationalError, psycopg2.InterfaceError):
+                    self._safe_rollback()
+                    raise
                 except psycopg2.DatabaseError as e:
-                    self.connection.rollback()
+                    self._safe_rollback()
                     logger.error("PostgresCache.insert_or_append: %s", e)
                     raise CacheError("PostgresCache.insert_or_append", e) from e
                 finally:
-                    # Ensure transaction is closed before setting autocommit
-                    # to avoid "set_session cannot be used inside a transaction" error
-                    if (
-                        self.connection.get_transaction_status()
-                        != psycopg2.extensions.TRANSACTION_STATUS_IDLE
-                    ):
-                        self.connection.rollback()
-                    self.connection.autocommit = True
+                    self._safe_set_autocommit()
+        finally:
+            self._tx_lock.release()
 
     @connection
     def delete(
@@ -287,13 +425,8 @@ class PostgresCache(Cache, PostgresBase):
             bool: True if the conversation was deleted, False if not found.
 
         """
-        with self._tx_lock:
-            # This transaction status check is required for evaluation tests that use
-            # multi-turn conversations. Without it, rapid cache writes (appending each
-            # turn's messages) can leave an active transaction when autocommit=True is
-            # set in the finally block, causing psycopg2 to raise "set_session cannot
-            # be used inside a transaction". Rollback any active transaction to ensure
-            # clean autocommit mode transition.
+        self._acquire_lock()
+        try:
             if (
                 self.connection.get_transaction_status()
                 != psycopg2.extensions.TRANSACTION_STATUS_IDLE
@@ -307,21 +440,24 @@ class PostgresCache(Cache, PostgresBase):
                         PostgresCache.DELETE_CONVERSATION_METADATA_STATEMENT,
                         (user_id, conversation_id),
                     )
-                    self.connection.commit()
+                    try:
+                        self.connection.commit()
+                    except (psycopg2.OperationalError, psycopg2.InterfaceError) as e:
+                        raise CacheError(
+                            "PostgresCache.delete: ambiguous commit", e
+                        ) from e
                     return deleted
+                except (psycopg2.OperationalError, psycopg2.InterfaceError):
+                    self._safe_rollback()
+                    raise
                 except psycopg2.DatabaseError as e:
-                    self.connection.rollback()
+                    self._safe_rollback()
                     logger.error("PostgresCache.delete: %s", e)
                     raise CacheError("PostgresCache.delete", e) from e
                 finally:
-                    # Ensure transaction is closed before setting autocommit
-                    # to avoid "set_session cannot be used inside a transaction" error
-                    if (
-                        self.connection.get_transaction_status()
-                        != psycopg2.extensions.TRANSACTION_STATUS_IDLE
-                    ):
-                        self.connection.rollback()
-                    self.connection.autocommit = True
+                    self._safe_set_autocommit()
+        finally:
+            self._tx_lock.release()
 
     @connection
     def list(
@@ -338,7 +474,8 @@ class PostgresCache(Cache, PostgresBase):
             topic_summary, last_message_timestamp, and message_count.
 
         """
-        with self._tx_lock:
+        self._acquire_lock()
+        try:
             with self.connection.cursor() as cursor:
                 try:
                     cursor.execute(
@@ -354,9 +491,13 @@ class PostgresCache(Cache, PostgresBase):
                         )
                         for row in rows
                     ]
+                except (psycopg2.OperationalError, psycopg2.InterfaceError):
+                    raise
                 except psycopg2.DatabaseError as e:
                     logger.error("PostgresCache.list: %s", e)
                     raise CacheError("PostgresCache.list", e) from e
+        finally:
+            self._tx_lock.release()
 
     @connection
     def set_topic_summary(
@@ -374,46 +515,39 @@ class PostgresCache(Cache, PostgresBase):
             topic_summary: The topic summary to store.
             skip_user_id_check: Skip user_id suid check.
         """
-        with self._tx_lock:
+        self._acquire_lock()
+        try:
             with self.connection.cursor() as cursor:
                 try:
                     cursor.execute(
                         PostgresCache.INSERT_OR_UPDATE_TOPIC_SUMMARY_STATEMENT,
                         (user_id, conversation_id, topic_summary),
                     )
+                except (psycopg2.OperationalError, psycopg2.InterfaceError):
+                    raise
                 except psycopg2.DatabaseError as e:
                     logger.error("PostgresCache.set_topic_summary: %s", e)
                     raise CacheError("PostgresCache.set_topic_summary", e) from e
+        finally:
+            self._tx_lock.release()
+
+    @property
+    def consecutive_failures(self) -> int:
+        """Return the number of consecutive health-check failures (thread-safe)."""
+        with self._health_lock:
+            return self._consecutive_failures
 
     def ready(self) -> bool:
         """Check if the cache is ready.
 
-        Postgres cache checks if the connection is alive. When a dead
-        connection is detected and the database is available again, the
-        connection is automatically re-established.
+        Returns the background health loop's last-known status.
+        Non-blocking and deadlock-immune.
 
         Returns:
             True if the cache is ready, False otherwise.
         """
-        with self._tx_lock:
-            if not self.connection or self.connection.closed == 1:
-                try:
-                    logger.info("Detected dead connection, attempting reconnect")
-                    self.connect()
-                    return True
-                except Exception as e:
-                    logger.warning("Reconnect attempt failed: %s", e)
-                    return False
-            try:
-                return self.connection.poll() == psycopg2.extensions.POLL_OK
-            except (psycopg2.OperationalError, psycopg2.InterfaceError):
-                try:
-                    logger.info("Connection error during poll, attempting reconnect")
-                    self.connect()
-                    return True
-                except Exception as e:
-                    logger.warning("Reconnect attempt failed: %s", e)
-                    return False
+        with self._health_lock:
+            return self._health_status
 
     @staticmethod
     def _select(

--- a/ols/utils/postgres.py
+++ b/ols/utils/postgres.py
@@ -11,21 +11,78 @@ from typing import Any, Callable
 import psycopg2
 
 from ols.app.models.config import PostgresConfig
+from ols.src.cache.cache_error import CacheError
 from ols.utils.ssl import libpq_tls_params
 
 logger = logging.getLogger(__name__)
 
 
+def _do_reconnect(connectable: Any, func_name: str) -> None:
+    """Perform reconnect, wrapping errors in CacheError."""
+    try:
+        connectable.connect()
+    except Exception as reconnect_err:
+        raise CacheError(
+            f"reconnect failed in {func_name}", reconnect_err
+        ) from reconnect_err
+
+
+def _handle_connection_error(connectable: Any, func_name: str) -> None:
+    """Handle connection error by marking unhealthy and reconnecting.
+
+    Note: Does NOT call _mark_healthy() here. The caller is responsible
+    for marking healthy only after the retry operation succeeds, to avoid
+    incorrectly reporting healthy status if the retry also fails.
+    """
+    if hasattr(connectable, "_mark_unhealthy"):
+        connectable._mark_unhealthy()
+
+    _do_reconnect(connectable, func_name)
+
+
 def connection(f: Callable) -> Callable:
     """Ensure the object is connected before calling the wrapped method.
 
-    If the connection is lost, reconnect transparently.
+    On connection-level errors (OperationalError, InterfaceError), attempt
+    a single reconnect and retry. On SQL/data errors (DatabaseError), wrap
+    in CacheError and propagate immediately.
+
+    Thread safety: If the connectable has a ``_tx_lock``, the reconnect is
+    performed while holding that lock to prevent races with concurrent
+    cache operations.
     """
 
     def wrapper(connectable: Any, *args: Any, **kwargs: Any) -> Callable:
-        if not connectable.connected():
-            connectable.connect()
-        return f(connectable, *args, **kwargs)
+        try:
+            if not connectable.connected():
+                try:
+                    connectable.connect()
+                except Exception as connect_err:
+                    if isinstance(
+                        connect_err,
+                        (psycopg2.OperationalError, psycopg2.InterfaceError),
+                    ):
+                        raise
+                    raise CacheError(
+                        f"initial connect failed in {f.__name__}", connect_err
+                    ) from connect_err
+            return f(connectable, *args, **kwargs)
+        except (psycopg2.OperationalError, psycopg2.InterfaceError) as e:
+            logger.warning(
+                "Connection error in %s, attempting reconnect: %s", f.__name__, e
+            )
+            _handle_connection_error(connectable, f.__name__)
+            try:
+                result = f(connectable, *args, **kwargs)
+                if hasattr(connectable, "_mark_healthy"):
+                    connectable._mark_healthy()
+                return result
+            except (psycopg2.OperationalError, psycopg2.InterfaceError) as retry_err:
+                raise CacheError(
+                    f"retry failed in {f.__name__}", retry_err
+                ) from retry_err
+        except psycopg2.DatabaseError as e:
+            raise CacheError(f"{f.__name__}", e) from e
 
     return wrapper
 
@@ -84,6 +141,13 @@ class PostgresBase(ABC):
             logger.exception("Error initializing Postgres schema:\n%s", e)
             raise
         self.connection.autocommit = True
+        cursor = self.connection.cursor()
+        try:
+            cursor.execute(
+                "SET statement_timeout = %s", (str(config.statement_timeout),)
+            )
+        finally:
+            cursor.close()
 
     def connected(self) -> bool:
         """Check if the connection to Postgres is alive."""

--- a/tests/unit/app/endpoints/test_health.py
+++ b/tests/unit/app/endpoints/test_health.py
@@ -1,6 +1,7 @@
 """Unit tests for health endpoints handlers."""
 
 import time
+from collections.abc import Generator
 from unittest.mock import Mock, patch
 
 import pytest
@@ -14,9 +15,17 @@ from ols.app.endpoints.health import (
     llm_is_ready,
     readiness_probe_get_method,
 )
-from ols.app.models.config import InMemoryCacheConfig
+from ols.app.models.config import InMemoryCacheConfig, PostgresConfig
 from ols.app.models.models import LivenessResponse, ReadinessResponse
 from ols.src.cache.in_memory_cache import InMemoryCache
+from ols.src.cache.postgres_cache import PostgresCache
+
+
+@pytest.fixture(autouse=True)
+def _suppress_health_loop() -> Generator[None, None, None]:
+    """Prevent the background health-check thread from making real DB calls."""
+    with patch.object(PostgresCache, "_health_check_loop"):
+        yield
 
 
 def mock_cache():
@@ -220,9 +229,58 @@ def test_readiness_probe_get_method_cache_not_ready():
             readiness_probe_get_method()
 
 
-def test_liveness_probe_get_method():
-    """Test the liveness_probe function."""
-    # the tested function returns constant right now
-    # i.e. it does not depend on application state
-    response = liveness_probe_get_method()
-    assert response == LivenessResponse(alive=True)
+def test_liveness_probe_get_method() -> None:
+    """Test the liveness_probe function when no postgres cache is configured."""
+    mock_response = Mock()
+    result = liveness_probe_get_method(mock_response)
+    assert result == LivenessResponse(alive=True)
+
+
+def test_liveness_probe_returns_alive_when_postgres_healthy() -> None:
+    """Test liveness probe returns alive when postgres failures below threshold."""
+    with patch("psycopg2.connect"):
+        pg_config = PostgresConfig()
+        cache = PostgresCache(pg_config)
+
+    with (
+        patch.object(config, "_conversation_cache", cache),
+        patch.object(config.ols_config, "liveness_db_failure_threshold", 3),
+    ):
+        mock_response = Mock()
+        result = liveness_probe_get_method(mock_response)
+        assert result == LivenessResponse(alive=True)
+
+
+def test_liveness_probe_returns_503_when_postgres_unhealthy() -> None:
+    """Test liveness probe returns 503 when postgres failures reach threshold."""
+    with patch("psycopg2.connect"):
+        pg_config = PostgresConfig()
+        cache = PostgresCache(pg_config)
+        for _ in range(3):
+            cache._mark_unhealthy()
+
+    with (
+        patch.object(config, "_conversation_cache", cache),
+        patch.object(config.ols_config, "liveness_db_failure_threshold", 3),
+    ):
+        mock_response = Mock()
+        result = liveness_probe_get_method(mock_response)
+        assert mock_response.status_code == 503
+        assert result == LivenessResponse(alive=False, reason="database unreachable")
+
+
+def test_liveness_probe_returns_alive_when_below_threshold() -> None:
+    """Test liveness probe returns alive when failures below threshold."""
+    with patch("psycopg2.connect"):
+        pg_config = PostgresConfig()
+        cache = PostgresCache(pg_config)
+        for _ in range(2):
+            cache._mark_unhealthy()
+
+    with (
+        patch.object(config, "_conversation_cache", cache),
+        patch.object(config.ols_config, "liveness_db_failure_threshold", 3),
+    ):
+        mock_response = Mock()
+        result = liveness_probe_get_method(mock_response)
+        assert result == LivenessResponse(alive=True)

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -2005,6 +2005,21 @@ def test_postgres_config_default_values():
     assert postgres_config.dbname == constants.POSTGRES_CACHE_DBNAME
     assert postgres_config.user == constants.POSTGRES_CACHE_USER
     assert postgres_config.max_entries == constants.POSTGRES_CACHE_MAX_ENTRIES
+    assert postgres_config.statement_timeout == constants.POSTGRES_STATEMENT_TIMEOUT
+    assert postgres_config.lock_timeout == constants.POSTGRES_LOCK_TIMEOUT
+    assert (
+        postgres_config.health_check_interval == constants.CACHE_HEALTH_CHECK_INTERVAL
+    )
+
+
+def test_postgres_config_custom_timeout_values():
+    """Test the PostgresConfig model with custom timeout values."""
+    postgres_config = PostgresConfig(
+        statement_timeout=10000, lock_timeout=30, health_check_interval=60
+    )
+    assert postgres_config.statement_timeout == 10000
+    assert postgres_config.lock_timeout == 30
+    assert postgres_config.health_check_interval == 60
 
 
 def test_postgres_config_correct_values():
@@ -2238,6 +2253,23 @@ def test_ols_config(tmpdir):
     )
     assert ols_config.offload_storage_path == constants.DEFAULT_OFFLOAD_STORAGE_PATH
     assert ols_config.solr_hybrid is None
+    assert (
+        ols_config.liveness_db_failure_threshold
+        == constants.LIVENESS_DB_FAILURE_THRESHOLD
+    )
+
+
+def test_ols_config_with_custom_liveness_threshold():
+    """Test OLSConfig with custom liveness threshold."""
+    ols_config = OLSConfig(
+        {
+            "default_provider": "test_default_provider",
+            "default_model": "test_default_model",
+            "conversation_cache": {"type": "memory", "memory": {"max_entries": 100}},
+            "liveness_db_failure_threshold": 5,
+        }
+    )
+    assert ols_config.liveness_db_failure_threshold == 5
 
 
 def test_ols_config_with_custom_offload_storage_path():

--- a/tests/unit/cache/test_postgres_cache.py
+++ b/tests/unit/cache/test_postgres_cache.py
@@ -1,6 +1,7 @@
 """Unit tests for PostgresCache class."""
 
 import json
+from typing import Generator
 from unittest.mock import MagicMock, call, patch
 
 import psycopg2
@@ -12,6 +13,16 @@ from ols.app.models.models import CacheEntry, MessageDecoder, MessageEncoder
 from ols.src.cache.cache_error import CacheError
 from ols.src.cache.postgres_cache import PostgresCache
 from ols.utils import suid
+
+pytestmark = pytest.mark.usefixtures("_suppress_health_loop")
+
+
+@pytest.fixture(autouse=True)
+def _suppress_health_loop() -> Generator[None, None, None]:
+    """Prevent the background health-check thread from making real DB calls."""
+    with patch.object(PostgresCache, "_health_check_loop"):
+        yield
+
 
 user_id = suid.get_suid()
 conversation_id = suid.get_suid()
@@ -643,7 +654,7 @@ def test_delete_operation_not_found():
 
 
 def test_delete_operation_on_exception():
-    """Test the Cache.delete operation when an exception is raised."""
+    """Test the Cache.delete operation when exception is thrown."""
     # Mock the database cursor behavior to raise an exception
     mock_cursor = MagicMock()
     mock_cursor.execute.side_effect = psycopg2.DatabaseError("PLSQL error")
@@ -658,8 +669,9 @@ def test_delete_operation_on_exception():
         config = PostgresConfig()
         cache = PostgresCache(config)
 
-        # Verify that the exception is raised
-        with pytest.raises(psycopg2.DatabaseError, match="PLSQL error"):
+        # DatabaseError is now caught by the @connection decorator and
+        # wrapped in CacheError (consistent with other operations)
+        with pytest.raises(CacheError, match="PLSQL error"):
             cache.delete(user_id, conversation_id)
 
 
@@ -797,92 +809,76 @@ def test_cleanup_method_when_clean_performed():
     mock_cursor.execute.assert_has_calls(calls, any_order=False)
 
 
-def test_ready():
-    """Test the Cache.ready operation."""
-    # do not use real PostgreSQL instance
+def test_ready_returns_health_status() -> None:
+    """Test that ready() returns the background health loop status."""
     with patch("psycopg2.connect"):
-        # initialize Postgres cache
         config = PostgresConfig()
         cache = PostgresCache(config)
 
-        # mock the connection state 0 - open
-        cache.connection.closed = 0
-        # patch the poll function to return POLL_OK
-        cache.connection.poll = MagicMock(return_value=psycopg2.extensions.POLL_OK)
-        # cache is ready
-        assert cache.ready()
+        # initially healthy
+        assert cache.ready() is True
+
+        # mark unhealthy
+        cache._mark_unhealthy()
+        assert cache.ready() is False
+
+        # restore healthy
+        with cache._health_lock:
+            cache._health_status = True
+        assert cache.ready() is True
 
 
-def test_ready_reconnects_on_closed_connection():
-    """Test that ready() reconnects when connection is closed."""
-    with patch("psycopg2.connect") as mock_connect:
+def test_mark_unhealthy() -> None:
+    """Test that _mark_unhealthy sets health status to False."""
+    with patch("psycopg2.connect"):
         config = PostgresConfig()
         cache = PostgresCache(config)
 
-        # simulate closed connection
-        cache.connection.closed = 1
-
-        # ready() should attempt reconnect and succeed
-        assert cache.ready()
-        # connect() is called during __init__ and again during reconnect
-        assert mock_connect.call_count == 2
+        assert cache.ready() is True
+        cache._mark_unhealthy()
+        assert cache.ready() is False
 
 
-def test_ready_reconnects_on_none_connection():
-    """Test that ready() reconnects when connection is None."""
-    with patch("psycopg2.connect") as mock_connect:
+def test_lock_timeout() -> None:
+    """Test that lock acquisition timeout raises CacheError."""
+    with patch("psycopg2.connect"):
+        config = PostgresConfig(lock_timeout=1)
+        cache = PostgresCache(config)
+
+        # Manually acquire the lock so the next acquire times out
+        cache._tx_lock.acquire()
+        try:
+            with pytest.raises(CacheError, match="lock acquisition timeout"):
+                cache._acquire_lock()
+        finally:
+            cache._tx_lock.release()
+
+
+def test_health_check_loop_recovers() -> None:
+    """Test that the health check loop sets health status on success."""
+    with patch("psycopg2.connect"):
         config = PostgresConfig()
         cache = PostgresCache(config)
 
-        # simulate lost connection
-        cache.connection = None
+        # Mark unhealthy, then simulate a health check success
+        cache._mark_unhealthy()
+        assert cache.ready() is False
 
-        # ready() should attempt reconnect and succeed
-        assert cache.ready()
-        assert mock_connect.call_count == 2
+        # Simulate the health check by directly calling the relevant logic
+        with cache._health_lock:
+            cache._health_status = True
+            cache._consecutive_failures = 0
+        assert cache.ready() is True
 
 
-def test_ready_returns_false_when_reconnect_fails():
-    """Test that ready() returns False when reconnect attempt fails."""
-    with patch("psycopg2.connect") as mock_connect:
+def test_consecutive_failures_tracked() -> None:
+    """Test that consecutive failures are tracked."""
+    with patch("psycopg2.connect"):
         config = PostgresConfig()
         cache = PostgresCache(config)
 
-        # simulate closed connection
-        cache.connection.closed = 1
-        # make reconnect fail
-        mock_connect.side_effect = psycopg2.OperationalError("connection refused")
+        for _ in range(5):
+            cache._mark_unhealthy()
 
-        assert not cache.ready()
-
-
-def test_ready_reconnects_on_poll_error():
-    """Test that ready() reconnects when poll raises OperationalError."""
-    with patch("psycopg2.connect") as mock_connect:
-        config = PostgresConfig()
-        cache = PostgresCache(config)
-
-        cache.connection.closed = 0
-        cache.connection.poll = MagicMock(
-            side_effect=psycopg2.OperationalError("Connection closed")
-        )
-
-        # ready() should attempt reconnect and succeed
-        assert cache.ready()
-        assert mock_connect.call_count == 2
-
-
-def test_ready_returns_false_when_poll_reconnect_fails():
-    """Test that ready() returns False when reconnect after poll error fails."""
-    with patch("psycopg2.connect") as mock_connect:
-        config = PostgresConfig()
-        cache = PostgresCache(config)
-
-        cache.connection.closed = 0
-        cache.connection.poll = MagicMock(
-            side_effect=psycopg2.InterfaceError("Connection closed")
-        )
-        # make reconnect fail
-        mock_connect.side_effect = psycopg2.OperationalError("connection refused")
-
-        assert not cache.ready()
+        assert cache.ready() is False
+        assert cache.consecutive_failures == 5

--- a/tests/unit/cache/test_postgres_cache_transaction_fix.py
+++ b/tests/unit/cache/test_postgres_cache_transaction_fix.py
@@ -1,5 +1,6 @@
 """Unit tests for PostgresCache transaction management fix."""
 
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import psycopg2
@@ -13,6 +14,14 @@ from ols.src.cache.cache_error import CacheError
 from ols.src.cache.postgres_cache import PostgresCache
 from ols.utils import suid
 
+
+@pytest.fixture(autouse=True)
+def _suppress_health_loop() -> Generator[None, None, None]:
+    """Prevent the background health-check thread from making real DB calls."""
+    with patch.object(PostgresCache, "_health_check_loop"):
+        yield
+
+
 user_id = suid.get_suid()
 conversation_id = suid.get_suid()
 cache_entry = CacheEntry(
@@ -20,16 +29,14 @@ cache_entry = CacheEntry(
 )
 
 
-def test_insert_or_append_transaction_status_check_on_success():
+def test_insert_or_append_transaction_status_check_on_success() -> None:
     """Test that transaction status is checked before setting autocommit on success."""
     mock_cursor = MagicMock()
     mock_cursor.fetchone.return_value = None
 
     with patch("psycopg2.connect") as mock_connect:
-        # Mock connection with proper transaction status
         mock_connection = mock_connect.return_value
         mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
-        # After successful commit, transaction should be IDLE
         mock_connection.get_transaction_status.return_value = (
             psycopg2.extensions.TRANSACTION_STATUS_IDLE
         )
@@ -39,28 +46,22 @@ def test_insert_or_append_transaction_status_check_on_success():
 
         cache.insert_or_append(user_id, conversation_id, cache_entry)
 
-    # Verify transaction status was checked
     mock_connection.get_transaction_status.assert_called()
-    # Commit should be called (successful operation)
     mock_connection.commit.assert_called()
-    # Rollback should NOT be called in finally (transaction already IDLE)
-    # Note: rollback might be called in except block, but not in finally
     assert mock_connection.autocommit is True
 
 
-def test_insert_or_append_transaction_status_check_on_error():
+def test_insert_or_append_transaction_status_check_on_error() -> None:
     """Test that active transaction is rolled back before setting autocommit on error."""
     mock_cursor = MagicMock()
-    # Simulate database error
     mock_cursor.execute.side_effect = [
-        None,  # SELECT 1 (connection check)
-        psycopg2.DatabaseError("test error"),  # advisory lock fails
+        None,
+        psycopg2.DatabaseError("test error"),
     ]
 
     with patch("psycopg2.connect") as mock_connect:
         mock_connection = mock_connect.return_value
         mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
-        # After error, transaction is still ACTIVE (not IDLE)
         mock_connection.get_transaction_status.return_value = (
             psycopg2.extensions.TRANSACTION_STATUS_INERROR
         )
@@ -71,25 +72,19 @@ def test_insert_or_append_transaction_status_check_on_error():
         with pytest.raises(CacheError):
             cache.insert_or_append(user_id, conversation_id, cache_entry)
 
-    # Verify transaction status was checked in finally
     mock_connection.get_transaction_status.assert_called()
-    # Rollback should be called three times:
-    # 1. Before disabling autocommit (transaction is not IDLE)
-    # 2. In the except block
-    # 3. In the finally block because transaction is not IDLE
     assert mock_connection.rollback.call_count == 3
     assert mock_connection.autocommit is True
 
 
-def test_delete_transaction_status_check_on_success():
+def test_delete_transaction_status_check_on_success() -> None:
     """Test that transaction status is checked before setting autocommit on delete success."""
     mock_cursor = MagicMock()
-    mock_cursor.rowcount = 1  # Simulate successful delete
+    mock_cursor.rowcount = 1
 
     with patch("psycopg2.connect") as mock_connect:
         mock_connection = mock_connect.return_value
         mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
-        # After successful commit, transaction should be IDLE
         mock_connection.get_transaction_status.return_value = (
             psycopg2.extensions.TRANSACTION_STATUS_IDLE
         )
@@ -105,18 +100,17 @@ def test_delete_transaction_status_check_on_success():
     assert mock_connection.autocommit is True
 
 
-def test_delete_transaction_status_check_on_error():
+def test_delete_transaction_status_check_on_error() -> None:
     """Test that active transaction is rolled back before setting autocommit on delete error."""
     mock_cursor = MagicMock()
     mock_cursor.execute.side_effect = [
-        None,  # SELECT 1 (connection check)
-        psycopg2.DatabaseError("delete failed"),  # delete fails
+        None,
+        psycopg2.DatabaseError("delete failed"),
     ]
 
     with patch("psycopg2.connect") as mock_connect:
         mock_connection = mock_connect.return_value
         mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
-        # After error, transaction is still ACTIVE
         mock_connection.get_transaction_status.return_value = (
             psycopg2.extensions.TRANSACTION_STATUS_INERROR
         )
@@ -128,12 +122,11 @@ def test_delete_transaction_status_check_on_error():
             cache.delete(user_id, conversation_id)
 
     mock_connection.get_transaction_status.assert_called()
-    # Rollback called three times: before disabling autocommit, in except, and in finally
     assert mock_connection.rollback.call_count == 3
     assert mock_connection.autocommit is True
 
 
-def test_no_extra_rollback_when_transaction_idle():
+def test_no_extra_rollback_when_transaction_idle() -> None:
     """Test that no extra rollback is called when transaction is already IDLE."""
     mock_cursor = MagicMock()
     mock_cursor.fetchone.return_value = None
@@ -141,7 +134,6 @@ def test_no_extra_rollback_when_transaction_idle():
     with patch("psycopg2.connect") as mock_connect:
         mock_connection = mock_connect.return_value
         mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
-        # Transaction is IDLE (normal successful case)
         mock_connection.get_transaction_status.return_value = (
             psycopg2.extensions.TRANSACTION_STATUS_IDLE
         )
@@ -151,9 +143,61 @@ def test_no_extra_rollback_when_transaction_idle():
 
         cache.insert_or_append(user_id, conversation_id, cache_entry)
 
-    # In successful case with IDLE transaction:
-    # - commit() is called (during init and during insert_or_append)
-    # - rollback() should NOT be called in finally (transaction is IDLE)
     assert mock_connection.commit.call_count >= 1
-    # Rollback should not be called at all in the success case
     mock_connection.rollback.assert_not_called()
+
+
+def test_insert_or_append_ambiguous_commit_raises_cache_error() -> None:
+    """Test that connection errors during commit raise CacheError, not raw exception."""
+    mock_cursor = MagicMock()
+    mock_cursor.fetchone.return_value = None
+    commit_count = [0]
+
+    def commit_fails_on_second_call() -> None:
+        commit_count[0] += 1
+        if commit_count[0] > 1:
+            raise psycopg2.OperationalError("connection lost during commit")
+
+    with patch("psycopg2.connect") as mock_connect:
+        mock_connection = mock_connect.return_value
+        mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
+        mock_connection.get_transaction_status.return_value = (
+            psycopg2.extensions.TRANSACTION_STATUS_IDLE
+        )
+        mock_connection.commit.side_effect = commit_fails_on_second_call
+
+        config = PostgresConfig()
+        cache = PostgresCache(config)
+
+        with pytest.raises(CacheError, match="ambiguous commit"):
+            cache.insert_or_append(user_id, conversation_id, cache_entry)
+
+    assert commit_count[0] == 2
+
+
+def test_delete_ambiguous_commit_raises_cache_error() -> None:
+    """Test that connection errors during commit in delete raise CacheError."""
+    mock_cursor = MagicMock()
+    mock_cursor.rowcount = 1
+    commit_count = [0]
+
+    def commit_fails_on_second_call() -> None:
+        commit_count[0] += 1
+        if commit_count[0] > 1:
+            raise psycopg2.InterfaceError("connection lost during commit")
+
+    with patch("psycopg2.connect") as mock_connect:
+        mock_connection = mock_connect.return_value
+        mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
+        mock_connection.get_transaction_status.return_value = (
+            psycopg2.extensions.TRANSACTION_STATUS_IDLE
+        )
+        mock_connection.commit.side_effect = commit_fails_on_second_call
+
+        config = PostgresConfig()
+        cache = PostgresCache(config)
+
+        with pytest.raises(CacheError, match="ambiguous commit"):
+            cache.delete(user_id, conversation_id)
+
+    assert commit_count[0] == 2

--- a/tests/unit/utils/test_postgres.py
+++ b/tests/unit/utils/test_postgres.py
@@ -6,6 +6,7 @@ import psycopg2
 import pytest
 
 from ols.app.models.config import TLSSecurityProfile
+from ols.src.cache.cache_error import CacheError
 from ols.utils.postgres import PostgresBase, connection
 
 
@@ -30,6 +31,8 @@ class TestConnectionDecorator:
             """Initialize connectable."""
             self._connected = False
             self._raise_on_call = raise_on_call
+            self._call_count = 0
+            self._unhealthy_marked = False
 
         def connected(self) -> bool:
             """Check connection status."""
@@ -43,6 +46,10 @@ class TestConnectionDecorator:
             """Drop connection."""
             self._connected = False
 
+        def _mark_unhealthy(self) -> None:
+            """Mark as unhealthy."""
+            self._unhealthy_marked = True
+
         @connection
         def do_work(self) -> str:
             """Perform work requiring a connection."""
@@ -50,7 +57,28 @@ class TestConnectionDecorator:
                 raise RuntimeError("work failed")
             return "done"
 
-    def test_auto_reconnects_when_disconnected(self):
+        @connection
+        def do_work_operational_error(self) -> str:
+            """Raise OperationalError on first call, succeed on retry."""
+            self._call_count += 1
+            if self._call_count == 1:
+                raise psycopg2.OperationalError("connection lost")
+            return "recovered"
+
+        @connection
+        def do_work_interface_error(self) -> str:
+            """Raise InterfaceError on first call, succeed on retry."""
+            self._call_count += 1
+            if self._call_count == 1:
+                raise psycopg2.InterfaceError("cannot reach server")
+            return "recovered"
+
+        @connection
+        def do_work_database_error(self) -> str:
+            """Raise DatabaseError (SQL error, no retry)."""
+            raise psycopg2.DatabaseError("SQL syntax error")
+
+    def test_auto_reconnects_when_disconnected(self) -> None:
         """Decorator calls connect() when not connected."""
         c = self.Connectable()
         c.disconnect()
@@ -60,7 +88,7 @@ class TestConnectionDecorator:
         assert c.connected() is True
         assert result == "done"
 
-    def test_does_not_reconnect_when_connected(self):
+    def test_does_not_reconnect_when_connected(self) -> None:
         """Decorator skips connect() when already connected."""
         c = self.Connectable()
         c.connect()
@@ -68,7 +96,7 @@ class TestConnectionDecorator:
             c.do_work()
             mock_connect.assert_not_called()
 
-    def test_propagates_exception_after_reconnect(self):
+    def test_propagates_exception_after_reconnect(self) -> None:
         """Decorator reconnects then lets the wrapped exception propagate."""
         c = self.Connectable(raise_on_call=True)
         c.disconnect()
@@ -76,6 +104,66 @@ class TestConnectionDecorator:
         with pytest.raises(RuntimeError, match="work failed"):
             c.do_work()
         assert c.connected() is True
+
+    def test_operational_error_triggers_reconnect_and_retry(self) -> None:
+        """OperationalError causes reconnect + retry, succeeding on second attempt."""
+        c = self.Connectable()
+        c.connect()
+        result = c.do_work_operational_error()
+        assert result == "recovered"
+        assert c._unhealthy_marked is True
+
+    def test_interface_error_triggers_reconnect_and_retry(self) -> None:
+        """InterfaceError causes reconnect + retry, succeeding on second attempt."""
+        c = self.Connectable()
+        c.connect()
+        result = c.do_work_interface_error()
+        assert result == "recovered"
+        assert c._unhealthy_marked is True
+
+    def test_database_error_wraps_in_cache_error_no_retry(self) -> None:
+        """DatabaseError is wrapped in CacheError without reconnect attempt."""
+        c = self.Connectable()
+        c.connect()
+        with patch.object(c, "connect") as mock_connect:
+            with pytest.raises(CacheError, match="SQL syntax error"):
+                c.do_work_database_error()
+            mock_connect.assert_not_called()
+        assert c._unhealthy_marked is False
+
+    def test_connection_error_reconnect_failure_raises_cache_error(self) -> None:
+        """When reconnect fails after OperationalError, CacheError is raised."""
+        c = self.Connectable()
+        c.connect()
+        original_connect = c.connect
+        call_count = [0]
+
+        def failing_connect() -> None:
+            call_count[0] += 1
+            if call_count[0] > 0:
+                raise psycopg2.OperationalError("cannot connect")
+            original_connect()
+
+        c.connect = failing_connect
+        with pytest.raises(CacheError, match="reconnect failed"):
+            c.do_work_operational_error()
+
+    def test_retry_failure_wraps_in_cache_error(self) -> None:
+        """When retry also fails with OperationalError, it's wrapped in CacheError."""
+
+        class AlwaysFailsConnectable(self.Connectable):
+            """Connectable that always raises OperationalError."""
+
+            @connection
+            def do_work_always_fails(self) -> str:
+                """Raise OperationalError on every call."""
+                raise psycopg2.OperationalError("persistent failure")
+
+        c = AlwaysFailsConnectable()
+        c.connect()
+        with pytest.raises(CacheError, match="retry failed"):
+            c.do_work_always_fails()
+        assert c._unhealthy_marked is True
 
 
 class TestPostgresBaseConnect:
@@ -93,7 +181,8 @@ class TestPostgresBaseConnect:
                 call("CREATE INDEX IF NOT EXISTS i1 ON t1 (id)"),
             ]
         )
-        cursor.close.assert_called_once()
+        # close is called twice: once for DDL cursor, once for statement_timeout cursor
+        assert cursor.close.call_count == 2
         mock_connect.return_value.commit.assert_called_once()
 
     def test_connect_sets_autocommit_after_init(self):
@@ -102,6 +191,16 @@ class TestPostgresBaseConnect:
             FakeComponent(config=MagicMock())
 
         assert mock_connect.return_value.autocommit is True
+
+    def test_connect_sets_statement_timeout(self):
+        """Statement timeout is set after autocommit is enabled."""
+        mock_config = MagicMock()
+        mock_config.statement_timeout = 5000
+        with patch("psycopg2.connect") as mock_connect:
+            cursor = mock_connect.return_value.cursor.return_value
+            FakeComponent(config=mock_config)
+
+        cursor.execute.assert_any_call("SET statement_timeout = %s", ("5000",))
 
     def test_connect_closes_connection_on_ddl_failure(self):
         """Connection is closed and exception propagates when DDL fails."""

--- a/uv.lock
+++ b/uv.lock
@@ -4069,7 +4069,7 @@ wheels = [
 
 [[package]]
 name = "sentence-transformers"
-version = "5.7.0"
+version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -4083,9 +4083,9 @@ dependencies = [
     { name = "transformers" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/59/867381b1414a975da6c9953f48a07c05cb0629305e2d37c9bcc9764367b2/sentence_transformers-5.7.0.tar.gz", hash = "sha256:fd8c8fc35e6323631dff9f3760969ebf7980dc3cfda0ab1354bc6a774cc0e5d8", size = 466382, upload-time = "2026-08-06T12:12:33.371Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/43/6b53e6a2098440ce21478742facbc058f1a66ba2cb80b24bdc64942e1e2c/sentence_transformers-6.0.0.tar.gz", hash = "sha256:9e8c2c24f3b1c7473cd5f519a3d3cff60daaeb95533b82d045ffb43ee5f2dac4", size = 575048, upload-time = "2026-08-18T13:33:49.919Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/c8/f63d99e354532f5b83e735dd1e001bda92495fbfde934f65d924abf2b071/sentence_transformers-5.7.0-py3-none-any.whl", hash = "sha256:b78141da3d8137e70d965866e2ca43190b9266f3d4d8752e250ded75e7136730", size = 611333, upload-time = "2026-08-06T12:12:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fe/9d19b01fe87945f9455c617bf5d33dfbf29fe06ab6580bc0bea06080c788/sentence_transformers-6.0.0-py3-none-any.whl", hash = "sha256:b974ac67523ea2a955afa87b1024129305472bd884367dcc969261cb086790e9", size = 739640, upload-time = "2026-08-18T13:33:48.428Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implement background health-check loop, smarter error classification in the @connection decorator, operation timeouts, and enhanced liveness/readiness probes so OLS can recover automatically when the backing PostgreSQL database is restarted.

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the `/liveness` endpoint to detect repeated PostgreSQL connectivity failures.
  - Returns HTTP `503` with a clear “database unreachable” reason when the failure threshold is reached.
  - Added configurable PostgreSQL timeouts, health-check intervals, and liveness failure thresholds.
  - Liveness responses now optionally include an explanation for unhealthy status.

- **Bug Fixes**
  - Improved database connection recovery, transaction safety, and error handling.
  - Added background health monitoring to improve cache readiness reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->