### PR TITLE
OLS-3670 - changing gemini model for lseval to match tests

### DIFF
--- a/eval/system_vertex_gemini_lseval.yaml
+++ b/eval/system_vertex_gemini_lseval.yaml
@@ -1,5 +1,5 @@
 # LightSpeed Evaluation Framework Configuration
-# OLS Provider: Google Vertex AI gemini-3.5-flash (model being evaluated)
+# OLS Provider: Google Vertex AI gemini-3.1-flash-lite (model being evaluated)
 # Judge LLM: OpenAI GPT-5-mini (scoring responses)
 
 # Core Evaluation Configuration
@@ -21,7 +21,7 @@ llm:
   num_retries: 3
 
 # OLS API Configuration
-# Targets the OLS /query endpoint using Google Vertex AI gemini-3.5-flash as the backend LLM.
+# Targets the OLS /query endpoint using Google Vertex AI gemini-3.1-flash-lite as the backend LLM.
 # api_base is overridden at runtime with the actual OLS service URL.
 # Requires OLS to be configured with a google_vertex provider (Vertex AI credentials in olsconfig).
 # Override the model via LSEVAL_OLS_MODEL env var if your Vertex deployment uses a different model.
@@ -31,7 +31,7 @@ api:
   endpoint_type: query
   timeout: 300
   provider: "google_vertex"
-  model: "gemini-3.5-flash"
+  model: "gemini-3.1-flash-lite"
   no_tools: null
   system_prompt: null
 

--- a/tests/config/operator_install/olsconfig.crd.vertex_gemini_lseval.yaml
+++ b/tests/config/operator_install/olsconfig.crd.vertex_gemini_lseval.yaml
@@ -8,7 +8,7 @@ spec:
       - credentialsSecretRef:
           name: llmcreds
         models:
-          - name: gemini-3.5-flash
+          - name: gemini-3.1-flash-lite
         name: google_vertex
         type: google_vertex
         googleVertexConfig:
@@ -16,7 +16,7 @@ spec:
           location: "us-central1"
         url: https://us-central1-aiplatform.googleapis.com/
   ols:
-    defaultModel: gemini-3.5-flash
+    defaultModel: gemini-3.1-flash-lite
     defaultProvider: google_vertex
     deployment:
       replicas: 1

--- a/tests/scripts/test-e2e-cluster-periodics.sh
+++ b/tests/scripts/test-e2e-cluster-periodics.sh
@@ -45,7 +45,7 @@ function run_suites() {
     run_suite "openai" "not azure_entra_id and not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "default"
     (( rc = rc || $? ))
 
-    run_suite "google_vertex" "not azure_entra_id and not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "google_vertex" "$VERTEX_PROVIDER_KEY_PATH" "gemini-2.5-flash-lite" "$OLS_IMAGE" "default"
+    run_suite "google_vertex" "not azure_entra_id and not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "google_vertex" "$VERTEX_PROVIDER_KEY_PATH" "gemini-3.1-flash-lite" "$OLS_IMAGE" "default"
     (( rc = rc || $? ))
 
     run_suite "google_vertex_anthropic" "not azure_entra_id and not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "google_vertex_anthropic" "$VERTEX_PROVIDER_KEY_PATH" "claude-sonnet-4-6" "$OLS_IMAGE" "default"
@@ -78,7 +78,7 @@ function run_suites() {
     (( rc = rc || $? ))
     run_suite "watsonx_tool_calling" "tool_calling" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-4-h-small" "$OLS_IMAGE" "tool_calling"
     (( rc = rc || $? ))
-    run_suite "google_vertex_tool_calling" "tool_calling" "google_vertex" "$VERTEX_PROVIDER_KEY_PATH" "gemini-2.5-flash-lite" "$OLS_IMAGE" "tool_calling"
+    run_suite "google_vertex_tool_calling" "tool_calling" "google_vertex" "$VERTEX_PROVIDER_KEY_PATH" "gemini-3.1-flash-lite" "$OLS_IMAGE" "tool_calling"
     (( rc = rc || $? ))
     run_suite "google_vertex_anthropic_tool_calling" "tool_calling" "google_vertex_anthropic" "$VERTEX_PROVIDER_KEY_PATH" "claude-sonnet-4-6" "$OLS_IMAGE" "tool_calling"
     (( rc = rc || $? ))

--- a/tests/scripts/test-e2e-cluster.sh
+++ b/tests/scripts/test-e2e-cluster.sh
@@ -47,7 +47,7 @@ function run_suites() {
   run_suite "openai_mcp" "mcp" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "mcp"
   (( rc = rc || $? ))
 
-  run_suite "google_vertex" "not azure_entra_id and not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "google_vertex" "$VERTEX_PROVIDER_KEY_PATH" "gemini-2.5-flash-lite" "$OLS_IMAGE" "default"
+  run_suite "google_vertex" "not azure_entra_id and not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "google_vertex" "$VERTEX_PROVIDER_KEY_PATH" "gemini-3.1-flash-lite" "$OLS_IMAGE" "default"
   (( rc = rc || $? ))
 
   run_suite "google_vertex_anthropic" "not azure_entra_id and not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "google_vertex_anthropic" "$VERTEX_PROVIDER_KEY_PATH" "claude-sonnet-4-6" "$OLS_IMAGE" "default"
@@ -72,7 +72,7 @@ function run_suites() {
   (( rc = rc || $? ))
   run_suite "openai_tool_calling" "tool_calling" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "tool_calling"
   (( rc = rc || $? ))
-  # run_suite "google_vertex_tool_calling" "tool_calling" "google_vertex" "$VERTEX_PROVIDER_KEY_PATH" "gemini-2.5-flash-lite" "$OLS_IMAGE" "tool_calling"
+  # run_suite "google_vertex_tool_calling" "tool_calling" "google_vertex" "$VERTEX_PROVIDER_KEY_PATH" "gemini-3.1-flash-lite" "$OLS_IMAGE" "tool_calling"
   # (( rc = rc || $? ))
   run_suite "google_vertex_anthropic_tool_calling" "tool_calling" "google_vertex_anthropic" "$VERTEX_PROVIDER_KEY_PATH" "claude-sonnet-4-6" "$OLS_IMAGE" "tool_calling"
   (( rc = rc || $? ))

--- a/tests/scripts/test-lseval-presubmit.sh
+++ b/tests/scripts/test-lseval-presubmit.sh
@@ -56,7 +56,7 @@ function run_suites() {
 
   # Vertex Gemini
   SUITE_ID="lseval_presubmit_vertex_gemini" run_suite \
-    "lseval_presubmit_vertex_gemini" "lseval" "vertex_gemini" "$VERTEX_PROVIDER_KEY_PATH" "gemini-3.5-flash" "$OLS_IMAGE" "lseval"
+    "lseval_presubmit_vertex_gemini" "lseval" "vertex_gemini" "$VERTEX_PROVIDER_KEY_PATH" "gemini-3.1-flash-lite" "$OLS_IMAGE" "lseval"
   (( rc = rc || $? ))
 
   # Vertex Claude


### PR DESCRIPTION
changing gemini from 3.5 flash which is not available to us to 3.1-flash-lite

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
  - Updated Google Vertex AI evaluation defaults to use the `gemini-3.1-flash-lite` model.
  - Standardized the configured model across provider and API settings.

- **Tests**
  - Updated Vertex AI end-to-end, tool-calling, and presubmit test suites to run against `gemini-3.1-flash-lite`.
  - Kept automated validation aligned with the current model configuration and evaluation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->