### PR TITLE
OLS-3540 Add MCP semantic convention attributes on tool spans

### DIFF
--- a/.ai/spec/what/audit-logging.md
+++ b/.ai/spec/what/audit-logging.md
@@ -67,7 +67,7 @@ Implementation spec for compliance audit logging in lightspeed-service (OLS). Pa
 | `mcp.session.id` | Recommended | MCP session identifier |
 | `mcp.protocol.version` | Recommended | MCP protocol version |
 | `gen_ai.tool.call.id` | Recommended | Tool call ID from MCP response |
-| `network.transport` | Recommended | `stdio` or `sse` |
+| `network.transport` | Recommended | OTel OSI-layer values: `tcp` (mapped from MCP transports `streamable_http`/`sse`) or `pipe` (mapped from `stdio`) |
 
 12. Non-MCP tools MUST carry all attributes from rule 10 (including `gen_ai.operation.name`) and MUST NOT add MCP-specific attributes from rule 11.
 
@@ -77,9 +77,13 @@ Implementation spec for compliance audit logging in lightspeed-service (OLS). Pa
 
 14. Thinking/reasoning output from the LLM MUST be recorded as a `gen_ai.choice` span event with an additional `gen_ai.reasoning_content` attribute attached to the `chat {gen_ai.request.model}` span. When the model emits both completion and thinking content, they MAY be combined into a single `gen_ai.choice` event with both attributes.
 
+### Tool Result Events
+
+14b. Tool execution output MUST be recorded as a `tool.result` span event attached to the `execute_tool {gen_ai.tool.name}` span. The event carries a `success` attribute (boolean). When `capture_content` is `true`, the event additionally carries an `output` attribute with the tool's text output. When `capture_content` is `false`, the `tool.result` event is still emitted with `success` but the `output` attribute is omitted.
+
 ### Content Capture Policy
 
-14a. Completion and thinking span event attributes (`gen_ai.completion`, `gen_ai.reasoning_content`) contain LLM output that may include PII or sensitive data. Recording these attributes MUST be opt-in, controlled by an `audit.capture_content` configuration flag (default: `false`). When `capture_content` is `false`, `gen_ai.choice` events are still emitted but the content attributes are omitted. This aligns with the OTel GenAI semantic convention requirement level of Opt-In for content attributes.
+14a. Completion and thinking span event attributes (`gen_ai.completion`, `gen_ai.reasoning_content`) and tool output (`output` on `tool.result` events) contain LLM/tool output that may include PII or sensitive data. Recording these attributes MUST be opt-in, controlled by an `audit.capture_content` configuration flag (default: `false`). When `capture_content` is `false`, events are still emitted but content attributes are omitted. This aligns with the OTel GenAI semantic convention requirement level of Opt-In for content attributes.
 
 ### Single-Emission Rule
 
