### PR TITLE
OTA-1870: enable built-in MCP sidecar for cluster-updates tests

### DIFF
--- a/tests/config/operator_install/olsconfig.crd.openai_cluster_updates.yaml
+++ b/tests/config/operator_install/olsconfig.crd.openai_cluster_updates.yaml
@@ -24,7 +24,7 @@ spec:
       replicas: 1
     disableAuth: false
     logLevel: INFO
-    introspectionEnabled: false
+    introspectionEnabled: true
     userDataCollection:
       feedbackDisabled: true
       transcriptsDisabled: true
@@ -35,13 +35,3 @@ spec:
       alpha: 0.8
       topK: 10
       threshold: 0.01
-  mcpServers:
-    - name: openshift-cluster
-      url: https://kubernetes.default.svc
-      headers:
-        - name: Authorization
-          valueFrom:
-            type: kubernetes
-  featureGates:
-    - MCPServer
-    - ToolFiltering

--- a/tests/e2e/utils/ols_installer.py
+++ b/tests/e2e/utils/ols_installer.py
@@ -141,6 +141,12 @@ def update_ols_config() -> None:
     # logs beying redacted/removed completely - we need log at info level
     olsconfig["ols_config"]["logging_config"]["lib_log_level"] = "INFO"
 
+    # The operator auto-generates reference_content pointing to a RAG index
+    # that doesn't exist in the CI image; strip it for cluster_updates tests
+    # which evaluate MCP tool calling, not RAG document retrieval.
+    if os.getenv("OLS_CONFIG_SUFFIX") == "cluster_updates":
+        olsconfig["ols_config"].pop("reference_content", None)
+
     # patch reference content config for new format
     # Todo: remove this when the operator PR is merged:
     # https://github.com/openshift/lightspeed-operator/pull/668

--- a/tests/scripts/test-cluster-updates.sh
+++ b/tests/scripts/test-cluster-updates.sh
@@ -32,6 +32,11 @@ chmod +x operator-sdk_${OS}_${ARCH} && mv operator-sdk_${OS}_${ARCH} $HOME/.loca
 export PATH=$HOME/.local/bin:$PATH
 operator-sdk version
 
+# Grant cluster-reader and monitoring-edit RBAC so the MCP sidecar can
+# fetch ClusterVersion, ClusterOperators, Nodes, alerts, etc.
+oc create namespace openshift-lightspeed --dry-run=client -o yaml | oc apply -f -
+oc apply -f eval/rbac-cluster-updates.yaml
+
 # Export OpenAI key so the judge LLM can authenticate
 if [ ! -f "$OPENAI_PROVIDER_KEY_PATH" ]; then
     echo "ERROR: OPENAI_PROVIDER_KEY_PATH file not found: $OPENAI_PROVIDER_KEY_PATH" >&2


### PR DESCRIPTION
Use operator introspection instead of explicit mcpServers config so the operator deploys the built-in MCP sidecar. Add RBAC for the sidecar to access cluster resources, and strip the RAG reference_content that the CI image lacks.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Fabricio Aguiar <fabricio.aguiar@gmail.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

Ref: https://github.com/openshift/release/pull/81342#discussion_r3580020452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled introspection for cluster update testing.
  * Added the required permissions setup for cluster update evaluations.

* **Bug Fixes**
  * Prevented invalid automatically generated reference content from being used in cluster update tests.
  * Removed obsolete MCP server and feature gate configuration from the test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->