### PR TITLE
OLS-3782 Adding additional logs to capture Azure Entra ID e2e test failures.

### DIFF
--- a/ols/src/llms/providers/azure_openai.py
+++ b/ols/src/llms/providers/azure_openai.py
@@ -12,6 +12,7 @@ from langchain_openai import AzureChatOpenAI
 
 from ols import constants
 from ols.app.models.config import AzureOpenAIConfig
+from ols.src.llms.llm_loader import LLMConfigurationError
 from ols.src.llms.providers.provider import LLMProvider
 from ols.src.llms.providers.registry import register_llm_provider_as
 
@@ -111,27 +112,22 @@ class AzureOpenAI(LLMProvider):
         """Load LLM."""
         return AzureChatOpenAI(**self.params)
 
-    def resolve_access_token(self, azure_config: AzureOpenAIConfig) -> Optional[str]:
+    def resolve_access_token(self, azure_config: AzureOpenAIConfig) -> str:
         """Retrieve and cache Azure OpenAI access token."""
         if TOKEN_CACHE.is_expired():
             logger.info(
                 "Cached AD token has expired (or missing) - generating a new one"
             )
             access_token = self.retrieve_access_token(azure_config)
-            if access_token:
-                TOKEN_CACHE.update_token(access_token.token, access_token.expires_on)
-            else:
-                return None
+            TOKEN_CACHE.update_token(access_token.token, access_token.expires_on)
         return TOKEN_CACHE.access_token
 
-    def retrieve_access_token(
-        self, azure_config: AzureOpenAIConfig
-    ) -> Optional[AccessToken]:
+    def retrieve_access_token(self, azure_config: AzureOpenAIConfig) -> AccessToken:
         """Retrieve access token to call Azure OpenAI."""
         if azure_config is None:
-            raise ValueError(
+            raise LLMConfigurationError(
                 "Credentials for API token is not set and "
-                "Azure-specific parameters are not provided."
+                "Azure-specific parameters are not provided. "
                 "It is not possible to retrieve access token."
             )
         if azure_config.tenant_id is None:
@@ -141,7 +137,6 @@ class AzureOpenAI(LLMProvider):
         if azure_config.client_secret is None:
             raise_missing_attribute_error("client_secret")
 
-        # everything is there, try to retrieve credential
         try:
             credential = ClientSecretCredential(
                 azure_config.tenant_id,
@@ -150,12 +145,14 @@ class AzureOpenAI(LLMProvider):
             )
             return credential.get_token("https://cognitiveservices.azure.com/.default")
         except Exception as e:
-            logger.error("Error retrieving access token: %s", e)
-            return None
+            logger.error("Failed to acquire Azure Entra ID access token: %s", e)
+            raise LLMConfigurationError(
+                f"Failed to acquire Azure Entra ID access token: {e}"
+            ) from e
 
 
 def raise_missing_attribute_error(attribute_name: str) -> None:
     """Raise exception when some attribute is missing in configuration."""
-    raise ValueError(
+    raise LLMConfigurationError(
         f"{attribute_name} should be set in azure_openai_config in order to retrieve access token."
     )

--- a/tests/unit/llms/providers/test_azure_openai.py
+++ b/tests/unit/llms/providers/test_azure_openai.py
@@ -10,6 +10,7 @@ from langchain_openai import AzureChatOpenAI
 from pydantic import AnyHttpUrl
 
 from ols.app.models.config import AzureOpenAIConfig, ProviderConfig
+from ols.src.llms.llm_loader import LLMConfigurationError
 from ols.src.llms.providers.azure_openai import (
     TOKEN_EXPIRATION_LEEWAY,
     AzureOpenAI,
@@ -357,7 +358,9 @@ def test_none_params_handling(provider_config):
 
 def test_missing_credentials_check(provider_config_without_credentials):
     """Test that check for missing credentials is in place ."""
-    with pytest.raises(ValueError, match="Credentials for API token is not set"):
+    with pytest.raises(
+        LLMConfigurationError, match="Credentials for API token is not set"
+    ):
         AzureOpenAI(
             model="uber-model",
             params={},
@@ -368,7 +371,7 @@ def test_missing_credentials_check(provider_config_without_credentials):
 def test_missing_tenant_id(provider_config_without_tenant_id):
     """Test that check for missing tenant_id is in place ."""
     with pytest.raises(
-        ValueError, match="tenant_id should be set in azure_openai_config"
+        LLMConfigurationError, match="tenant_id should be set in azure_openai_config"
     ):
         AzureOpenAI(
             model="uber-model",
@@ -380,7 +383,7 @@ def test_missing_tenant_id(provider_config_without_tenant_id):
 def test_missing_client_id(provider_config_without_client_id):
     """Test that check for missing client_id is in place ."""
     with pytest.raises(
-        ValueError, match="client_id should be set in azure_openai_config"
+        LLMConfigurationError, match="client_id should be set in azure_openai_config"
     ):
         AzureOpenAI(
             model="uber-model",
@@ -392,7 +395,8 @@ def test_missing_client_id(provider_config_without_client_id):
 def test_missing_client_secret(provider_config_without_client_secret):
     """Test that check for missing credentials_path is in place ."""
     with pytest.raises(
-        ValueError, match="client_secret should be set in azure_openai_config"
+        LLMConfigurationError,
+        match="client_secret should be set in azure_openai_config",
     ):
         AzureOpenAI(
             model="uber-model",
@@ -455,21 +459,23 @@ def test_retrieve_access_token(provider_config_access_token_related_parameters):
 def test_retrieve_access_token_on_error(
     provider_config_access_token_related_parameters,
 ):
-    """Test how error is handled during accessing token."""
+    """Test that LLMConfigurationError is raised when token acquisition fails."""
     with (
         patch(
             "ols.src.llms.providers.azure_openai.ClientSecretCredential",
             new=MockedCredentialThrowingException,
         ),
-        patch("ols.src.llms.providers.azure_openai.TokenCache.expires_on", new=0),
+        patch("ols.src.llms.providers.azure_openai.TOKEN_CACHE.expires_on", new=0),
+        pytest.raises(
+            LLMConfigurationError,
+            match="Failed to acquire Azure Entra ID access token",
+        ),
     ):
-        azure_openai = AzureOpenAI(
+        AzureOpenAI(
             model="uber-model",
             params={},
             provider_config=provider_config_access_token_related_parameters,
         )
-        assert "api_key" not in azure_openai.default_params
-        assert azure_openai.default_params["azure_ad_token"] is None
 
 
 def test_token_is_expired():


### PR DESCRIPTION
## Summary

- When Azure Entra ID token acquisition fails, `retrieve_access_token()` now raises `LLMConfigurationError` instead of silently returning `None`
- Previously, the `None` token propagated into the `AzureChatOpenAI` client, causing `httpx.RemoteProtocolError: Server disconnected without sending a response` at invocation time
- `raise_missing_attribute_error()` also updated to raise `LLMConfigurationError` for consistency across all config validation paths
- `logger.error()` retained before raising so operators can detect credential failures in log aggregation
- The readiness probe's generic exception handler catches `LLMConfigurationError` and reports the provider as unhealthy (HTTP 503)

## Test plan

- [x] All 19 existing Azure OpenAI unit tests pass
- [x] `test_retrieve_access_token_on_error` asserts `LLMConfigurationError` is raised
- [x] `test_missing_tenant_id`, `test_missing_client_id`, `test_missing_client_secret` updated to assert `LLMConfigurationError`
- [x] `black` and `ruff` pass
- [ ] CI: `test_azure_entra_id` e2e test passes with valid Entra ID credentials

Fixes: https://redhat.atlassian.net/browse/OLS-3782

🤖 Generated with [Claude Code](https://claude.com/claude-code)
