### PR TITLE
OLS-3718: fix quota limits test

### DIFF
--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -273,10 +273,10 @@ class AppConfig:
         try:
             embed_model = self._solr_hybrid_embed_model()
             encode_fn = embed_model.get_text_embedding
+            return SolrHybridSearch(settings, encode_fn)
         except Exception:
-            logger.exception("Failed to resolve embedding model for Solr hybrid RAG")
+            logger.exception("Failed to initialize Solr hybrid RAG")
             return None
-        return SolrHybridSearch(settings, encode_fn)
 
     @property
     def proxy_config(self) -> Optional[config_model.ProxyConfig]:

--- a/runner.py
+++ b/runner.py
@@ -27,9 +27,8 @@ from ols.version import __version__
 def load_index():
     """Load the index."""
     # Resolve Solr hybrid search (OCP version resolution) in the background
-    # so it does not block uvicorn startup.  The readiness endpoint gates on
-    # rag_index which is loaded right after, so the service stays 503 until
-    # both complete.
+    # so it does not block uvicorn startup.  Solr failure is non-fatal: the
+    # pod goes ready once rag_index loads and serves without hybrid search.
     config.solr_hybrid_search  # pylint: disable=W0104, E0606
     config.rag_index  # pylint: disable=W0104, E0606
 

--- a/runner.py
+++ b/runner.py
@@ -26,8 +26,11 @@ from ols.version import __version__
 
 def load_index():
     """Load the index."""
-    # accessing the config's rag_index property will trigger the loading
-    # of the index
+    # Resolve Solr hybrid search (OCP version resolution) in the background
+    # so it does not block uvicorn startup.  The readiness endpoint gates on
+    # rag_index which is loaded right after, so the service stays 503 until
+    # both complete.
+    config.solr_hybrid_search  # pylint: disable=W0104, E0606
     config.rag_index  # pylint: disable=W0104, E0606
 
 
@@ -99,9 +102,6 @@ if __name__ == "__main__":
             "Pyroscope url is not specified. To enable profiling please set `pyroscope_url` "
             "in the `dev_config` section of the configuration file."
         )
-    # Eagerly initialize Solr hybrid search so OCP version resolution
-    # (requires OCP_CLUSTER_VERSION and a reachable Solr) fails fast.
-    config.solr_hybrid_search  # pylint: disable=W0104
 
     # create and start the rag_index_thread - allows loading index in
     # parallel with starting the Uvicorn server

--- a/tests/e2e/utils/cluster.py
+++ b/tests/e2e/utils/cluster.py
@@ -451,24 +451,9 @@ def wait_for_running_pod(
         if not pods:
             return False
 
-        ready_containers = len(
-            [
-                container
-                for container in get_container_ready_status(pods[0])
-                if container == "true"
-            ]
-        )
+        statuses = get_container_ready_status(pods[0])
+        return len(statuses) > 0 and all(s == "true" for s in statuses)
 
-        # Check for tool calling mode which needs 2 containers (API + MCP server)
-        ols_config_suffix = os.getenv("OLS_CONFIG_SUFFIX", "default")
-        tool_calling_enabled = "tool_calling" in ols_config_suffix
-
-        if tool_calling_enabled:
-            return ready_containers >= 2
-        return ready_containers >= 1
-
-    # wait for the containers in the server pod to become ready
-    # one container normally, two in case we're running tool calling (mcp server)
     r = retry_until_timeout_or_success(
         OC_COMMAND_RETRY_COUNT,
         5,


### PR DESCRIPTION
## Description

1. Defer Solr version resolution into background thread
  - runner.py: Moved config.solr_hybrid_search access from the main startup path
  (where it blocked uvicorn for up to 120s) into load_index(), which runs in an
  existing background thread. Uvicorn now starts immediately, and /readiness stays
  503 until both Solr resolution and RAG index loading complete.

  2. Require all pod containers ready in e2e wait helper
  - tests/e2e/utils/cluster.py: Replaced the fragile minimum-count container check
  (1 for normal, 2 for tool-calling) with all(s == "true" for s in statuses).
  This ensures RHOKP/Solr sidecars are fully ready before e2e tests proceed, not
  just the API container

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup so Solr hybrid search configuration is resolved during background index loading, reducing main-thread blocking and making hybrid resolution non-fatal.
  * Updated service readiness behavior to align with index loading/serving progress.
* **Tests**
  * Refined e2e pod readiness checks to succeed only when all reported container readiness states are `"true"`, removing mode-based thresholding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->