### PR TITLE
OLS-3584 - fix test ca certs

### DIFF
--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -451,12 +451,31 @@ def test_generated_service_certs_rotation():
     cluster_utils.delete_resource(
         resource="secret", name=service_tls, namespace="openshift-lightspeed"
     )
-    response = pytest.client.post(
-        "/v1/query",
-        json={"query": "what is kubernetes?"},
-        timeout=LLM_REST_API_TIMEOUT,
+    assert wait_for_ols(
+        pytest.ols_url, timeout=300, interval=10
+    ), "OLS did not become ready after service certificate rotation"
+
+    response: requests.Response | None = None
+
+    def _query_succeeds() -> bool:
+        nonlocal response
+        response = pytest.client.post(
+            "/v1/query",
+            json={"query": "what is kubernetes?"},
+            timeout=LLM_REST_API_TIMEOUT,
+        )
+        return response.status_code == requests.codes.ok
+
+    assert retry_until_timeout_or_success(
+        6,
+        30,
+        _query_succeeds,
+        "Retrying query while route stabilizes after service cert rotation",
+    ), (
+        f"OLS returned "
+        f"{response.status_code if response is not None else 'no response (all attempts raised)'}"
+        f" after service certificate rotation"
     )
-    assert response.status_code == requests.codes.ok
 
 
 @pytest.mark.certificates
@@ -469,10 +488,12 @@ def test_ca_service_certs_rotation():
 
     def _new_pod_is_running():
         current_pods = cluster_utils.get_pod_by_prefix(fail_not_found=False)
-        return len(current_pods) == 1 and current_pods != original_pods
+        return len(current_pods) >= 1 and any(
+            pod not in original_pods for pod in current_pods
+        )
 
     assert retry_until_timeout_or_success(
-        30,
+        60,
         10,
         _new_pod_is_running,
         "Waiting for operator to roll pods after CA cert rotation",

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -451,20 +451,28 @@ def test_generated_service_certs_rotation():
     cluster_utils.delete_resource(
         resource="secret", name=service_tls, namespace="openshift-lightspeed"
     )
+    # Readiness gate only; verify=False fallback is acceptable here because
+    # the retried query below validates the service is functional end-to-end.
     assert wait_for_ols(
         pytest.ols_url, timeout=300, interval=10
     ), "OLS did not become ready after service certificate rotation"
 
     response: requests.Response | None = None
+    last_error: Exception | None = None
 
     def _query_succeeds() -> bool:
-        nonlocal response
-        response = pytest.client.post(
-            "/v1/query",
-            json={"query": "what is kubernetes?"},
-            timeout=LLM_REST_API_TIMEOUT,
-        )
-        return response.status_code == requests.codes.ok
+        nonlocal response, last_error
+        last_error = None
+        try:
+            response = pytest.client.post(
+                "/v1/query",
+                json={"query": "what is kubernetes?"},
+                timeout=LLM_REST_API_TIMEOUT,
+            )
+            return response.status_code == requests.codes.ok
+        except Exception as e:
+            last_error = e
+            raise
 
     assert retry_until_timeout_or_success(
         6,
@@ -472,9 +480,8 @@ def test_generated_service_certs_rotation():
         _query_succeeds,
         "Retrying query while route stabilizes after service cert rotation",
     ), (
-        f"OLS returned "
-        f"{response.status_code if response is not None else 'no response (all attempts raised)'}"
-        f" after service certificate rotation"
+        "OLS query failed after service cert rotation: "
+        f"{last_error or (f'status {response.status_code}' if response else 'unknown')}"
     )
 
 
@@ -500,20 +507,28 @@ def test_ca_service_certs_rotation():
     ), "Timed out waiting for pod rollout after CA certificate rotation"
 
     cluster_utils.wait_for_running_pod()
+    # Readiness gate only; verify=False fallback is acceptable here because
+    # the retried query below validates the service is functional end-to-end.
     assert wait_for_ols(
         pytest.ols_url, timeout=300, interval=10
     ), "OLS did not become ready after CA certificate rotation"
 
     response: requests.Response | None = None
+    last_error: Exception | None = None
 
     def _query_succeeds() -> bool:
-        nonlocal response
-        response = pytest.client.post(
-            "/v1/query",
-            json={"query": "what is kubernetes?"},
-            timeout=LLM_REST_API_TIMEOUT,
-        )
-        return response.status_code == requests.codes.ok
+        nonlocal response, last_error
+        last_error = None
+        try:
+            response = pytest.client.post(
+                "/v1/query",
+                json={"query": "what is kubernetes?"},
+                timeout=LLM_REST_API_TIMEOUT,
+            )
+            return response.status_code == requests.codes.ok
+        except Exception as e:
+            last_error = e
+            raise
 
     assert retry_until_timeout_or_success(
         6,
@@ -521,9 +536,8 @@ def test_ca_service_certs_rotation():
         _query_succeeds,
         "Retrying query while route stabilizes after CA cert rotation",
     ), (
-        f"OLS returned "
-        f"{response.status_code if response is not None else 'no response (all attempts raised)'}"
-        f" after CA certificate rotation"
+        "OLS query failed after CA cert rotation: "
+        f"{last_error or (f'status {response.status_code}' if response else 'unknown')}"
     )
 
 


### PR DESCRIPTION
## Description

### Fix 1 — test_generated_service_certs_rotation: Instead of immediately querying
  after deleting the TLS secret (which returned 500), the test now waits for OLS
  readiness (wait_for_ols with 300s timeout) and then retries the query 6 times
  with 30s intervals. This mirrors the pattern already used in the CA rotation
  test and accounts for the time needed to regenerate the serving cert and restart
  with the RHOKP sidecar.

 ### Fix 2 — test_ca_service_certs_rotation: Two changes:
  - Timeout doubled from 5 minutes (30×10s) to 10 minutes (60×10s) to accommodate
  the RHOKP sidecar startup probe (~6 min worst case) plus the service-ca operator
  reconciliation time.
  - Rollout check relaxed: len == 1 and != changed to len >= 1 and any(new).
  During rolling updates, both old and new pods may be Running simultaneously —
  the old check returned False when it saw 2 pods.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service TLS certificate-rotation verification by retrying API requests until they succeed or time out.
  * Enhanced CA TLS certificate-rotation checks to recognize successful pod rollouts more reliably.
  * Added clearer failure details when requests do not return a successful response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->