### PR TITLE
OLS-3434 Add CI check for hermetic build hash file sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Put targets here if there is a risk that a target name might conflict with a filename.
 # this list is probably overkill right now.
 # See: https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html
-.PHONY: test test-unit test-e2e test-eval test-lseval-periodic test-lseval-troubleshooting test-cluster-updates images run format verify get-embeddings get-embeddings-byok get-embeddings-okp tls-scan
+.PHONY: test test-unit test-e2e test-eval test-lseval-periodic test-lseval-troubleshooting test-cluster-updates images run format verify verify-hermetic-requirements get-embeddings get-embeddings-byok get-embeddings-okp tls-scan
 
 export PATH := $(HOME)/.local/bin:$(PATH)
 
@@ -134,12 +134,15 @@ format: ## Format the code into unified format
 	uv run black .
 	uv run ruff check . --fix
 
-verify:	install-woke install-deps-test ## Verify the code using various linters
+verify:	install-woke install-deps-test verify-hermetic-requirements ## Verify the code using various linters
 	uv run black . --check
 	uv run ruff check .
 	./woke . --exit-1-on-failure
 	uv run --extra evaluation pylint ols scripts tests runner.py
 	uv run mypy --explicit-package-bases --disallow-untyped-calls --disallow-untyped-defs --disallow-incomplete-defs ols/
+
+verify-hermetic-requirements:	## Verify hermetic build hash files are in sync with uv.lock
+	bash scripts/verify_hermetic_requirements.sh
 
 schema:	## Generate OpenAPI schema file
 	uv run python scripts/generate_openapi_schema.py docs/openapi.json

