### PR TITLE
OLS-3353 - Adding artifact exporting to tls-scan  

### DIFF
--- a/.ai/spec/what/security.md
+++ b/.ai/spec/what/security.md
@@ -13,7 +13,7 @@ The service must protect customer data, enforce transport-layer encryption, reda
 5. When no TLS security profile is configured, the service must use default cipher suites that include the `IntermediateType` ciphers plus FIPS-compliant CBC ciphers (`ECDHE-ECDSA-AES128-SHA256`, `ECDHE-RSA-AES128-SHA256`, `ECDHE-ECDSA-AES256-SHA384`, `ECDHE-RSA-AES256-SHA384`, `DHE-RSA-AES128-SHA256`, `DHE-RSA-AES256-SHA256`) for compatibility with HAProxy reencrypt routes.
 6. The service must support certificate rotation: when certificates change on disk, the service must pick up the new certificates on restart or configuration reload.
 7. The private key password must be read from a file referenced by `ols_config.tls_config.tls_key_password_path`, never stored as a plaintext value in configuration.
-8. The service's TLS endpoint configuration must be verifiable by automated TLS scanning tools (`make tls-scan`). TLS profile compliance is verified in CI on every PR (OLS-2866, OLS-3353).
+8. The service's TLS endpoint configuration must be verifiable by automated TLS scanning tools (`make tls-scan`). CI gating is planned (OLS-2866, OLS-3353).
 
 ### FIPS compliance
 
@@ -121,5 +121,4 @@ The service must protect customer data, enforce transport-layer encryption, reda
 
 ## Planned Changes
 
-- Automated TLS scanning verification of OLS service endpoints using tls-scanner (OLS-2866, CI-automated in OLS-3353).
 - [PLANNED: OLS-2717] Enable TLS on openshift-mcp-server connections.

--- a/.ai/spec/what/security.md
+++ b/.ai/spec/what/security.md
@@ -13,7 +13,7 @@ The service must protect customer data, enforce transport-layer encryption, reda
 5. When no TLS security profile is configured, the service must use default cipher suites that include the `IntermediateType` ciphers plus FIPS-compliant CBC ciphers (`ECDHE-ECDSA-AES128-SHA256`, `ECDHE-RSA-AES128-SHA256`, `ECDHE-ECDSA-AES256-SHA384`, `ECDHE-RSA-AES256-SHA384`, `DHE-RSA-AES128-SHA256`, `DHE-RSA-AES256-SHA256`) for compatibility with HAProxy reencrypt routes.
 6. The service must support certificate rotation: when certificates change on disk, the service must pick up the new certificates on restart or configuration reload.
 7. The private key password must be read from a file referenced by `ols_config.tls_config.tls_key_password_path`, never stored as a plaintext value in configuration.
-8. [PLANNED: OLS-2866] The service's TLS endpoint configuration must be verifiable by automated TLS scanning tools.
+8. The service's TLS endpoint configuration must be verifiable by automated TLS scanning tools (`make tls-scan`). TLS profile compliance is verified in CI on every PR (OLS-2866, OLS-3353).
 
 ### FIPS compliance
 
@@ -121,5 +121,5 @@ The service must protect customer data, enforce transport-layer encryption, reda
 
 ## Planned Changes
 
-- [PLANNED: OLS-2866] Automated TLS scanning verification of OLS service endpoints using tls-scanner.
+- Automated TLS scanning verification of OLS service endpoints using tls-scanner (OLS-2866, CI-automated in OLS-3353).
 - [PLANNED: OLS-2717] Enable TLS on openshift-mcp-server connections.

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ shellcheck: ## Run shellcheck
 	shellcheck -- */*.sh
 
 tls-scan: ## Run TLS profile compliance scan against OLS endpoints
-	./scripts/tls-scan.sh
+	ARTIFACT_DIR="$(ARTIFACT_DIR)" ./scripts/tls-scan.sh
 
 konflux-requirements:	## Generate hermetic requirements.*.txt file for konflux build
 	python3 scripts/konflux_resolve.py --profile cpu

--- a/scripts/tls-scan.sh
+++ b/scripts/tls-scan.sh
@@ -177,10 +177,19 @@ export_artifacts() {
     fi
     local dest="${ARTIFACT_DIR}/tls-scan"
     mkdir -p "${dest}"
-    cp -v "${SCAN_DIR}"/*.json "${dest}/" 2>/dev/null || true
-    cp -v "${SCAN_DIR}"/*-junit.xml "${dest}/" 2>/dev/null || true
-    cp -v "${SCAN_DIR}"/pqc-check.log "${dest}/" 2>/dev/null || true
-    cp -v "${SCAN_DIR}"/*-scan.log "${dest}/" 2>/dev/null || true
+    shopt -s nullglob
+    local artifacts=(
+        "${SCAN_DIR}"/*.json
+        "${SCAN_DIR}"/*-junit.xml
+        "${SCAN_DIR}"/pqc-check.log
+        "${SCAN_DIR}"/*-scan.log
+    )
+    shopt -u nullglob
+    if ((${#artifacts[@]} == 0)); then
+        log "No TLS scan artifacts found in ${SCAN_DIR}"
+        return 0
+    fi
+    cp -v -- "${artifacts[@]}" "${dest}/" || return 1
     log "Artifacts exported to ${dest}"
 }
 

--- a/scripts/tls-scan.sh
+++ b/scripts/tls-scan.sh
@@ -171,6 +171,19 @@ report_results() {
     log "All TLS scans passed"
 }
 
+export_artifacts() {
+    if [[ -z "${ARTIFACT_DIR:-}" ]]; then
+        return
+    fi
+    local dest="${ARTIFACT_DIR}/tls-scan"
+    mkdir -p "${dest}"
+    cp -v "${SCAN_DIR}"/*.json "${dest}/" 2>/dev/null || true
+    cp -v "${SCAN_DIR}"/*-junit.xml "${dest}/" 2>/dev/null || true
+    cp -v "${SCAN_DIR}"/pqc-check.log "${dest}/" 2>/dev/null || true
+    cp -v "${SCAN_DIR}"/*-scan.log "${dest}/" 2>/dev/null || true
+    log "Artifacts exported to ${dest}"
+}
+
 generate_certs
 extract_scanner
 
@@ -198,4 +211,5 @@ for profile in IntermediateType ModernType; do
     stop_ols
 done
 
+export_artifacts
 report_results


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TLS scan results can now be exported as JSON, JUnit, post-quantum cryptography, and scan log artifacts when artifact collection is enabled.
* **Documentation**
  * Updated security requirements to reference the TLS scan command and planned continuous integration gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->