### PR TITLE
OLS-3670 - fixing openai model consistency

### DIFF
--- a/eval/system_openai_lseval.yaml
+++ b/eval/system_openai_lseval.yaml
@@ -1,5 +1,5 @@
 # LightSpeed Evaluation Framework Configuration
-# OLS Provider: OpenAI GPT-4o-mini (model being evaluated)
+# OLS Provider: OpenAI GPT-5.4-mini (model being evaluated)
 # Judge LLM: OpenAI GPT-5-mini (scoring responses)
 
 # Core Evaluation Configuration
@@ -22,7 +22,7 @@ llm:
   num_retries: 3
 
 # OLS API Configuration
-# Targets the OLS /query endpoint using OpenAI GPT-4o-mini as the backend LLM.
+# Targets the OLS /query endpoint using OpenAI GPT-5.4-mini as the backend LLM.
 # api_base is overridden at runtime with the actual OLS service URL.
 # Requires OPENAI_API_KEY environment variable (used by OLS via K8s secret).
 api:
@@ -31,7 +31,7 @@ api:
   endpoint_type: query
   timeout: 300
   provider: "openai"
-  model: "gpt-4o-mini"
+  model: "gpt-5.4-mini"
   no_tools: null
   system_prompt: null
 

--- a/tests/scripts/test-lseval-presubmit.sh
+++ b/tests/scripts/test-lseval-presubmit.sh
@@ -66,7 +66,7 @@ function run_suites() {
 
   # Bedrock DeepSeek
   SUITE_ID="lseval_presubmit_bedrock_deepseek" run_suite \
-    "lseval_presubmit_bedrock_deepseek" "lseval" "bedrock_deepseek" "iam" "us.deepseek.r1-v1:0" "$OLS_IMAGE" "lseval"
+    "lseval_presubmit_bedrock_deepseek" "lseval" "bedrock_deepseek" "iam" "deepseek.v3.2" "$OLS_IMAGE" "lseval"
   (( rc = rc || $? ))
 
   set -e


### PR DESCRIPTION
## Description

1. eval/system_openai_lseval.yaml — Updated api.model from gpt-4o-mini to
  gpt-5.4-mini (and two comments) so the eval harness requests the model the
  CRD actually allows.
2. tests/scripts/test-lseval-presubmit.sh — Updated the bedrock_deepseek
  MODEL arg from us.deepseek.r1-v1:0 to deepseek.v3.2 to match the CRD and
  eval config.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the evaluated OpenAI model to GPT-5.4-mini.
  * Updated the Bedrock DeepSeek presubmit tests to use the DeepSeek V3.2 model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->