### PR TITLE
OLS-3670 - adding lseval presubmit evaluations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,12 @@ test-lseval-periodic: ## Run LSEval periodic evaluation (full 797-question datas
 	uv run --extra lseval --extra evaluation pytest tests/e2e/evaluation/test_lseval_periodic.py -vv -s --durations=0 -o junit_suite_name="${SUITE_ID}" --junit-prefix="${SUITE_ID}" --junit-xml="${ARTIFACT_DIR}/junit_e2e_${SUITE_ID}.xml" \
 	--eval_out_dir ${ARTIFACT_DIR} -m lseval --lseval_provider ${PROVIDER}
 
+test-lseval-presubmit: ## Run LSEval presubmit evaluation (10-question short dataset) - requires running OLS server
+	@echo "Running LSEval presubmit evaluation..."
+	@echo "Reports will be written to ${ARTIFACT_DIR}"
+	uv run --extra lseval --extra evaluation pytest tests/e2e/evaluation/test_lseval_presubmit.py -vv -s --durations=0 -o junit_suite_name="${SUITE_ID}" --junit-prefix="${SUITE_ID}" --junit-xml="${ARTIFACT_DIR}/junit_e2e_${SUITE_ID}.xml" \
+	--eval_out_dir ${ARTIFACT_DIR} -m lseval --lseval_provider ${PROVIDER}
+
 # DISABLED: re-enable by uncommenting the recipe body below.
 # test-lseval-troubleshooting: ## Run LSEval troubleshooting evaluation (scenario + MCP suites) - requires running OLS server with OpenAI keys
 # 	@echo "Running LSEval troubleshooting evaluation..."

--- a/eval/system_bedrock_deepseek_lseval.yaml
+++ b/eval/system_bedrock_deepseek_lseval.yaml
@@ -1,0 +1,95 @@
+# LightSpeed Evaluation Framework Configuration
+# OLS Provider: Bedrock DeepSeek deepseek-r1 (model being evaluated)
+# Judge LLM: OpenAI GPT-5-mini (scoring responses)
+
+# Core Evaluation Configuration
+# Limits concurrent evaluations to avoid OpenAI API rate limiting on the judge LLM.
+# Each thread issues one OLS call and one judge LLM call, so 5 threads produce
+# at most 10 concurrent external API requests at any time.
+core:
+  max_threads: 5
+
+# Judge LLM Configuration
+# Uses OpenAI GPT-5-mini for evaluation scoring.
+# Requires OPENAI_API_KEY environment variable.
+llm:
+  provider: "openai"
+  model: "gpt-5-mini"
+  temperature: 1
+  max_tokens: 4096
+  timeout: 300
+  num_retries: 3
+
+# OLS API Configuration
+# Targets the OLS /query endpoint using Bedrock DeepSeek deepseek-r1 as the backend LLM.
+# api_base is overridden at runtime with the actual OLS service URL.
+# Requires OLS to be configured with a bedrock provider (IAM credentials in olsconfig).
+# Override the model via LSEVAL_OLS_MODEL env var if your Bedrock deployment uses a different model.
+api:
+  enabled: true
+  api_base: http://localhost:8080
+  endpoint_type: query
+  timeout: 300
+  provider: "bedrock"
+  model: "deepseek-r1"
+  no_tools: null
+  system_prompt: null
+
+# Metrics evaluated per conversation turn
+metrics_metadata:
+  turn_level:
+    "custom:answer_correctness":
+      # threshold intentionally omitted: no agreed baseline yet.
+      # Scores are recorded to track the trend over time; a threshold
+      # will be introduced once the average trend is established.
+      description: "Correctness vs expected answer using custom LLM evaluation"
+      default: true
+
+# Output Configuration
+output:
+  output_dir: "./eval_output"
+  base_filename: "evaluation"
+  enabled_outputs:
+    - csv
+    - json
+
+  csv_columns:
+    - "conversation_group_id"
+    - "turn_id"
+    - "metric_identifier"
+    - "score"
+    - "threshold"
+    - "result"
+    - "reason"
+    - "query"
+    - "response"
+    - "execution_time"
+
+# Visualization settings
+visualization:
+  figsize: [12, 8]
+  dpi: 300
+  enabled_graphs:
+    - "score_distribution"
+    - "status_breakdown"
+
+# Environment Variables
+environment:
+  DEEPEVAL_TELEMETRY_OPT_OUT: "YES"
+  DEEPEVAL_DISABLE_PROGRESS_BAR: "YES"
+  LITELLM_LOG: ERROR
+
+# Logging Configuration
+logging:
+  source_level: INFO
+  package_level: ERROR
+  log_format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+  show_timestamps: true
+  package_overrides:
+    httpx: ERROR
+    urllib3: ERROR
+    requests: ERROR
+    matplotlib: ERROR
+    LiteLLM: WARNING
+    DeepEval: WARNING
+    ragas: WARNING

