### PR TITLE
OLS-1894 Add ROSA product support to Solr chunk filter query

### DIFF
--- a/.ai/spec/what/rag.md
+++ b/.ai/spec/what/rag.md
@@ -22,7 +22,7 @@ The RAG subsystem augments LLM responses with relevant documentation so that ans
 
 9. Tool calling is enabled when Solr hybrid is configured, even without MCP servers. This ensures OKP retrieval works in non-agentic deployments.
 
-10. [PLANNED: OLS-1894] When the `OLS_ROSA_PRODUCT` environment variable is set (by the operator on ROSA clusters), the Solr `chunk_filter_query` must include the ROSA product alongside `openshift_container_platform`. The filter becomes a compound OR: `(product:openshift_container_platform AND product_version:<ocp_resolved>) OR (product:<rosa_product> AND product_version:<rosa_resolved>)`. ROSA product version resolution uses the same facet-query + clamp-to-nearest mechanism as OCP: extract the major version from `OCP_CLUSTER_VERSION`, query Solr for available versions of the ROSA product, and clamp to nearest. When `OLS_ROSA_PRODUCT` is absent, the filter is OCP-only (no change from current behavior).
+10. [OLS-1894] When the `OLS_ROSA_PRODUCT` environment variable is set (by the operator on ROSA clusters), the Solr `chunk_filter_query` includes the ROSA product alongside `openshift_container_platform`. The filter becomes a compound OR: `(product:openshift_container_platform AND product_version:<ocp_resolved>) OR (product:<rosa_product> AND product_version:<rosa_resolved>)`. ROSA product version resolution uses the same facet-query + clamp-to-nearest mechanism as OCP: extract the major version from `OCP_CLUSTER_VERSION`, query Solr for available versions of the ROSA product, and clamp to nearest. When `OLS_ROSA_PRODUCT` is absent, the filter is OCP-only (no change from current behavior). If the ROSA product is not found in Solr, the service logs a warning and falls back to OCP-only filtering.
 
 ## Behavioral Rules — BYOK Retrieval (Customer Content)
 
@@ -122,7 +122,7 @@ Customers can supply their own documentation as additional RAG indexes, so that 
 
 ## Planned Changes
 
-- [PLANNED: OLS-1894] ROSA-aware OKP retrieval — extend `chunk_filter_query` to include ROSA product docs when `OLS_ROSA_PRODUCT` env var is set by the operator.
+- [DONE: OLS-1894] ROSA-aware OKP retrieval — service reads `OLS_ROSA_PRODUCT` env var and builds compound Solr filter. Operator-side detection pending.
 - [PLANNED: OLS-2704] RAG as a service / MCP — externalize RAG retrieval behind an MCP interface.
 - [PLANNED: OLS-1872] BYOK — internal web source integration (Git, Confluence).
 - [PLANNED: OLS-1812] Add embedding model path to CRD for each index, enabling per-index embedding model configuration through the operator.

--- a/ols/src/rag_index/solr_support.py
+++ b/ols/src/rag_index/solr_support.py
@@ -353,10 +353,15 @@ class SolrHybridSearch:
 
     _OCP_CLUSTER_VERSION_ENV = "OCP_CLUSTER_VERSION"
     _OCP_PRODUCT = "openshift_container_platform"
