### PR TITLE
OLS-3584: exclude rag tests from non-tool-calling e2e suites

### DIFF
--- a/tests/scripts/test-e2e-cluster-periodics.sh
+++ b/tests/scripts/test-e2e-cluster-periodics.sh
@@ -39,22 +39,22 @@ function run_suites() {
   # empty test_tags means run all tests
   if [ -z "${DISCONNECTED:-}" ]; then
     # Tests for not disconnected environments
-    run_suite "azure_openai" "not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "azure_openai" "$AZUREOPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "default"
+    run_suite "azure_openai" "not certificates and not (tool_calling and not smoketest) and not byok1 and not byok2 and not quota_limits and not data_export" "azure_openai" "$AZUREOPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "default"
     (( rc = rc || $? ))
 
-    run_suite "openai" "not azure_entra_id and not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "default"
+    run_suite "openai" "not azure_entra_id and not certificates and not (tool_calling and not smoketest) and not byok1 and not byok2 and not quota_limits and not data_export" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "default"
     (( rc = rc || $? ))
 
-    run_suite "google_vertex" "not azure_entra_id and not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "google_vertex" "$VERTEX_PROVIDER_KEY_PATH" "gemini-2.5-flash-lite" "$OLS_IMAGE" "default"
+    run_suite "google_vertex" "not azure_entra_id and not certificates and not (tool_calling and not smoketest) and not byok1 and not byok2 and not quota_limits and not data_export" "google_vertex" "$VERTEX_PROVIDER_KEY_PATH" "gemini-2.5-flash-lite" "$OLS_IMAGE" "default"
     (( rc = rc || $? ))
 
-    run_suite "google_vertex_anthropic" "not azure_entra_id and not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "google_vertex_anthropic" "$VERTEX_PROVIDER_KEY_PATH" "claude-sonnet-4-6" "$OLS_IMAGE" "default"
+    run_suite "google_vertex_anthropic" "not azure_entra_id and not certificates and not (tool_calling and not smoketest) and not byok1 and not byok2 and not quota_limits and not data_export" "google_vertex_anthropic" "$VERTEX_PROVIDER_KEY_PATH" "claude-sonnet-4-6" "$OLS_IMAGE" "default"
     (( rc = rc || $? ))
 
-    run_suite "watsonx" "not azure_entra_id and not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-4-h-small" "$OLS_IMAGE" "default"
+    run_suite "watsonx" "not azure_entra_id and not certificates and not (tool_calling and not smoketest) and not byok1 and not byok2 and not quota_limits and not data_export" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-4-h-small" "$OLS_IMAGE" "default"
     (( rc = rc || $? ))
 
-    run_suite "rhaiis_vllm" "not azure_entra_id and not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "rhaiis_vllm" "$RHAIIS_PROVIDER_KEY_PATH" "meta-llama/Llama-3.1-70B-Instruct" "$OLS_IMAGE" "default"
+    run_suite "rhaiis_vllm" "not azure_entra_id and not certificates and not (tool_calling and not smoketest) and not byok1 and not byok2 and not quota_limits and not data_export" "rhaiis_vllm" "$RHAIIS_PROVIDER_KEY_PATH" "meta-llama/Llama-3.1-70B-Instruct" "$OLS_IMAGE" "default"
     (( rc = rc || $? ))
 
     # smoke tests for RHOAI VLLM-compatible provider

--- a/tests/scripts/test-e2e-cluster.sh
+++ b/tests/scripts/test-e2e-cluster.sh
@@ -37,23 +37,23 @@ function run_suites() {
   # runsuite arguments:
   # suiteid test_tags provider provider_keypath model ols_image os_config_suffix
   # empty test_tags means run all tests
-  run_suite "azure_openai" "not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "azure_openai" "$AZUREOPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "default"
+  run_suite "azure_openai" "not certificates and not (tool_calling and not smoketest) and not byok1 and not byok2 and not quota_limits and not data_export" "azure_openai" "$AZUREOPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "default"
   (( rc = rc || $? ))
 
-  run_suite "openai" "not azure_entra_id and not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "default"
+  run_suite "openai" "not azure_entra_id and not certificates and not (tool_calling and not smoketest) and not byok1 and not byok2 and not quota_limits and not data_export" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "default"
   (( rc = rc || $? ))
 
   # MCP e2e: run early while CR is still default openai shape; avoids races after tool_calling (introspection true).
   run_suite "openai_mcp" "mcp" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "mcp"
   (( rc = rc || $? ))
 
-  run_suite "google_vertex" "not azure_entra_id and not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "google_vertex" "$VERTEX_PROVIDER_KEY_PATH" "gemini-2.5-flash-lite" "$OLS_IMAGE" "default"
+  run_suite "google_vertex" "not azure_entra_id and not certificates and not (tool_calling and not smoketest) and not byok1 and not byok2 and not quota_limits and not data_export" "google_vertex" "$VERTEX_PROVIDER_KEY_PATH" "gemini-2.5-flash-lite" "$OLS_IMAGE" "default"
   (( rc = rc || $? ))
 
-  run_suite "google_vertex_anthropic" "not azure_entra_id and not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "google_vertex_anthropic" "$VERTEX_PROVIDER_KEY_PATH" "claude-sonnet-4-6" "$OLS_IMAGE" "default"
+  run_suite "google_vertex_anthropic" "not azure_entra_id and not certificates and not (tool_calling and not smoketest) and not byok1 and not byok2 and not quota_limits and not data_export" "google_vertex_anthropic" "$VERTEX_PROVIDER_KEY_PATH" "claude-sonnet-4-6" "$OLS_IMAGE" "default"
   (( rc = rc || $? ))
 
-  run_suite "watsonx" "not azure_entra_id and not certificates and not (tool_calling and not smoketest and not rag) and not byok1 and not byok2 and not quota_limits and not data_export" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-4-h-small" "$OLS_IMAGE" "default"
+  run_suite "watsonx" "not azure_entra_id and not certificates and not (tool_calling and not smoketest) and not byok1 and not byok2 and not quota_limits and not data_export" "watsonx" "$WATSONX_PROVIDER_KEY_PATH" "ibm/granite-4-h-small" "$OLS_IMAGE" "default"
   (( rc = rc || $? ))
 
   # smoke tests for RHOAI VLLM-compatible provider


### PR DESCRIPTION
## Summary

- Removes the `and not rag` exception from pytest marker filters in non-tool-calling e2e suites
- `test_rag_question` is marked `@pytest.mark.tool_calling` because it relies on `search_openshift_documentation` tool to populate `referenced_documents`
- Tool infrastructure is not reliably available in non-tool-calling suites after operator reconciliation between suite switches (30s sleep before operator scale-down is insufficient for MCP server registration)
- The test already runs in dedicated tool_calling suites (`openai_tool_calling`, `azure_openai_tool_calling`, etc.) where introspection is properly configured

## Root Cause

After recent changes to how RAG works (via tool calling rather than direct Solr embedding), `test_rag_question` requires the `search_openshift_documentation` tool. Non-tool-calling suites don't reliably have tools available because `_reconcile_olsconfig_with_operator()` only waits 30s before scaling down the operator, which isn't always enough for the MCP server to register the tool. The CI logs confirm: `input_tokens: 668` (no tools in prompt) and `tool_calls: []` in the failing openai suite vs `input_tokens: 841+` with tool calls in the passing tool_calling suite.

## Test plan

- [ ] `pull-ci-openshift-lightspeed-service-main-e2e-ols-cluster` passes
- [ ] `test_rag_question` still passes in the tool_calling suites
- [ ] No test_rag_question failures in non-tool-calling suites (because it's excluded)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test coverage to include retrieval-augmented generation (RAG) scenarios for supported providers.
  * Continued excluding certificate, non-smoketest tool-calling, BYOK, quota-limit, and data-export scenarios from applicable test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->