### PR TITLE
OLS-3352: fix ModernType TLS profile startup crash

### DIFF
--- a/ols/runners/uvicorn.py
+++ b/ols/runners/uvicorn.py
@@ -36,7 +36,8 @@ def start_uvicorn(config: AppConfig) -> None:
     sec_profile = config.ols_config.tls_security_profile
     ssl_version = ssl_utils.get_ssl_version(sec_profile)
     min_tls_version = ssl_utils.get_min_tls_version(sec_profile)
-    ssl_ciphers = ssl_utils.get_ciphers(sec_profile)
+    ssl_ciphers_str = ssl_utils.get_ciphers(sec_profile)
+    ciphers = ssl_utils.split_ciphers(ssl_ciphers_str)
 
     uvicorn_config = uvicorn.Config(
         "ols.app.main:app",
@@ -48,12 +49,17 @@ def start_uvicorn(config: AppConfig) -> None:
         ssl_certfile=ssl_certfile,
         ssl_keyfile_password=ssl_keyfile_password,
         ssl_version=ssl_version,
-        ssl_ciphers=ssl_ciphers,
+        ssl_ciphers=ciphers.tls12 or "DEFAULT",
         access_log=log_level < logging.INFO,
     )
     uvicorn_config.load()
-    if uvicorn_config.ssl is not None and min_tls_version is not None:
-        uvicorn_config.ssl.minimum_version = min_tls_version
+    if uvicorn_config.ssl is not None:
+        if min_tls_version is not None:
+            uvicorn_config.ssl.minimum_version = min_tls_version
+        if ciphers.tls13 is not None and hasattr(
+            uvicorn_config.ssl, "set_ciphersuites"
+        ):
+            uvicorn_config.ssl.set_ciphersuites(ciphers.tls13)
 
     server = uvicorn.Server(uvicorn_config)
     server.run()

--- a/ols/utils/ssl.py
+++ b/ols/utils/ssl.py
@@ -109,7 +109,7 @@ def split_ciphers(cipher_string: Optional[str]) -> SplitCiphers:
     for cipher in (c.strip() for c in cipher_string.replace(":", ",").split(",")):
         if not cipher:
             continue
-        if cipher.startswith("TLS_"):
+        if cipher.startswith("TLS_") and "_WITH_" not in cipher:
             tls13.append(cipher)
         else:
             tls12.append(cipher)

--- a/ols/utils/ssl.py
+++ b/ols/utils/ssl.py
@@ -2,6 +2,7 @@
 
 import logging
 import ssl
+from dataclasses import dataclass
 from typing import Any, Optional
 
 from ols import constants
@@ -83,3 +84,37 @@ def get_ciphers(sec_profile: Optional[TLSSecurityProfile]) -> str:
     ciphers = tls.ciphers_as_string(sec_profile.ciphers, sec_profile.profile_type)
     logger.info("Allowing following ciphers: %s", ciphers)
     return ciphers
+
+
+@dataclass(frozen=True, slots=True)
+class SplitCiphers:
+    """TLS 1.2 ciphers and TLS 1.3 ciphersuites separated for OpenSSL APIs."""
+
+    tls12: Optional[str]
+    tls13: Optional[str]
+
+
+def split_ciphers(cipher_string: Optional[str]) -> SplitCiphers:
+    """Separate a cipher string into TLS 1.2 ciphers and TLS 1.3 ciphersuites.
+
+    TLS 1.3 ciphersuites are identified by the 'TLS_' prefix per RFC 8446.
+    Output uses colon separation as required by OpenSSL APIs.
+    Accepts comma-separated, colon-separated, or mixed input.
+    """
+    if not cipher_string:
+        return SplitCiphers(tls12=None, tls13=None)
+
+    tls12: list[str] = []
+    tls13: list[str] = []
+    for cipher in (c.strip() for c in cipher_string.replace(":", ",").split(",")):
+        if not cipher:
+            continue
+        if cipher.startswith("TLS_"):
+            tls13.append(cipher)
+        else:
+            tls12.append(cipher)
+
+    return SplitCiphers(
+        tls12=":".join(tls12) if tls12 else None,
+        tls13=":".join(tls13) if tls13 else None,
+    )

--- a/tests/integration/test_runners.py
+++ b/tests/integration/test_runners.py
@@ -9,6 +9,7 @@ import pytest
 from ols import config, constants
 from ols.runners.quota_scheduler import start_quota_scheduler
 from ols.runners.uvicorn import start_uvicorn
+from ols.utils.ssl import split_ciphers
 
 MINIMAL_CONFIG_FILE = "tests/config/valid_config.yaml"
 CORRECT_CONFIG_FILE = "tests/config/config_for_integration_tests.yaml"
