### PR TITLE
OLS-3584 - ca certs rotation fix

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -16,6 +16,7 @@ from tests.e2e.utils import client as client_utils
 from tests.e2e.utils import cluster, ols_installer
 from tests.e2e.utils.adapt_ols_config import adapt_ols_config
 from tests.e2e.utils.mcp_setup import setup_mcp_on_cluster, teardown_mcp_on_cluster
+from tests.e2e.utils.retry import retry_until_timeout_or_success
 from tests.e2e.utils.wait_for_ols import wait_for_ols
 from tests.scripts.must_gather import must_gather
 
@@ -141,6 +142,73 @@ def pytest_sessionstart():
     # Gather OLS artifacts in case OLS does not become ready
     if on_cluster and not OLS_READY:
         must_gather()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _operator_running_for_certs(request):
+    """Scale up the operator for certificate rotation tests.
+
+    The operator controller-manager is normally scaled to 0 during e2e tests
+    to prevent interference. Certificate rotation tests need it running so it
+    can detect CA bundle changes and trigger pod rollouts.
+    """
+    if not any(
+        item.get_closest_marker("certificates") for item in request.session.items
+    ):
+        yield
+        return
+
+    print("Scaling up operator controller manager for certificate tests...")
+    cluster.run_oc(
+        [
+            "scale",
+            "deployment/lightspeed-operator-controller-manager",
+            "--replicas",
+            "1",
+        ]
+    )
+    try:
+        if not retry_until_timeout_or_success(
+            60,
+            5,
+            lambda: (
+                pods := cluster.get_pod_by_prefix(
+                    prefix="lightspeed-operator-controller-manager",
+                    fail_not_found=False,
+                )
+            )
+            and all(s == "true" for s in cluster.get_container_ready_status(pods[0])),
+            "Waiting for operator controller manager to be ready",
+        ):
+            raise RuntimeError(
+                "Timed out waiting for operator controller manager to be ready"
+            )
+        print("Operator controller manager is ready")
+
+        yield
+    finally:
+        print("Scaling down operator controller manager after certificate tests...")
+        cluster.run_oc(
+            [
+                "scale",
+                "deployment/lightspeed-operator-controller-manager",
+                "--replicas",
+                "0",
+            ]
+        )
+        if not retry_until_timeout_or_success(
+            30,
+            3,
+            lambda: not cluster.get_pod_by_prefix(
+                prefix="lightspeed-operator-controller-manager",
+                fail_not_found=False,
+            ),
+            "Waiting for operator controller manager to scale down",
+        ):
+            raise RuntimeError(
+                "Timed out waiting for operator controller manager to scale down"
+            )
+        print("Operator controller manager scaled down")
 
 
 def pytest_runtest_makereport(item, call) -> TestReport:

--- a/tests/e2e/utils/cluster.py
+++ b/tests/e2e/utils/cluster.py
@@ -12,6 +12,10 @@ from tests.e2e.utils.wait_for_ols import wait_for_ols
 OC_COMMAND_RETRY_COUNT = 120
 
 
+class PodNotFoundError(Exception):
+    """Raised when a pod is not found on the cluster."""
+
+
 OC_SUBPROCESS_TIMEOUT = 120
 
 
@@ -271,6 +275,8 @@ def get_pod_containers(pod, namespace: str = "openshift-lightspeed") -> list[str
         )
         return result.stdout.strip("'").split()
     except subprocess.CalledProcessError as e:
+        if "NotFound" in (e.stderr or ""):
+            raise PodNotFoundError(f"Pod {pod} not found") from e
         raise Exception(f"Error getting containers of pod {pod}") from e
 
 

--- a/tests/scripts/must_gather.py
+++ b/tests/scripts/must_gather.py
@@ -11,6 +11,7 @@ from ols.constants import DEFAULT_CONFIGURATION_FILE
 
 sys.path.append(Path(__file__).parent.parent.parent.as_posix())
 from tests.e2e.utils import cluster as cluster_utils
+from tests.e2e.utils.cluster import PodNotFoundError
 
 
 def must_gather():
@@ -157,7 +158,12 @@ def must_gather():
     pod_logs_dir = cluster_dir / "podlogs"
     pod_logs_dir.mkdir(exist_ok=True)
     for pod in cluster_utils.get_running_pods():
-        for container in cluster_utils.get_pod_containers(pod):
+        try:
+            containers = cluster_utils.get_pod_containers(pod)
+        except PodNotFoundError:
+            print(f"Pod {pod} vanished before logs could be collected, skipping")
+            continue
+        for container in containers:
             cluster_utils.run_oc_and_store_stdout(
                 [
                     "logs",


### PR DESCRIPTION
adding fixture for ca certs rotation and must gather condition for missing pods

## Description
1. tests/e2e/conftest.py — Scale operator up for certificate rotation tests

  Added a session-scoped autouse fixture _operator_running_for_certs that
  scales lightspeed-operator-controller-manager to 1 replica before
  certificate tests run, and back to 0 after they finish. The operator needs
  to be running because the CA rotation test (test_ca_service_certs_rotation)
  deletes the signing-key secret in openshift-service-ca, which causes the
  service-ca operator to regenerate the CA bundle in the
  openshift-service-ca.crt configmap. The lightspeed-operator watches that
  configmap and triggers an app-server pod rollout via the force-reload
  annotation — but only if it's actually running. Previously it was always
  scaled to 0 during tests, so no rollout ever happened and the test timed out
  every time. The fixture is gated on the certificates marker, so it's a
  no-op for all other test suites.

  2. tests/scripts/must_gather.py — Handle pods vanishing during log 
  collection

  Wrapped the get_pod_containers() call in a try/except so that if a pod
  disappears between get_running_pods() and get_pod_containers(), it's skipped
  with a log message instead of crashing the entire pytest_sessionfinish
  teardown. This race condition is now possible because the operator is
  actively managing pods during certificate tests — the old app-server pod can
  be gone by the time must_gather tries to collect its logs.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic collection so it continues when a pod disappears during data gathering.
  * Certificate-related test runs now ensure the required operator component is ready before execution and clean it up afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->