### PR TITLE
OLS-3539 Replace dual-path audit with OTel-only span events

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -40,7 +40,6 @@ from ols.src.quota.quota_limiter import QuotaLimiter
 from ols.src.quota.token_usage_history import TokenUsageHistory
 from ols.utils import errors_parsing, suid
 from ols.utils.audit_logger import AuditContext, AuditLogger
-from ols.utils.otel import clear_conversation_trace_id, set_conversation_trace_id
 from ols.utils.token_handler import PromptTooLongError
 
 logger = logging.getLogger(__name__)
@@ -124,8 +123,17 @@ def conversation_request(
     audit_ctx = processed_request.audit_ctx
     lifecycle_cm = audit_ctx.span("request.lifecycle") if audit_ctx else nullcontext()
 
-    try:
-        with lifecycle_cm:
+    with lifecycle_cm:
+        try:
+            if audit_ctx:
+                audit_ctx.logger.request_started(
+                    mode=llm_request.mode,
+                    query=llm_request.query,
+                    attachments=[a.model_dump() for a in processed_request.attachments],
+                    provider=llm_request.provider,
+                    model=llm_request.model,
+                    capture_content=audit_ctx.capture_content,
+                )
             summarizer_response: SummarizerResponse | Generator
 
             client_headers = llm_request.mcp_headers
@@ -208,8 +216,6 @@ def conversation_request(
                     summarizer_response.token_counter, "reasoning_tokens"
                 )
                 audit_ctx.logger.request_completed(
-                    audit_ctx.trace_id,
-                    audit_ctx.user_id,
                     total_turns=getattr(
                         summarizer_response.token_counter, "llm_calls", 1
                     ),
@@ -219,17 +225,12 @@ def conversation_request(
                         doc.doc_url for doc in referenced_documents if doc.doc_url
                     ],
                 )
-    except Exception as request_error:
-        if audit_ctx:
-            audit_ctx.logger.request_failed(
-                audit_ctx.trace_id,
-                audit_ctx.user_id,
-                error=type(request_error).__name__,
-            )
-        raise
-    finally:
-        if audit_ctx:
-            clear_conversation_trace_id()
+        except Exception as request_error:
+            if audit_ctx:
+                audit_ctx.logger.request_failed(
+                    error=type(request_error).__name__,
+                )
+            raise
 
     return LLMResponse(
         conversation_id=processed_request.conversation_id,
@@ -322,67 +323,51 @@ def process_request(auth: Any, llm_request: LLMRequest) -> ProcessedRequest:
         )
     timestamps["retrieve conversation"] = time.time()
 
-    trace_id = suid.conversation_id_to_trace_id(conversation_id)
     audit_logger = AuditLogger(enabled=config.ols_config.audit.enabled)
-    set_conversation_trace_id(trace_id)
-    try:
-        audit_ctx = AuditContext(
-            trace_id=trace_id, user_id=user_id, logger=audit_logger
-        )
+    audit_ctx = AuditContext(
+        conversation_id=conversation_id, user_id=user_id, logger=audit_logger
+    )
 
-        with audit_ctx.span("request.auth"):
-            audit_ctx.logger.request_auth(audit_ctx.trace_id, audit_ctx.user_id)
+    with audit_ctx.span("request.auth"):
+        audit_ctx.logger.request_auth()
 
-        skip_user_id_check = retrieve_skip_user_id_check(auth)
+    skip_user_id_check = retrieve_skip_user_id_check(auth)
 
-        user_token = retrieve_user_token(auth)
+    user_token = retrieve_user_token(auth)
 
-        # Important note: Redact the query before attempting to do any
-        # logging of the query to avoid leaking PII into logs.
+    # Important note: Redact the query before attempting to do any
+    # logging of the query to avoid leaking PII into logs.
 
-        # Redact the query
-        llm_request = redact_query(conversation_id, llm_request)
-        timestamps["redact query"] = time.time()
+    # Redact the query
+    llm_request = redact_query(conversation_id, llm_request)
+    timestamps["redact query"] = time.time()
 
-        # Retrieve attachments from the request
-        attachments = retrieve_attachments(llm_request)
+    # Retrieve attachments from the request
+    attachments = retrieve_attachments(llm_request)
 
-        # Redact all attachments
-        attachments = redact_attachments(conversation_id, attachments)
+    # Redact all attachments
+    attachments = redact_attachments(conversation_id, attachments)
 
-        audit_ctx.logger.request_started(
-            audit_ctx.trace_id,
-            audit_ctx.user_id,
-            mode=llm_request.mode,
-            query=llm_request.query,
-            attachments=[a.model_dump() for a in attachments],
-            provider=llm_request.provider,
-            model=llm_request.model,
-        )
+    # All attachments should be appended to query - but store original
+    # query for later use in transcript storage
+    query_without_attachments = llm_request.query
+    llm_request.query = append_attachments_to_query(llm_request.query, attachments)
+    timestamps["append attachments"] = time.time()
 
-        # All attachments should be appended to query - but store original
-        # query for later use in transcript storage
-        query_without_attachments = llm_request.query
-        llm_request.query = append_attachments_to_query(llm_request.query, attachments)
-        timestamps["append attachments"] = time.time()
+    validate_requested_provider_model(llm_request)
 
-        validate_requested_provider_model(llm_request)
-
-        check_tokens_available(config.quota_limiters, user_id)
-        return ProcessedRequest(
-            user_id=user_id,
-            conversation_id=conversation_id,
-            query_without_attachments=query_without_attachments,
-            attachments=attachments,
-            timestamps=timestamps,
-            skip_user_id_check=skip_user_id_check,
-            user_token=user_token,
-            mode=llm_request.mode,
-            audit_ctx=audit_ctx,
-        )
-    except Exception:
-        clear_conversation_trace_id()
-        raise
+    check_tokens_available(config.quota_limiters, user_id)
+    return ProcessedRequest(
+        user_id=user_id,
+        conversation_id=conversation_id,
+        query_without_attachments=query_without_attachments,
+        attachments=attachments,
+        timestamps=timestamps,
+        skip_user_id_check=skip_user_id_check,
+        user_token=user_token,
+        mode=llm_request.mode,
+        audit_ctx=audit_ctx,
+    )
 
 
 def check_tokens_available(

--- a/ols/app/endpoints/streaming_ols.py
+++ b/ols/app/endpoints/streaming_ols.py
@@ -41,7 +41,6 @@ from ols.constants import MEDIA_TYPE_TEXT
 from ols.src.auth.auth import get_auth_dependency
 from ols.utils import errors_parsing
 from ols.utils.audit_logger import AuditContext
-from ols.utils.otel import clear_conversation_trace_id
 from ols.utils.token_handler import PromptTooLongError
 
 logger = logging.getLogger(__name__)
@@ -133,11 +132,8 @@ def conversation_request(
     except Exception as setup_error:
         if processed_request.audit_ctx:
             processed_request.audit_ctx.logger.request_failed(
-                processed_request.audit_ctx.trace_id,
-                processed_request.audit_ctx.user_id,
                 error=type(setup_error).__name__,
             )
-            clear_conversation_trace_id()
         raise
 
 
@@ -404,6 +400,15 @@ async def response_processing_wrapper(  # noqa: C901  # pylint: disable=R0912,R0
         exit_stack.enter_context(audit_ctx.span("request.lifecycle"))
 
     try:
+        if audit_ctx:
+            audit_ctx.logger.request_started(
+                mode=llm_request.mode,
+                query=llm_request.query,
+                attachments=[a.model_dump() for a in attachments],
+                provider=llm_request.provider,
+                model=llm_request.model,
+                capture_content=audit_ctx.capture_content,
+            )
         if media_type == constants.MEDIA_TYPE_JSON:
             yield stream_start_event(conversation_id)
 
@@ -493,16 +498,12 @@ async def response_processing_wrapper(  # noqa: C901  # pylint: disable=R0912,R0
                         raise ValueError(msg)
         except PromptTooLongError as summarizer_error:
             if audit_ctx:
-                audit_ctx.logger.request_failed(
-                    audit_ctx.trace_id, audit_ctx.user_id, error="prompt_too_long"
-                )
+                audit_ctx.logger.request_failed(error="prompt_too_long")
             yield prompt_too_long_error(summarizer_error, media_type)
             return
         except Exception as summarizer_error:
             if audit_ctx:
                 audit_ctx.logger.request_failed(
-                    audit_ctx.trace_id,
-                    audit_ctx.user_id,
                     error=type(summarizer_error).__name__,
                 )
             yield generic_llm_error(summarizer_error, media_type)
@@ -547,8 +548,6 @@ async def response_processing_wrapper(  # noqa: C901  # pylint: disable=R0912,R0
                 referenced_documents = ReferencedDocument.from_rag_chunks(rag_chunks)
                 reasoning_tokens = calc_tokens(token_counter, "reasoning_tokens")
                 audit_ctx.logger.request_completed(
-                    audit_ctx.trace_id,
-                    audit_ctx.user_id,
                     total_turns=getattr(token_counter, "llm_calls", 1),
                     total_input_tokens=input_tokens,
                     total_output_tokens=output_tokens + reasoning_tokens,
@@ -571,8 +570,6 @@ async def response_processing_wrapper(  # noqa: C901  # pylint: disable=R0912,R0
         except Exception as finalization_error:
             if audit_ctx:
                 audit_ctx.logger.request_failed(
-                    audit_ctx.trace_id,
-                    audit_ctx.user_id,
                     error=type(finalization_error).__name__,
                 )
             logger.exception(
@@ -588,5 +585,3 @@ async def response_processing_wrapper(  # noqa: C901  # pylint: disable=R0912,R0
                 )
     finally:
         exit_stack.close()
-        if audit_ctx:
-            clear_conversation_trace_id()

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -221,10 +221,7 @@ class DocsSummarizer(QueryHelper):
                 self._tracker.charge(TokenCategory.RAG, rag_tokens)
 
                 if self._audit_ctx and span:
-                    span.set_attribute("chunk_count", len(rag_chunks))
                     self._audit_ctx.logger.rag_retrieved(
-                        self._audit_ctx.trace_id,
-                        self._audit_ctx.user_id,
                         chunk_count=len(rag_chunks),
                         scores=[
                             node.get_score(raise_error=False)
@@ -420,10 +417,7 @@ class DocsSummarizer(QueryHelper):
                     history, truncated = item
 
             if self._audit_ctx and span:
-                span.set_attribute("turn_count", len(history) // 2)
                 self._audit_ctx.logger.history_retrieved(
-                    self._audit_ctx.trace_id,
-                    self._audit_ctx.user_id,
                     turn_count=len(history) // 2,
                     compressed=compressed,
                     truncated=truncated,

--- a/ols/src/query_helpers/llm_execution_agent.py
+++ b/ols/src/query_helpers/llm_execution_agent.py
@@ -14,6 +14,7 @@ from langchain_core.messages.ai import AIMessageChunk
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.tools.structured import StructuredTool
 from langchain_openai import ChatOpenAI
+from opentelemetry.trace import SpanKind
 
 from ols import constants
 from ols.app.metrics import TokenMetricUpdater
@@ -255,7 +256,7 @@ class LLMExecutionAgent:
         prev_input_tokens: int,
         prev_output_tokens: int,
     ) -> tuple[int, int]:
-        """Emit audit events for a completed LLM turn and return updated token counters."""
+        """Emit audit span events for a completed LLM turn."""
         if not self._audit_ctx:
             return prev_input_tokens, prev_output_tokens
         cur_input = token_counter.token_counter.input_tokens
@@ -263,23 +264,16 @@ class LLMExecutionAgent:
             token_counter.token_counter.output_tokens
             + token_counter.token_counter.reasoning_tokens
         )
+        capture = self._audit_ctx.capture_content
         thinking = "".join(round_result.collected_thinking)
         text = "".join(round_result.collected_text)
         if thinking:
             self._audit_ctx.logger.llm_thinking(
-                self._audit_ctx.trace_id,
-                self._audit_ctx.user_id,
-                content=thinking,
+                content=thinking, capture_content=capture
             )
         if text:
-            self._audit_ctx.logger.llm_text(
-                self._audit_ctx.trace_id,
-                self._audit_ctx.user_id,
-                content=text,
-            )
+            self._audit_ctx.logger.llm_text(content=text, capture_content=capture)
         self._audit_ctx.logger.llm_turn(
-            self._audit_ctx.trace_id,
-            self._audit_ctx.user_id,
             turn_index=turn_index,
             input_tokens=cur_input - prev_input_tokens,
             output_tokens=cur_output - prev_output_tokens,
@@ -324,7 +318,16 @@ class LLMExecutionAgent:
 
             round_result = RoundLLMResult()
             turn_span = (
-                self._audit_ctx.span("llm.turn", turn_index=i)
+                self._audit_ctx.span(
+                    f"chat {self.model}",
+                    kind=SpanKind.CLIENT,
+                    **{
+                        "gen_ai.operation.name": "chat",
+                        "gen_ai.request.model": self.model,
+                        "gen_ai.provider.name": self.provider,
+                    },
+                    turn_index=i,
+                )
                 if self._audit_ctx
                 else nullcontext()
             )

--- a/ols/src/tools/tools.py
+++ b/ols/src/tools/tools.py
@@ -417,8 +417,6 @@ async def _evaluate_and_emit_approval_event(
 
     if audit_ctx:
         audit_ctx.logger.tool_approval_requested(
-            audit_ctx.trace_id,
-            audit_ctx.user_id,
             tool_name=tool_name,
             approval_id=approval_id,
         )
@@ -437,8 +435,6 @@ async def _evaluate_and_emit_approval_event(
 
     if audit_ctx:
         audit_ctx.logger.tool_approval_decision(
-            audit_ctx.trace_id,
-            audit_ctx.user_id,
             approval_id=approval_id,
             decision=outcome,
             tool_name=tool_name,
@@ -537,15 +533,22 @@ async def _execute_single_tool_call_stream(
     mcp_server = (getattr(tool, "metadata", None) or {}).get("mcp_server", "")
 
     tool_span = (
-        audit_ctx.span(f"tool.{tool_name}", mcp_server=mcp_server)
+        audit_ctx.span(
+            f"execute_tool {tool_name}",
+            **{
+                "gen_ai.operation.name": "execute_tool",
+                "gen_ai.tool.name": tool_name,
+                "gen_ai.tool.call.id": tool_id,
+                "gen_ai.tool.type": "function",
+            },
+            mcp_server=mcp_server,
+        )
         if audit_ctx
         else nullcontext()
     )
     with tool_span:
         if audit_ctx:
             audit_ctx.logger.tool_call(
-                audit_ctx.trace_id,
-                audit_ctx.user_id,
                 tool_name=tool_name,
                 mcp_server=mcp_server or None,
                 arguments=list(tool_args.keys()),
@@ -576,9 +579,6 @@ async def _execute_single_tool_call_stream(
 
         if audit_ctx:
             audit_ctx.logger.tool_result(
-                audit_ctx.trace_id,
-                audit_ctx.user_id,
-                tool_name=tool_name,
                 output_length=len(tool_output),
                 success=status == "success",
                 duration_ms=duration_ms,

--- a/ols/utils/audit_logger.py
+++ b/ols/utils/audit_logger.py
@@ -1,57 +1,18 @@
-"""Structured JSON audit logger for compliance audit events."""
+"""Structured audit logger emitting OTel span events for compliance."""
 
-import json
 import logging
-import sys
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from typing import Any, Generator, Optional
 
 from opentelemetry import trace
-
-JsonScalar = str | int | float | bool | None
-JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
-
-
-def _normalize_json(value: Any) -> JsonValue:
-    """Coerce a value to a JSON-safe type."""
-    if isinstance(value, (str, int, float, bool)) or value is None:
-        return value
-    if isinstance(value, dict):
-        return {str(k): _normalize_json(v) for k, v in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_normalize_json(item) for item in value]
-    return str(value)
-
+from opentelemetry.trace import SpanKind, StatusCode
 
 _fallback_logger = logging.getLogger(__name__)
 
 
-class _AuditJsonFormatter(logging.Formatter):
-    """Formatter that passes through pre-formatted JSON strings."""
-
-    def format(self, record: logging.LogRecord) -> str:
-        return record.getMessage()
-
-
-def _setup_audit_logger() -> logging.Logger:
-    """Create and configure the ols.audit logger with JSON output to stdout."""
-    logger = logging.getLogger("ols.audit")
-    logger.setLevel(logging.INFO)
-    logger.propagate = False
-
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(_AuditJsonFormatter())
-    logger.addHandler(handler)
-    return logger
-
-
-_audit_logger = _setup_audit_logger()
-
-
 class AuditLogger:
-    """Emits structured JSON audit events to stdout.
+    """Emits audit data as OTel span events.
 
     When disabled, all methods are no-ops.
     """
@@ -60,83 +21,75 @@ class AuditLogger:
         """Initialize the audit logger."""
         self._enabled = enabled
 
-    def _emit(
-        self, event: str, trace_id: str, user_id: str, **fields: JsonValue
-    ) -> None:
+    def _add_span_event(self, name: str, **attrs: Any) -> None:
         if not self._enabled:
             return
-        try:
-            record: dict[str, Any] = {
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-                "level": "info",
-                "event": event,
-                "trace_id": trace_id,
-                "user_id": user_id,
-            }
-            record.update({k: _normalize_json(v) for k, v in fields.items()})
-            _audit_logger.info(json.dumps(record, ensure_ascii=False, allow_nan=False))
-        except Exception:
-            _fallback_logger.warning(
-                "Failed to emit audit event %s", event, exc_info=True
-            )
+        span = trace.get_current_span()
+        if span is None or not span.is_recording():
+            return
+        filtered = {k: v for k, v in attrs.items() if v is not None}
+        span.add_event(name, attributes=filtered)
+
+    def _set_span_attrs(self, **attrs: Any) -> None:
+        if not self._enabled:
+            return
+        span = trace.get_current_span()
+        if span is None or not span.is_recording():
+            return
+        for k, v in attrs.items():
+            if v is not None:
+                span.set_attribute(k, v)
 
     def request_started(
         self,
-        trace_id: str,
-        user_id: str,
+        *,
         mode: str,
         query: str,
         attachments: list[dict[str, Any]],
         provider: Optional[str],
         model: Optional[str],
+        capture_content: bool = True,
     ) -> None:
-        """Emit audit.request.started event."""
-        self._emit(
-            "audit.request.started",
-            trace_id,
-            user_id,
+        """Emit request.started span event on request.lifecycle span."""
+        self._add_span_event(
+            "request.started",
             mode=mode,
-            query=query,
-            attachments=attachments,
-            provider=provider,
-            model=model,
+            query=query if capture_content else None,
+            attachment_count=len(attachments),
+            provider=provider or "",
+            model=model or "",
         )
 
-    def request_auth(self, trace_id: str, user_id: str) -> None:
-        """Emit audit.request.auth event."""
-        self._emit("audit.request.auth", trace_id, user_id)
+    def request_auth(self) -> None:
+        """No-op — auth is tracked by its own span."""
 
     def rag_retrieved(
         self,
-        trace_id: str,
-        user_id: str,
+        *,
         chunk_count: int,
         scores: list[float],
         source_documents: list[str],
     ) -> None:
-        """Emit audit.rag.retrieved event."""
-        self._emit(
-            "audit.rag.retrieved",
-            trace_id,
-            user_id,
+        """Set RAG attributes on request.rag span."""
+        self._set_span_attrs(chunk_count=chunk_count)
+        self._add_span_event(
+            "rag.retrieved",
             chunk_count=chunk_count,
-            scores=scores,
+            scores=[round(s, 4) for s in scores],
             source_documents=source_documents,
         )
 
     def history_retrieved(
         self,
-        trace_id: str,
-        user_id: str,
+        *,
         turn_count: int,
         compressed: bool,
         truncated: bool,
     ) -> None:
-        """Emit audit.history.retrieved event."""
-        self._emit(
-            "audit.history.retrieved",
-            trace_id,
-            user_id,
+        """Set history attributes on request.history span."""
+        self._set_span_attrs(turn_count=turn_count)
+        self._add_span_event(
+            "history.retrieved",
             turn_count=turn_count,
             compressed=compressed,
             truncated=truncated,
@@ -144,63 +97,58 @@ class AuditLogger:
 
     def llm_turn(
         self,
-        trace_id: str,
-        user_id: str,
+        *,
         turn_index: int,
         input_tokens: int,
         output_tokens: int,
     ) -> None:
-        """Emit audit.llm.turn event."""
-        self._emit(
-            "audit.llm.turn",
-            trace_id,
-            user_id,
-            turn_index=turn_index,
-            tokens_in=input_tokens,
-            tokens_out=output_tokens,
+        """Set token usage attributes on the chat span."""
+        self._set_span_attrs(
+            **{
+                "gen_ai.usage.input_tokens": input_tokens,
+                "gen_ai.usage.output_tokens": output_tokens,
+                "turn_index": turn_index,
+            }
         )
 
-    def llm_thinking(self, trace_id: str, user_id: str, content: str) -> None:
-        """Emit audit.llm.thinking event."""
-        self._emit("audit.llm.thinking", trace_id, user_id, content=content)
+    def llm_thinking(self, *, content: str, capture_content: bool = True) -> None:
+        """Emit gen_ai.choice span event for reasoning content."""
+        attrs: dict[str, Any] = {}
+        if capture_content:
+            attrs["gen_ai.reasoning_content"] = content
+        self._add_span_event("gen_ai.choice", **attrs)
 
-    def llm_text(self, trace_id: str, user_id: str, content: str) -> None:
-        """Emit audit.llm.text event."""
-        self._emit("audit.llm.text", trace_id, user_id, content=content)
+    def llm_text(self, *, content: str, capture_content: bool = True) -> None:
+        """Emit gen_ai.choice span event for completion text."""
+        attrs: dict[str, Any] = {}
+        if capture_content:
+            attrs["gen_ai.completion"] = content
+        self._add_span_event("gen_ai.choice", **attrs)
 
     def tool_call(
         self,
-        trace_id: str,
-        user_id: str,
+        *,
         tool_name: str,
         mcp_server: Optional[str],
         arguments: list[str],
     ) -> None:
-        """Emit audit.tool.call event."""
-        self._emit(
-            "audit.tool.call",
-            trace_id,
-            user_id,
+        """Emit tool.call span event on execute_tool span."""
+        self._add_span_event(
+            "tool.call",
             tool_name=tool_name,
-            mcp_server=mcp_server,
+            mcp_server=mcp_server or "",
             arguments=arguments,
         )
 
     def tool_result(
         self,
-        trace_id: str,
-        user_id: str,
-        tool_name: str,
+        *,
         output_length: int,
         success: bool,
         duration_ms: Optional[int],
     ) -> None:
-        """Emit audit.tool.result event."""
-        self._emit(
-            "audit.tool.result",
-            trace_id,
-            user_id,
-            tool_name=tool_name,
+        """Set tool result attributes on execute_tool span."""
+        self._set_span_attrs(
             output_length=output_length,
             success=success,
             duration_ms=duration_ms,
@@ -208,59 +156,61 @@ class AuditLogger:
 
     def tool_approval_requested(
         self,
-        trace_id: str,
-        user_id: str,
+        *,
         tool_name: str,
         approval_id: str,
     ) -> None:
-        """Emit audit.tool.approval.requested event."""
-        self._emit(
-            "audit.tool.approval.requested",
-            trace_id,
-            user_id,
+        """Emit approval.requested span event."""
+        self._add_span_event(
+            "approval.requested",
             tool_name=tool_name,
             approval_id=approval_id,
         )
 
     def tool_approval_decision(
         self,
-        trace_id: str,
-        user_id: str,
+        *,
         approval_id: str,
         decision: str,
         tool_name: str,
     ) -> None:
-        """Emit audit.tool.approval.decision event."""
-        self._emit(
-            "audit.tool.approval.decision",
-            trace_id,
-            user_id,
+        """Emit approval.decision span event."""
+        self._add_span_event(
+            "approval.decision",
             approval_id=approval_id,
             decision=decision,
             tool_name=tool_name,
         )
 
-    def request_failed(self, trace_id: str, user_id: str, error: str) -> None:
-        """Emit audit.request.failed event."""
-        self._emit("audit.request.failed", trace_id, user_id, error=error)
+    def request_failed(self, *, error: str) -> None:
+        """Set error status and event on request.lifecycle span."""
+        if not self._enabled:
+            return
+        span = trace.get_current_span()
+        if span is None or not span.is_recording():
+            return
+        span.set_status(StatusCode.ERROR, error)
+        span.add_event("request.failed", attributes={"error": error})
 
     def request_completed(
         self,
-        trace_id: str,
-        user_id: str,
+        *,
         total_turns: int,
         total_input_tokens: int,
         total_output_tokens: int,
         referenced_documents: list[str],
     ) -> None:
-        """Emit audit.request.completed event."""
-        self._emit(
-            "audit.request.completed",
-            trace_id,
-            user_id,
+        """Set completion attributes on request.lifecycle span."""
+        self._set_span_attrs(
             total_turns=total_turns,
-            total_tokens_in=total_input_tokens,
-            total_tokens_out=total_output_tokens,
+            total_input_tokens=total_input_tokens,
+            total_output_tokens=total_output_tokens,
+        )
+        self._add_span_event(
+            "request.completed",
+            total_turns=total_turns,
+            total_input_tokens=total_input_tokens,
+            total_output_tokens=total_output_tokens,
             referenced_documents=referenced_documents,
         )
 
@@ -269,13 +219,21 @@ class AuditLogger:
 class AuditContext:
     """Immutable context for audit logging throughout a request lifecycle."""
 
-    trace_id: str
+    conversation_id: str
     user_id: str
     logger: AuditLogger
+    capture_content: bool = True
     tracer: trace.Tracer = field(default_factory=lambda: trace.get_tracer("ols.audit"))
 
     @contextmanager
-    def span(self, name: str, **attrs: Any) -> Generator[trace.Span, None, None]:
-        """Start an OTEL span independent of the logging toggle (per spec rule 3)."""
-        with self.tracer.start_as_current_span(name, attributes=attrs) as s:
+    def span(
+        self,
+        name: str,
+        kind: SpanKind = SpanKind.INTERNAL,
+        **attrs: Any,
+    ) -> Generator[trace.Span, None, None]:
+        """Start an OTEL span with conversation_id and user_id auto-injected."""
+        attrs.setdefault("gen_ai.conversation.id", self.conversation_id)
+        attrs.setdefault("user_id", self.user_id)
+        with self.tracer.start_as_current_span(name, kind=kind, attributes=attrs) as s:
             yield s

--- a/ols/utils/otel.py
+++ b/ols/utils/otel.py
@@ -1,57 +1,95 @@
 """OpenTelemetry tracing setup for audit spans."""
 
 import atexit
-import contextvars
+import base64
+import json
 import logging
-from typing import Optional
+import sys
+import threading
+from typing import Any, Optional, Sequence
 
+from google.protobuf.json_format import MessageToDict
 from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.id_generator import IdGenerator, RandomIdGenerator
+from opentelemetry.sdk.trace.export import (
+    BatchSpanProcessor,
+    ReadableSpan,
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
+)
 
 logger = logging.getLogger(__name__)
 
 _TRACER_NAME = "ols.audit"
 
-_trace_id_var: contextvars.ContextVar[Optional[int]] = contextvars.ContextVar(
-    "_trace_id_var", default=None
-)
+
+def _b64_to_hex(val: str) -> str:
+    """Decode a base64-encoded protobuf bytes field to lowercase hex."""
+    return base64.b64decode(val).hex()
 
 
-class _ConversationIdGenerator(IdGenerator):
-    """Id generator that uses a context-local trace_id override when set."""
-
-    def __init__(self) -> None:
-        self._random = RandomIdGenerator()
-
-    def generate_span_id(self) -> int:
-        return self._random.generate_span_id()
-
-    def generate_trace_id(self) -> int:
-        override = _trace_id_var.get()
-        if override is not None:
-            return override
-        return self._random.generate_trace_id()
+_ID_KEYS = ("traceId", "spanId", "parentSpanId")
 
 
-_id_generator = _ConversationIdGenerator()
+def _hex_ids(obj: dict[str, Any], keys: tuple[str, ...]) -> None:
+    """Convert base64-encoded ID fields to hex in-place."""
+    for k in keys:
+        if k in obj:
+            obj[k] = _b64_to_hex(obj[k])
+
+
+def _proto_to_otlp_json(d: dict[str, Any]) -> dict[str, Any]:
+    """Fix ProtoJSON → OTLP JSON: hex traceId/spanId, already int enums."""
+    for rs in d.get("resourceSpans", []):
+        for ss in rs.get("scopeSpans", []):
+            for span in ss.get("spans", []):
+                _hex_ids(span, _ID_KEYS)
+                for link in span.get("links", []):
+                    _hex_ids(link, ("traceId", "spanId"))
+    return d
+
+
+_stdout_lock = threading.Lock()
+
+
+class OTLPJsonStdoutExporter(SpanExporter):
+    """Write OTLP-encoded spans as single-line JSON to stdout."""
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        """Encode spans to OTLP proto, convert to dict, and write as single-line JSON."""
+        try:
+            pb = encode_spans(spans)
+            d = MessageToDict(pb, use_integers_for_enums=True)
+            line = json.dumps(_proto_to_otlp_json(d))
+            with _stdout_lock:
+                sys.stdout.write(line + "\n")
+                sys.stdout.flush()
+        except Exception:
+            logger.warning("Failed to export audit spans to stdout", exc_info=True)
+            return SpanExportResult.FAILURE
+        return SpanExportResult.SUCCESS
 
 
 def init_tracer(
     otel_endpoint: Optional[str] = None,
     insecure: bool = False,
     certificate_file: Optional[str] = None,
+    audit_enabled: bool = False,
 ) -> trace.Tracer:
-    """Initialize the OTEL tracer with OTLP exporter or no-op."""
+    """Initialize the OTEL tracer with exporters based on configuration."""
     resource = Resource.create({"service.name": "lightspeed-service"})
-    provider = TracerProvider(resource=resource, id_generator=_id_generator)
+    provider = TracerProvider(resource=resource)
+
+    if audit_enabled:
+        provider.add_span_processor(SimpleSpanProcessor(OTLPJsonStdoutExporter()))
+        logger.info("OTEL stdout JSON exporter enabled for audit compliance")
+
     if otel_endpoint:
-        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (  # pylint: disable=C0415
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (  # pylint: disable=import-outside-toplevel
             OTLPSpanExporter,
-        )
-        from opentelemetry.sdk.trace.export import (  # pylint: disable=C0415
-            BatchSpanProcessor,
         )
 
         credentials = None
@@ -66,19 +104,9 @@ def init_tracer(
         )
         provider.add_span_processor(BatchSpanProcessor(exporter))
         logger.info("OTEL tracer configured with endpoint: %s", otel_endpoint)
-    else:
+    elif not audit_enabled:
         logger.info("OTEL tracer configured with no-op exporter (no endpoint)")
 
     trace.set_tracer_provider(provider)
     atexit.register(provider.shutdown)
     return trace.get_tracer(_TRACER_NAME)
-
-
-def set_conversation_trace_id(trace_id_hex: str) -> None:
-    """Set the trace_id override for the current context."""
-    _trace_id_var.set(int(trace_id_hex, 16))
-
-
-def clear_conversation_trace_id() -> None:
-    """Clear the trace_id override for the current context."""
-    _trace_id_var.set(None)

--- a/ols/utils/suid.py
+++ b/ols/utils/suid.py
@@ -12,11 +12,6 @@ def get_suid() -> str:
     return str(uuid.uuid4())
 
 
-def conversation_id_to_trace_id(conversation_id: str) -> str:
-    """Convert a UUID conversation_id to a 32-hex-char OTEL trace ID."""
-    return conversation_id.replace("-", "")
-
-
 def check_suid(suid: str) -> bool:
     """Check if given string is a proper session ID."""
     try:

--- a/runner.py
+++ b/runner.py
@@ -92,7 +92,13 @@ if __name__ == "__main__":
             )
             if os.path.isfile(ca_bundle):
                 ca_cert_path = ca_bundle
-    init_tracer(otel_endpoint, insecure=otel_insecure, certificate_file=ca_cert_path)
+    audit_enabled = bool(config.ols_config.audit and config.ols_config.audit.enabled)
+    init_tracer(
+        otel_endpoint,
+        insecure=otel_insecure,
+        certificate_file=ca_cert_path,
+        audit_enabled=audit_enabled,
+    )
 
     if config.dev_config.pyroscope_url:
         start_with_pyroscope_enabled(config, logger)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,8 +1,56 @@
 """Configuration for unit tests."""
 
+from typing import Sequence
+
 import pytest
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
+)
 
 from ols import config
+from ols.utils.audit_logger import AuditContext, AuditLogger
+
+
+class CollectingExporter(SpanExporter):
+    """Span exporter that collects finished spans in a list."""
+
+    def __init__(self):
+        """Initialize the collecting exporter."""
+        self.spans = []
+
+    def export(self, spans: Sequence) -> SpanExportResult:
+        """Export spans by appending to the internal list."""
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self):
+        """Shut down the exporter."""
+
+
+@pytest.fixture()
+def otel_setup():
+    """Set up an OTel provider with a collecting exporter."""
+    exporter = CollectingExporter()
+    provider = TracerProvider(resource=Resource.create({"service.name": "test"}))
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("ols.audit.test")
+    yield exporter, tracer
+    provider.shutdown()
+
+
+def make_audit_ctx(otel_setup, conversation_id="conv-test", user_id="user-test"):
+    """Create an AuditContext wired to the test OTel provider."""
+    _, tracer = otel_setup
+    return AuditContext(
+        conversation_id=conversation_id,
+        user_id=user_id,
+        logger=AuditLogger(enabled=True),
+        tracer=tracer,
+    )
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/unit/query_helpers/test_llm_execution_agent.py
+++ b/tests/unit/query_helpers/test_llm_execution_agent.py
@@ -8,6 +8,7 @@ import pytest
 from langchain_core.messages import ToolMessage
 from langchain_core.messages.ai import AIMessageChunk
 from langchain_core.tools.structured import StructuredTool
+from opentelemetry.trace import SpanKind
 from pydantic import BaseModel
 
 from ols import config
@@ -21,6 +22,7 @@ from ols.src.query_helpers.llm_execution_agent import (  # noqa: E402
     RoundLLMResult,
 )
 from ols.src.tools.tools import ApprovalRequiredEvent, ToolResultEvent  # noqa: E402
+from ols.utils.audit_logger import AuditContext, AuditLogger  # noqa: E402
 from ols.utils.token_handler import (  # noqa: E402
     TokenBudgetTracker,
     TokenCategory,
@@ -28,6 +30,7 @@ from ols.utils.token_handler import (  # noqa: E402
 )
 from tests.mock_classes.mock_llm_loader import MockLLMLoader  # noqa: E402
 from tests.mock_classes.mock_tools import mock_tools_map  # noqa: E402
+from tests.unit.conftest import make_audit_ctx  # noqa: E402
 
 
 class SampleTool(StructuredTool):
@@ -723,3 +726,129 @@ async def test_execute_emits_end_chunk_with_rag_and_truncated():
     assert chunks[1].data["rag_chunks"] is rag_chunks
     assert chunks[1].data["truncated"] is True
     assert "token_counter" in chunks[1].data
+
+
+class TestGenAISpanNaming:
+    """Verify LLM turn spans use GenAI semantic convention names and attributes."""
+
+    def test_emit_turn_audit_emits_genai_events(self, otel_setup) -> None:
+        """Verify _emit_turn_audit emits gen_ai.choice events and token attributes."""
+        audit_ctx = make_audit_ctx(otel_setup)
+        agent = _make_agent(audit_ctx=audit_ctx)
+
+        token_counter = MagicMock()
+        token_counter.token_counter.input_tokens = 100
+        token_counter.token_counter.output_tokens = 40
+        token_counter.token_counter.reasoning_tokens = 10
+
+        result = RoundLLMResult()
+        result.collected_thinking = ["thinking hard"]
+        result.collected_text = ["the answer"]
+
+        with audit_ctx.span("chat mock_model", kind=SpanKind.CLIENT):
+            agent._emit_turn_audit(result, 1, token_counter, 0, 0)
+
+        exporter, _ = otel_setup
+        span = exporter.spans[0]
+        events = {e.name: e for e in span.events}
+        assert "gen_ai.choice" in events
+        choice_events = [e for e in span.events if e.name == "gen_ai.choice"]
+        reasoning_events = [
+            e for e in choice_events if "gen_ai.reasoning_content" in e.attributes
+        ]
+        completion_events = [
+            e for e in choice_events if "gen_ai.completion" in e.attributes
+        ]
+        assert len(reasoning_events) == 1
+        assert (
+            reasoning_events[0].attributes["gen_ai.reasoning_content"]
+            == "thinking hard"
+        )
+        assert len(completion_events) == 1
+        assert completion_events[0].attributes["gen_ai.completion"] == "the answer"
+        assert span.attributes["gen_ai.usage.input_tokens"] == 100
+        assert span.attributes["gen_ai.usage.output_tokens"] == 50
+
+    def test_emit_turn_audit_skips_empty_thinking(self, otel_setup) -> None:
+        """Verify _emit_turn_audit skips thinking event when no reasoning content."""
+        audit_ctx = make_audit_ctx(otel_setup)
+        agent = _make_agent(audit_ctx=audit_ctx)
+
+        token_counter = MagicMock()
+        token_counter.token_counter.input_tokens = 50
+        token_counter.token_counter.output_tokens = 20
+        token_counter.token_counter.reasoning_tokens = 0
+
+        result = RoundLLMResult()
+        result.collected_thinking = []
+        result.collected_text = ["just text"]
+
+        with audit_ctx.span("chat mock_model", kind=SpanKind.CLIENT):
+            agent._emit_turn_audit(result, 1, token_counter, 0, 0)
+
+        exporter, _ = otel_setup
+        span = exporter.spans[0]
+        choice_events = [e for e in span.events if e.name == "gen_ai.choice"]
+        assert len(choice_events) == 1
+        assert "gen_ai.completion" in choice_events[0].attributes
+        assert all(
+            "gen_ai.reasoning_content" not in e.attributes for e in choice_events
+        )
+
+    def test_chat_span_has_genai_attributes(self, otel_setup) -> None:
+        """Verify the chat span carries gen_ai.* attributes and correct kind."""
+        audit_ctx = make_audit_ctx(otel_setup)
+        with audit_ctx.span(
+            "chat gpt-4",
+            kind=SpanKind.CLIENT,
+            **{
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gpt-4",
+                "gen_ai.provider.name": "openai",
+            },
+            turn_index=1,
+        ):
+            pass
+
+        exporter, _ = otel_setup
+        span = exporter.spans[0]
+        assert span.name == "chat gpt-4"
+        assert span.kind == SpanKind.CLIENT
+        assert span.attributes["gen_ai.operation.name"] == "chat"
+        assert span.attributes["gen_ai.request.model"] == "gpt-4"
+        assert span.attributes["gen_ai.provider.name"] == "openai"
+        assert span.attributes["gen_ai.conversation.id"] == "conv-test"
+        assert span.attributes["user_id"] == "user-test"
+        assert span.attributes["turn_index"] == 1
+
+    def test_emit_turn_audit_respects_capture_content_false(self, otel_setup) -> None:
+        """Verify gen_ai.choice events omit content when capture_content is False."""
+        _, tracer = otel_setup
+        audit_ctx = AuditContext(
+            conversation_id="conv-test",
+            user_id="user-test",
+            logger=AuditLogger(enabled=True),
+            tracer=tracer,
+            capture_content=False,
+        )
+        agent = _make_agent(audit_ctx=audit_ctx)
+
+        token_counter = MagicMock()
+        token_counter.token_counter.input_tokens = 10
+        token_counter.token_counter.output_tokens = 5
+        token_counter.token_counter.reasoning_tokens = 0
+
+        result = RoundLLMResult()
+        result.collected_thinking = ["secret thoughts"]
+        result.collected_text = ["secret answer"]
+
+        with audit_ctx.span("chat mock_model", kind=SpanKind.CLIENT):
+            agent._emit_turn_audit(result, 1, token_counter, 0, 0)
+
+        exporter, _ = otel_setup
+        span = exporter.spans[0]
+        choice_events = [e for e in span.events if e.name == "gen_ai.choice"]
+        assert len(choice_events) == 2
+        for e in choice_events:
+            assert "gen_ai.completion" not in e.attributes
+            assert "gen_ai.reasoning_content" not in e.attributes

--- a/tests/unit/tools/test_tools.py
+++ b/tests/unit/tools/test_tools.py
@@ -21,6 +21,7 @@ from ols.src.tools.tools import (
     get_tool_by_name,
 )
 from ols.utils.token_handler import TokenHandler
+from tests.unit.conftest import make_audit_ctx
 
 _LARGE_TOKEN_BUDGET = 100_000
 
@@ -833,3 +834,113 @@ async def test_execute_tool_calls_stream_divides_budget_per_tool(
             f"Tool received budget {budget}, expected {expected_per_tool} "
             f"(total {total_budget} / 3 tools)"
         )
+
+
+class TestExecuteToolGenAISpans:
+    """Verify execute_tool_calls_stream creates spans with GenAI semantic attributes."""
+
+    @pytest.mark.asyncio
+    async def test_tool_span_name_and_attributes(self, otel_setup) -> None:
+        """Verify tool span is named 'execute_tool {name}' with GenAI attributes."""
+        audit_ctx = make_audit_ctx(
+            otel_setup, conversation_id="conv-tool-test", user_id="user-tool-test"
+        )
+        tool = FakeTool("my_tool")
+        tool_calls = [("call-123", {"arg": "val"}, tool)]
+
+        _ = [
+            event
+            async for event in execute_tool_calls_stream(
+                tool_calls,
+                tools_token_budget=_LARGE_TOKEN_BUDGET,
+                streaming=False,
+                audit_ctx=audit_ctx,
+            )
+        ]
+
+        exporter, _ = otel_setup
+        spans = exporter.spans
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "execute_tool my_tool"
+        assert span.attributes["gen_ai.operation.name"] == "execute_tool"
+        assert span.attributes["gen_ai.tool.name"] == "my_tool"
+        assert span.attributes["gen_ai.tool.call.id"] == "call-123"
+        assert span.attributes["gen_ai.tool.type"] == "function"
+        assert span.attributes["gen_ai.conversation.id"] == "conv-tool-test"
+        assert span.attributes["user_id"] == "user-tool-test"
+
+    @pytest.mark.asyncio
+    async def test_tool_span_emits_tool_call_event(self, otel_setup) -> None:
+        """Verify tool span contains a tool.call span event."""
+        audit_ctx = make_audit_ctx(
+            otel_setup, conversation_id="conv-tool-test", user_id="user-tool-test"
+        )
+        tool = FakeTool("check_pods")
+        tool_calls = [("call-456", {"ns": "default"}, tool)]
+
+        _ = [
+            event
+            async for event in execute_tool_calls_stream(
+                tool_calls,
+                tools_token_budget=_LARGE_TOKEN_BUDGET,
+                streaming=False,
+                audit_ctx=audit_ctx,
+            )
+        ]
+
+        exporter, _ = otel_setup
+        span = exporter.spans[0]
+        event_names = [e.name for e in span.events]
+        assert "tool.call" in event_names
+        call_event = next(e for e in span.events if e.name == "tool.call")
+        assert call_event.attributes["tool_name"] == "check_pods"
+
+    @pytest.mark.asyncio
+    async def test_tool_span_emits_result_attributes(self, otel_setup) -> None:
+        """Verify tool span has result attributes after execution."""
+        audit_ctx = make_audit_ctx(
+            otel_setup, conversation_id="conv-tool-test", user_id="user-tool-test"
+        )
+        tool = FakeTool("get_logs")
+        tool_calls = [("call-789", {}, tool)]
+
+        _ = [
+            event
+            async for event in execute_tool_calls_stream(
+                tool_calls,
+                tools_token_budget=_LARGE_TOKEN_BUDGET,
+                streaming=False,
+                audit_ctx=audit_ctx,
+            )
+        ]
+
+        exporter, _ = otel_setup
+        span = exporter.spans[0]
+        assert span.attributes["success"] is True
+        assert span.attributes["output_length"] > 0
+        assert "duration_ms" in span.attributes
+
+    @pytest.mark.asyncio
+    async def test_tool_span_includes_mcp_server(self, otel_setup) -> None:
+        """Verify tool span includes mcp_server attribute when present."""
+        audit_ctx = make_audit_ctx(
+            otel_setup, conversation_id="conv-tool-test", user_id="user-tool-test"
+        )
+        tool = FakeTool("remote_tool")
+        tool.metadata = {"mcp_server": "my-mcp-server"}
+        tool_calls = [("call-mcp", {}, tool)]
+
+        _ = [
+            event
+            async for event in execute_tool_calls_stream(
+                tool_calls,
+                tools_token_budget=_LARGE_TOKEN_BUDGET,
+                streaming=False,
+                audit_ctx=audit_ctx,
+            )
+        ]
+
+        exporter, _ = otel_setup
+        span = exporter.spans[0]
+        assert span.attributes["mcp_server"] == "my-mcp-server"

--- a/tests/unit/utils/test_audit_logger.py
+++ b/tests/unit/utils/test_audit_logger.py
@@ -1,265 +1,291 @@
-"""Unit tests for the structured audit logger."""
+"""Unit tests for the structured audit logger (OTel span events)."""
 
 import json
-import logging
 
 import pytest
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.trace import SpanKind
 
 from ols.utils.audit_logger import AuditContext, AuditLogger
+from ols.utils.otel import OTLPJsonStdoutExporter
+from tests.unit.conftest import make_audit_ctx
 
 
 @pytest.fixture()
-def captured_records(monkeypatch: pytest.MonkeyPatch) -> list[str]:
-    """Capture JSON strings emitted by the ols.audit logger."""
-    records: list[str] = []
-    audit_log = logging.getLogger("ols.audit")
-
-    class _Capture(logging.Handler):
-        def emit(self, record: logging.LogRecord) -> None:
-            records.append(record.getMessage())
-
-    handler = _Capture()
-    monkeypatch.setattr(audit_log, "handlers", [handler])
-    return records
+def audit_ctx(otel_setup):
+    """Create an AuditContext wired to the test provider."""
+    return make_audit_ctx(otel_setup, conversation_id="conv-123", user_id="user@test")
 
 
-class TestAuditLoggerEmit:
-    """Verify _emit produces valid JSON with required fields."""
+def _get_spans(otel_setup):
+    """Return collected spans from the otel_setup fixture."""
+    exporter, _ = otel_setup
+    return exporter.spans
 
-    def test_emit_produces_valid_json(self, captured_records: list[str]) -> None:
-        """Test _emit produces valid JSON with all required fields."""
-        logger = AuditLogger(enabled=True)
-        logger._emit("test.event", "abc123", "user@test", foo="bar")
 
-        assert len(captured_records) == 1
-        record = json.loads(captured_records[0])
-        assert record["event"] == "test.event"
-        assert record["trace_id"] == "abc123"
-        assert record["user_id"] == "user@test"
-        assert record["foo"] == "bar"
-        assert record["level"] == "info"
-        assert "timestamp" in record
+class TestAuditLoggerDisabled:
+    """Verify disabled logger emits nothing."""
 
-    def test_disabled_logger_emits_nothing(self, captured_records: list[str]) -> None:
-        """Test disabled logger emits no records."""
-        logger = AuditLogger(enabled=False)
-        logger._emit("test.event", "abc123", "user@test")
-        assert len(captured_records) == 0
-
-    def test_emit_nan_does_not_crash(self, captured_records: list[str]) -> None:
-        """Test _emit with NaN value logs warning instead of crashing."""
-        logger = AuditLogger(enabled=True)
-        logger._emit("test.event", "abc123", "user@test", score=float("nan"))
-        assert len(captured_records) == 0
+    def test_disabled_logger_emits_nothing(self, otel_setup) -> None:
+        """Verify all methods are no-ops when logger is disabled."""
+        exporter, tracer = otel_setup
+        ctx = AuditContext(
+            conversation_id="c1",
+            user_id="u1",
+            logger=AuditLogger(enabled=False),
+            tracer=tracer,
+        )
+        with ctx.span("test"):
+            ctx.logger.request_started(
+                mode="chat", query="q", attachments=[], provider="p", model="m"
+            )
+            ctx.logger.request_auth()
+            ctx.logger.llm_turn(turn_index=1, input_tokens=0, output_tokens=0)
+            ctx.logger.request_completed(
+                total_turns=1,
+                total_input_tokens=0,
+                total_output_tokens=0,
+                referenced_documents=[],
+            )
+        spans = exporter.spans
+        assert len(spans) == 1
+        assert len(spans[0].events) == 0
 
 
 class TestAuditLoggerMethods:
-    """Verify each typed method emits the correct event name."""
+    """Verify each method emits the correct span event or attributes."""
 
-    def test_request_started(self, captured_records: list[str]) -> None:
-        """Test request_started emits correct event."""
-        logger = AuditLogger()
-        logger.request_started(
-            "t1",
-            "u1",
-            mode="chat",
-            query="hello",
-            attachments=[{"type": "log"}],
-            provider="openai",
-            model="gpt-4",
-        )
-        record = json.loads(captured_records[0])
-        assert record["event"] == "audit.request.started"
-        assert record["mode"] == "chat"
-        assert record["query"] == "hello"
-        assert record["attachments"] == [{"type": "log"}]
-        assert record["provider"] == "openai"
-        assert record["model"] == "gpt-4"
+    def test_request_started(self, audit_ctx, otel_setup) -> None:
+        """Verify request_started emits span event with request metadata."""
+        with audit_ctx.span("request.lifecycle"):
+            audit_ctx.logger.request_started(
+                mode="chat",
+                query="hello",
+                attachments=[{"type": "log"}],
+                provider="openai",
+                model="gpt-4",
+            )
+        span = _get_spans(otel_setup)[0]
+        assert len(span.events) == 1
+        assert span.events[0].name == "request.started"
+        assert span.events[0].attributes["mode"] == "chat"
+        assert span.events[0].attributes["query"] == "hello"
+        assert span.events[0].attributes["provider"] == "openai"
 
-    def test_request_auth(self, captured_records: list[str]) -> None:
-        """Test request_auth emits correct event."""
-        logger = AuditLogger()
-        logger.request_auth("t1", "u1")
-        record = json.loads(captured_records[0])
-        assert record["event"] == "audit.request.auth"
+    def test_request_started_no_capture(self, audit_ctx, otel_setup) -> None:
+        """Verify request_started omits query when capture_content is False."""
+        with audit_ctx.span("request.lifecycle"):
+            audit_ctx.logger.request_started(
+                mode="chat",
+                query="hello",
+                attachments=[],
+                provider="openai",
+                model="gpt-4",
+                capture_content=False,
+            )
+        span = _get_spans(otel_setup)[0]
+        assert span.events[0].name == "request.started"
+        assert "query" not in span.events[0].attributes
 
-    def test_rag_retrieved(self, captured_records: list[str]) -> None:
-        """Test rag_retrieved emits correct event."""
-        logger = AuditLogger()
-        logger.rag_retrieved(
-            "t1", "u1", chunk_count=3, scores=[0.9, 0.8], source_documents=["doc1"]
-        )
-        record = json.loads(captured_records[0])
-        assert record["event"] == "audit.rag.retrieved"
-        assert record["chunk_count"] == 3
-        assert record["scores"] == [0.9, 0.8]
-        assert record["source_documents"] == ["doc1"]
+    def test_request_auth_is_noop(self, audit_ctx, otel_setup) -> None:
+        """Verify request_auth emits no events."""
+        with audit_ctx.span("request.auth"):
+            audit_ctx.logger.request_auth()
+        assert len(_get_spans(otel_setup)[0].events) == 0
 
-    def test_history_retrieved(self, captured_records: list[str]) -> None:
-        """Test history_retrieved emits correct event."""
-        logger = AuditLogger()
-        logger.history_retrieved(
-            "t1", "u1", turn_count=5, compressed=True, truncated=False
-        )
-        record = json.loads(captured_records[0])
-        assert record["event"] == "audit.history.retrieved"
-        assert record["turn_count"] == 5
-        assert record["compressed"] is True
-        assert record["truncated"] is False
+    def test_rag_retrieved(self, audit_ctx, otel_setup) -> None:
+        """Verify rag_retrieved sets attributes and adds event."""
+        with audit_ctx.span("request.rag"):
+            audit_ctx.logger.rag_retrieved(
+                chunk_count=3,
+                scores=[0.9, 0.8],
+                source_documents=["doc1", "doc2"],
+            )
+        span = _get_spans(otel_setup)[0]
+        assert span.attributes["chunk_count"] == 3
+        assert span.events[0].name == "rag.retrieved"
+        assert span.events[0].attributes["scores"] == (0.9, 0.8)
 
-    def test_llm_turn(self, captured_records: list[str]) -> None:
-        """Test llm_turn emits correct event with token counts."""
-        logger = AuditLogger()
-        logger.llm_turn("t1", "u1", turn_index=1, input_tokens=100, output_tokens=50)
-        record = json.loads(captured_records[0])
-        assert record["event"] == "audit.llm.turn"
-        assert record["tokens_in"] == 100
-        assert record["tokens_out"] == 50
+    def test_history_retrieved(self, audit_ctx, otel_setup) -> None:
+        """Verify history_retrieved sets attributes and adds event."""
+        with audit_ctx.span("request.history"):
+            audit_ctx.logger.history_retrieved(
+                turn_count=5, compressed=True, truncated=False
+            )
+        span = _get_spans(otel_setup)[0]
+        assert span.attributes["turn_count"] == 5
+        assert span.events[0].name == "history.retrieved"
 
-    def test_llm_thinking(self, captured_records: list[str]) -> None:
-        """Test llm_thinking emits correct event."""
-        logger = AuditLogger()
-        logger.llm_thinking("t1", "u1", content="thinking...")
-        record = json.loads(captured_records[0])
-        assert record["event"] == "audit.llm.thinking"
-        assert record["content"] == "thinking..."
+    def test_llm_turn(self, audit_ctx, otel_setup) -> None:
+        """Verify llm_turn sets GenAI token usage attributes."""
+        with audit_ctx.span("chat gpt-4", kind=SpanKind.CLIENT):
+            audit_ctx.logger.llm_turn(turn_index=1, input_tokens=100, output_tokens=50)
+        span = _get_spans(otel_setup)[0]
+        assert span.attributes["gen_ai.usage.input_tokens"] == 100
+        assert span.attributes["gen_ai.usage.output_tokens"] == 50
 
-    def test_llm_text(self, captured_records: list[str]) -> None:
-        """Test llm_text emits correct event."""
-        logger = AuditLogger()
-        logger.llm_text("t1", "u1", content="response text")
-        record = json.loads(captured_records[0])
-        assert record["event"] == "audit.llm.text"
-        assert record["content"] == "response text"
+    def test_llm_thinking(self, audit_ctx, otel_setup) -> None:
+        """Verify llm_thinking emits gen_ai.choice event with reasoning content."""
+        with audit_ctx.span("chat gpt-4", kind=SpanKind.CLIENT):
+            audit_ctx.logger.llm_thinking(content="thinking...")
+        span = _get_spans(otel_setup)[0]
+        assert span.events[0].name == "gen_ai.choice"
+        assert span.events[0].attributes["gen_ai.reasoning_content"] == "thinking..."
 
-    def test_tool_call(self, captured_records: list[str]) -> None:
-        """Test tool_call emits correct event."""
-        logger = AuditLogger()
-        logger.tool_call(
-            "t1", "u1", tool_name="my_tool", mcp_server="srv", arguments=["a"]
-        )
-        record = json.loads(captured_records[0])
-        assert record["event"] == "audit.tool.call"
-        assert record["tool_name"] == "my_tool"
-        assert record["mcp_server"] == "srv"
-        assert record["arguments"] == ["a"]
+    def test_llm_thinking_no_capture(self, audit_ctx, otel_setup) -> None:
+        """Verify llm_thinking omits content when capture_content is False."""
+        with audit_ctx.span("chat gpt-4", kind=SpanKind.CLIENT):
+            audit_ctx.logger.llm_thinking(content="thinking...", capture_content=False)
+        span = _get_spans(otel_setup)[0]
+        assert span.events[0].name == "gen_ai.choice"
+        assert "gen_ai.reasoning_content" not in span.events[0].attributes
 
-    def test_tool_result(self, captured_records: list[str]) -> None:
-        """Test tool_result emits correct event."""
-        logger = AuditLogger()
-        logger.tool_result(
-            "t1",
-            "u1",
-            tool_name="my_tool",
-            output_length=2,
-            success=True,
-            duration_ms=42,
-        )
-        record = json.loads(captured_records[0])
-        assert record["event"] == "audit.tool.result"
-        assert record["tool_name"] == "my_tool"
-        assert record["output_length"] == 2
-        assert record["success"] is True
-        assert record["duration_ms"] == 42
+    def test_llm_text(self, audit_ctx, otel_setup) -> None:
+        """Verify llm_text emits gen_ai.choice event with completion text."""
+        with audit_ctx.span("chat gpt-4", kind=SpanKind.CLIENT):
+            audit_ctx.logger.llm_text(content="response text")
+        span = _get_spans(otel_setup)[0]
+        assert span.events[0].name == "gen_ai.choice"
+        assert span.events[0].attributes["gen_ai.completion"] == "response text"
 
-    def test_tool_approval_requested(self, captured_records: list[str]) -> None:
-        """Test tool_approval_requested emits correct event."""
-        logger = AuditLogger()
-        logger.tool_approval_requested(
-            "t1", "u1", tool_name="my_tool", approval_id="ap1"
-        )
-        record = json.loads(captured_records[0])
-        assert record["event"] == "audit.tool.approval.requested"
-        assert record["tool_name"] == "my_tool"
-        assert record["approval_id"] == "ap1"
+    def test_llm_text_no_capture(self, audit_ctx, otel_setup) -> None:
+        """Verify llm_text omits content when capture_content is False."""
+        with audit_ctx.span("chat gpt-4", kind=SpanKind.CLIENT):
+            audit_ctx.logger.llm_text(content="response text", capture_content=False)
+        span = _get_spans(otel_setup)[0]
+        assert span.events[0].name == "gen_ai.choice"
+        assert "gen_ai.completion" not in span.events[0].attributes
 
-    def test_tool_approval_decision(self, captured_records: list[str]) -> None:
-        """Test tool_approval_decision emits correct event."""
-        logger = AuditLogger()
-        logger.tool_approval_decision(
-            "t1", "u1", approval_id="ap1", decision="approved", tool_name="my_tool"
-        )
-        record = json.loads(captured_records[0])
-        assert record["event"] == "audit.tool.approval.decision"
-        assert record["approval_id"] == "ap1"
-        assert record["decision"] == "approved"
-        assert record["tool_name"] == "my_tool"
+    def test_tool_call(self, audit_ctx, otel_setup) -> None:
+        """Verify tool_call emits tool.call span event."""
+        with audit_ctx.span("execute_tool my_tool"):
+            audit_ctx.logger.tool_call(
+                tool_name="my_tool", mcp_server="srv", arguments=["a"]
+            )
+        span = _get_spans(otel_setup)[0]
+        assert span.events[0].name == "tool.call"
+        assert span.events[0].attributes["tool_name"] == "my_tool"
 
-    def test_request_failed(self, captured_records: list[str]) -> None:
-        """Test request_failed emits correct event."""
-        logger = AuditLogger()
-        logger.request_failed("t1", "u1", error="prompt_too_long")
-        record = json.loads(captured_records[0])
-        assert record["event"] == "audit.request.failed"
-        assert record["error"] == "prompt_too_long"
+    def test_tool_result(self, audit_ctx, otel_setup) -> None:
+        """Verify tool_result sets span attributes."""
+        with audit_ctx.span("execute_tool my_tool"):
+            audit_ctx.logger.tool_result(output_length=2, success=True, duration_ms=42)
+        span = _get_spans(otel_setup)[0]
+        assert span.attributes["output_length"] == 2
+        assert span.attributes["success"] is True
+        assert span.attributes["duration_ms"] == 42
 
-    def test_request_completed(self, captured_records: list[str]) -> None:
-        """Test request_completed emits correct event."""
-        logger = AuditLogger()
-        logger.request_completed(
-            "t1",
-            "u1",
-            total_turns=3,
-            total_input_tokens=500,
-            total_output_tokens=200,
-            referenced_documents=["https://docs.example.com"],
-        )
-        record = json.loads(captured_records[0])
-        assert record["event"] == "audit.request.completed"
-        assert record["total_turns"] == 3
-        assert record["total_tokens_in"] == 500
-        assert record["total_tokens_out"] == 200
-        assert record["referenced_documents"] == ["https://docs.example.com"]
+    def test_tool_approval_requested(self, audit_ctx, otel_setup) -> None:
+        """Verify tool_approval_requested emits approval.requested event."""
+        with audit_ctx.span("execute_tool my_tool"):
+            audit_ctx.logger.tool_approval_requested(
+                tool_name="my_tool", approval_id="ap1"
+            )
+        assert _get_spans(otel_setup)[0].events[0].name == "approval.requested"
 
-    def test_disabled_methods_are_noop(self, captured_records: list[str]) -> None:
-        """Test all methods are no-ops when disabled."""
-        logger = AuditLogger(enabled=False)
-        logger.request_started(
-            "t1", "u1", mode="chat", query="q", attachments=[], provider="p", model="m"
-        )
-        logger.request_auth("t1", "u1")
-        logger.rag_retrieved("t1", "u1", chunk_count=1, scores=[], source_documents=[])
-        logger.history_retrieved(
-            "t1", "u1", turn_count=0, compressed=False, truncated=False
-        )
-        logger.llm_turn("t1", "u1", turn_index=1, input_tokens=0, output_tokens=0)
-        logger.request_completed(
-            "t1",
-            "u1",
-            total_turns=1,
-            total_input_tokens=0,
-            total_output_tokens=0,
-            referenced_documents=[],
-        )
-        assert len(captured_records) == 0
+    def test_tool_approval_decision(self, audit_ctx, otel_setup) -> None:
+        """Verify tool_approval_decision emits approval.decision event."""
+        with audit_ctx.span("execute_tool my_tool"):
+            audit_ctx.logger.tool_approval_decision(
+                approval_id="ap1", decision="approved", tool_name="my_tool"
+            )
+        span = _get_spans(otel_setup)[0]
+        assert span.events[0].name == "approval.decision"
+        assert span.events[0].attributes["decision"] == "approved"
+
+    def test_request_failed(self, audit_ctx, otel_setup) -> None:
+        """Verify request_failed sets error status and emits event."""
+        with audit_ctx.span("request.lifecycle"):
+            audit_ctx.logger.request_failed(error="prompt_too_long")
+        span = _get_spans(otel_setup)[0]
+        assert span.status.status_code.name == "ERROR"
+        assert span.events[0].name == "request.failed"
+        assert span.events[0].attributes["error"] == "prompt_too_long"
+
+    def test_request_completed(self, audit_ctx, otel_setup) -> None:
+        """Verify request_completed sets attributes and emits event."""
+        with audit_ctx.span("request.lifecycle"):
+            audit_ctx.logger.request_completed(
+                total_turns=3,
+                total_input_tokens=500,
+                total_output_tokens=200,
+                referenced_documents=["https://docs.example.com"],
+            )
+        span = _get_spans(otel_setup)[0]
+        assert span.attributes["total_turns"] == 3
+        assert span.attributes["total_input_tokens"] == 500
+        assert span.events[0].name == "request.completed"
 
 
 class TestAuditContext:
     """Verify AuditContext is frozen and carries the right fields."""
 
     def test_frozen_dataclass(self) -> None:
-        """Test AuditContext is immutable."""
-        ctx = AuditContext(trace_id="abc", user_id="user1", logger=AuditLogger())
-        assert ctx.trace_id == "abc"
+        """Verify AuditContext is immutable."""
+        ctx = AuditContext(
+            conversation_id="conv-abc", user_id="user1", logger=AuditLogger()
+        )
+        assert ctx.conversation_id == "conv-abc"
         assert ctx.user_id == "user1"
         with pytest.raises(AttributeError):
-            ctx.trace_id = "new"  # type: ignore[misc]
+            ctx.conversation_id = "new"  # type: ignore[misc]
+
+    def test_span_injects_conversation_id_and_user_id(self, otel_setup) -> None:
+        """Verify span() auto-injects gen_ai.conversation.id and user_id."""
+        _, tracer = otel_setup
+        ctx = AuditContext(
+            conversation_id="conv-xyz",
+            user_id="user42",
+            logger=AuditLogger(),
+            tracer=tracer,
+        )
+        with ctx.span("test.span"):
+            pass
+        span = _get_spans(otel_setup)[0]
+        assert span.attributes["gen_ai.conversation.id"] == "conv-xyz"
+        assert span.attributes["user_id"] == "user42"
+
+    def test_span_kind(self, otel_setup) -> None:
+        """Verify span() respects SpanKind parameter."""
+        _, tracer = otel_setup
+        ctx = AuditContext(
+            conversation_id="c1",
+            user_id="u1",
+            logger=AuditLogger(),
+            tracer=tracer,
+        )
+        with ctx.span("chat gpt-4", kind=SpanKind.CLIENT):
+            pass
+        assert _get_spans(otel_setup)[0].kind == SpanKind.CLIENT
 
 
-class TestConversationIdToTraceId:
-    """Verify UUID to trace ID conversion."""
+class TestOTLPJsonStdoutExporter:
+    """Verify OTLP JSON stdout exporter produces single-line JSON."""
 
-    def test_strips_hyphens(self) -> None:
-        """Test UUID hyphens are stripped to produce 32-char hex."""
-        from ols.utils.suid import conversation_id_to_trace_id
+    def test_exports_single_line_json(self, capsys) -> None:
+        """Verify exporter writes valid single-line OTLP JSON to stdout."""
+        provider = TracerProvider(
+            resource=Resource.create({"service.name": "test-stdout"})
+        )
+        stdout_exporter = OTLPJsonStdoutExporter()
+        provider.add_span_processor(SimpleSpanProcessor(stdout_exporter))
 
-        result = conversation_id_to_trace_id("550e8400-e29b-41d4-a716-446655440000")
-        assert result == "550e8400e29b41d4a716446655440000"
-        assert len(result) == 32
+        tracer = provider.get_tracer("test")
+        with tracer.start_as_current_span("test.span", kind=SpanKind.CLIENT):
+            pass
 
-    def test_already_stripped(self) -> None:
-        """Test already-stripped IDs pass through unchanged."""
-        from ols.utils.suid import conversation_id_to_trace_id
-
-        result = conversation_id_to_trace_id("550e8400e29b41d4a716446655440000")
-        assert result == "550e8400e29b41d4a716446655440000"
+        provider.force_flush()
+        captured = capsys.readouterr()
+        lines = [x for x in captured.out.strip().split("\n") if x]
+        assert len(lines) >= 1
+        parsed = json.loads(lines[-1])
+        assert "resourceSpans" in parsed
+        span = parsed["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        assert len(span["traceId"]) == 32
+        assert all(c in "0123456789abcdef" for c in span["traceId"])
+        assert len(span["spanId"]) == 16
+        assert all(c in "0123456789abcdef" for c in span["spanId"])
+        assert isinstance(span["kind"], int)
+        provider.shutdown()

--- a/tests/unit/utils/test_otel.py
+++ b/tests/unit/utils/test_otel.py
@@ -19,16 +19,15 @@ def _reset_tracer():
 class TestInitTracer:
     """Tests for init_tracer function."""
 
-    @patch("opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter")
-    @patch("opentelemetry.sdk.trace.export.BatchSpanProcessor")
-    def test_no_endpoint_creates_noop(self, mock_processor, mock_exporter):
-        """No endpoint means no exporter is created."""
+    @patch("ols.utils.otel.BatchSpanProcessor")
+    def test_no_endpoint_creates_noop(self, mock_processor):
+        """No endpoint and no audit means no exporter is created."""
         tracer = init_tracer()
         assert tracer is not None
-        mock_exporter.assert_not_called()
+        mock_processor.assert_not_called()
 
     @patch("opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter")
-    @patch("opentelemetry.sdk.trace.export.BatchSpanProcessor")
+    @patch("ols.utils.otel.BatchSpanProcessor")
     def test_insecure_mode(self, mock_processor, mock_exporter):
         """Insecure mode passes insecure=True explicitly."""
         init_tracer(otel_endpoint="localhost:4317", insecure=True)
@@ -37,7 +36,7 @@ class TestInitTracer:
         )
 
     @patch("opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter")
-    @patch("opentelemetry.sdk.trace.export.BatchSpanProcessor")
+    @patch("ols.utils.otel.BatchSpanProcessor")
     def test_secure_with_certificate_file(self, mock_processor, mock_exporter):
         """Secure mode with certificate_file creates gRPC SSL credentials."""
         ca_path = "/tmp/ols.pem"  # noqa: S108
@@ -57,7 +56,7 @@ class TestInitTracer:
         )
 
     @patch("opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter")
-    @patch("opentelemetry.sdk.trace.export.BatchSpanProcessor")
+    @patch("ols.utils.otel.BatchSpanProcessor")
     def test_secure_without_certificate_file(self, mock_processor, mock_exporter):
         """Secure mode without certificate_file passes credentials=None."""
         init_tracer(otel_endpoint="localhost:4317", insecure=False)
@@ -66,7 +65,7 @@ class TestInitTracer:
         )
 
     @patch("opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter")
-    @patch("opentelemetry.sdk.trace.export.BatchSpanProcessor")
+    @patch("ols.utils.otel.BatchSpanProcessor")
     def test_insecure_mode_ignores_certificate_file(
         self, mock_processor, mock_exporter
     ):
@@ -79,3 +78,31 @@ class TestInitTracer:
         mock_exporter.assert_called_once_with(
             endpoint="localhost:4317", insecure=True, credentials=None
         )
+
+    @patch("ols.utils.otel.SimpleSpanProcessor")
+    def test_audit_enabled_adds_stdout_exporter(self, mock_simple_processor):
+        """audit_enabled=True adds OTLPJsonStdoutExporter via SimpleSpanProcessor."""
+        init_tracer(audit_enabled=True)
+        mock_simple_processor.assert_called_once()
+        exporter = mock_simple_processor.call_args[0][0]
+        from ols.utils.otel import OTLPJsonStdoutExporter
+
+        assert isinstance(exporter, OTLPJsonStdoutExporter)
+
+    @patch("ols.utils.otel.SimpleSpanProcessor")
+    def test_audit_disabled_no_stdout_exporter(self, mock_simple_processor):
+        """audit_enabled=False does not add stdout exporter."""
+        init_tracer(audit_enabled=False)
+        mock_simple_processor.assert_not_called()
+
+    @patch("opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter")
+    @patch("ols.utils.otel.BatchSpanProcessor")
+    @patch("ols.utils.otel.SimpleSpanProcessor")
+    def test_audit_and_endpoint_adds_both(
+        self, mock_simple_processor, mock_batch_processor, mock_exporter
+    ):
+        """Both audit and endpoint add stdout + OTLP exporters."""
+        init_tracer(otel_endpoint="localhost:4317", insecure=True, audit_enabled=True)
+        mock_simple_processor.assert_called_once()
+        mock_batch_processor.assert_called_once()
+        mock_exporter.assert_called_once()


### PR DESCRIPTION
## Summary

- Remove conversation_id-as-trace-id machinery (`_ConversationIdGenerator`, `set/clear_conversation_trace_id`, `conversation_id_to_trace_id`) — each HTTP request now generates a fresh trace ID
- Add `gen_ai.conversation.id` and `user_id` attributes on every span via `AuditContext.span()`
- Rename LLM turn spans from `llm.turn` to `chat {model}` with `SpanKind.CLIENT` and GenAI semantic attributes (`gen_ai.operation.name`, `gen_ai.request.model`, `gen_ai.provider.name`, token usage)
- Rename tool spans from `tool.{name}` to `execute_tool {name}` with GenAI tool attributes (`gen_ai.tool.name`, `gen_ai.tool.call.id`, `gen_ai.tool.type`)
- Replace custom JSON audit events with OTel span events (single-emission rule)
- Add `OTLPJsonStdoutExporter` for audit compliance — single-line OTLP JSON to stdout via `SimpleSpanProcessor`
- Fix `request_started` span event placement inside `request.lifecycle` span context (was silently dropped when emitted before span opened)

## Test plan

- [x] Unit tests pass (1159 passed)
- [x] Format and lint clean
- [x] End-to-end verified on OpenShift cluster with Jaeger — full trace visible with query text, GenAI attributes, `gen_ai.choice` events with reasoning/completion content, tool spans
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry span-event-based audit telemetry covering request lifecycle, RAG/history retrieval, LLM thinking/completion, and tool/approval actions.
  * Added support for exporting audit telemetry as single-line OTLP-encoded JSON to stdout when auditing is enabled.
* **Improvements**
  * Enhanced GenAI span instrumentation (including chat span kind and richer tool spans).
  * Improved handling of content capture to omit reasoning/query details when disabled.
* **Tests**
  * Expanded unit tests to validate emitted span names, events, attributes, and audit/OTel tracer initialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->