### PR TITLE
OLS-3311 Fix HuggingFace cache dir permissions in Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -99,6 +99,7 @@ RUN if [ -d /cachi2/output/deps/generic ]; then \
     done
 
 # Pre-populate HuggingFace cache so models can be loaded by ID with TRANSFORMERS_OFFLINE=1
+USER root
 RUN for model_dir in all-mpnet-base-v2 granite-embedding-30m-english; do \
     case "$model_dir" in \
       all-mpnet-base-v2) hf_id="sentence-transformers--all-mpnet-base-v2" ;; \
@@ -108,7 +109,8 @@ RUN for model_dir in all-mpnet-base-v2 granite-embedding-30m-english; do \
     mkdir -p "$repo_dir/snapshots/local" "$repo_dir/refs" && \
     echo "local" > "$repo_dir/refs/main" && \
     ln -sf "/app-root/embeddings_model/${model_dir}"/* "$repo_dir/snapshots/local/" ; \
-    done
+    done && \
+    chown -R 1001:0 /app-root/.cache
 
 # this directory is checked by ecosystem-cert-preflight-checks task in Konflux
 COPY LICENSE /licenses/


### PR DESCRIPTION
The HuggingFace cache population step runs as the default non-root user which cannot create /app-root/.cache. Switch to root for the mkdir/symlink operations and chown the result back to 1001:0.

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

/assign @blublinsky 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container startup reliability by ensuring preloaded model cache files are accessible to the app’s runtime user.
  * Reduced the chance of permission-related failures when loading embedding models from cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->