@@ -126,6 +130,7 @@ request.lifecycle               [root, INTERNAL, gen_ai.conversation.id=<conv_id
 ├── request.history             [INTERNAL]
 ├── chat gpt-4o                 [CLIENT, repeats per LLM turn]
 │   ├── execute_tool search     [INTERNAL, repeats per tool call]
+│   │   └── (span events: tool.result)
 │   └── (span events: gen_ai.choice)
 └── request.store               [INTERNAL]
 ```

--- a/ols/src/tools/tools.py
+++ b/ols/src/tools/tools.py
@@ -530,19 +530,29 @@ async def _execute_single_tool_call_stream(
     """
     tool_id, tool_args, tool = tool_call
     tool_name = getattr(tool, "name", "unknown")
-    mcp_server = (getattr(tool, "metadata", None) or {}).get("mcp_server", "")
+    metadata = getattr(tool, "metadata", None) or {}
+    mcp_server = metadata.get("mcp_server", "")
+
+    span_attrs: dict[str, str] = {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": tool_name,
+        "gen_ai.tool.call.id": tool_id,
+        "gen_ai.tool.type": "function",
+    }
+    if mcp_server:
+        span_attrs["mcp.method.name"] = "tools/call"
+        mcp_transport = metadata.get("mcp_transport", "")
+        if mcp_transport:
+            span_attrs["network.transport"] = mcp_transport
+        session_id = metadata.get("mcp_session_id", "")
+        if session_id:
+            span_attrs["mcp.session.id"] = session_id
+        protocol_version = metadata.get("mcp_protocol_version", "")
+        if protocol_version:
+            span_attrs["mcp.protocol.version"] = protocol_version
 
     tool_span = (
-        audit_ctx.span(
-            f"execute_tool {tool_name}",
-            **{
-                "gen_ai.operation.name": "execute_tool",
-                "gen_ai.tool.name": tool_name,
-                "gen_ai.tool.call.id": tool_id,
-                "gen_ai.tool.type": "function",
-            },
-            mcp_server=mcp_server,
-        )
+        audit_ctx.span(f"execute_tool {tool_name}", **span_attrs, mcp_server=mcp_server)
         if audit_ctx
         else nullcontext()
     )
@@ -582,6 +592,7 @@ async def _execute_single_tool_call_stream(
                 output_length=len(tool_output),
                 success=status == "success",
                 duration_ms=duration_ms,
+                output_content=tool_output if audit_ctx.capture_content else None,
             )
 
         yield _tool_result_event(

--- a/ols/utils/audit_logger.py
+++ b/ols/utils/audit_logger.py
@@ -146,13 +146,18 @@ class AuditLogger:
         output_length: int,
         success: bool,
         duration_ms: Optional[int],
+        output_content: Optional[str] = None,
     ) -> None:
-        """Set tool result attributes on execute_tool span."""
+        """Set tool result attributes and emit tool.result event on execute_tool span."""
         self._set_span_attrs(
             output_length=output_length,
             success=success,
             duration_ms=duration_ms,
         )
+        attrs: dict[str, Any] = {"success": success}
+        if output_content is not None:
+            attrs["output"] = output_content
+        self._add_span_event("tool.result", **attrs)
 
     def tool_approval_requested(
         self,

--- a/ols/utils/mcp_utils.py
+++ b/ols/utils/mcp_utils.py
@@ -32,6 +32,18 @@ ClientHeaders: TypeAlias = dict[str, dict[str, str]]
 MCPServersDict: TypeAlias = dict[str, MCPServerTransport]
 
 
+_MCP_TO_NETWORK_TRANSPORT: dict[str, str] = {
+    "streamable_http": "tcp",
+    "sse": "tcp",
+    "stdio": "pipe",
+}
+
+
+def _mcp_transport_to_network(mcp_transport: str) -> str:
+    """Map MCP transport type to OTel network.transport value (OSI layer)."""
+    return _MCP_TO_NETWORK_TRANSPORT.get(mcp_transport, mcp_transport)
+
+
 def get_servers_requiring_client_headers(
     mcp_servers: MCPServers | None,
 ) -> dict[str, list[str]]:
@@ -206,12 +218,17 @@ async def gather_mcp_tools(
                     tool for tool in server_tools if tool.name in allowed_tool_names
                 ]
 
-            # Add MCP server name to each tool's metadata
+            # Add MCP server name and transport metadata to each tool's metadata
+            server_config = mcp_servers[server_name]
+            mcp_transport = _mcp_transport_to_network(
+                server_config.get("transport", "")
+            )
             for tool in server_tools:
                 _normalize_tool_schema(tool)
                 if not hasattr(tool, "metadata") or tool.metadata is None:
                     tool.metadata = {}
                 tool.metadata["mcp_server"] = server_name
+                tool.metadata["mcp_transport"] = mcp_transport
 
             all_tools.extend(server_tools)
             logger.info(

--- a/tests/unit/tools/test_tools.py
+++ b/tests/unit/tools/test_tools.py
@@ -944,3 +944,65 @@ class TestExecuteToolGenAISpans:
         exporter, _ = otel_setup
         span = exporter.spans[0]
         assert span.attributes["mcp_server"] == "my-mcp-server"
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_span_carries_mcp_attributes():
+    """MCP-sourced tool span must carry mcp.* and gen_ai.tool.* attributes."""
+    from unittest.mock import MagicMock
+
+    tool = FakeTool(
+        "mcp_tool",
+        metadata={
+            "mcp_server": "ocp-mcp",
+            "mcp_transport": "tcp",
+        },
+    )
+    tool_calls = [("call_42", {}, tool)]
+
+    mock_audit = MagicMock()
+    mock_span = MagicMock()
+    mock_audit.span.return_value.__enter__ = MagicMock(return_value=mock_span)
+    mock_audit.span.return_value.__exit__ = MagicMock(return_value=False)
+    mock_audit.logger = MagicMock()
+
+    async for _ in execute_tool_calls_stream(tool_calls, 100_000, audit_ctx=mock_audit):
+        pass
+
+    mock_audit.span.assert_called_once()
+    call_kwargs = mock_audit.span.call_args
+    attrs = call_kwargs.kwargs or {}
+    assert call_kwargs.args[0] == "execute_tool mcp_tool"
+    assert attrs["mcp.method.name"] == "tools/call"
+    assert "mcp.session.id" not in attrs
+    assert "mcp.protocol.version" not in attrs
+    assert attrs["network.transport"] == "tcp"
+    assert attrs["gen_ai.tool.name"] == "mcp_tool"
+    assert attrs["gen_ai.tool.call.id"] == "call_42"
+    assert attrs["gen_ai.tool.type"] == "function"
+    assert attrs["gen_ai.operation.name"] == "execute_tool"
+
+
+@pytest.mark.asyncio
+async def test_non_mcp_tool_span_has_no_mcp_attributes():
+    """Non-MCP tool span must carry only gen_ai.tool.* attributes, no mcp.*."""
+    from unittest.mock import MagicMock
+
+    tool = FakeTool("builtin_tool", metadata={"mcp_server": ""})
+    tool_calls = [("call_99", {}, tool)]
+
+    mock_audit = MagicMock()
+    mock_span = MagicMock()
+    mock_audit.span.return_value.__enter__ = MagicMock(return_value=mock_span)
+    mock_audit.span.return_value.__exit__ = MagicMock(return_value=False)
+    mock_audit.logger = MagicMock()
+
+    async for _ in execute_tool_calls_stream(tool_calls, 100_000, audit_ctx=mock_audit):
+        pass
+
+    call_kwargs = mock_audit.span.call_args
+    attrs = call_kwargs.kwargs or {}
+    assert "mcp.method.name" not in attrs
+    assert "mcp.session.id" not in attrs
+    assert attrs["gen_ai.tool.name"] == "builtin_tool"
+    assert attrs["gen_ai.tool.call.id"] == "call_99"

--- a/tests/unit/utils/test_audit_logger.py
+++ b/tests/unit/utils/test_audit_logger.py
@@ -169,13 +169,28 @@ class TestAuditLoggerMethods:
         assert span.events[0].attributes["tool_name"] == "my_tool"
 
     def test_tool_result(self, audit_ctx, otel_setup) -> None:
-        """Verify tool_result sets span attributes."""
+        """Verify tool_result sets span attributes and emits tool.result event."""
         with audit_ctx.span("execute_tool my_tool"):
-            audit_ctx.logger.tool_result(output_length=2, success=True, duration_ms=42)
+            audit_ctx.logger.tool_result(
+                output_length=2, success=True, duration_ms=42, output_content="ok"
+            )
         span = _get_spans(otel_setup)[0]
         assert span.attributes["output_length"] == 2
         assert span.attributes["success"] is True
         assert span.attributes["duration_ms"] == 42
+        result_event = span.events[0]
+        assert result_event.name == "tool.result"
+        assert result_event.attributes["success"] is True
+        assert result_event.attributes["output"] == "ok"
+
+    def test_tool_result_no_content(self, audit_ctx, otel_setup) -> None:
+        """Verify tool_result omits output when content not provided."""
+        with audit_ctx.span("execute_tool my_tool"):
+            audit_ctx.logger.tool_result(output_length=5, success=True, duration_ms=10)
+        span = _get_spans(otel_setup)[0]
+        result_event = span.events[0]
+        assert result_event.name == "tool.result"
+        assert "output" not in result_event.attributes
 
     def test_tool_approval_requested(self, audit_ctx, otel_setup) -> None:
         """Verify tool_approval_requested emits approval.requested event."""

--- a/tests/unit/utils/test_mcp_utils.py
+++ b/tests/unit/utils/test_mcp_utils.py
@@ -8,6 +8,7 @@ from langchain_core.tools.structured import StructuredTool
 from ols import constants
 from ols.app.models.config import MCPServerConfig
 from ols.utils.mcp_utils import (
+    _mcp_transport_to_network,
     build_mcp_config,
     gather_mcp_tools,
     get_mcp_tools,
@@ -509,6 +510,30 @@ class TestGatherMcpTools:
             assert result[0].metadata is not None
             assert result[0].metadata["mcp_server"] == "test-server"
 
+    async def test_gather_mcp_tools_metadata_capture(self) -> None:
+        """Verify MCP metadata capture."""
+        with patch("ols.utils.mcp_utils.MultiServerMCPClient") as mock_client_cls:
+            tool = MagicMock(spec=StructuredTool)
+            tool.name = "test_tool"
+            tool.metadata = {}
+            tool.args_schema = {"type": "object", "properties": {}}
+
+            mock_client = AsyncMock()
+            mock_client.get_tools.return_value = [tool]
+            mock_client_cls.return_value = mock_client
+
+            servers = {
+                "test-server": {"transport": "streamable_http", "url": "http://test"}
+            }
+            result = await gather_mcp_tools(servers)
+
+            assert len(result) == 1
+            assert result[0].metadata["mcp_server"] == "test-server"
+            assert "mcp_session_id" not in result[0].metadata
+            assert "mcp_protocol_version" not in result[0].metadata
+            assert "mcp_transport" in result[0].metadata
+            assert result[0].metadata["mcp_transport"] == "tcp"
+
 
 @pytest.mark.asyncio
 class TestGetMcpTools:
@@ -647,3 +672,18 @@ class TestGetMcpTools:
             result = await get_mcp_tools("test query")
 
             assert result == []
+
+
+@pytest.mark.parametrize(
+    ("mcp_transport", "expected"),
+    [
+        ("streamable_http", "tcp"),
+        ("sse", "tcp"),
+        ("stdio", "pipe"),
+        ("unknown_transport", "unknown_transport"),
+        ("", ""),
+    ],
+)
+def test_mcp_transport_to_network(mcp_transport: str, expected: str) -> None:
+    """Verify MCP transport types map to correct OTel network.transport values."""
+    assert _mcp_transport_to_network(mcp_transport) == expected


### PR DESCRIPTION
## Summary

- Add OTel GenAI semantic convention attributes (`gen_ai.operation.name`, `gen_ai.tool.name`, `gen_ai.tool.call.id`, `gen_ai.tool.type`) to all tool execution spans
- Add MCP-specific attributes (`mcp.method.name`, `network.transport`) to MCP-sourced tool spans, with conditional `mcp.session.id` and `mcp.protocol.version` when available
- Capture MCP server metadata (server name, transport type) during tool gathering in `mcp_utils.py` and propagate via `tool.metadata`
- Map MCP transport types to OTel `network.transport` OSI-layer values (`streamable_http` → `tcp`, `sse` → `tcp`, `stdio` → `pipe`)
- Capture tool output content in `tool.result` span event, gated by `capture_content` flag (per spec rule 3: full fidelity when audit is enabled)

## Test plan

- [x] Unit tests: new tests covering MCP tool span attributes, non-MCP tool span attributes, MCP metadata capture, and tool result content capture
- [x] `make test-unit` — 1169 tests pass
- [x] `make format` / `make verify` — clean
- [x] In-cluster: verified spans in Jaeger show correct `gen_ai.*` and `mcp.*` attributes on tool execution spans, and `tool.result` event with output content


<img width="2039" height="1991" alt="image" src="https://github.com/user-attachments/assets/00952155-b744-480f-ac50-84ca472ca242" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)