### PR TITLE
OLS-3548 Omit temperature for models that deprecate it

### DIFF
--- a/examples/olsconfig.yaml
+++ b/examples/olsconfig.yaml
@@ -13,6 +13,7 @@ llm_providers:
         #   reasoning_effort: low      # low | medium | high (default: low)
         #   reasoning_summary: concise  # auto | concise | detailed (default: concise)
         #   verbosity: low             # low | medium | high (default: low)
+        #   temperature_supported: true  # set to false for models that reject temperature (default: true)
   - name: my_azure_openai
     type: azure_openai
     url: "https://myendpoint.openai.azure.com/"

--- a/examples/olsconfig.yaml
+++ b/examples/olsconfig.yaml
@@ -13,7 +13,6 @@ llm_providers:
         #   reasoning_effort: low      # low | medium | high (default: low)
         #   reasoning_summary: concise  # auto | concise | detailed (default: concise)
         #   verbosity: low             # low | medium | high (default: low)
-        #   temperature_supported: true  # set to false for models that reject temperature (default: true)
   - name: my_azure_openai
     type: azure_openai
     url: "https://myendpoint.openai.azure.com/"
@@ -60,6 +59,10 @@ llm_providers:
       # use fully qualified Bedrock model IDs (e.g. anthropic.claude-opus-4-7,
       # openai.gpt-5.4, deepseek.v3.1)
       - name: anthropic.claude-opus-4-7
+      # For models that reject the temperature parameter, set temperature_supported: false:
+      # - name: anthropic.claude-sonnet-5
+      #   parameters:
+      #     temperature_supported: false
   # - name: my_bedrock_iam
   #   type: bedrock
   #   url: "https://bedrock-mantle.us-east-1.api.aws"

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -62,6 +62,7 @@ class ModelParameters(BaseModel):
     reasoning_effort: ReasoningLevel = ReasoningLevel.LOW
     reasoning_summary: ReasoningSummary = ReasoningSummary.CONCISE
     verbosity: ReasoningLevel = ReasoningLevel.LOW
+    temperature_supported: bool = True
 
     @field_validator("tool_budget_ratio")
     @classmethod

--- a/ols/src/llms/providers/provider.py
+++ b/ols/src/llms/providers/provider.py
@@ -374,6 +374,13 @@ class LLMProvider(AbstractLLMProvider):
             )
             updated_params = {**updated_params, **config.dev_config.llm_params}
 
+        # Temperature stripping is intentionally applied after all param merges
+        # (including dev_config overrides) because it enforces a physical model
+        # constraint: if the model's API does not accept a temperature argument,
+        # passing one causes an API error regardless of how it was configured.
+        # This is not a precedence decision — dev_config still wins over defaults
+        # and call-site params — it is a hard capability check that must happen
+        # last, after the final merged param set is known.
         if not self._model_supports_temperature() and "temperature" in updated_params:
             logger.warning(
                 "Model %s does not support temperature; removing it from parameters",

--- a/ols/src/llms/providers/provider.py
+++ b/ols/src/llms/providers/provider.py
@@ -374,7 +374,23 @@ class LLMProvider(AbstractLLMProvider):
             )
             updated_params = {**updated_params, **config.dev_config.llm_params}
 
+        if not self._model_supports_temperature() and "temperature" in updated_params:
+            logger.warning(
+                "Model %s does not support temperature; removing it from parameters",
+                self.model,
+            )
+            updated_params.pop("temperature", None)
+
         return updated_params
