### PR TITLE
OLS-3493 Align audit logging and observability specs with OTel GenAI

### DIFF
--- a/.ai/spec/what/audit-logging.md
+++ b/.ai/spec/what/audit-logging.md
@@ -69,13 +69,17 @@ Implementation spec for compliance audit logging in lightspeed-service (OLS). Pa
 | `gen_ai.tool.call.id` | Recommended | Tool call ID from MCP response |
 | `network.transport` | Recommended | `stdio` or `sse` |
 
-12. Non-MCP tools MUST get only the standard `gen_ai.tool.*` attributes from rule 10.
+12. Non-MCP tools MUST carry all attributes from rule 10 (including `gen_ai.operation.name`) and MUST NOT add MCP-specific attributes from rule 11.
 
 ### Span Events
 
-13. Text output from the LLM MUST be recorded as a `gen_ai.content.completion` span event attached to the `chat {gen_ai.request.model}` span. The event carries a `gen_ai.completion` attribute with the text content.
+13. Text output from the LLM MUST be recorded as a `gen_ai.choice` span event attached to the `chat {gen_ai.request.model}` span. The event carries a `gen_ai.completion` attribute with the text content. This aligns with OTel GenAI Semantic Conventions.
 
-14. Thinking/reasoning output from the LLM MUST be recorded as a `gen_ai.agent.thinking` span event attached to the `chat {gen_ai.request.model}` span. The event carries a `content` attribute with the thinking content.
+14. Thinking/reasoning output from the LLM MUST be recorded as a `gen_ai.choice` span event with an additional `gen_ai.reasoning_content` attribute attached to the `chat {gen_ai.request.model}` span. When the model emits both completion and thinking content, they MAY be combined into a single `gen_ai.choice` event with both attributes.
+
+### Content Capture Policy
+
+14a. Completion and thinking span event attributes (`gen_ai.completion`, `gen_ai.reasoning_content`) contain LLM output that may include PII or sensitive data. Recording these attributes MUST be opt-in, controlled by an `audit.capture_content` configuration flag (default: `false`). When `capture_content` is `false`, `gen_ai.choice` events are still emitted but the content attributes are omitted. This aligns with the OTel GenAI semantic convention requirement level of Opt-In for content attributes.
 
 ### Single-Emission Rule
 
@@ -101,6 +105,7 @@ Implementation spec for compliance audit logging in lightspeed-service (OLS). Pa
 ols_config:
   audit:
     enabled: true             # default: true (audit on even if section is absent)
+    capture_content: false    # default: false; opt-in to record LLM output in span events
     otel:
       endpoint: ""            # optional OTLP gRPC endpoint; no-op exporter when empty/absent
       tls_mode: Secure        # Secure (default) | Insecure
