### PR TITLE
OLS-3313: Deprecate OCP-specific FAISS RAG in favor of OKP Solr

### DIFF
--- a/.ai/spec/what/rag.md
+++ b/.ai/spec/what/rag.md
@@ -32,7 +32,7 @@ The RAG subsystem augments LLM responses with relevant documentation so that ans
 
 4. Each index must be loaded independently. If one index fails to load, the remaining indexes must continue loading and the service must operate with whatever indexes succeeded. Partial load must be logged as a warning.
 
-5. When a configured index path does not exist, the system must attempt to locate a `latest` directory in the parent of the configured path. If found, the system must use that path and clear the configured `product_docs_index_id` (since the actual index identity is unknown). If neither the configured path nor the `latest` fallback exists, the index must fail to load.
+5. When a configured index path does not exist, validation must fail immediately with a hard configuration error. There is no fallback logic — BYOK users supply their own paths and are responsible for ensuring they exist.
 
 6. The embedding model used for BYOK vector similarity is configurable via a filesystem path to a HuggingFace-compatible model (`embeddings_model_path`). If no path is configured, the service must fall back to the default model (`sentence-transformers/all-mpnet-base-v2`), which is bundled directly in the service image. The chosen model must be redistributable under an Apache 2.0 compatible license. [PLANNED: OLS-1812 — operator CRD support for per-index embedding model path]
 
@@ -51,7 +51,7 @@ The RAG subsystem augments LLM responses with relevant documentation so that ans
     - If no reference content is configured, RAG libraries must never be loaded.
     - Type annotations for RAG-specific types must be aliased to `Any` at module scope to avoid import-time dependencies.
 
-13. The readiness probe must check whether the BYOK index has finished loading. If reference content is configured but the index has not yet loaded, the service must report not ready (HTTP 503) with cause "Index is not ready". If no reference content is configured (BYOK is absent and only OKP is active), the index check must pass — BYOK RAG is optional. The service must not accept user queries until any configured BYOK index is fully loaded.
+13. The readiness probe must check whether the BYOK index has finished loading. If reference content is configured with a non-empty indexes list but the index has not yet loaded, the service must report not ready (HTTP 503) with cause "Index is not ready". If no reference content is configured, or if reference content is present but has no indexes (empty list or None), the index check must pass — BYOK RAG is optional. The service must not accept user queries until any configured BYOK index is fully loaded.
 
 ## Behavioral Rules — Tool & Skill Filtering (Hybrid RAG)
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,6 @@
 # vim: set filetype=dockerfile
-ARG LIGHTSPEED_RAG_CONTENT_IMAGE=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/own-app-lightspeed-rag-content@sha256:d78b0dc9eb2f15cad9b3a79c886cbeba9c385798b91ae5f8e4a13e1168238298
 ARG BUILDER_BASE_IMAGE=registry.redhat.io/rhel9/python-312@sha256:46f883684d02cef2a7abb0c4124f18308ad920018d76c5c56f130dae02bfed05
 ARG RUNTIME_BASE_IMAGE=registry.redhat.io/rhel9/python-312-minimal@sha256:804b928fd278fa03c2edf0352378eca73c8efcf665c6e0180e074340b9f22a50
-FROM --platform=linux/amd64 ${LIGHTSPEED_RAG_CONTENT_IMAGE} AS lightspeed-rag-content
 
 FROM --platform=$BUILDPLATFORM ${BUILDER_BASE_IMAGE} AS builder
 ARG BUILDER_DNF_COMMAND=dnf
@@ -93,7 +91,6 @@ COPY --from=builder /app-root/.venv .venv
 COPY --from=builder /app-root/.tiktoken_cache .tiktoken_cache
 COPY ols ./ols
 COPY runner.py /app-root/runner.py
-COPY --from=lightspeed-rag-content /rag/vector_db/ocp_product_docs ./vector_db/ocp_product_docs
 COPY --chmod=775 embeddings_model ./embeddings_model
 RUN if [ -d /cachi2/output/deps/generic ]; then \
     cp /cachi2/output/deps/generic/all-mpnet-base-v2-model.safetensors embeddings_model/all-mpnet-base-v2/model.safetensors ; \