--- a/eval/system_bedrock_deepseek_lseval.yaml
+++ b/eval/system_bedrock_deepseek_lseval.yaml
@@ -1,5 +1,5 @@
 # LightSpeed Evaluation Framework Configuration
-# OLS Provider: Bedrock DeepSeek deepseek-r1 (model being evaluated)
+# OLS Provider: Bedrock DeepSeek us.deepseek.r1-v1:0 (model being evaluated)
 # Judge LLM: OpenAI GPT-5-mini (scoring responses)
 
 # Core Evaluation Configuration
@@ -21,7 +21,7 @@ llm:
   num_retries: 3
 
 # OLS API Configuration
-# Targets the OLS /query endpoint using Bedrock DeepSeek deepseek-r1 as the backend LLM.
+# Targets the OLS /query endpoint using Bedrock DeepSeek us.deepseek.r1-v1:0 as the backend LLM.
 # api_base is overridden at runtime with the actual OLS service URL.
 # Requires OLS to be configured with a bedrock provider (IAM credentials in olsconfig).
 # Override the model via LSEVAL_OLS_MODEL env var if your Bedrock deployment uses a different model.
@@ -31,7 +31,7 @@ api:
   endpoint_type: query
   timeout: 300
   provider: "bedrock"
-  model: "deepseek-r1"
+  model: "us.deepseek.r1-v1:0"
   no_tools: null
   system_prompt: null
 

--- a/eval/system_vertex_claude_lseval.yaml
+++ b/eval/system_vertex_claude_lseval.yaml
@@ -1,0 +1,95 @@
+# LightSpeed Evaluation Framework Configuration
+# OLS Provider: Google Vertex Anthropic claude-opus-4-6 (model being evaluated)
+# Judge LLM: OpenAI GPT-5-mini (scoring responses)
+
+# Core Evaluation Configuration
+# Limits concurrent evaluations to avoid OpenAI API rate limiting on the judge LLM.
+# Each thread issues one OLS call and one judge LLM call, so 5 threads produce
+# at most 10 concurrent external API requests at any time.
+core:
+  max_threads: 5
+
+# Judge LLM Configuration
+# Uses OpenAI GPT-5-mini for evaluation scoring.
+# Requires OPENAI_API_KEY environment variable.
+llm:
+  provider: "openai"
+  model: "gpt-5-mini"
+  temperature: 1
+  max_tokens: 4096
+  timeout: 300
+  num_retries: 3
+
+# OLS API Configuration
+# Targets the OLS /query endpoint using Google Vertex Anthropic claude-opus-4-6 as the backend LLM.
+# api_base is overridden at runtime with the actual OLS service URL.
+# Requires OLS to be configured with a google_vertex_anthropic provider (Vertex AI credentials in olsconfig).
+# Override the model via LSEVAL_OLS_MODEL env var if your Vertex deployment uses a different model.
+api:
+  enabled: true
+  api_base: http://localhost:8080
+  endpoint_type: query
+  timeout: 300
+  provider: "google_vertex_anthropic"
+  model: "claude-opus-4-6"
+  no_tools: null
+  system_prompt: null
+
+# Metrics evaluated per conversation turn
+metrics_metadata:
+  turn_level:
+    "custom:answer_correctness":
+      # threshold intentionally omitted: no agreed baseline yet.
+      # Scores are recorded to track the trend over time; a threshold
+      # will be introduced once the average trend is established.
+      description: "Correctness vs expected answer using custom LLM evaluation"
+      default: true
+
+# Output Configuration
+output:
+  output_dir: "./eval_output"
+  base_filename: "evaluation"
+  enabled_outputs:
+    - csv
+    - json
+
+  csv_columns:
+    - "conversation_group_id"
+    - "turn_id"
+    - "metric_identifier"
+    - "score"
+    - "threshold"
+    - "result"
+    - "reason"
+    - "query"
+    - "response"
+    - "execution_time"
+
+# Visualization settings
+visualization:
+  figsize: [12, 8]
+  dpi: 300
+  enabled_graphs:
+    - "score_distribution"
+    - "status_breakdown"
+
+# Environment Variables
+environment:
+  DEEPEVAL_TELEMETRY_OPT_OUT: "YES"
+  DEEPEVAL_DISABLE_PROGRESS_BAR: "YES"
+  LITELLM_LOG: ERROR
+
+# Logging Configuration
+logging:
+  source_level: INFO
+  package_level: ERROR
+  log_format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+  show_timestamps: true
+  package_overrides:
+    httpx: ERROR
+    urllib3: ERROR
+    requests: ERROR
+    matplotlib: ERROR
+    LiteLLM: WARNING
+    DeepEval: WARNING
+    ragas: WARNING