@@ -121,7 +126,7 @@ request.lifecycle               [root, INTERNAL, gen_ai.conversation.id=<conv_id
 ├── request.history             [INTERNAL]
 ├── chat gpt-4o                 [CLIENT, repeats per LLM turn]
 │   ├── execute_tool search     [INTERNAL, repeats per tool call]
-│   └── (span events: gen_ai.content.completion, gen_ai.agent.thinking)
+│   └── (span events: gen_ai.choice)
 └── request.store               [INTERNAL]
 ```
 

--- a/.ai/spec/what/audit-logging.md
+++ b/.ai/spec/what/audit-logging.md
@@ -1,72 +1,136 @@
 # Audit Logging
 
-Implementation spec for compliance audit logging in lightspeed-service (OLS). Parent spec: `ols/.ai/spec/what/audit-logging.md` (authoritative for cross-repo requirements, event semantics, and correlation contract).
+Implementation spec for compliance audit logging in lightspeed-service (OLS). Parent spec: `ols/.ai/spec/what/audit-logging.md` (authoritative for cross-repo requirements, event semantics, correlation contract, and OTel GenAI attribute reference).
 
 ## Behavioral Rules
 
-### Audit Events
+### Per-Request Traces
 
-1. The service MUST emit the following structured JSON audit events to stdout. Every event carries `trace_id` (`conversation_id` with hyphens stripped to 32 hex chars) and `user_id` (authenticated user identity from k8s token validation).
+1. Each incoming HTTP request MUST generate a fresh, auto-generated OTel trace ID. The service MUST NOT use `conversation_id` as the trace ID.
 
-| Event | When | Payload |
+2. `gen_ai.conversation.id` MUST be set as a span attribute on every span in the request trace. The value is the `conversation_id` UUID. Users query by `gen_ai.conversation.id` to see all requests in a conversation.
+
+3. `user_id` (authenticated user identity from k8s token validation) MUST be set as a span attribute on every span in the request trace.
+
+4. For multi-turn conversations, each request produces a separate trace with its own trace ID. All traces for the same conversation share `gen_ai.conversation.id` as a span attribute.
+
+### Span Hierarchy
+
+5. The service MUST create a root span `request.lifecycle` (kind `INTERNAL`) for each incoming request.
+
+6. Child spans of `request.lifecycle`:
+
+| Span Name | Kind | When | Key Attributes |
+|---|---|---|---|
+| `request.auth` | `INTERNAL` | User authentication | `user_id` |
+| `request.rag` | `INTERNAL` | RAG chunk retrieval | Chunk count, source documents |
+| `request.history` | `INTERNAL` | Conversation history load | Turn count, compressed (yes/no) |
+| `chat {gen_ai.request.model}` | `CLIENT` | Each LLM turn | GenAI inference attributes (see below) |
+| `execute_tool {gen_ai.tool.name}` | `INTERNAL` | Each tool call (child of `chat` span) | GenAI tool attributes (see below) |
+| `request.store` | `INTERNAL` | Response storage | |
+
+7. The root span `request.lifecycle` keeps its current name -- it encompasses the full HTTP request (auth, RAG, history, LLM turns, storage), not just the LLM call. Non-GenAI child spans (`request.auth`, `request.rag`, `request.history`, `request.store`) also keep their current names.
+
+### GenAI Attributes on LLM Turn Span
+
+8. Each `chat {gen_ai.request.model}` span MUST carry the following attributes:
+
+| Attribute | Requirement | Description |
 |---|---|---|
-| `audit.request.started` | Request enters the service | Mode (ask/troubleshooting), query text, attachments, provider/model |
-| `audit.request.auth` | User authenticated | User identity from k8s token |
-| `audit.rag.retrieved` | RAG chunks retrieved | Chunk count, similarity scores, source documents |
-| `audit.history.retrieved` | Conversation history loaded | Turn count, compressed (yes/no) |
-| `audit.llm.turn` | Each LLM turn completes | Turn index, token counts (input/output), cost |
-| `audit.llm.thinking` | LLM emits reasoning/thinking | Thinking content |
-| `audit.llm.text` | LLM emits text output | Text content |
-| `audit.tool.call` | Tool invocation starts | Tool name, MCP server, input arguments |
-| `audit.tool.result` | Tool invocation completes | Tool name, output, success/failure, duration |
-| `audit.tool.approval.requested` | Tool requires human approval | Tool name, approval ID |
-| `audit.tool.approval.decision` | User approves/denies tool | Approval ID, decision, tool name |
-| `audit.request.completed` | Response fully streamed | Total turns, total tokens, total cost, referenced documents |
+| `gen_ai.operation.name` | Required | `"chat"` |
+| `gen_ai.request.model` | Required | Model name requested (e.g., `gpt-4o`, `claude-sonnet-4-20250514`) |
+| `gen_ai.response.model` | Recommended | Actual model from provider response |
+| `gen_ai.provider.name` | Required | Provider name (e.g., `openai`, `anthropic`, `watsonx`) |
+| `gen_ai.usage.input_tokens` | Recommended | Input token count for this turn |
+| `gen_ai.usage.output_tokens` | Recommended | Output token count for this turn |
 
-2. OLS runs its own tool-calling loop (not an SDK agentic loop), so per-turn token counts are available and MUST be reported on `audit.llm.turn`.
+9. OLS runs its own tool-calling loop (not an SDK agentic loop), so per-turn token counts are available and MUST be reported via `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens` on each `chat {gen_ai.request.model}` span.
 
-### Correlation Key Propagation
+### GenAI Attributes on Tool Span
 
-3. `conversation_id` MUST be present on every audit log line from request entry through all tool calls to response completion. The `conversation_id` is generated or validated at request entry (stage 1 of the query pipeline).
+10. Each `execute_tool {gen_ai.tool.name}` span MUST carry the following attributes:
 
-4. `user_id` MUST be present on every audit event for that request. The user identity is available from k8s token validation at request entry.
+| Attribute | Requirement | Description |
+|---|---|---|
+| `gen_ai.operation.name` | Required | `"execute_tool"` |
+| `gen_ai.tool.name` | Required | Tool name |
+| `gen_ai.tool.call.id` | Recommended | Tool call ID from LLM response |
+| `gen_ai.tool.type` | Recommended | `"function"` |
 
-5. Both `conversation_id` and `user_id` MUST be set on the logging context at request entry and propagated through all downstream code paths (RAG retrieval, history, LLM generation, tool execution).
+### MCP Attributes
 
-### OTEL Spans
+11. When a tool is MCP-sourced, the `execute_tool {gen_ai.tool.name}` span MUST additionally carry:
 
-6. The service MUST create a root span `request.lifecycle` for each incoming request. The OTEL trace ID MUST be the `conversation_id` with hyphens stripped.
+| Attribute | Requirement | Description |
+|---|---|---|
+| `mcp.method.name` | Recommended | MCP method invoked (e.g., `tools/call`) |
+| `mcp.session.id` | Recommended | MCP session identifier |
+| `mcp.protocol.version` | Recommended | MCP protocol version |
+| `gen_ai.tool.call.id` | Recommended | Tool call ID from MCP response |
+| `network.transport` | Recommended | `stdio` or `sse` |
 
-7. Child spans: `request.auth`, `request.rag`, `request.history`, `llm.turn` (repeats per turn), `tool.{name}` (repeats per tool call within a turn), `request.store`.
+12. Non-MCP tools MUST get only the standard `gen_ai.tool.*` attributes from rule 10.
 
-8. For multi-turn conversations, each request is a separate trace sharing the same `conversation_id` as trace ID. This means querying by trace ID returns the full conversation.
+### Span Events
+
+13. Text output from the LLM MUST be recorded as a `gen_ai.content.completion` span event attached to the `chat {gen_ai.request.model}` span. The event carries a `gen_ai.completion` attribute with the text content.
+
+14. Thinking/reasoning output from the LLM MUST be recorded as a `gen_ai.agent.thinking` span event attached to the `chat {gen_ai.request.model}` span. The event carries a `content` attribute with the thinking content.
+
+### Single-Emission Rule
+
+15. Each audit-significant datum MUST be recorded exactly once, as an OTel span or span event. The stdout and OTLP exporters are two destinations for the same emission, not two separate emission paths.
+
+16. Python `logging` MUST emit only developer-debugging messages and MUST NOT re-emit data that appears in spans or span events. This collapses any current dual-emission (structured JSON + OTel span) into a single path: OTel spans/events for audit (two exporters, one emission), standard logging for developer debugging only.
+
+### Structured Log Format
+
+17. Audit data MUST be emitted as OTel spans and span events. The stdout exporter serializes them as OTLP JSON -- the standard OTel wire format. There is no custom JSON format.
+
+18. Two exporters on the same TracerProvider:
+    - **OTLP exporter** -- sends spans to a trace backend when an endpoint is configured.
+    - **Stdout exporter** -- serializes spans as OTLP JSON to stdout (always, when audit enabled). Python OTel SDK provides `opentelemetry.sdk.trace.export.ConsoleSpanExporter` natively.
+
+19. The stdout exporter MUST NOT truncate span attributes or event attributes. Full fidelity is preserved. The stdout signal is the compliance record.
 
 ### Configuration
 
-9. The service reads audit config from `olsconfig.yaml` (generated by the lightspeed-operator from `OLSConfig.spec.audit`):
+20. The service reads audit config from `olsconfig.yaml` (generated by the lightspeed-operator from `OLSConfig.spec.audit`):
 
 ```yaml
 ols_config:
   audit:
-    logging: Enabled        # Enabled (default) | Disabled
+    enabled: true             # default: true (audit on even if section is absent)
     otel:
-      endpoint: ""          # optional OTLP gRPC endpoint; no-op exporter when empty/absent
-      tls_mode: Secure      # Secure (default) | Insecure
+      endpoint: ""            # optional OTLP gRPC endpoint; no-op exporter when empty/absent
+      tls_mode: Secure        # Secure (default) | Insecure
 ```
 
-10. `audit.logging` controls structured JSON audit events to stdout. Defaults to `Enabled` — when the config section is absent or the field is not set, audit logging is on. Set to `Disabled` to suppress all audit events.
+21. `audit.enabled` controls audit emission. Defaults to `true` -- when the config section is absent or the field is not set, audit logging is on. Set to `false` to suppress all audit spans and events.
 
-11. `audit.otel.endpoint` controls OTEL trace export. When set, the service configures an OTLP exporter with the given endpoint. `tls_mode` defaults to `Secure`; set to `Insecure` for plaintext gRPC. When endpoint is absent, a no-op exporter is used. Tracing is independent of logging — either can be enabled without the other.
+22. `audit.otel.endpoint` controls OTLP trace export. When set, the service configures an OTLP exporter with the given endpoint. `tls_mode` defaults to `Secure`; set to `Insecure` for plaintext gRPC. When endpoint is absent, a no-op OTLP exporter is used. The stdout exporter always emits regardless of whether an OTLP endpoint is configured.
 
-### Structured JSON Format
+### Span Hierarchy Diagram
 
-12. All audit events MUST be single JSON lines to stdout with at minimum: `timestamp`, `level`, `event`, `trace_id`, `user_id`. Additional fields vary by event type per the catalog above.
+23. Per-request trace structure:
 
-13. The existing partial structured JSON logging (user_question, tool_call events) SHOULD be aligned with the audit event format to avoid two different structured log schemas in the same output stream.
+```
+request.lifecycle               [root, INTERNAL, gen_ai.conversation.id=<conv_id>, user_id=<uid>]
+├── request.auth                [INTERNAL]
+├── request.rag                 [INTERNAL]
+├── request.history             [INTERNAL]
+├── chat gpt-4o                 [CLIENT, repeats per LLM turn]
+│   ├── execute_tool search     [INTERNAL, repeats per tool call]
+│   └── (span events: gen_ai.content.completion, gen_ai.agent.thinking)
+└── request.store               [INTERNAL]
+```
+
+For multi-turn conversations, each request produces a separate trace. All traces for the same conversation share `gen_ai.conversation.id` as a span attribute. Query by `gen_ai.conversation.id` to see the full conversation.
 
 ## Cross-References
 
-- `observability.md` — existing Prometheus metrics and logging
-- `query-processing.md` — query pipeline stages where audit events are emitted
-- `tools.md` — tool execution and approval flow
-- `auth.md` — k8s token validation where user identity is extracted
+- `observability.md` -- existing Prometheus metrics and `gen_ai.*` histogram metrics
+- `query-processing.md` -- query pipeline stages where spans are created
+- `tools.md` -- tool execution flow, MCP integration
+- `auth.md` -- k8s token validation where user identity is extracted
+- Parent spec `ols/.ai/spec/what/audit-logging.md` -- OTel GenAI attribute reference, correlation model, single-emission rule

--- a/.ai/spec/what/observability.md
+++ b/.ai/spec/what/observability.md
@@ -18,6 +18,11 @@ The service exposes Prometheus metrics, records conversation transcripts and use
    | `ols_llm_token_received_total` | Counter | `provider`, `model` | Cumulative output tokens received from LLMs. |
    | `ols_llm_reasoning_token_total` | Counter | `provider`, `model` | Cumulative reasoning summary tokens received from LLMs. |
    | `ols_provider_model_configuration` | Gauge | `provider`, `model` | Configured provider/model combinations. Value `1` for the default, `0` for others. |
+   | `gen_ai.client.token.usage` | Histogram | `gen_ai.token.type` (input/output/reasoning), `gen_ai.request.model`, `gen_ai.provider.name` | Per-request token usage distribution per OTel GenAI semantic conventions. Bucket boundaries: [1, 4, 16, 64, 256, 1024, 4096, 16384, 65536]. Unit: `{token}`. |
+   | `gen_ai.client.operation.duration` | Histogram | `gen_ai.request.model`, `gen_ai.provider.name`, `gen_ai.operation.name` | LLM inference call duration per OTel GenAI semantic conventions. Unit: `s`. |
+   | `gen_ai.execute_tool.duration` | Histogram | `gen_ai.tool.name` | Tool execution duration per OTel GenAI semantic conventions. Unit: `s`. |
+
+   The `gen_ai.*` histogram metrics follow OTel GenAI Semantic Conventions v1.41. They complement the existing `ols_*` counter metrics: `gen_ai.client.token.usage` provides per-request distribution analysis (p50/p95/p99) while `ols_llm_token_sent_total`/`ols_llm_token_received_total` provide cumulative totals. Both are emitted.
 
 2. The `_created` timestamp metadata on all counters must be suppressed (via `disable_created_metrics()`).
 
@@ -99,7 +104,7 @@ The service exposes Prometheus metrics, records conversation transcripts and use
 
 ## Constraints
 
-1. All metric names use the `ols_` prefix. No other prefix is permitted.
+1. Existing metrics use the `ols_` prefix. New OTel GenAI semantic convention metrics use the `gen_ai.` prefix. No other prefix is permitted.
 2. The six redacted header names (`authorization`, `proxy-authorization`, `cookie`, `www-authenticate`, `proxy-authenticate`, `set-cookie`) are defined as frozen sets and must not be logged in plaintext under any log level.
 3. Enabling feedback or transcripts without providing the corresponding `*_storage` path is a validation error at startup.
 4. Sentiment values are restricted to exactly `-1` or `1`; any other integer is rejected with a validation error.
@@ -108,5 +113,7 @@ The service exposes Prometheus metrics, records conversation transcripts and use
 
 ## Planned Changes
 
-- [PLANNED: OLS-1279] The `ols_response_duration_seconds` histogram currently measures total request handling time, not isolated LLM call duration. A dedicated LLM-only duration metric is needed.
+- [PLANNED: OLS-1279] Subsumed by `gen_ai.client.operation.duration` histogram which measures isolated LLM call duration. The existing `ols_response_duration_seconds` measures total HTTP request handling time (different scope).
 - [PLANNED: OLS-1805] Transcripts should be enhanced to include per-request token usage (input, output, reasoning token counts).
+- [PLANNED] Streaming metrics `gen_ai.client.operation.time_to_first_chunk` and `gen_ai.client.operation.time_per_output_chunk` (Histogram, unit `s`) for OLS when streaming is the default path.
+- [PLANNED] MCP metrics `mcp.client.operation.duration` and `mcp.client.session.duration` (Histogram, unit `s`) pending sufficient usage data.

--- a/.ai/spec/what/observability.md
+++ b/.ai/spec/what/observability.md
@@ -18,7 +18,7 @@ The service exposes Prometheus metrics, records conversation transcripts and use
    | `ols_llm_token_received_total` | Counter | `provider`, `model` | Cumulative output tokens received from LLMs. |
    | `ols_llm_reasoning_token_total` | Counter | `provider`, `model` | Cumulative reasoning summary tokens received from LLMs. |
    | `ols_provider_model_configuration` | Gauge | `provider`, `model` | Configured provider/model combinations. Value `1` for the default, `0` for others. |
-   | `gen_ai.client.token.usage` | Histogram | `gen_ai.token.type` (input/output/reasoning), `gen_ai.request.model`, `gen_ai.provider.name` | Per-request token usage distribution per OTel GenAI semantic conventions. Bucket boundaries: [1, 4, 16, 64, 256, 1024, 4096, 16384, 65536]. Unit: `{token}`. |
+   | `gen_ai.client.token.usage` | Histogram | `gen_ai.operation.name`, `gen_ai.token.type` (input/output), `gen_ai.request.model`, `gen_ai.provider.name` | Per-request token usage distribution per OTel GenAI semantic conventions. Bucket boundaries: [1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864]. Unit: `{token}`. Reasoning tokens are tracked separately via `gen_ai.usage.reasoning_tokens` span attribute on `chat` spans, not as a `gen_ai.token.type` value. |
    | `gen_ai.client.operation.duration` | Histogram | `gen_ai.request.model`, `gen_ai.provider.name`, `gen_ai.operation.name` | LLM inference call duration per OTel GenAI semantic conventions. Unit: `s`. |
    | `gen_ai.execute_tool.duration` | Histogram | `gen_ai.tool.name` | Tool execution duration per OTel GenAI semantic conventions. Unit: `s`. |
 
@@ -104,7 +104,7 @@ The service exposes Prometheus metrics, records conversation transcripts and use
 
 ## Constraints
 
-1. Existing metrics use the `ols_` prefix. New OTel GenAI semantic convention metrics use the `gen_ai.` prefix. No other prefix is permitted.
+1. Existing metrics use the `ols_` prefix. New OTel semantic convention metrics use their standard prefix: `gen_ai.` for GenAI metrics, `mcp.` for MCP metrics (planned). No other prefix is permitted.
 2. The six redacted header names (`authorization`, `proxy-authorization`, `cookie`, `www-authenticate`, `proxy-authenticate`, `set-cookie`) are defined as frozen sets and must not be logged in plaintext under any log level.
 3. Enabling feedback or transcripts without providing the corresponding `*_storage` path is a validation error at startup.
 4. Sentiment values are restricted to exactly `-1` or `1`; any other integer is rejected with a validation error.


### PR DESCRIPTION
## Summary
- Update audit-logging spec: per-request traces, GenAI span naming, MCP attributes, single-emission rule
- Update observability spec: add gen_ai.* histogram metrics alongside existing ols_* counters, update [OLS-1279](https://redhat.atlassian.net/browse/OLS-1279) as subsumed

## Test plan
- [ ] Verify spec consistency with parent spec (ols/.ai/spec/what/audit-logging.md)
- [ ] Review gen_ai.* metric definitions against OTel GenAI Semantic Conventions v1.41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated audit logging guidance to use OpenTelemetry traces, spans, events, and OTLP JSON output.
  - Added requirements for tracing requests, LLM operations, tool calls, user context, and conversation identifiers.
  - Clarified audit configuration, export settings, and single-emission logging rules.
  - Added OpenTelemetry GenAI histogram metrics for token usage, LLM operation duration, and tool execution duration.
  - Clarified supported metric naming conventions and metric scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->