--- a/docs/ai/config.md
+++ b/docs/ai/config.md
@@ -107,11 +107,6 @@ If you add a new config class that needs file existence checks or cross-section 
 
 Omit the key to leave Solr hybrid RAG off (no client, no tool). When present, values map to `SolrHybridSettings` and the feature is active. `solr_http_base` must be a valid `http` or `https` URL with a host (checked in `validate_yaml()`).
 
-When ``solr_hybrid`` is defined, every entry under ``reference_content.indexes``
-must include ``byok_index: true`` if any local indexes are configured. That rejects
-Solr together with an unmarked local vector index (duplicate product RAG); omit
-``indexes`` for Solr-only, or mark BYOK indexes explicitly.
-
 ```yaml
 ols_config:
   solr_hybrid:
@@ -119,9 +114,8 @@ ols_config:
     # max_results, hybrid_*, max_expansion_neighbors: optional overrides
 ```
 
-Do not duplicate the same product documentation in Solr and a local product index.
-You may use ``solr_hybrid`` for product docs and ``reference_content`` for separate
-BYOK indexes; each BYOK row must set ``byok_index: true`` when ``solr_hybrid`` is present.
+Product documentation is served exclusively via Solr (OKP). Local FAISS indexes
+under ``reference_content`` are for BYOK (user-supplied) content only.
 
 ### Hybrid search and chunk expansion
 