--- a/eval/system_vertex_gemini_lseval.yaml
+++ b/eval/system_vertex_gemini_lseval.yaml
@@ -1,0 +1,95 @@
+# LightSpeed Evaluation Framework Configuration
+# OLS Provider: Google Vertex AI gemini-3.5-flash (model being evaluated)
+# Judge LLM: OpenAI GPT-5-mini (scoring responses)
+
+# Core Evaluation Configuration
+# Limits concurrent evaluations to avoid OpenAI API rate limiting on the judge LLM.
+# Each thread issues one OLS call and one judge LLM call, so 5 threads produce
+# at most 10 concurrent external API requests at any time.
+core:
+  max_threads: 5
+
+# Judge LLM Configuration
+# Uses OpenAI GPT-5-mini for evaluation scoring.
+# Requires OPENAI_API_KEY environment variable.
+llm:
+  provider: "openai"
+  model: "gpt-5-mini"
+  temperature: 1
+  max_tokens: 4096
+  timeout: 300
+  num_retries: 3
+
+# OLS API Configuration
+# Targets the OLS /query endpoint using Google Vertex AI gemini-3.5-flash as the backend LLM.
+# api_base is overridden at runtime with the actual OLS service URL.
+# Requires OLS to be configured with a google_vertex provider (Vertex AI credentials in olsconfig).
+# Override the model via LSEVAL_OLS_MODEL env var if your Vertex deployment uses a different model.
+api:
+  enabled: true
+  api_base: http://localhost:8080
+  endpoint_type: query
+  timeout: 300
+  provider: "google_vertex"
+  model: "gemini-3.5-flash"
+  no_tools: null
+  system_prompt: null
+
+# Metrics evaluated per conversation turn
+metrics_metadata:
+  turn_level:
+    "custom:answer_correctness":
+      # threshold intentionally omitted: no agreed baseline yet.
+      # Scores are recorded to track the trend over time; a threshold
+      # will be introduced once the average trend is established.
+      description: "Correctness vs expected answer using custom LLM evaluation"
+      default: true
+
+# Output Configuration
+output:
+  output_dir: "./eval_output"
+  base_filename: "evaluation"
+  enabled_outputs:
+    - csv
+    - json
+
+  csv_columns:
+    - "conversation_group_id"
+    - "turn_id"
+    - "metric_identifier"
+    - "score"
+    - "threshold"
+    - "result"
+    - "reason"
+    - "query"
+    - "response"
+    - "execution_time"
+
+# Visualization settings
+visualization:
+  figsize: [12, 8]
+  dpi: 300
+  enabled_graphs:
+    - "score_distribution"
+    - "status_breakdown"
+
+# Environment Variables
+environment:
+  DEEPEVAL_TELEMETRY_OPT_OUT: "YES"
+  DEEPEVAL_DISABLE_PROGRESS_BAR: "YES"
+  LITELLM_LOG: ERROR
+
+# Logging Configuration
+logging:
+  source_level: INFO
+  package_level: ERROR
+  log_format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+  show_timestamps: true
+  package_overrides:
+    httpx: ERROR
+    urllib3: ERROR
+    requests: ERROR
+    matplotlib: ERROR
+    LiteLLM: WARNING
+    DeepEval: WARNING
+    ragas: WARNING

