### PR TITLE
OLS-3526: note standalone MCP is not near-term

### DIFF
--- a/.ai/spec/what/tools.md
+++ b/.ai/spec/what/tools.md
@@ -253,4 +253,4 @@ solely on general knowledge.
 | OLS-2684 | Remove client MCP headers -- eliminate the `"client"` header placeholder mechanism |
 | OLS-2491 | MCP client improvements -- transport and reliability enhancements |
 | OLS-1797 | Block sensitive tool args -- reject tool calls whose arguments match blocked patterns before execution |
-| OLS-3526 | The operator-managed OpenShift MCP server moves from a localhost sidecar to a standalone HTTPS service (`https://openshift-mcp-server.<ns>.svc:8443/mcp`). No service code changes required -- the URL and CA bundle are operator-configured via `olsconfig.yaml` and existing Rule 5 applies. |
+| OLS-3526 | Operator may later move OpenShift MCP from localhost sidecar to a standalone HTTPS service. Still in refinement — not near-term. No service code changes expected when it lands (URL/CA via `olsconfig.yaml`; Rule 5). |


### PR DESCRIPTION
## Summary
- Soften the [OLS-3526](https://redhat.atlassian.net/browse/OLS-3526) planned-change note so it does not imply standalone HTTPS MCP is imminent
- Align with lightspeed-operator refinement status (full rules land with implementation)

## Test plan
- [ ] Spec review — Planned Changes wording matches deferred status


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OpenShift MCP migration roadmap to clarify that the move to a standalone HTTPS service is planned for a later stage and remains under refinement.
  * Clarified that the future service endpoint and certificate authority will be configured through `olsconfig.yaml`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->