--- a/docs/config.puml
+++ b/docs/config.puml
@@ -187,7 +187,6 @@ class "ReferenceContentIndex" as ols.app.models.config.ReferenceContentIndex {
   product_docs_index_id : Optional[str]
   product_docs_index_path : Optional[FilePath]
   product_docs_origin : Optional[str]
-  byok_index : bool
   validate_yaml() -> None
 }
 class "SchedulerConfig" as ols.app.models.config.SchedulerConfig {

--- a/examples/olsconfig-local-ollama.yaml
+++ b/examples/olsconfig-local-ollama.yaml
@@ -18,10 +18,6 @@ llm_providers:
       - name: 'llama3.1:latest'
 ols_config:
   # max_workers: 1
-  reference_content:
-#    indexes:
-#      - product_docs_index_path: "./vector_db/ocp_product_docs/4.15"
-#        product_docs_index_id: ocp-product-docs-4_15
   conversation_cache:
     type: memory
     memory:

--- a/examples/olsconfig.yaml
+++ b/examples/olsconfig.yaml
@@ -78,13 +78,11 @@ ols_config:
   # Product docs via Solr hybrid (OKP).  Omit solr_hybrid to disable.
   solr_hybrid:
     solr_http_base: "https://solr.example.com:8983"
-  # BYOK / local FAISS indexes.
-  # With solr_hybrid present, every index must set byok_index: true.
+  # BYOK / local FAISS indexes (user-supplied content only).
   reference_content:
     indexes:
       - product_docs_index_path: "./vector_db/user_application_docs/version_1"
         product_docs_index_id: user-application-docs-version_1
-        byok_index: true
   conversation_cache:
     type: memory
     memory:

--- a/examples/openshift-lightspeed-tls.yaml
+++ b/examples/openshift-lightspeed-tls.yaml
@@ -212,10 +212,6 @@ data:
           - name: <model-name-2>
     ols_config:
       max_workers: 1
-      reference_content:
-        indexes:
-          - product_docs_index_path: "./vector_db/ocp_product_docs/4.15"
-            product_docs_index_id: ocp-product-docs-4_15
       conversation_cache:
         type: memory
         memory:

--- a/ols/app/endpoints/health.py
+++ b/ols/app/endpoints/health.py
@@ -62,9 +62,10 @@ def llm_is_ready() -> bool:
 
 def index_is_ready() -> bool:
     """Check if the index is loaded."""
-    if config.rag_index is None and config.ols_config.reference_content is not None:
-        return False
-    return True
+    ref = config.ols_config.reference_content
+    if ref is None or not ref.indexes:
+        return True
+    return config.rag_index is not None
 
 
 def cache_is_ready() -> bool:

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -975,19 +975,17 @@ class LoggingConfig(BaseModel):
 
 
 class ReferenceContentIndex(BaseModel):
-    """One on-disk FAISS / vector index (e.g. BYOK or other local RAG stores).
+    """One on-disk FAISS / vector index for BYOK RAG stores.
 
     Field names are historical: ``product_docs_*`` is used for any persisted
-    LlamaIndex vector store path, not only shipped product documentation. Managed
-    OpenShift product docs are typically retrieved via ``ols_config.solr_hybrid``
-    instead of a second index here. When ``solr_hybrid`` is enabled, any local index
-    listed alongside it must set ``byok_index: true`` (see ``OLSConfig.validate_yaml``).
+    LlamaIndex vector store path. Managed OpenShift product docs are served
+    exclusively via ``ols_config.solr_hybrid`` (OKP); this class is only for
+    user-supplied BYOK indexes.
     """
 
     product_docs_index_path: Optional[FilePath] = None
     product_docs_index_id: Optional[str] = None
     product_docs_origin: Optional[str] = None
-    byok_index: bool = False
 
     def __init__(self, data: Optional[dict] = None) -> None:
         """Initialize configuration and perform basic validation."""
@@ -997,34 +995,17 @@ class ReferenceContentIndex(BaseModel):
         self.product_docs_index_path = data.get("product_docs_index_path", None)
         self.product_docs_index_id = data.get("product_docs_index_id", None)
         self.product_docs_origin = data.get("product_docs_origin", None)
-        self.byok_index = bool(data.get("byok_index", False))
 
     def validate_yaml(self) -> None:
         """Validate reference content index config."""
         if self.product_docs_index_path is not None:
-            try:
-                checks.dir_check(
-                    self.product_docs_index_path, "Reference content index path"
-                )
-            except checks.InvalidConfigurationError as e_original:
-                # special case for OCP documents not having the current version.
-                # we use the "latest" version from the vector store directory.
-                default_path = os.path.join(
-                    os.path.dirname(self.product_docs_index_path), "latest"
-                )
-                try:
-                    checks.dir_check(default_path, "Reference content index path")
-                    self.product_docs_index_path = FilePath(default_path)
-                    # we don't know the index_id for "latest" so ignore what
-                    # the config says and load whatever index is there
-                    self.product_docs_index_id = None
-                except checks.InvalidConfigurationError:
-                    raise e_original
-        else:
-            if self.product_docs_index_id is not None:
-                raise checks.InvalidConfigurationError(
-                    "product_docs_index_id is specified but product_docs_index_path is missing"
-                )
+            checks.dir_check(
+                self.product_docs_index_path, "Reference content index path"
+            )
+        elif self.product_docs_index_id is not None:
+            raise checks.InvalidConfigurationError(
+                "product_docs_index_id is specified but product_docs_index_path is missing"
+            )
 
 
 class ReferenceContent(BaseModel):
@@ -1414,24 +1395,6 @@ class OLSConfig(BaseModel):
             self.proxy_config.validate_yaml()
         if self.solr_hybrid is not None:
             self.solr_hybrid.validate_yaml()
-        self._validate_solr_hybrid_vs_reference_indexes()
-
-    def _validate_solr_hybrid_vs_reference_indexes(self) -> None:
-        """Reject Solr hybrid together with local indexes that are not BYOK-only."""
-        solr = self.solr_hybrid
-        if solr is None:
-            return
-        rc = self.reference_content
-        if rc is None or not rc.indexes:
-            return
-        if any(not idx.byok_index for idx in rc.indexes):
-            raise checks.InvalidConfigurationError(
-                "ols_config.solr_hybrid is enabled together with "
-                "ols_config.reference_content.indexes entries that are not marked "
-                "BYOK-only. Remove local product vector indexes when using Solr, or set "
-                "byok_index: true on each index that is intentionally kept with Solr "
-                "(e.g. BYOK)."
-            )
 
 
 class DevConfig(BaseModel):

--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -159,10 +159,11 @@ class AppConfig:
     @property
     def rag_index_loader(self) -> Optional[IndexLoader]:
         """Return the RAG index loader, or ``None`` when no reference content is configured."""
-        if self.config.ols_config.reference_content is None:  # type: ignore[attr-defined]
+        ref = self.config.ols_config.reference_content  # type: ignore[attr-defined]
+        if ref is None or not ref.indexes:
             return None
         if self._rag_index_loader is None:
-            self._rag_index_loader = IndexLoader(self.ols_config.reference_content)
+            self._rag_index_loader = IndexLoader(ref)
         return self._rag_index_loader
 
     def _byok_embed_model(self) -> Any:

--- a/tests/unit/app/endpoints/test_health.py
+++ b/tests/unit/app/endpoints/test_health.py
@@ -172,7 +172,7 @@ def test_readiness_probe_get_method_index_is_ready():
     ):
         # simulate that the index is loaded
         config._rag_index_loader = Mock(vector_indexes=["idx"])
-        config.ols_config.reference_content = "some content"
+        config.ols_config.reference_content = Mock(indexes=["idx_cfg"])
         assert index_is_ready()
         response = readiness_probe_get_method()
         assert response == ReadinessResponse(ready=True, reason="service is ready")
@@ -185,12 +185,20 @@ def test_readiness_probe_get_method_index_is_ready():
         response = readiness_probe_get_method()
         assert response == ReadinessResponse(ready=True, reason="service is ready")
 
+        # reference_content present but no indexes — should still be ready
+        config._rag_index_loader = None
+        config.ols_config.reference_content = Mock(indexes=None)
+        assert index_is_ready()
+
+        config.ols_config.reference_content = Mock(indexes=[])
+        assert index_is_ready()
+
 
 def test_readiness_probe_get_method_index_not_ready():
     """Test the readiness_probe function when index is not loaded."""
     with patch("ols.app.endpoints.health.llm_is_ready_persistent_state", new=True):
         config._rag_index_loader = Mock(vector_indexes=None)
-        config.ols_config.reference_content = "something else than None"
+        config.ols_config.reference_content = Mock(indexes=["idx_cfg"])
 
         assert not index_is_ready()
         with pytest.raises(HTTPException, match="Service is not ready"):

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -2336,60 +2336,6 @@ def test_ols_config_validate_yaml_solr_hybrid_rejects_invalid_base_url():
         ols_config.validate_yaml(disable_tls=True)
 
 
-def test_ols_config_validate_yaml_rejects_solr_with_non_byok_indexes(tmp_path):
-    """Solr enabled with local indexes requires byok_index on each index row."""
-    idx_dir = tmp_path / "idx"
-    idx_dir.mkdir()
-    ols_config = OLSConfig(
-        {
-            "default_provider": "p",
-            "default_model": "m",
-            "conversation_cache": {"type": "memory", "memory": {"max_entries": 10}},
-            "logging_config": {"logging_level": "INFO"},
-            "solr_hybrid": {
-                "solr_http_base": "https://solr.example.com",
-            },
-            "reference_content": {
-                "indexes": [
-                    {
-                        "product_docs_index_path": str(idx_dir),
-                        "product_docs_index_id": "idx1",
-                    }
-                ],
-            },
-        }
-    )
-    with pytest.raises(InvalidConfigurationError, match="byok_index"):
-        ols_config.validate_yaml(disable_tls=True)
-
-
-def test_ols_config_validate_yaml_allows_solr_with_byok_indexes(tmp_path):
-    """Solr plus BYOK-marked local indexes passes validation."""
-    idx_dir = tmp_path / "idx"
-    idx_dir.mkdir()
-    ols_config = OLSConfig(
-        {
-            "default_provider": "p",
-            "default_model": "m",
-            "conversation_cache": {"type": "memory", "memory": {"max_entries": 10}},
-            "logging_config": {"logging_level": "INFO"},
-            "solr_hybrid": {
-                "solr_http_base": "https://solr.example.com",
-            },
-            "reference_content": {
-                "indexes": [
-                    {
-                        "product_docs_index_path": str(idx_dir),
-                        "product_docs_index_id": "idx1",
-                        "byok_index": True,
-                    }
-                ],
-            },
-        }
-    )
-    ols_config.validate_yaml(disable_tls=True)
-
-
 def test_ols_config_tool_round_cap_fraction():
     """tool_round_cap_fraction is on OLSConfig and uses TOOL_ROUND_CAP_FRACTION bounds."""
     base = {
@@ -3208,16 +3154,6 @@ def test_reference_content_index_constructor():
     )
     assert reference_content_index.product_docs_index_id == "id"
     assert reference_content_index.product_docs_index_path == "/path/"
-    assert reference_content_index.byok_index is False
-
-    byok = ReferenceContentIndex(
-        {
-            "product_docs_index_id": "id2",
-            "product_docs_index_path": "/path2/",
-            "byok_index": True,
-        }
-    )
-    assert byok.byok_index is True
 
 
 def test_reference_content_index_equality():
@@ -3346,12 +3282,8 @@ def test_reference_content_yaml_validation():
         reference_content.validate_yaml()
 
 
-def test_reference_content_yaml_validation_fallback_to_default_dir(tmp_path):
-    """Test the ReferenceContent YAML validation method fallback to default dir."""
-    default_dir = tmp_path / "latest"
-    default_dir.mkdir()
-
-    # index path to inexistent dir in the temp dir should fallback to "default" dir
+def test_reference_content_yaml_validation_nonexistent_dir(tmp_path):
+    """Test that validation raises for a non-existent index directory."""
     inexistent_dir = tmp_path / "non_existing_dir"
     reference_content = ReferenceContent()
     reference_content.indexes = [
@@ -3359,12 +3291,6 @@ def test_reference_content_yaml_validation_fallback_to_default_dir(tmp_path):
             {"product_docs_index_id": "foo", "product_docs_index_path": inexistent_dir}
         )
     ]
-    reference_content.validate_yaml()
-    assert reference_content.indexes[0].product_docs_index_path == default_dir
-    assert reference_content.indexes[0].product_docs_index_id is None
-
-    # exception should be raised if the default dir does not exist, either
-    default_dir.rmdir()
     with pytest.raises(
         InvalidConfigurationError,
         match=r"Reference content index path '.+' does not exist",


### PR DESCRIPTION
## Description

**Summary**
- Remove `byok_index` field from `ReferenceContentIndex` — all local FAISS indexes
  are now BYOK by definition; OCP product docs are served exclusively via OKP/Solr
- Remove the `latest` version fallback in `ReferenceContentIndex.validate_yaml()` —
  non-existent index paths are a hard config error
- Remove `_validate_solr_hybrid_vs_reference_indexes` cross-validation — no longer
  needed when every local index is BYOK
- Fix readiness probe deadlock when `reference_content` is present but has no indexes
  (unblocks operator PR #1653 dropping RAG from the CR)
- Clean up examples and docs to reflect BYOK-only local FAISS

## Type of change

- [ ] Refactor
- [ x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
https://redhat.atlassian.net/browse/OLS-3313
- Closes #
https://redhat.atlassian.net/browse/OLS-3313

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness behavior: “not ready” now triggers only when reference content is configured with a non-empty indexes list while BYOK indexes are not yet loaded; readiness passes when reference content is absent or has no indexes.
  * Tightened configuration validation to fail immediately if a configured BYOK index path does not exist (removed the previous directory fallback).

* **Documentation**
  * Updated docs and examples for Solr hybrid and local BYOK reference-content setup, clarifying that product docs come from Solr while local FAISS indexes are for user-supplied content.

* **Build/Packaging**
  * Removed prepopulated product-doc vector content from the container image.

* **Tests**
  * Updated unit tests to match the revised readiness and configuration validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->