### PR TITLE
Pin langchain community to 0.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ dependencies = [
     "kubernetes<34.1.0",
     "psycopg2-binary>=2.9.9",
     "azure-identity>=1.18.0",
-    "langchain-community>=0.3.81",
+    "langchain-community>=0.3.81,<0.4.2",
     "sqlalchemy>=2.0.35",
     "ibm-watsonx-ai>=1.3.6",
     "certifi>=2024.8.30",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,8 @@ dependencies = [
     "kubernetes<34.1.0",
     "psycopg2-binary>=2.9.9",
     "azure-identity>=1.18.0",
+    # TODO: Remove upper bound once ragas fixes compatibility with langchain-community >= 0.4.2
+    # See: https://github.com/vibrantlabsai/ragas/issues/2741
     "langchain-community>=0.3.81,<0.4.2",
     "sqlalchemy>=2.0.35",
     "ibm-watsonx-ai>=1.3.6",

--- a/uv.lock
+++ b/uv.lock
@@ -2778,7 +2778,7 @@ requires-dist = [
     { name = "kubernetes", specifier = "<34.1.0" },
     { name = "langchain", specifier = ">=0.3.12" },
     { name = "langchain-aws", specifier = ">=1.6.0" },
-    { name = "langchain-community", specifier = ">=0.3.81" },
+    { name = "langchain-community", specifier = ">=0.3.81,<0.4.2" },
     { name = "langchain-google-genai", specifier = ">=4.0.0" },
     { name = "langchain-google-vertexai", specifier = ">=2.1.0" },
     { name = "langchain-ibm", specifier = ">=0.3.2" },


### PR DESCRIPTION
## Description

pinning langchain version to avoid ragas error in eval
Temporary workaround until there is a fix for https://github.com/vibrantlabsai/ragas/issues/2741. Without fix, eval is broken.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a third-party dependency version constraint to cap it within a tested, compatible release range.
  * Includes notes indicating the upper bound is temporary to address a compatibility concern and prevent unexpected behavior from newer versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->