### PR TITLE
OLS-3526: spec note for standalone MCP server URL change

### DIFF
--- a/.ai/spec/what/tools.md
+++ b/.ai/spec/what/tools.md
@@ -253,3 +253,4 @@ solely on general knowledge.
 | OLS-2684 | Remove client MCP headers -- eliminate the `"client"` header placeholder mechanism |
 | OLS-2491 | MCP client improvements -- transport and reliability enhancements |
 | OLS-1797 | Block sensitive tool args -- reject tool calls whose arguments match blocked patterns before execution |
+| OLS-3526 | The operator-managed OpenShift MCP server moves from a localhost sidecar to a standalone HTTPS service (`https://openshift-mcp-server.<ns>.svc:8443/mcp`). No service code changes required -- the URL and CA bundle are operator-configured via `olsconfig.yaml` and existing Rule 5 applies. |


### PR DESCRIPTION
## Summary

- Adds planned change note to `tools.md` for [OLS-3526](https://redhat.atlassian.net/browse/OLS-3526): the operator-managed OpenShift MCP server moves from a localhost sidecar to a standalone HTTPS service
- No lightspeed-service code changes required — the URL and CA bundle are operator-configured via `olsconfig.yaml` and existing Rule 5 (CA bundle for TLS verification) applies

## Test plan

- [ ] Confirm no service-side changes are needed for the MCP URL change

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a planned change describing the migration of the OpenShift MCP server endpoint to a standalone HTTPS service.
  * Documented operator configuration of the service URL and CA bundle through `olsconfig.yaml`, including existing TLS verification requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->