+    _ROSA_PRODUCT_ENV = "OLS_ROSA_PRODUCT"
 
     @staticmethod
     def _resolve_chunk_filter_query(solr_http_base: str, timeout_s: float) -> str:
         """Build ``chunk_filter_query`` from the cluster's OCP version.
+
+        When ``OLS_ROSA_PRODUCT`` is set (by the operator on ROSA clusters),
+        the filter becomes a compound OR including both OCP and ROSA product
+        documentation.
 
         Raises:
             InvalidConfigurationError: If ``OCP_CLUSTER_VERSION`` is not set
@@ -370,34 +375,77 @@ class SolrHybridSearch:
             )
 
         env_version = env_version.strip()
-        available = SolrHybridSearch._fetch_available_ocp_versions(
-            solr_http_base, timeout_s
+        ocp_resolved = SolrHybridSearch._resolve_product_version(
+            SolrHybridSearch._OCP_PRODUCT, solr_http_base, timeout_s, env_version
+        )
+
+        ocp_filter = (
+            f"(product:{SolrHybridSearch._OCP_PRODUCT}"
+            f" AND product_version:{ocp_resolved})"
+        )
+
+        rosa_product = os.environ.get(SolrHybridSearch._ROSA_PRODUCT_ENV, "").strip()
+        if rosa_product:
+            try:
+                rosa_resolved = SolrHybridSearch._resolve_product_version(
+                    rosa_product, solr_http_base, timeout_s, env_version
+                )
+            except InvalidConfigurationError:
+                logger.warning(
+                    "ROSA product '%s' not found in Solr — falling back to OCP-only",
+                    rosa_product,
+                )
+            else:
+                rosa_filter = (
+                    f"(product:{rosa_product} AND product_version:{rosa_resolved})"
+                )
+                logger.info(
+                    "ROSA product detected: product=%s, resolved_version=%s",
+                    rosa_product,
+                    rosa_resolved,
+                )
+                return f"is_chunk:true AND ({ocp_filter} OR {rosa_filter})"
+
+        return f"is_chunk:true AND {ocp_filter}"
+
+    @staticmethod
+    def _resolve_product_version(
+        product: str,
+        solr_http_base: str,
+        timeout_s: float,
+        env_version: str,
+    ) -> str:
+        """Resolve the best available Solr version for *product*.
+
+        Queries Solr for available versions of the given product, then clamps
+        ``env_version`` to the nearest available major.minor.
+        """
+        available = SolrHybridSearch._fetch_available_product_versions(
+            product, solr_http_base, timeout_s
         )
         if not available:
             raise InvalidConfigurationError(
-                "Cannot fetch available OCP versions from Solr at "
-                f"{solr_http_base} — service cannot start"
+                f"Cannot fetch available versions for product '{product}' "
+                f"from Solr at {solr_http_base} — service cannot start"
             )
         resolved = SolrHybridSearch._clamp_version(env_version, available)
         logger.info(
-            "OCP version resolved: env=%s, available=%s, resolved=%s",
+            "Product version resolved: product=%s, env=%s, available=%s, resolved=%s",
+            product,
             env_version,
             available,
             resolved,
         )
-        return (
-            f"is_chunk:true AND product:{SolrHybridSearch._OCP_PRODUCT}"
-            f" AND product_version:{resolved}"
-        )
+        return resolved
 
     _SOLR_STARTUP_RETRIES = 24
     _SOLR_STARTUP_BACKOFF_S = 5
 
     @staticmethod
-    def _fetch_available_ocp_versions(
-        solr_http_base: str, timeout_s: float
+    def _fetch_available_product_versions(
+        product: str, solr_http_base: str, timeout_s: float
     ) -> list[str]:
-        """Query Solr for available ``product_version`` values for OCP.
+        """Query Solr for available ``product_version`` values for *product*.
 
         Retries up to ``_SOLR_STARTUP_RETRIES`` times with
         ``_SOLR_STARTUP_BACKOFF_S`` seconds between attempts to tolerate
@@ -407,7 +455,7 @@ class SolrHybridSearch:
         select_url = f"{base}/solr/{_SOLR_COLLECTION}/select"
         params = {
             "q": "*:*",
-            "fq": f"product:{SolrHybridSearch._OCP_PRODUCT}",
+            "fq": f"product:{product}",
             "rows": "0",
             "facet": "true",
             "facet.field": "product_version",
@@ -435,7 +483,9 @@ class SolrHybridSearch:
                 )
                 time.sleep(SolrHybridSearch._SOLR_STARTUP_BACKOFF_S)
         logger.error(
-            "Failed to fetch OCP versions from Solr after all retries: %s", last_error
+            "Failed to fetch versions for product '%s' from Solr after all retries: %s",
+            product,
+            last_error,
         )
         return []
 

--- a/tests/unit/rag_index/test_solr_support.py
+++ b/tests/unit/rag_index/test_solr_support.py
@@ -598,3 +598,84 @@ def test_resolve_builds_filter_with_clamped_version() -> None:
         result = SolrHybridSearch._resolve_chunk_filter_query("http://solr:8080", 10.0)
     assert "product_version:4.19" in result
     assert "openshift_container_platform" in result
+    assert " OR " not in result
+
+
+def test_resolve_builds_compound_filter_with_rosa_product() -> None:
+    """OLS_ROSA_PRODUCT env var adds a compound OR filter for ROSA docs."""
+    facet_response = httpx.Response(
+        200,
+        json={
+            "facet_counts": {
+                "facet_fields": {"product_version": ["4.18", 10, "4.19", 5]}
+            }
+        },
+        request=httpx.Request("GET", "http://solr:8080/solr/portal-rag/select"),
+    )
+    env = {
+        "OCP_CLUSTER_VERSION": "4.19.7",
+        "OLS_ROSA_PRODUCT": "red_hat_openshift_service_on_aws",
+    }
+    with (
+        patch.dict("os.environ", env),
+        patch("ols.src.rag_index.solr_support.httpx.get", return_value=facet_response),
+    ):
+        result = SolrHybridSearch._resolve_chunk_filter_query("http://solr:8080", 10.0)
+    assert "openshift_container_platform" in result
+    assert "red_hat_openshift_service_on_aws" in result
+    assert " OR " in result
+    assert result.startswith("is_chunk:true AND (")
+
+
+def test_resolve_falls_back_to_ocp_when_rosa_product_missing_from_solr() -> None:
+    """ROSA product absent from Solr falls back to OCP-only filter."""
+    ocp_response = httpx.Response(
+        200,
+        json={
+            "facet_counts": {
+                "facet_fields": {"product_version": ["4.18", 10, "4.19", 5]}
+            }
+        },
+        request=httpx.Request("GET", "http://solr:8080/solr/portal-rag/select"),
+    )
+    rosa_response = httpx.Response(
+        200,
+        json={"facet_counts": {"facet_fields": {"product_version": []}}},
+        request=httpx.Request("GET", "http://solr:8080/solr/portal-rag/select"),
+    )
+    env = {
+        "OCP_CLUSTER_VERSION": "4.19.7",
+        "OLS_ROSA_PRODUCT": "red_hat_openshift_service_on_aws",
+    }
+    with (
+        patch.dict("os.environ", env),
+        patch(
+            "ols.src.rag_index.solr_support.httpx.get",
+            side_effect=[ocp_response, rosa_response],
+        ),
+    ):
+        result = SolrHybridSearch._resolve_chunk_filter_query("http://solr:8080", 10.0)
+    assert "openshift_container_platform" in result
+    assert "red_hat_openshift_service_on_aws" not in result
+    assert " OR " not in result
+
+
+def test_resolve_ignores_empty_rosa_product() -> None:
+    """Empty OLS_ROSA_PRODUCT is treated as absent — OCP-only filter."""
+    facet_response = httpx.Response(
+        200,
+        json={
+            "facet_counts": {
+                "facet_fields": {"product_version": ["4.18", 10, "4.19", 5]}
+            }
+        },
+        request=httpx.Request("GET", "http://solr:8080/solr/portal-rag/select"),
+    )
+    env = {"OCP_CLUSTER_VERSION": "4.19.7", "OLS_ROSA_PRODUCT": "  "}
+    with (
+        patch.dict("os.environ", env),
+        patch("ols.src.rag_index.solr_support.httpx.get", return_value=facet_response),
+    ):
+        result = SolrHybridSearch._resolve_chunk_filter_query("http://solr:8080", 10.0)
+    assert " OR " not in result
+    assert "openshift_container_platform" in result


### PR DESCRIPTION
**Summary**
- Extend `SolrHybridSearch._resolve_chunk_filter_query()` to read the `OLS_ROSA_PRODUCT` environment variable (set by the operator on ROSA clusters) and build a compound OR filter including both OCP and ROSA product documentation
- Generalize `_fetch_available_ocp_versions` → `_fetch_available_product_versions` to accept any product name, and extract `_resolve_product_version` as a reusable helper
- Gracefully degrade to OCP-only filtering when the ROSA product is not found in Solr (log warning, no hard failure)


<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [x ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
https://redhat.atlassian.net/browse/OLS-2603
- Closes #
https://redhat.atlassian.net/browse/OLS-2603

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retrieval can now include content for both OCP and ROSA products when ROSA is configured and available.
  * Automatically falls back to OCP-only retrieval if ROSA product information cannot be resolved.
* **Documentation**
  * Updated retrieval specifications to document ROSA-aware filtering and fallback behavior.
* **Tests**
  * Added coverage for ROSA-enabled, unavailable, and empty configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->