### PR TITLE
OLS-3353 - fix tls scan to address changes from OLS-3797

### DIFF
--- a/scripts/tls-scan.sh
+++ b/scripts/tls-scan.sh
@@ -102,7 +102,9 @@ start_ols() {
     local profile_type="$1"
     local config_file="${SCAN_DIR}/config-${profile_type}.yaml"
     log "Starting OLS with ${profile_type} profile..."
-    OLS_CONFIG_FILE="${config_file}" uv run python runner.py > "${SCAN_DIR}/ols-${profile_type}.log" 2>&1 &
+    mkdir -p "${SCAN_DIR}/certs/bundle"
+    SSL_CERT_FILE="${SCAN_DIR}/certs/bundle/ca-bundle.crt" \
+        OLS_CONFIG_FILE="${config_file}" uv run python runner.py > "${SCAN_DIR}/ols-${profile_type}.log" 2>&1 &
     OLS_PID=$!
 }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secure startup by ensuring the certificate bundle is available before launching the service.
  * Configured the service to use its bundled certificate authority for TLS connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->