+
+    def _model_supports_temperature(self) -> bool:
+        """Check whether the current model supports the temperature parameter."""
+        if self.provider_config is None:
+            return True
+        model_config = self.provider_config.models.get(self.model)
+        if model_config is None:
+            return True
+        return model_config.parameters.temperature_supported
 
     def _construct_httpx_client(
         self, use_async: bool

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -229,6 +229,7 @@ def test_model_parameters():
     assert default_params.reasoning_effort == ReasoningLevel.LOW
     assert default_params.reasoning_summary == ReasoningSummary.CONCISE
     assert default_params.verbosity == ReasoningLevel.LOW
+    assert default_params.temperature_supported is True
 
     parameters = ModelParameters(max_tokens_for_response=10, unknown_param="hello")
 
@@ -243,6 +244,9 @@ def test_model_parameters():
     assert reasoning_params.reasoning_effort == ReasoningLevel.HIGH
     assert reasoning_params.reasoning_summary == ReasoningSummary.DETAILED
     assert reasoning_params.verbosity == ReasoningLevel.MEDIUM
+
+    assert ModelParameters(temperature_supported=False).temperature_supported is False
+    assert ModelParameters(temperature_supported=True).temperature_supported is True
 
     # max_tokens_for_response needs to be positive integer
     with pytest.raises(ValidationError, match="Input should be greater than 0"):

--- a/tests/unit/llms/providers/test_bedrock.py
+++ b/tests/unit/llms/providers/test_bedrock.py
@@ -297,6 +297,94 @@ def test_anthropic_passes_temperature(
     assert call_kwargs["temperature"] == 0.5
 
 
+@patch(
+    "ols.src.llms.providers.bedrock.ChatBedrockConverse",
+    autospec=True,
+)
+def test_temperature_stripped_when_not_supported(
+    mock_chat: MagicMock,
+) -> None:
+    """Test that temperature is omitted when model sets temperature_supported=False."""
+    pc = ProviderConfig(
+        {
+            "name": "some_provider",
+            "type": "bedrock",
+            "url": "https://bedrock-mantle.us-east-1.api.aws",
+            "credentials_path": "tests/config/secret/apitoken",
+            "models": [
+                {
+                    "name": "anthropic.claude-sonnet-5",
+                    "parameters": {"temperature_supported": False},
+                }
+            ],
+        }
+    )
+    bedrock = Bedrock(
+        model="anthropic.claude-sonnet-5",
+        params={},
+        provider_config=pc,
+    )
+    assert "temperature" not in bedrock.params
+
+    bedrock.load()
+    call_kwargs = mock_chat.call_args[1]
+    assert "temperature" not in call_kwargs
+
+
+@patch(
+    "ols.src.llms.providers.bedrock.ChatBedrockConverse",
+    autospec=True,
+)
+def test_temperature_present_when_supported(
+    mock_chat: MagicMock, provider_config: ProviderConfig
+) -> None:
+    """Test that temperature is present by default (temperature_supported=True)."""
+    bedrock = Bedrock(
+        model="anthropic.claude-opus-4-7",
+        params={},
+        provider_config=provider_config,
+    )
+    assert "temperature" in bedrock.params
+
+    bedrock.load()
+    call_kwargs = mock_chat.call_args[1]
+    assert "temperature" in call_kwargs
+
+
+@patch(
+    "ols.src.llms.providers.bedrock.ChatBedrockConverse",
+    autospec=True,
+)
+def test_temperature_stripped_even_when_caller_passes_it(
+    mock_chat: MagicMock,
+) -> None:
+    """Test that caller-supplied temperature is also stripped when not supported."""
+    pc = ProviderConfig(
+        {
+            "name": "some_provider",
+            "type": "bedrock",
+            "url": "https://bedrock-mantle.us-east-1.api.aws",
+            "credentials_path": "tests/config/secret/apitoken",
+            "models": [
+                {
+                    "name": "anthropic.claude-sonnet-5",
+                    "parameters": {"temperature_supported": False},
+                }
+            ],
+        }
+    )
+    bedrock = Bedrock(
+        model="anthropic.claude-sonnet-5",
+        params={"temperature": 0.5},
+        provider_config=pc,
+    )
+    assert "temperature" not in bedrock.params
+
+    bedrock.load()
+    call_kwargs = mock_chat.call_args[1]
+    assert "temperature" not in call_kwargs
+
+
 def test_region_extraction(provider_config: ProviderConfig) -> None:
     """Test that region is correctly extracted from the Mantle URL."""
     bedrock = Bedrock(

--- a/tests/unit/llms/providers/test_bedrock.py
+++ b/tests/unit/llms/providers/test_bedrock.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from ols import config
 from ols.app.models.config import ProviderConfig
 from ols.src.llms.llm_loader import LLMConfigurationError
 from ols.src.llms.providers.bedrock import Bedrock
@@ -383,6 +384,42 @@ def test_temperature_stripped_even_when_caller_passes_it(
     bedrock.load()
     call_kwargs = mock_chat.call_args[1]
     assert "temperature" not in call_kwargs
+
+
+@patch(
+    "ols.src.llms.providers.bedrock.ChatBedrockConverse",
+    autospec=True,
+)
+def test_temperature_stripped_when_set_via_dev_config(
+    mock_chat: MagicMock,
+) -> None:
+    """Test that dev_config temperature override is stripped when model does not support it."""
+    config.dev_config.llm_params = {"temperature": 0.7}
+    pc = ProviderConfig(
+        {
+            "name": "some_provider",
+            "type": "bedrock",
+            "url": "https://bedrock-mantle.us-east-1.api.aws",
+            "credentials_path": "tests/config/secret/apitoken",
+            "models": [
+                {
+                    "name": "anthropic.claude-sonnet-5",
+                    "parameters": {"temperature_supported": False},
+                }
+            ],
+        }
+    )
+    bedrock = Bedrock(
+        model="anthropic.claude-sonnet-5",
+        params={},
+        provider_config=pc,
+    )
+    assert "temperature" not in bedrock.params
+
+    bedrock.load()
+    call_kwargs = mock_chat.call_args[1]
+    assert "temperature" not in call_kwargs
+    config.dev_config.llm_params = {}
 
 
 def test_region_extraction(provider_config: ProviderConfig) -> None:

--- a/tests/unit/llms/providers/test_bedrock.py
+++ b/tests/unit/llms/providers/test_bedrock.py
@@ -392,9 +392,10 @@ def test_temperature_stripped_even_when_caller_passes_it(
 )
 def test_temperature_stripped_when_set_via_dev_config(
     mock_chat: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that dev_config temperature override is stripped when model does not support it."""
-    config.dev_config.llm_params = {"temperature": 0.7}
+    monkeypatch.setattr(config.dev_config, "llm_params", {"temperature": 0.7})
     pc = ProviderConfig(
         {
             "name": "some_provider",
@@ -419,7 +420,6 @@ def test_temperature_stripped_when_set_via_dev_config(
     bedrock.load()
     call_kwargs = mock_chat.call_args[1]
     assert "temperature" not in call_kwargs
-    config.dev_config.llm_params = {}
 
 
 def test_region_extraction(provider_config: ProviderConfig) -> None:


### PR DESCRIPTION
## Summary

- Adds `temperature_supported` boolean flag to `ModelParameters` (defaults to `True` for backward compatibility)
- The base `LLMProvider` strips `temperature` from LLM params when the model's config sets `temperature_supported: false`
- Fixes HTTP 400 errors from models like `claude-sonnet-5` that have deprecated the `temperature` parameter

## How to use

In `olsconfig.yaml`, set `temperature_supported: false` on any model that rejects `temperature`:

```yaml
models:
  - name: anthropic.claude-sonnet-5
    parameters:
      temperature_supported: false
```

Models without this setting (or with `temperature_supported: true`) continue to receive `temperature` as before.

## Test plan

- [x] New unit tests verify temperature is stripped when `temperature_supported=False`
- [x] New unit tests verify temperature is still present when `temperature_supported=True` (default)
- [x] New unit tests verify caller-supplied temperature is also stripped when not supported
- [x] All 98 existing LLM provider unit tests pass
- [x] All 210 config model tests pass
- [x] mypy type check passes on modified files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to indicate whether a model supports temperature controls.
  * Automatically omit `temperature` for models that do not support it; supported models retain existing behavior.

* **Documentation**
  * Updated the example configuration to show how to disable temperature support for specific models.

* **Tests**
  * Added coverage for the new option and temperature handling across configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->