### PR TITLE
OTA-1927 Fix cluster-updates model mismatch (gpt-4o-mini → gpt-4.1-mini)

### DIFF
--- a/tests/config/operator_install/olsconfig.crd.openai_cluster_updates.yaml
+++ b/tests/config/operator_install/olsconfig.crd.openai_cluster_updates.yaml
@@ -14,11 +14,11 @@ spec:
       - credentialsSecretRef:
           name: llmcreds
         models:
-          - name: gpt-4o-mini
+          - name: gpt-4.1-mini
         name: openai
         type: openai
   ols:
-    defaultModel: gpt-4o-mini
+    defaultModel: gpt-4.1-mini
     defaultProvider: openai
     deployment:
       replicas: 1

--- a/tests/scripts/test-cluster-updates.sh
+++ b/tests/scripts/test-cluster-updates.sh
@@ -46,14 +46,14 @@ function run_suites() {
   set +e
   echo "=== Running cluster_updates evaluation suite ==="
   echo "  Provider: openai"
-  echo "  Model: gpt-4o-mini"
+  echo "  Model: gpt-4.1-mini"
   echo "  Config suffix: cluster_updates"
   echo "  Artifact dir: $ARTIFACT_DIR"
 
   # Deploy OLS with OpenAI GPT-4o-mini and run cluster-updates evaluation (18 conversations, 35 evaluations).
   # run_suite arguments: suiteid test_tags provider provider_keypath model ols_image ols_config_suffix
   # OLS_CONFIG_SUFFIX="cluster_updates" → ols_installer builds: olsconfig.crd.openai_cluster_updates.yaml
-  run_suite "cluster_updates" "cluster_updates" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4o-mini" "$OLS_IMAGE" "cluster_updates"
+  run_suite "cluster_updates" "cluster_updates" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "cluster_updates"
   rc=$?
 
   if [ $rc -ne 0 ]; then


### PR DESCRIPTION
## Summary
- The OLSConfig (`olsconfig.crd.openai_cluster_updates.yaml`) and test script (`test-cluster-updates.sh`) deployed OLS with `gpt-4o-mini` as the only valid model
- The eval system config (`system_cluster_updates.yaml`) sends requests with `model: "gpt-4.1-mini"`
- This mismatch caused OLS to reject every cluster-updates query with HTTP 422: `Model 'gpt-4.1-mini' is not a valid model for provider 'openai'. Valid models are: ['gpt-4o-mini']`
- Fix: update the OLSConfig and test script to use `gpt-4.1-mini`, aligning with the eval config

## Test plan
- [ ] Verify `ols-cluster-updates-periodics` CI job passes with the updated config
- [ ] Confirm OLS accepts `gpt-4.1-mini` requests without HTTP 422 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the cluster-updates test setup to use a newer model configuration.
  * Adjusted the related test script to run with the updated model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->