### PR TITLE
OLS-2866 add make tls-scan target for TLS profile compliance scanning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Put targets here if there is a risk that a target name might conflict with a filename.
 # this list is probably overkill right now.
 # See: https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html
-.PHONY: test test-unit test-e2e test-eval test-lseval-periodic test-lseval-troubleshooting images run format verify get-embeddings get-embeddings-byok get-embeddings-okp
+.PHONY: test test-unit test-e2e test-eval test-lseval-periodic test-lseval-troubleshooting images run format verify get-embeddings get-embeddings-byok get-embeddings-okp tls-scan
 
 export PATH := $(HOME)/.local/bin:$(PATH)
 
@@ -181,6 +181,9 @@ shellcheck: ## Run shellcheck
 	wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv \
 	shellcheck --version
 	shellcheck -- */*.sh
+
+tls-scan: ## Run TLS profile compliance scan against OLS endpoints
+	./scripts/tls-scan.sh
 
 konflux-requirements:	## Generate hermetic requirements.*.txt file for konflux build
 	./scripts/konflux_requirements.sh

--- a/scripts/tls-scan.sh
+++ b/scripts/tls-scan.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+set -euo pipefail
+
+SCAN_DIR="/tmp/ols-tls-scan"
+OLS_PORT=8443
+SCANNER_IMAGE="${SCANNER_IMAGE:-quay.io/openshift-lightspeed/ols-qe:tls-scanner}"
+OLS_PID=""
+FAILURES=0
+
+log() {
+    echo "[tls-scan] $*"
+}
+
+cleanup() {
+    if [[ -n "${OLS_PID}" ]]; then
+        kill "${OLS_PID}" 2>/dev/null || true
+        wait "${OLS_PID}" 2>/dev/null || true
+    fi
+    podman rm "tls-scanner-extract-$$" 2>/dev/null || true
+    if [[ "${TLS_SCAN_KEEP_ARTIFACTS:-0}" != "1" ]]; then
+        rm -rf "${SCAN_DIR}"
+        log "Cleaned up ${SCAN_DIR}"
+    else
+        log "Artifacts preserved in ${SCAN_DIR}"
+    fi
+}
+
+trap cleanup EXIT
+
+generate_certs() {
+    log "Generating TLS certificates..."
+    mkdir -p "${SCAN_DIR}"
+    openssl req -x509 -newkey rsa:4096 -sha256 -days 1 -noenc \
+        -keyout "${SCAN_DIR}/server.key" \
+        -out "${SCAN_DIR}/server.crt" \
+        -subj "/CN=localhost" \
+        -addext "subjectAltName=DNS:localhost,IP:127.0.0.1,IP:::1" \
+        2>/dev/null
+    log "Certificates generated in ${SCAN_DIR}"
+}
+
+extract_scanner() {
+    log "Extracting tls-scanner from ${SCANNER_IMAGE}..."
+    local container_name="tls-scanner-extract-$$"
+    podman create --name "${container_name}" "${SCANNER_IMAGE}" >/dev/null 2>&1
+    podman cp "${container_name}:/usr/local/bin/tls-scanner" "${SCAN_DIR}/tls-scanner"
+    podman cp "${container_name}:/opt/testssl" "${SCAN_DIR}/testssl"
+    podman rm "${container_name}" >/dev/null 2>&1
+    chmod +x "${SCAN_DIR}/tls-scanner"
+    export PATH="${SCAN_DIR}/testssl:${PATH}"
+    log "tls-scanner extracted"
+}
+
+generate_config() {
+    local profile_type="$1"
+    local config_file="${SCAN_DIR}/config-${profile_type}.yaml"
+    log "Generating OLS config for ${profile_type}..."
+    cat > "${config_file}" <<EOF
+llm_providers:
+  - name: test-provider
+    type: openai
+    url: "http://localhost:1234"
+    credentials_path: tests/config/secret/apitoken
+    models:
+      - name: test-model
+
+ols_config:
+  conversation_cache:
+    type: memory
+    memory:
+      max_entries: 10
+  default_provider: test-provider
+  default_model: test-model
+  logging_config:
+    app_log_level: warning
+    lib_log_level: warning
+  tls_config:
+    tls_certificate_path: ${SCAN_DIR}/server.crt
+    tls_key_path: ${SCAN_DIR}/server.key
+  tlsSecurityProfile:
+    type: ${profile_type}
+
+dev_config:
+  disable_auth: true
+  disable_tls: false
+EOF
+    log "Config written to ${config_file}"
+}
+
+start_ols() {
+    local profile_type="$1"
+    local config_file="${SCAN_DIR}/config-${profile_type}.yaml"
+    log "Starting OLS with ${profile_type} profile..."
+    OLS_CONFIG_FILE="${config_file}" .venv/bin/python runner.py > "${SCAN_DIR}/ols-${profile_type}.log" 2>&1 &
+    OLS_PID=$!
+}
+
+wait_for_ols() {
+    local max_wait=60
+    local waited=0
+    log "Waiting for OLS to be ready on port ${OLS_PORT}..."
+    while ! curl -sk "https://localhost:${OLS_PORT}/liveness" >/dev/null 2>&1; do
+        if ! kill -0 "${OLS_PID}" 2>/dev/null; then
+            log "ERROR: OLS process died during startup"
+            log "OLS log output:"
+            cat "${SCAN_DIR}/ols-"*.log 2>/dev/null || true
+            return 1
+        fi
+        if [[ ${waited} -ge ${max_wait} ]]; then
+            log "ERROR: OLS did not become ready within ${max_wait}s"
+            return 1
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    log "OLS ready on port ${OLS_PORT} (took ${waited}s)"
+}
+
+stop_ols() {
+    if [[ -n "${OLS_PID}" ]]; then
+        log "Stopping OLS (PID ${OLS_PID})..."
+        kill "${OLS_PID}" 2>/dev/null || true
+        wait "${OLS_PID}" 2>/dev/null || true
+        OLS_PID=""
+    fi
+}
+
+run_scan() {
+    local profile_type="$1"
+    log "Running tls-scanner for ${profile_type}..."
+    if "${SCAN_DIR}/tls-scanner" \
+        -host localhost \
+        -port "${OLS_PORT}" \
+        -json-file "${SCAN_DIR}/${profile_type}.json" \
+        -junit-file "${SCAN_DIR}/${profile_type}-junit.xml" \
+        -log-file "${SCAN_DIR}/${profile_type}-scan.log"; then
+        log "PASS: ${profile_type}"
+    else
+        log "FAIL: ${profile_type} (tls-scanner exit code: $?)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+run_pqc_check() {
+    log "Running tls-scanner PQC check (ML-KEM)..."
+    if "${SCAN_DIR}/tls-scanner" \
+        -host localhost \
+        -port "${OLS_PORT}" \
+        -pqc-check \
+        > "${SCAN_DIR}/pqc-check.log" 2>&1; then
+        log "PASS: ML-KEM (post-quantum)"
+    else
+        log "FAIL: ML-KEM (post-quantum) — tls-scanner exit code: $?"
+        log "PQC check output:"
+        cat "${SCAN_DIR}/pqc-check.log"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+report_results() {
+    local total=3
+    local passed=$((total - FAILURES))
+    echo ""
+    log "=== Results: ${passed}/${total} passed ==="
+    if [[ ${FAILURES} -gt 0 ]]; then
+        log "FAILED — ${FAILURES} scan(s) did not pass"
+        log "Inspect artifacts in ${SCAN_DIR} (re-run with TLS_SCAN_KEEP_ARTIFACTS=1)"
+        exit 1
+    fi
+    log "All TLS scans passed"
+}
+
+# --- Main ---
+generate_certs
+extract_scanner
+
+PASS_NUM=0
+for profile in IntermediateType ModernType; do
+    PASS_NUM=$((PASS_NUM + 1))
+    log "=== Pass ${PASS_NUM}/3: ${profile} ==="
+    generate_config "${profile}"
+    start_ols "${profile}"
+    if wait_for_ols; then
+        run_scan "${profile}"
+    else
+        log "FAIL: ${profile} (OLS did not start)"
+        FAILURES=$((FAILURES + 1))
+    fi
+    stop_ols
+done
+
+log "=== Pass 3/3: ML-KEM (post-quantum) ==="
+start_ols "ModernType"
+if wait_for_ols; then
+    run_pqc_check
+else
+    log "FAIL: ML-KEM (OLS did not start)"
+    FAILURES=$((FAILURES + 1))
+fi
+stop_ols
+
+report_results

--- a/scripts/tls-scan.sh
+++ b/scripts/tls-scan.sh
@@ -6,6 +6,7 @@ OLS_PORT=8443
 SCANNER_IMAGE="${SCANNER_IMAGE:-quay.io/openshift-lightspeed/ols-qe:tls-scanner}"
 OLS_PID=""
 FAILURES=0
+TOTAL_CHECKS=0
 
 log() {
     echo "[tls-scan] $*"
@@ -91,7 +92,7 @@ start_ols() {
     local profile_type="$1"
     local config_file="${SCAN_DIR}/config-${profile_type}.yaml"
     log "Starting OLS with ${profile_type} profile..."
-    OLS_CONFIG_FILE="${config_file}" .venv/bin/python runner.py > "${SCAN_DIR}/ols-${profile_type}.log" 2>&1 &
+    OLS_CONFIG_FILE="${config_file}" uv run python runner.py > "${SCAN_DIR}/ols-${profile_type}.log" 2>&1 &
     OLS_PID=$!
 }
 
@@ -158,7 +159,7 @@ run_pqc_check() {
 }
 
 report_results() {
-    local total=3
+    local total=${TOTAL_CHECKS}
     local passed=$((total - FAILURES))
     echo ""
     log "=== Results: ${passed}/${total} passed ==="
@@ -170,33 +171,31 @@ report_results() {
     log "All TLS scans passed"
 }
 
-# --- Main ---
 generate_certs
 extract_scanner
 
-PASS_NUM=0
 for profile in IntermediateType ModernType; do
-    PASS_NUM=$((PASS_NUM + 1))
-    log "=== Pass ${PASS_NUM}/3: ${profile} ==="
+    TOTAL_CHECKS=$((TOTAL_CHECKS + 1))
+    log "=== Check ${TOTAL_CHECKS}: ${profile} ==="
     generate_config "${profile}"
     start_ols "${profile}"
     if wait_for_ols; then
         run_scan "${profile}"
+        if [[ "${profile}" == "ModernType" ]]; then
+            TOTAL_CHECKS=$((TOTAL_CHECKS + 1))
+            log "=== Check ${TOTAL_CHECKS}: ML-KEM (post-quantum) ==="
+            run_pqc_check
+        fi
     else
         log "FAIL: ${profile} (OLS did not start)"
         FAILURES=$((FAILURES + 1))
+        if [[ "${profile}" == "ModernType" ]]; then
+            TOTAL_CHECKS=$((TOTAL_CHECKS + 1))
+            log "FAIL: ML-KEM (OLS did not start)"
+            FAILURES=$((FAILURES + 1))
+        fi
     fi
     stop_ols
 done
-
-log "=== Pass 3/3: ML-KEM (post-quantum) ==="
-start_ols "ModernType"
-if wait_for_ols; then
-    run_pqc_check
-else
-    log "FAIL: ML-KEM (OLS did not start)"
-    FAILURES=$((FAILURES + 1))
-fi
-stop_ols
 
 report_results


### PR DESCRIPTION
## Summary
- Add `scripts/tls-scan.sh` and `make tls-scan` Makefile target that runs the `openshift/tls-scanner` tool against locally-spawned OLS endpoints
- Verifies TLS security profile compliance (IntermediateType, ModernType) and post-quantum ML-KEM readiness
- The script generates self-signed certs, extracts tls-scanner from its container image (`quay.io/openshift-lightspeed/ols-qe:tls-scanner`), starts OLS with each profile, runs the scanner, and reports results with JUnit/JSON artifacts

## Known Issue
ModernType profile currently fails at OLS startup — TLS 1.3 ciphersuites are passed to `SSLContext.set_ciphers()` instead of `SSLContext.set_ciphersuites()`. Tracked in [OLS-3352](https://redhat.atlassian.net/browse/OLS-3352).

## Related Tickets
- [OLS-2866](https://redhat.atlassian.net/browse/OLS-2866) — This PR
- [OLS-3352](https://redhat.atlassian.net/browse/OLS-3352) — ModernType TLS bug (blocker for full pass)
- [OLS-3353](https://redhat.atlassian.net/browse/OLS-3353) — Follow-up: automate in CI

## Test plan
- [ ] Run `make tls-scan` locally — IntermediateType should pass, ModernType fails (known bug [OLS-3352](https://redhat.atlassian.net/browse/OLS-3352))
- [ ] Run `shellcheck scripts/tls-scan.sh` — no warnings
- [ ] Verify `TLS_SCAN_KEEP_ARTIFACTS=1 make tls-scan` preserves artifacts in `/tmp/ols-tls-scan/`
- [ ] Verify cleanup removes `/tmp/ols-tls-scan/` on normal exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `tls-scan` command to run TLS profile compliance checks against OLS endpoints.
  * The scan workflow now supports checking multiple TLS profiles and a PQC-related verification, with results saved as artifacts for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->