### PR TITLE
OLS-3601 PostgresCache.ready() reconnect after transient postgres outage

### DIFF
--- a/ols/src/cache/postgres_cache.py
+++ b/ols/src/cache/postgres_cache.py
@@ -388,21 +388,32 @@ class PostgresCache(Cache, PostgresBase):
     def ready(self) -> bool:
         """Check if the cache is ready.
 
-        Postgres cache checks if the connection is alive.
+        Postgres cache checks if the connection is alive. When a dead
+        connection is detected and the database is available again, the
+        connection is automatically re-established.
 
         Returns:
             True if the cache is ready, False otherwise.
         """
-        # TODO: when the connection is closed and the database is back online,
-        # we need to reestablish the connection => implement this
-        if not self.connection or self.connection.closed == 1:
-            return False
-        try:
-            return self.connection.poll() == psycopg2.extensions.POLL_OK
-        except (psycopg2.OperationalError, psycopg2.InterfaceError):
-            # OperationalError - the once alive connection is closed
-            # InterfaceError - cannot reach the database server
-            return False
+        with self._tx_lock:
+            if not self.connection or self.connection.closed == 1:
+                try:
+                    logger.info("Detected dead connection, attempting reconnect")
+                    self.connect()
+                    return True
+                except Exception as e:
+                    logger.warning("Reconnect attempt failed: %s", e)
+                    return False
+            try:
+                return self.connection.poll() == psycopg2.extensions.POLL_OK
+            except (psycopg2.OperationalError, psycopg2.InterfaceError):
+                try:
+                    logger.info("Connection error during poll, attempting reconnect")
+                    self.connect()
+                    return True
+                except Exception as e:
+                    logger.warning("Reconnect attempt failed: %s", e)
+                    return False
 
     @staticmethod
     def _select(

--- a/tests/unit/cache/test_postgres_cache.py
+++ b/tests/unit/cache/test_postgres_cache.py
@@ -812,17 +812,77 @@ def test_ready():
         # cache is ready
         assert cache.ready()
 
-        # mock the connection state 1 - closed
+
+def test_ready_reconnects_on_closed_connection():
+    """Test that ready() reconnects when connection is closed."""
+    with patch("psycopg2.connect") as mock_connect:
+        config = PostgresConfig()
+        cache = PostgresCache(config)
+
+        # simulate closed connection
         cache.connection.closed = 1
-        # cache is not ready
+
+        # ready() should attempt reconnect and succeed
+        assert cache.ready()
+        # connect() is called during __init__ and again during reconnect
+        assert mock_connect.call_count == 2
+
+
+def test_ready_reconnects_on_none_connection():
+    """Test that ready() reconnects when connection is None."""
+    with patch("psycopg2.connect") as mock_connect:
+        config = PostgresConfig()
+        cache = PostgresCache(config)
+
+        # simulate lost connection
+        cache.connection = None
+
+        # ready() should attempt reconnect and succeed
+        assert cache.ready()
+        assert mock_connect.call_count == 2
+
+
+def test_ready_returns_false_when_reconnect_fails():
+    """Test that ready() returns False when reconnect attempt fails."""
+    with patch("psycopg2.connect") as mock_connect:
+        config = PostgresConfig()
+        cache = PostgresCache(config)
+
+        # simulate closed connection
+        cache.connection.closed = 1
+        # make reconnect fail
+        mock_connect.side_effect = psycopg2.OperationalError("connection refused")
+
         assert not cache.ready()
 
-        for error_type in (psycopg2.OperationalError, psycopg2.InterfaceError):
-            # mock the connection state 0 - open
-            cache.connection.closed = 0
-            # patch the poll function to raise OperationalError
-            cache.connection.poll = MagicMock(
-                side_effect=error_type("Connection closed")
-            )
-            # cache is not ready
-            assert not cache.ready()
+
+def test_ready_reconnects_on_poll_error():
+    """Test that ready() reconnects when poll raises OperationalError."""
+    with patch("psycopg2.connect") as mock_connect:
+        config = PostgresConfig()
+        cache = PostgresCache(config)
+
+        cache.connection.closed = 0
+        cache.connection.poll = MagicMock(
+            side_effect=psycopg2.OperationalError("Connection closed")
+        )
+
+        # ready() should attempt reconnect and succeed
+        assert cache.ready()
+        assert mock_connect.call_count == 2
+
+
+def test_ready_returns_false_when_poll_reconnect_fails():
+    """Test that ready() returns False when reconnect after poll error fails."""
+    with patch("psycopg2.connect") as mock_connect:
+        config = PostgresConfig()
+        cache = PostgresCache(config)
+
+        cache.connection.closed = 0
+        cache.connection.poll = MagicMock(
+            side_effect=psycopg2.InterfaceError("Connection closed")
+        )
+        # make reconnect fail
+        mock_connect.side_effect = psycopg2.OperationalError("connection refused")
+
+        assert not cache.ready()


### PR DESCRIPTION
## Description

When the postgres connection drops (e.g. pod eviction), ready() now calls self.connect() to re-establish the connection instead of permanently returning False.  This prevents the readiness probe from being stuck at 503 until a manual pod restart.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache connection reliability by automatically reconnecting when connections are missing, closed, or encounter polling errors.
  * Cache readiness now accurately reports whether recovery succeeds or fails.

* **Tests**
  * Expanded coverage for connection recovery and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->