@@ -27,10 +28,11 @@ def _run_start_uvicorn_and_assert(
     ssl_ciphers: str,
     min_tls_version,
     access_log: bool,
+    expected_ciphersuites=None,
 ) -> None:
     """Call start_uvicorn with mocked uvicorn internals and assert expectations."""
     fake_uvicorn_config = SimpleNamespace(
-        ssl=SimpleNamespace(minimum_version=None),
+        ssl=SimpleNamespace(minimum_version=None, set_ciphersuites=Mock()),
         loaded=False,
     )
     fake_uvicorn_config.load = Mock(
@@ -61,6 +63,12 @@ def _run_start_uvicorn_and_assert(
         )
         assert fake_uvicorn_config.loaded is True
         assert fake_uvicorn_config.ssl.minimum_version == min_tls_version
+        if expected_ciphersuites is not None and hasattr(
+            ssl.SSLContext, "set_ciphersuites"
+        ):
+            fake_uvicorn_config.ssl.set_ciphersuites.assert_called_once_with(
+                expected_ciphersuites
+            )
         mocked_server.assert_called_once_with(fake_uvicorn_config)
         fake_server.run.assert_called_once_with()
 
@@ -68,6 +76,7 @@ def _run_start_uvicorn_and_assert(
 def test_start_uvicorn_minimal_setup():
     """Test the function to start Uvicorn server."""
     config.reload_from_yaml_file(MINIMAL_CONFIG_FILE)
+    default_ciphers = split_ciphers(constants.DEFAULT_SSL_CIPHERS)
 
     _run_start_uvicorn_and_assert(
         host="0.0.0.0",  # noqa: S104
@@ -75,7 +84,8 @@ def test_start_uvicorn_minimal_setup():
         ssl_keyfile=None,
         ssl_certfile=None,
         ssl_keyfile_password=None,
-        ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
+        ssl_ciphers=default_ciphers.tls12 or "DEFAULT",
+        expected_ciphersuites=default_ciphers.tls13,
         min_tls_version=None,
         access_log=False,
     )
@@ -84,6 +94,9 @@ def test_start_uvicorn_minimal_setup():
 def test_start_uvicorn_full_setup():
     """Test the function to start Uvicorn server."""
     config.reload_from_yaml_file(CORRECT_CONFIG_FILE)
+    custom_ciphers = split_ciphers(
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+    )
 
     _run_start_uvicorn_and_assert(
         host="0.0.0.0",  # noqa: S104
@@ -91,7 +104,8 @@ def test_start_uvicorn_full_setup():
         ssl_keyfile="tests/config/key",
         ssl_certfile="tests/config/empty_cert.crt",
         ssl_keyfile_password="* this is password *",  # noqa: S106
-        ssl_ciphers="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+        ssl_ciphers=custom_ciphers.tls12 or "DEFAULT",
+        expected_ciphersuites=custom_ciphers.tls13,
         min_tls_version=ssl.TLSVersion.TLSv1_3,
         access_log=False,
     )

--- a/tests/unit/runners/test_uvicorn_runner.py
+++ b/tests/unit/runners/test_uvicorn_runner.py
@@ -10,6 +10,7 @@ from ols import constants
 from ols.app.models.config import Config, TLSSecurityProfile
 from ols.runners.uvicorn import start_uvicorn
 from ols.utils import tls
+from ols.utils.ssl import split_ciphers
 
 
 @pytest.fixture
@@ -45,10 +46,15 @@ def _assert_start_uvicorn(
     port: int,
     min_tls_version,
     ssl_ciphers,
+    expected_ciphersuites=None,
 ) -> None:
     """Assert the Uvicorn runner configures and starts the server."""
+    fake_ssl_context = SimpleNamespace(
+        minimum_version=None,
+        set_ciphersuites=Mock(),
+    )
     fake_uvicorn_config = SimpleNamespace(
-        ssl=SimpleNamespace(minimum_version=None),
+        ssl=fake_ssl_context,
         loaded=False,
     )
     fake_uvicorn_config.load = Mock(
@@ -78,55 +84,71 @@ def _assert_start_uvicorn(
             access_log=False,
         )
         assert fake_uvicorn_config.loaded is True
-        assert fake_uvicorn_config.ssl.minimum_version == min_tls_version
+        assert fake_ssl_context.minimum_version == min_tls_version
+
+        if expected_ciphersuites is not None:
+            fake_ssl_context.set_ciphersuites.assert_called_once_with(
+                expected_ciphersuites
+            )
+        else:
+            fake_ssl_context.set_ciphersuites.assert_not_called()
+
         mocked_server.assert_called_once_with(fake_uvicorn_config)
         fake_server.run.assert_called_once_with()
 
 
 def test_start_uvicorn(default_config):
     """Test the function to start Uvicorn server."""
+    default_ciphers = split_ciphers(constants.DEFAULT_SSL_CIPHERS)
     _assert_start_uvicorn(
         default_config,
         host="0.0.0.0",  # noqa: S104
         port=8080,
         min_tls_version=None,
-        ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
+        ssl_ciphers=default_ciphers.tls12 or "DEFAULT",
+        expected_ciphersuites=default_ciphers.tls13,
     )
 
 
 def test_start_uvicorn_with_tls(default_config):
     """Test the function to start Uvicorn server with TLS enabled."""
     default_config.dev_config.disable_tls = False
+    default_ciphers = split_ciphers(constants.DEFAULT_SSL_CIPHERS)
     _assert_start_uvicorn(
         default_config,
         host="0.0.0.0",  # noqa: S104
         port=8443,
         min_tls_version=None,
-        ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
+        ssl_ciphers=default_ciphers.tls12 or "DEFAULT",
+        expected_ciphersuites=default_ciphers.tls13,
     )
 
 
 def test_start_uvicorn_on_localhost(default_config):
     """Test the function to start Uvicorn server."""
     default_config.dev_config.run_on_localhost = True
+    default_ciphers = split_ciphers(constants.DEFAULT_SSL_CIPHERS)
     _assert_start_uvicorn(
         default_config,
         host="localhost",
         port=8080,
         min_tls_version=None,
-        ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
+        ssl_ciphers=default_ciphers.tls12 or "DEFAULT",
+        expected_ciphersuites=default_ciphers.tls13,
     )
 
 
 def test_start_uvicorn_on_non_default_port(default_config):
     """Test the function to start Uvicorn server on a non-default port."""
     default_config.dev_config.uvicorn_port_number = 8081
+    default_ciphers = split_ciphers(constants.DEFAULT_SSL_CIPHERS)
     _assert_start_uvicorn(
         default_config,
         host="0.0.0.0",  # noqa: S104
         port=8081,
         min_tls_version=None,
-        ssl_ciphers=constants.DEFAULT_SSL_CIPHERS,
+        ssl_ciphers=default_ciphers.tls12 or "DEFAULT",
+        expected_ciphersuites=default_ciphers.tls13,
     )
 
 
@@ -145,10 +167,13 @@ def test_start_uvicorn_applies_min_tls_version(
     default_config.ols_config.tls_security_profile = TLSSecurityProfile(
         {"type": profile_type}
     )
+    cipher_str = tls.ciphers_for_tls_profile(profile_type)
+    ciphers = split_ciphers(cipher_str)
     _assert_start_uvicorn(
         default_config,
         host="0.0.0.0",  # noqa: S104
         port=8443,
         min_tls_version=min_tls_version,
-        ssl_ciphers=tls.ciphers_for_tls_profile(profile_type),
+        ssl_ciphers=ciphers.tls12 or "DEFAULT",
+        expected_ciphersuites=ciphers.tls13,
     )

--- a/tests/unit/utils/test_ssl.py
+++ b/tests/unit/utils/test_ssl.py
@@ -173,3 +173,16 @@ class TestSplitCiphers:
         result = split_ciphers(cipher_str)
         assert result.tls12 == "ECDHE-RSA-AES128-GCM-SHA256"
         assert result.tls13 == "TLS_AES_128_GCM_SHA256"
+
+    def test_iana_format_tls12_not_misclassified(self):
+        """IANA-format TLS 1.2 names (TLS_*_WITH_*) stay in tls12."""
+        cipher_str = (
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, "
+            "TLS_AES_128_GCM_SHA256, "
+            "ECDHE-RSA-AES256-GCM-SHA384"
+        )
+        result = split_ciphers(cipher_str)
+        assert result.tls12 == (
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:ECDHE-RSA-AES256-GCM-SHA384"
+        )
+        assert result.tls13 == "TLS_AES_128_GCM_SHA256"

--- a/tests/unit/utils/test_ssl.py
+++ b/tests/unit/utils/test_ssl.py
@@ -9,6 +9,7 @@ from ols import constants
 from ols.app.models.config import TLSSecurityProfile
 from ols.utils import ssl as ssl_utils
 from ols.utils import tls
+from ols.utils.ssl import SplitCiphers, split_ciphers
 
 
 def test_postgres_ssl_mode_default_is_require():
@@ -115,3 +116,60 @@ class TestLibpqTlsParams:
             host="127.0.0.1", dbname="test", sslmode="require", **params
         )
         assert "ssl_min_protocol_version=TLSv1.2" in dsn
+
+
+class TestSplitCiphers:
+    """Tests for the split_ciphers helper."""
+
+    def test_none_input(self):
+        """Return both fields as None when input is None."""
+        result = split_ciphers(None)
+        assert result == SplitCiphers(tls12=None, tls13=None)
+
+    def test_empty_string(self):
+        """Return both fields as None when input is empty."""
+        result = split_ciphers("")
+        assert result == SplitCiphers(tls12=None, tls13=None)
+
+    def test_tls13_only(self):
+        """ModernType: all ciphers are TLS 1.3 ciphersuites."""
+        cipher_str = (
+            "TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, "
+            "TLS_CHACHA20_POLY1305_SHA256"
+        )
+        result = split_ciphers(cipher_str)
+        assert result.tls12 is None
+        assert result.tls13 == (
+            "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:"
+            "TLS_CHACHA20_POLY1305_SHA256"
+        )
+
+    def test_tls12_only(self):
+        """Custom profile with only TLS 1.2 ciphers."""
+        cipher_str = "ECDHE-RSA-AES128-GCM-SHA256, DHE-RSA-AES256-GCM-SHA384"
+        result = split_ciphers(cipher_str)
+        assert result.tls12 == "ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"
+        assert result.tls13 is None
+
+    def test_mixed_ciphers(self):
+        """IntermediateType: mix of TLS 1.2 and TLS 1.3."""
+        cipher_str = (
+            "TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, "
+            "TLS_CHACHA20_POLY1305_SHA256, "
+            "ECDHE-ECDSA-AES128-GCM-SHA256, ECDHE-RSA-AES128-GCM-SHA256"
+        )
+        result = split_ciphers(cipher_str)
+        assert result.tls12 == (
+            "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256"
+        )
+        assert result.tls13 == (
+            "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:"
+            "TLS_CHACHA20_POLY1305_SHA256"
+        )
+
+    def test_colon_separated_input(self):
+        """Accept colon-separated input (OpenSSL native format)."""
+        cipher_str = "TLS_AES_128_GCM_SHA256:ECDHE-RSA-AES128-GCM-SHA256"
+        result = split_ciphers(cipher_str)
+        assert result.tls12 == "ECDHE-RSA-AES128-GCM-SHA256"
+        assert result.tls13 == "TLS_AES_128_GCM_SHA256"


### PR DESCRIPTION
## Summary

Fixes fatal `ssl.SSLError: ('No cipher can be selected.',)` when starting OLS with `tlsSecurityProfile.type: ModernType`.

**Root cause:** ModernType's cipher list contains only TLS 1.3 ciphersuites (`TLS_AES_*`, `TLS_CHACHA20_*`) which `SSLContext.set_ciphers()` does not recognize — it only handles TLS 1.2 cipher strings.

**Fix:** New `split_ciphers()` helper separates TLS 1.2 ciphers from TLS 1.3 ciphersuites. The runner passes TLS 1.2 ciphers to Uvicorn's `ssl_ciphers` parameter, and applies TLS 1.3 via `set_ciphersuites()` post-load (guarded with `hasattr` for Python 3.12 which lacks this API). For ModernType, `"DEFAULT"` is passed to `set_ciphers()` and security is enforced by `minimum_version = TLSv1_3`.

## Changes

- `ols/utils/ssl.py` — add `SplitCiphers` dataclass and `split_ciphers()` function
- `ols/runners/uvicorn.py` — use split ciphers, call `set_ciphersuites()` post-load
- `tests/unit/utils/test_ssl.py` — 6 new tests for `split_ciphers()`
- `tests/unit/runners/test_uvicorn_runner.py` — updated assertions
- `tests/integration/test_runners.py` — updated to match new cipher handling

## Verification

Confirmed against real `ssl.SSLContext` on Python 3.12:
- Original bug reproduced: `set_ciphers()` with TLS 1.3-only names → `ssl.SSLError`
- Fix verified: `set_ciphers("DEFAULT")` + `minimum_version = TLSv1_3` → all 3 TLS 1.3 suites available

## Testing

- [x] `ruff check` — clean
- [x] Unit tests — 32/32 pass
- [x] Integration tests — 3/3 pass

## Related

- Unblocks `make tls-scan` ([OLS-2866](https://redhat.atlassian.net/browse/OLS-2866)) for ModernType verification

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring TLS 1.2 and TLS 1.3 cipher suites separately.
  * Supports comma-separated, colon-separated, and mixed cipher configuration formats.
  * TLS 1.3 cipher settings are applied when supported by the runtime.

* **Bug Fixes**
  * Improved TLS configuration handling to ensure minimum TLS versions are applied correctly.

* **Tests**
  * Added coverage for cipher parsing and TLS 1.2/1.3 configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->