### PR TITLE
OLS-3432 Add dynamic product filtering spec to RAG docs

### DIFF
--- a/.ai/spec/what/rag.md
+++ b/.ai/spec/what/rag.md
@@ -24,6 +24,8 @@ The RAG subsystem augments LLM responses with relevant documentation so that ans
 
 10. [OLS-1894] When the `OLS_ROSA_PRODUCT` environment variable is set (by the operator on ROSA clusters), the Solr `chunk_filter_query` includes the ROSA product alongside `openshift_container_platform`. The filter becomes a compound OR: `(product:openshift_container_platform AND product_version:<ocp_resolved>) OR (product:<rosa_product> AND product_version:<rosa_resolved>)`. ROSA product version resolution uses the same facet-query + clamp-to-nearest mechanism as OCP: extract the major version from `OCP_CLUSTER_VERSION`, query Solr for available versions of the ROSA product, and clamp to nearest. When `OLS_ROSA_PRODUCT` is absent, the filter is OCP-only (no change from current behavior). If the ROSA product is not found in Solr, the service logs a warning and falls back to OCP-only filtering.
 
+11. [PLANNED: OLS-3432] The `search_openshift_documentation` tool must support dynamic product filtering via an optional `additional_products` argument. At startup, available OpenShift-related products are discovered from Solr (facet query on `product:*openshift*`), excluding `openshift_container_platform` and ROSA products (`red_hat_openshift_service_on_aws`, `red_hat_openshift_service_on_aws_classic_architecture`). The discovered product names are listed in the tool description so the LLM can select relevant products per query. When `additional_products` is provided, the Solr `fq` becomes a compound OR: OCP (version-pinned) + each additional product (no version filter — layered products use independent versioning). Invalid product names are rejected. When `additional_products` is absent or empty, the filter is the static baseline (OCP-only, or OCP+ROSA on ROSA clusters). ROSA products are never in the dynamic list — they are handled by the static filter from OLS-1894.
+
 ## Behavioral Rules — BYOK Retrieval (Customer Content)
 
 1. BYOK FAISS vector indexes are built offline from customer-supplied Markdown documentation. Indexes are loaded from the local filesystem at startup and are never built or modified at runtime.
@@ -127,5 +129,5 @@ Customers can supply their own documentation as additional RAG indexes, so that 
 - [PLANNED: OLS-1872] BYOK — internal web source integration (Git, Confluence).
 - [PLANNED: OLS-1812] Add embedding model path to CRD for each index, enabling per-index embedding model configuration through the operator.
 - [PENDING] OKP server-side embedding — if OKP team confirms, the granite model can be removed from the service image.
-- [PLANNED] Multi-product OKP filtering — product-scoped retrieval for OpenStack and other layered products.
+- [PLANNED: OLS-3432] Dynamic product filtering — LLM-driven selection of additional OpenShift-related products (Pipelines, GitOps, Service Mesh, etc.) via tool argument. Depends on OLS-3310.
 - [PLANNED] Multi-version OKP support — query specific OCP version documentation.


### PR DESCRIPTION
## Summary
- Adds behavioral rule 10 to `.ai/spec/what/rag.md` for dynamic product filtering in the OKP Solr search tool ([OLS-3432](https://redhat.atlassian.net/browse/OLS-3432))
- Updates planned changes to replace generic "Multi-product OKP filtering" with the specific [OLS-3432](https://redhat.atlassian.net/browse/OLS-3432) entry
- Design spec: `docs/superpowers/specs/2026-07-06-dynamic-product-filtering.md` (in workspace root)

## Design
At startup, discover available OpenShift-related products from Solr (facet query on `product:*openshift*`), excluding OCP and ROSA products. Expose them as an optional `additional_products` argument on `search_openshift_documentation`. The LLM selects relevant products per query. OCP remains the always-included baseline. No version filter on additional products (independent versioning).

Depends on: [OLS-3310](https://redhat.atlassian.net/browse/OLS-3310) (PR #2926)

## Test plan
- [ ] Spec-only change — no code changes, no tests needed
- [ ] Verify spec consistency with [OLS-3310](https://redhat.atlassian.net/browse/OLS-3310) (PR #2926) codebase


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the RAG specification for the `search_openshift_documentation` tool to define dynamic multi-product filtering via an optional `additional_products` argument.
  * Documented how product names are discovered at startup, how the Solr filter logic changes when additional products are provided, and how invalid product names are rejected.
  * Clarified that ROSA products are excluded from the dynamic list and handled through the existing static ROSA filtering mechanism.
  * Replaced the previous placeholder roadmap item with the new planned dynamic filtering enhancement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->