--- a/tests/config/operator_install/olsconfig.crd.bedrock_deepseek_lseval.yaml
+++ b/tests/config/operator_install/olsconfig.crd.bedrock_deepseek_lseval.yaml
@@ -1,0 +1,25 @@
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+spec:
+  llm:
+    providers:
+      - credentialsSecretRef:
+          name: llmcreds
+        models:
+          - name: deepseek-r1
+        name: bedrock
+        type: bedrock
+        url: "https://bedrock-mantle.us-east-1.api.aws"
+  ols:
+    defaultModel: deepseek-r1
+    defaultProvider: bedrock
+    deployment:
+      replicas: 1
+    disableAuth: false
+    introspectionEnabled: false
+    logLevel: DEBUG
+    userDataCollection:
+      feedbackDisabled: true
+      transcriptsDisabled: true

--- a/tests/config/operator_install/olsconfig.crd.bedrock_deepseek_lseval.yaml
+++ b/tests/config/operator_install/olsconfig.crd.bedrock_deepseek_lseval.yaml
@@ -8,12 +8,12 @@ spec:
       - credentialsSecretRef:
           name: llmcreds
         models:
-          - name: deepseek-r1
+          - name: us.deepseek.r1-v1:0
         name: bedrock
         type: bedrock
         url: "https://bedrock-mantle.us-east-1.api.aws"
   ols:
-    defaultModel: deepseek-r1
+    defaultModel: us.deepseek.r1-v1:0
     defaultProvider: bedrock
     deployment:
       replicas: 1

--- a/tests/config/operator_install/olsconfig.crd.vertex_claude_lseval.yaml
+++ b/tests/config/operator_install/olsconfig.crd.vertex_claude_lseval.yaml
@@ -1,0 +1,28 @@
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+spec:
+  llm:
+    providers:
+      - credentialsSecretRef:
+          name: llmcreds
+        models:
+          - name: claude-opus-4-6
+        name: google_vertex_anthropic
+        type: google_vertex_anthropic
+        googleVertexAnthropicConfig:
+          projectID: "openshift-lightspeed-tests"
+          location: "global"
+        url: https://aiplatform.googleapis.com/
+  ols:
+    defaultModel: claude-opus-4-6
+    defaultProvider: google_vertex_anthropic
+    deployment:
+      replicas: 1
+    disableAuth: false
+    introspectionEnabled: false
+    logLevel: DEBUG
+    userDataCollection:
+      feedbackDisabled: true
+      transcriptsDisabled: true

--- a/tests/config/operator_install/olsconfig.crd.vertex_gemini_lseval.yaml
+++ b/tests/config/operator_install/olsconfig.crd.vertex_gemini_lseval.yaml
@@ -1,0 +1,28 @@
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+spec:
+  llm:
+    providers:
+      - credentialsSecretRef:
+          name: llmcreds
+        models:
+          - name: gemini-3.5-flash
+        name: google_vertex
+        type: google_vertex
+        googleVertexConfig:
+          projectID: "openshift-lightspeed-tests"
+          location: "us-central1"
+        url: https://us-central1-aiplatform.googleapis.com/
+  ols:
+    defaultModel: gemini-3.5-flash
+    defaultProvider: google_vertex
+    deployment:
+      replicas: 1
+    disableAuth: false
+    introspectionEnabled: false
+    logLevel: DEBUG
+    userDataCollection:
+      feedbackDisabled: true
+      transcriptsDisabled: true

