### PR TITLE
OLS-3353 - dropping podman call 

### DIFF
--- a/scripts/tls-scan.sh
+++ b/scripts/tls-scan.sh
@@ -7,6 +7,7 @@ SCANNER_IMAGE="${SCANNER_IMAGE:-quay.io/openshift-lightspeed/ols-qe:tls-scanner}
 OLS_PID=""
 FAILURES=0
 TOTAL_CHECKS=0
+PODMAN_CONTAINER_CREATED=0
 
 log() {
     echo "[tls-scan] $*"
@@ -17,7 +18,9 @@ cleanup() {
         kill "${OLS_PID}" 2>/dev/null || true
         wait "${OLS_PID}" 2>/dev/null || true
     fi
-    podman rm "tls-scanner-extract-$$" 2>/dev/null || true
+    if [[ "${PODMAN_CONTAINER_CREATED}" == "1" ]]; then
+        podman rm "tls-scanner-extract-$$" 2>/dev/null || true
+    fi
     if [[ "${TLS_SCAN_KEEP_ARTIFACTS:-0}" != "1" ]]; then
         rm -rf "${SCAN_DIR}"
         log "Cleaned up ${SCAN_DIR}"
@@ -41,12 +44,19 @@ generate_certs() {
 }
 
 extract_scanner() {
-    log "Extracting tls-scanner from ${SCANNER_IMAGE}..."
-    local container_name="tls-scanner-extract-$$"
-    podman create --name "${container_name}" "${SCANNER_IMAGE}" >/dev/null 2>&1
-    podman cp "${container_name}:/usr/local/bin/tls-scanner" "${SCAN_DIR}/tls-scanner"
-    podman cp "${container_name}:/opt/testssl" "${SCAN_DIR}/testssl"
-    podman rm "${container_name}" >/dev/null 2>&1
+    if [[ -x "/usr/local/bin/tls-scanner" && -d "/opt/testssl" ]]; then
+        log "tls-scanner already installed, copying to ${SCAN_DIR}..."
+        cp /usr/local/bin/tls-scanner "${SCAN_DIR}/tls-scanner"
+        cp -r /opt/testssl "${SCAN_DIR}/testssl"
+    else
+        log "Extracting tls-scanner from ${SCANNER_IMAGE}..."
+        local container_name="tls-scanner-extract-$$"
+        PODMAN_CONTAINER_CREATED=1
+        podman create --name "${container_name}" "${SCANNER_IMAGE}" >/dev/null 2>&1
+        podman cp "${container_name}:/usr/local/bin/tls-scanner" "${SCAN_DIR}/tls-scanner"
+        podman cp "${container_name}:/opt/testssl" "${SCAN_DIR}/testssl"
+        podman rm "${container_name}" >/dev/null 2>&1
+    fi
     chmod +x "${SCAN_DIR}/tls-scanner"
     export PATH="${SCAN_DIR}/testssl:${PATH}"
     log "tls-scanner extracted"


### PR DESCRIPTION
when binaries exist to avoid lack of permissions error in prow.

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS scanner setup by using locally available scanner tools when present.
  * Retained the existing fallback workflow when local tools are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->