--- a/scripts/verify_hermetic_requirements.sh
+++ b/scripts/verify_hermetic_requirements.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Verify that Konflux hermetic build hash files are in sync with uv.lock.
+# Catches PRs that update pyproject.toml/uv.lock without updating hash files.
+set -euo pipefail
+
+SOURCE_HASH_FILE=".konflux/requirements.hashes.source.txt"
+WHEEL_HASH_FILE=".konflux/requirements.hashes.wheel.txt"
+WHEEL_PYPI_HASH_FILE=".konflux/requirements.hashes.wheel.pypi.txt"
+
+# Packages in uv.lock runtime that are legitimately absent from hash files.
+# Keep this list minimal — a growing allowlist is a red flag.
+EXPECTED_MISSING=(
+    # Platform-specific (not built for linux x86_64)
+    pywin32
+
+    # Test packages pulled in transitively via langchain-google-vertexai
+    # → langchain-tests → pytest (and its plugin ecosystem)
+    iniconfig
+    langchain_tests
+    llama_index_cli
+    pluggy
+    py_cpuinfo
+    pytest
+    pytest_asyncio
+    pytest_benchmark
+    pytest_codspeed
+    pytest_recording
+    pytest_socket
+    syrupy
+    vcrpy
+
+    # Transitive deps resolved differently by uv export vs uv pip compile
+    # (extras, conditional markers, RHOAI overrides)
+    durationpy
+    grpcio_status
+    h2
+    hpack
+    hyperframe
+    importlib_metadata
+)
+
+log() { echo "==> $*"; }
+
+# PEP 503 normalization: lowercase, collapse [-_.]+ to single underscore
+normalize_names() {
+    sed 's/ *==.*//' | tr '[:upper:]' '[:lower:]' | sed 's/[-_.]\{1,\}/_/g' | sort -u
+}
+
+# --- Extract runtime packages from uv.lock ---
+log "Exporting runtime dependencies from uv.lock"
+UV_RUNTIME=$(uv export --locked --no-dev --no-editable --no-header --no-annotate --format requirements.txt \
+    | grep -E '^[a-zA-Z0-9]' \
+    | normalize_names)
+UV_COUNT=$(echo "$UV_RUNTIME" | wc -l | tr -d ' ')
+
+# --- Validate hash files exist ---
+for hash_file in "$SOURCE_HASH_FILE" "$WHEEL_HASH_FILE" "$WHEEL_PYPI_HASH_FILE"; do
+    if [[ ! -r "$hash_file" ]]; then
+        echo "ERROR: required hash file is missing or unreadable: $hash_file" >&2
+        exit 1
+    fi
+done
+
+# --- Extract packages from all three hash files ---
+log "Parsing hash files"
+HASH_PKGS=$( {
+    grep -E '^[a-zA-Z0-9]' "$SOURCE_HASH_FILE"
+    grep -E '^[a-zA-Z0-9]' "$WHEEL_HASH_FILE"
+    grep -E '^[a-zA-Z0-9]' "$WHEEL_PYPI_HASH_FILE" || true
+} | normalize_names)
+HASH_COUNT=$(echo "$HASH_PKGS" | grep -c . || true)
+
+# --- Build allowlist set ---
+ALLOW_SET=$(printf '%s\n' "${EXPECTED_MISSING[@]}" | normalize_names)
+ALLOW_COUNT=$(echo "$ALLOW_SET" | grep -c . || true)
+
+# --- Compute missing = (uv_runtime - hash_pkgs - allowlist) ---
+MISSING=$(comm -23 <(echo "$UV_RUNTIME") <(echo "$HASH_PKGS") \
+    | comm -23 - <(echo "$ALLOW_SET"))
+MISSING_COUNT=$(echo "$MISSING" | grep -c . || true)
+COVERED=$((HASH_COUNT + ALLOW_COUNT))
+
+# --- Check for stale allowlist entries ---
+STALE=$(
+    {
+        comm -23 <(echo "$ALLOW_SET") <(echo "$UV_RUNTIME")
+        comm -12 <(echo "$ALLOW_SET") <(echo "$HASH_PKGS")
+    } | sed '/^$/d' | sort -u
+)
+STALE_COUNT=$(echo "$STALE" | grep -c . || true)
+
+# --- Report ---
+log "$UV_COUNT runtime packages in uv.lock, $ALLOW_COUNT allowlisted, $HASH_COUNT in hash files"
+
+EXIT_CODE=0
+
+if [[ $MISSING_COUNT -gt 0 ]]; then
+    echo ""
+    echo "ERROR: $MISSING_COUNT package(s) in uv.lock but NOT in any hash file or allowlist:"
+    echo "$MISSING" | sed 's/^/  - /'
+    echo ""
+    echo "Fix: run 'make konflux-requirements' or surgically add the missing packages."
+    echo "See CLAUDE.md for the surgical approach."
+    EXIT_CODE=1
+fi
+
+if [[ $STALE_COUNT -gt 0 ]]; then
+    echo ""
+    echo "ERROR: $STALE_COUNT allowlist entry/entries no longer in uv.lock (stale):"
+    echo "$STALE" | sed 's/^/  - /'
+    echo ""
+    echo "Fix: remove stale entries from EXPECTED_MISSING in this script."
+    EXIT_CODE=1
+fi
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+    log "All runtime packages accounted for."
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Description

  Summary

  - Add make verify-hermetic-requirements that verifies all runtime dependencies in uv.lock are present in the Konflux hermetic build hash files
  (requirements.hashes.source.txt / requirements.hashes.wheel.txt)
  - Runs as part of make verify (Prow CI), so PRs that add deps to pyproject.toml without updating hash files will fail
  - Also detects stale entries in the allowlist when packages are removed from uv.lock

  Context

  [OLS-3417](https://redhat.atlassian.net/browse/OLS-3417) fixed a production crash caused by missing opentelemetry and Bedrock deps in the hermetic build. Two PRs had updated pyproject.toml and uv.lock but
  forgot to update the hash files. This check would have caught both before merge.

  Test plan

  - [x] make verify-hermetic-requirements passes on current main
  - [x] Removing a package from hash files causes the check to fail
  - [x] Adding a stale entry to the allowlist causes the check to fail
  - [x] Prow verify job passes
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a stricter verification step to ensure the runtime dependency set remains aligned with the hermetic build coverage.
  * Verification now provides clearer error details (including missing dependencies and stale allowlist items) and fails when discrepancies are detected.
* **Chores**
  * Introduced a new hermetic requirements check and wired it into the existing verification workflow to compare normalized runtime exports against the hermetic hash inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->