### PR TITLE
OLS-3799: Fix permanent Solr connection loss when RHOKP starts slowly

### DIFF
--- a/ols/src/rag_index/solr_support.py
+++ b/ols/src/rag_index/solr_support.py
@@ -416,7 +416,7 @@ class SolrHybridSearch:
         )
         return resolved
 
-    _SOLR_STARTUP_RETRIES = 24
+    _SOLR_STARTUP_RETRIES = 36
     _SOLR_STARTUP_BACKOFF_S = 5
 
     @staticmethod

--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -57,6 +57,9 @@ class AppConfig:
         self._tools_approval: Optional[config_model.ToolsApprovalConfig] = None
         self._pending_approval_store: Optional["PendingApprovalStoreBase"] = None
         self._cached_solr_embed_model: Any = None
+        self._cached_solr_hybrid_search: SolrHybridSearch | None = None
+        self._solr_hybrid_initialized: bool = False
+        self._solr_init_attempts: int = 0
         self._cached_byok_embed_model: Any = None
 
     @property
@@ -264,18 +267,45 @@ class AppConfig:
         )
         return self._cached_solr_embed_model
 
-    @cached_property
+    _SOLR_MAX_INIT_ATTEMPTS = 3
+
+    @property
     def solr_hybrid_search(self) -> SolrHybridSearch | None:
-        """Return Solr hybrid RAG client when ``ols_config.solr_hybrid`` is present."""
+        """Return Solr hybrid RAG client when ``ols_config.solr_hybrid`` is present.
+
+        Re-attempts initialization on every access until it succeeds, so
+        RHOKP starting after the app-server is tolerated without a pod restart.
+        Once connected, the result is cached for the lifetime of the process.
+        Gives up permanently after ``_SOLR_MAX_INIT_ATTEMPTS`` failures.
+        """
+        if self._solr_hybrid_initialized:
+            return self._cached_solr_hybrid_search
         settings = self.config.ols_config.solr_hybrid  # type: ignore[attr-defined]
         if settings is None:
+            self._solr_hybrid_initialized = True
             return None
         try:
             embed_model = self._solr_hybrid_embed_model()
             encode_fn = embed_model.get_text_embedding
-            return SolrHybridSearch(settings, encode_fn)
+            self._cached_solr_hybrid_search = SolrHybridSearch(settings, encode_fn)
+            self._solr_hybrid_initialized = True
+            return self._cached_solr_hybrid_search
         except Exception:
-            logger.exception("Failed to initialize Solr hybrid RAG")
+            self._solr_init_attempts += 1
+            if self._solr_init_attempts >= self._SOLR_MAX_INIT_ATTEMPTS:
+                logger.error(
+                    "Solr hybrid RAG permanently unavailable after %d attempts "
+                    "— product documentation search is disabled for this pod",
+                    self._solr_init_attempts,
+                )
+                self._solr_hybrid_initialized = True
+            else:
+                logger.warning(
+                    "Solr hybrid RAG not yet available (attempt %d/%d) "
+                    "— will retry on next request",
+                    self._solr_init_attempts,
+                    self._SOLR_MAX_INIT_ATTEMPTS,
+                )
             return None
 
     @property
@@ -324,8 +354,9 @@ class AppConfig:
                 del self.__dict__["tools_rag"]
             if "skills_rag" in self.__dict__:
                 del self.__dict__["skills_rag"]
-            if "solr_hybrid_search" in self.__dict__:
-                del self.__dict__["solr_hybrid_search"]
+            self._cached_solr_hybrid_search = None
+            self._solr_hybrid_initialized = False
+            self._solr_init_attempts = 0
         except Exception as e:
             print(f"Failed to load config file {config_file}: {e!s}")
             print(traceback.format_exc())

--- a/runner.py
+++ b/runner.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import sys
-import threading
 from pathlib import Path
 
 from ols.app.models.config import OtelTlsMode
@@ -25,10 +24,7 @@ from ols.version import __version__
 
 
 def load_index():
-    """Load the index."""
-    # Resolve Solr hybrid search (OCP version resolution) in the background
-    # so it does not block uvicorn startup.  Solr failure is non-fatal: the
-    # pod goes ready once rag_index loads and serves without hybrid search.
+    """Resolve Solr hybrid search and load RAG indexes before accepting requests."""
     config.solr_hybrid_search  # pylint: disable=W0104, E0606
     config.rag_index  # pylint: disable=W0104, E0606
 
@@ -108,10 +104,7 @@ if __name__ == "__main__":
             "in the `dev_config` section of the configuration file."
         )
 
-    # create and start the rag_index_thread - allows loading index in
-    # parallel with starting the Uvicorn server
-    rag_index_thread = threading.Thread(target=load_index)
-    rag_index_thread.start()
+    load_index()
 
     # start the quota scheduler
     start_quota_scheduler(config)

--- a/tests/unit/query_helpers/test_docs_summarizer.py
+++ b/tests/unit/query_helpers/test_docs_summarizer.py
@@ -224,13 +224,15 @@ async def test_resolve_tools_appends_openshift_docs_tool_when_solr_configured_no
         m_get.return_value = []
         prev = config.ols_config.solr_hybrid
         config.ols_config.solr_hybrid = SolrHybridSettings()
-        config.__dict__["solr_hybrid_search"] = MagicMock()
+        config._cached_solr_hybrid_search = MagicMock()
+        config._solr_hybrid_initialized = True
         try:
             summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
             tools = await summarizer._resolve_tools_for_request("query")
         finally:
             config.ols_config.solr_hybrid = prev
-            config.__dict__.pop("solr_hybrid_search", None)
+            config._cached_solr_hybrid_search = None
+            config._solr_hybrid_initialized = False
     assert [t.name for t in tools] == ["search_openshift_documentation"]
     m_get.assert_awaited_once()
 


### PR DESCRIPTION
## Description

Summary
When RHOKP takes longer than the retry window to start, the app-server permanently loses product documentation RAG with no recovery short of a pod restart. This PR fixes the root cause and simplifies the startup sequence.

**Root Cause**
solr_hybrid_search was a @cached_property — once it resolved to None (Solr unreachable), it stayed None forever
Index loading ran on a background thread, racing with request handling — a request could arrive before initialization completed

**Changes**

Removed background threading.Thread for index loading — load_index() now runs synchronously before start_uvicorn(). Eliminates race conditions between initialization and request handling. The readiness probe budget (8 min) accommodates the startup delay.
ols/utils/config.py

Changed solr_hybrid_search from @cached_property to @property with manual caching. On failure, returns None without caching — the next request re-attempts initialization. After 3 failed attempts, gives up permanently with an error log. On success, caches the result for the lifetime of the process.
ols/src/rag_index/solr_support.py

Increased _SOLR_STARTUP_RETRIES from 24 to 36 (120s → 180s) to better align with RHOKP's startup probe budget (6 min).
tests/unit/query_helpers/test_docs_summarizer.py

Updated test to use the new caching attributes instead of __dict__ manipulation.

**Result**
RHOKP starting after the app-server is tolerated without a pod restart
No race between background thread and request handling
Bounded retry: 3 attempts × 180s = 9 minutes max before permanent give-up with clear error log


## Type of change

- [ x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
https://redhat.atlassian.net/browse/OLS-3799
- Closes #
https://redhat.atlassian.net/browse/OLS-3799

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