--- a/tests/e2e/evaluation/test_lseval_presubmit.py
+++ b/tests/e2e/evaluation/test_lseval_presubmit.py
@@ -1,0 +1,79 @@
+r"""LSEval presubmit tests — short 10-question dataset across all providers.
+
+Runs ``eval/eval_data_short.yaml`` (10 questions) against the full provider matrix.
+The periodic suite uses the full 797-question dataset; this suite is a lightweight
+smoke test intended for presubmit CI.
+
+Each provider uses the judge LLM defined in ``eval/system_<provider>_lseval.yaml``
+(OpenAI ``gpt-5-mini`` for scoring).
+
+Local usage
+-----------
+1. Start OLS locally with the provider you want to evaluate::
+
+       OLS_CONFIG_FILE=olsconfig-openai.yaml make run
+
+2. Export the judge LLM key::
+
+       export OPENAI_API_KEY=<your-key>
+
+3. Run the eval for a single provider::
+
+       pytest tests/e2e/evaluation/test_lseval_presubmit.py \
+           -m lseval --lseval_provider openai \
+           --eval_out_dir /tmp/my-eval-results
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.evaluation.test_lseval_periodic import (
+    EVAL_DIR,
+    _run_lseval,
+    _skip_reason_for_provider,
+)
+
+_LSEVAL_PRESUBMIT_PROVIDERS = (
+    "openai",
+    "watsonx",
+    "azure_openai",
+    "rhoai_vllm",
+    "vertex_gemini",
+    "vertex_claude",
+    "bedrock_deepseek",
+)
+
+_PROVIDER_CONFIGS: dict[str, Path] = {
+    "openai": EVAL_DIR / "system_openai_lseval.yaml",
+    "watsonx": EVAL_DIR / "system_watsonx_lseval.yaml",
+    "azure_openai": EVAL_DIR / "system_azure_openai_lseval.yaml",
+    "rhoai_vllm": EVAL_DIR / "system_rhoai_vllm_lseval.yaml",
+    "vertex_gemini": EVAL_DIR / "system_vertex_gemini_lseval.yaml",
+    "vertex_claude": EVAL_DIR / "system_vertex_claude_lseval.yaml",
+    "bedrock_deepseek": EVAL_DIR / "system_bedrock_deepseek_lseval.yaml",
+}
+
+EVAL_DATA_SHORT = EVAL_DIR / "eval_data_short.yaml"
+
+
+@pytest.mark.lseval
+@pytest.mark.parametrize("provider", _LSEVAL_PRESUBMIT_PROVIDERS)
+def test_lseval_presubmit(request: pytest.FixtureRequest, provider: str) -> None:
+    """Run LSEval short dataset for the given OLS provider (presubmit smoke test).
+
+    Args:
+        request: Pytest fixture request object.
+        provider: OLS provider under evaluation (parametrized).
+    """
+    if reason := _skip_reason_for_provider(request, provider):
+        pytest.skip(reason)
+
+    out_dir_base = request.config.option.eval_out_dir or str(
+        EVAL_DIR / "results-lseval-presubmit"
+    )
+    _run_lseval(
+        EVAL_DATA_SHORT,
+        Path(out_dir_base) / "lseval" / provider,
+        _PROVIDER_CONFIGS[provider],
+    )

--- a/tests/scripts/test-lseval-presubmit.sh
+++ b/tests/scripts/test-lseval-presubmit.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# CI job: run the LSEval presubmit suite — short 10-question QnA dataset (eval/eval_data_short.yaml).
+# Runs all 6 non-RHOAI providers sequentially. Each provider deploys OLS with the
+# appropriate OLSConfig CRD, runs the 10-question eval, and tears down.
+# No trend recording — presubmit runs are smoke tests.
+#
+# Input environment variables:
+#   OPENAI_PROVIDER_KEY_PATH       - path to file containing the OpenAI API key (judge LLM + OLS)
+#   AZUREOPENAI_PROVIDER_KEY_PATH  - path to file containing the Azure OpenAI API key
+#   WATSONX_PROVIDER_KEY_PATH      - path to file containing the WatsonX API key
+#   VERTEX_PROVIDER_KEY_PATH       - path to file containing the Vertex AI credentials
+#   BEDROCK_AWS_ACCESS_KEY_ID      - AWS access key ID for Bedrock IAM
+#   BEDROCK_AWS_SECRET_ACCESS_KEY  - AWS secret access key for Bedrock IAM
+#   OLS_IMAGE                      - pullspec for the OLS container image to deploy
+
+set -eou pipefail
+
+make install-deps && make install-deps-test
+uv sync --extra evaluation --extra lseval
+
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/utils.sh"
+
+# Install operator-sdk
+export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
+export OS=$(uname | awk '{print tolower($0)}')
+export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.36.1
+curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
+mkdir -p $HOME/.local/bin
+chmod +x operator-sdk_${OS}_${ARCH} && mv operator-sdk_${OS}_${ARCH} $HOME/.local/bin/operator-sdk
+export PATH=$HOME/.local/bin:$PATH
+operator-sdk version
+
+# Export OpenAI key so the judge LLM can authenticate
+export OPENAI_API_KEY=$(cat "$OPENAI_PROVIDER_KEY_PATH")
+
+function run_suites() {
+  local rc=0
+  set +e
+
+  # OpenAI
+  SUITE_ID="lseval_presubmit_openai" run_suite \
+    "lseval_presubmit_openai" "lseval" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-5.4-mini" "$OLS_IMAGE" "lseval"
+  (( rc = rc || $? ))
+
+  # WatsonX
+  SUITE_ID="lseval_presubmit_watsonx" run_suite \
+    "lseval_presubmit_watsonx" "lseval" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-4-h-small" "$OLS_IMAGE" "lseval"
+  (( rc = rc || $? ))
+
+  # Azure OpenAI
+  SUITE_ID="lseval_presubmit_azure_openai" run_suite \
+    "lseval_presubmit_azure_openai" "lseval" "azure_openai" "$AZUREOPENAI_PROVIDER_KEY_PATH" "gpt-5.4-mini" "$OLS_IMAGE" "lseval"
+  (( rc = rc || $? ))
+
+  # Vertex Gemini
+  SUITE_ID="lseval_presubmit_vertex_gemini" run_suite \
+    "lseval_presubmit_vertex_gemini" "lseval" "vertex_gemini" "$VERTEX_PROVIDER_KEY_PATH" "gemini-3.5-flash" "$OLS_IMAGE" "lseval"
+  (( rc = rc || $? ))
+
+  # Vertex Claude
+  SUITE_ID="lseval_presubmit_vertex_claude" run_suite \
+    "lseval_presubmit_vertex_claude" "lseval" "vertex_claude" "$VERTEX_PROVIDER_KEY_PATH" "claude-opus-4-6" "$OLS_IMAGE" "lseval"
+  (( rc = rc || $? ))
+
+  # Bedrock DeepSeek
+  SUITE_ID="lseval_presubmit_bedrock_deepseek" run_suite \
+    "lseval_presubmit_bedrock_deepseek" "lseval" "bedrock_deepseek" "iam" "deepseek-r1" "$OLS_IMAGE" "lseval"
+  (( rc = rc || $? ))
+
+  set -e
+  cleanup_ols_operator
+  return $rc
+}
+
+function finish() {
+  if [ "${LOCAL_MODE:-0}" -eq 1 ]; then
+    rm -rf "$ARTIFACT_DIR"
+  fi
+}
+trap finish EXIT
+
+# ARTIFACT_DIR is set automatically in Prow; fall back to a temp dir locally
+if [ -z "${ARTIFACT_DIR:-}" ]; then
+  export ARTIFACT_DIR=$(mktemp -d)
+  readonly LOCAL_MODE=1
+fi
+
+run_suites

--- a/tests/scripts/test-lseval-presubmit.sh
+++ b/tests/scripts/test-lseval-presubmit.sh
@@ -66,7 +66,7 @@ function run_suites() {
 
   # Bedrock DeepSeek
   SUITE_ID="lseval_presubmit_bedrock_deepseek" run_suite \
-    "lseval_presubmit_bedrock_deepseek" "lseval" "bedrock_deepseek" "iam" "deepseek-r1" "$OLS_IMAGE" "lseval"
+    "lseval_presubmit_bedrock_deepseek" "lseval" "bedrock_deepseek" "iam" "us.deepseek.r1-v1:0" "$OLS_IMAGE" "lseval"
   (( rc = rc || $? ))
 
   set -e

--- a/tests/scripts/utils.sh
+++ b/tests/scripts/utils.sh
@@ -57,6 +57,9 @@ function run_suite() {
   elif [[ "$1" == lseval_periodic* ]]; then
   # Run LSEval periodic tests (full 797-question dataset)
     SUITE_ID=$1 TEST_TAGS=$2 PROVIDER=$3 PROVIDER_KEY_PATH=$4 MODEL=$5 OLS_IMAGE=$6 OLS_CONFIG_SUFFIX=$7 ARTIFACT_DIR=$ARTIFACT_DIR make test-lseval-periodic
+  elif [[ "$1" == lseval_presubmit* ]]; then
+  # Run LSEval presubmit tests (10-question short dataset)
+    SUITE_ID=$1 TEST_TAGS=$2 PROVIDER=$3 PROVIDER_KEY_PATH=$4 MODEL=$5 OLS_IMAGE=$6 OLS_CONFIG_SUFFIX=$7 ARTIFACT_DIR=$ARTIFACT_DIR make test-lseval-presubmit
   elif [ "$1" = "cluster_updates" ]; then
   # Run cluster-updates evaluation tests (18 conversations, 35 evaluations)
     SUITE_ID=$1 TEST_TAGS=$2 PROVIDER=$3 PROVIDER_KEY_PATH=$4 MODEL=$5 OLS_IMAGE=$6 OLS_CONFIG_SUFFIX=$7 ARTIFACT_DIR=$ARTIFACT_DIR make test-cluster-updates


### PR DESCRIPTION
## Description

## Summary

  Adds a lightweight lseval presubmit
  evaluation suite that runs the 10-question
  short dataset (`eval/eval_data_short.yaml`)
  across 7 LLM providers. In CI, 6 providers
  run sequentially (RHOAI excluded — too heavy
  for presubmit); all 7 are available locally
  via `--lseval_provider`.

  ### New files
  - 3 lseval system configs:
  `eval/system_{vertex_gemini,vertex_claude,be
  drock_deepseek}_lseval.yaml`
  - 3 OLSConfig CRDs: `tests/config/operator_i
  nstall/olsconfig.crd.{vertex_gemini,vertex_c
  laude,bedrock_deepseek}_lseval.yaml`
  - Presubmit pytest test: `tests/e2e/evaluati
  on/test_lseval_presubmit.py`
  - CI shell entrypoint:
  `tests/scripts/test-lseval-presubmit.sh`

  ### Modified files
  - `Makefile` — new `test-lseval-presubmit`
  target
  - `tests/scripts/utils.sh` —
  `lseval_presubmit*` dispatch in
  `run_suite()`
  - `tests/e2e/conftest.py` — expanded
  `--lseval_provider` choices to 7 providers

  ### Provider matrix

  | Provider | Model | CI | Local |
  |---|---|---|---|
  | openai | gpt-5.4-mini | ✅ | ✅ |
  | watsonx | ibm/granite-4-h-small | ✅ | ✅
  |
  | azure_openai | gpt-5.4-mini | ✅ | ✅ |
  | vertex_gemini | gemini-3.5-flash | ✅ | ✅
  |
  | vertex_claude | claude-opus-4-6 | ✅ | ✅
  |
  | bedrock_deepseek | deepseek-r1 | ✅ | ✅ |
  | rhoai_vllm | (configured per cluster) | ❌
  | ✅ |

  ### Dependencies
  - PR #3008 (OpenAI model upgrade to
  gpt-5.4-mini) must merge first
  - Companion release repo PR for the Prow CI
  job

  ## Test plan
  - [ ] Verify `uv run python -c "from
  tests.e2e.evaluation.test_lseval_presubmit
  import _LSEVAL_PRESUBMIT_PROVIDERS;
  print(len(_LSEVAL_PRESUBMIT_PROVIDERS))"`
  prints `7`
  - [ ] Verify all 7 system config YAML files
  parse correctly
  - [ ] Verify `make test-lseval-presubmit`
  target exists (`make -n
  test-lseval-presubmit`)
  - [ ] CI presubmit job runs successfully
  after companion release PR merges

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a presubmit evaluation suite covering multiple model providers using a short test dataset.
  * Added evaluation configurations for Bedrock, Vertex Claude, and Vertex Gemini.
  * Added deployment test configurations for the supported provider setups.

* **Testing**
  * Added CI and command-line support for running the new presubmit evaluation suite.
  * Added provider-specific output, reporting, and visualization settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->