### PR TITLE
OLS-2928 - increasing max completion tokens for every lseval

### DIFF
--- a/eval/system_azure_openai_lseval.yaml
+++ b/eval/system_azure_openai_lseval.yaml
@@ -16,7 +16,7 @@ llm:
   provider: "openai"
   model: "gpt-5-mini"
   temperature: 1
-  max_tokens: 512
+  max_tokens: 4096
   timeout: 300
   num_retries: 3
 

--- a/eval/system_openai_lseval.yaml
+++ b/eval/system_openai_lseval.yaml
@@ -17,7 +17,7 @@ llm:
   provider: "openai"
   model: "gpt-5-mini"
   temperature: 1
-  max_tokens: 512
+  max_tokens: 4096
   timeout: 300
   num_retries: 3
 

--- a/eval/system_rhelai_vllm_lseval.yaml
+++ b/eval/system_rhelai_vllm_lseval.yaml
@@ -19,7 +19,7 @@ llm:
   provider: "openai"
   model: "gpt-5-mini"
   temperature: 1
-  max_tokens: 512
+  max_tokens: 4096
   timeout: 300
   num_retries: 3
 

--- a/eval/system_rhoai_vllm_lseval.yaml
+++ b/eval/system_rhoai_vllm_lseval.yaml
@@ -19,7 +19,7 @@ llm:
   provider: "openai"
   model: "gpt-5-mini"
   temperature: 1
-  max_tokens: 512
+  max_tokens: 4096
   timeout: 300
   num_retries: 3
 

--- a/eval/system_watsonx_lseval.yaml
+++ b/eval/system_watsonx_lseval.yaml
@@ -16,7 +16,7 @@ llm:
   provider: "openai"
   model: "gpt-5-mini"
   temperature: 1
-  max_tokens: 512
+  max_tokens: 4096
   timeout: 300
   num_retries: 3
 


### PR DESCRIPTION
## Description

Changing max_completion_tokens to 4096 (initially was meant to be triple this but it seems claude had missread the info and instead of us having 4096 max_completion_tokens, we actually had 512).
This is to increase stability whenever evaluated llm response is long which causes gpt-5-mini, a reasoning model, to produce an extended answer, hitting the limit.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased the maximum response length available during model evaluations from 512 to 4,096 tokens.
  * Evaluation runs can now accommodate more detailed generated answers and scoring responses across supported model configurations.
  * No other evaluation settings were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->