### PR TITLE
OLS-3710 - fix rhoai and rhelai tests

### DIFF
--- a/eval/system_rhelai_vllm_lseval.yaml
+++ b/eval/system_rhelai_vllm_lseval.yaml
@@ -2,7 +2,7 @@
 # OLS Provider: RHEL AI vLLM (model being evaluated)
 # Judge LLM: OpenAI GPT-5-mini (scoring responses)
 #
-# The default model "gpt-3.5-turbo" is the alias registered in the vLLM deployment.
+# The default model "gpt-4.1-mini" is the alias registered in the vLLM deployment.
 # Override it for your deployment via the LSEVAL_OLS_MODEL environment variable, e.g.:
 #   export LSEVAL_OLS_MODEL=ibm/granite-3.1-8b-instruct
 
@@ -34,7 +34,7 @@ api:
   endpoint_type: query
   timeout: 300
   provider: "rhelai_vllm"
-  model: "gpt-3.5-turbo"
+  model: "gpt-4.1-mini"
   no_tools: null
   system_prompt: null
 

--- a/tests/config/operator_install/olsconfig.crd.rhelai_vllm.yaml
+++ b/tests/config/operator_install/olsconfig.crd.rhelai_vllm.yaml
@@ -14,11 +14,11 @@ spec:
       - credentialsSecretRef:
           name: llmcreds
         models:
-          - name: gpt-3.5-turbo
+          - name: gpt-4.1-mini
         name: rhelai_vllm
         type: rhelai_vllm
   ols:
-    defaultModel: gpt-3.5-turbo
+    defaultModel: gpt-4.1-mini
     defaultProvider: rhelai_vllm
     deployment:
       replicas: 1

--- a/tests/config/operator_install/olsconfig.crd.rhoai_vllm.yaml
+++ b/tests/config/operator_install/olsconfig.crd.rhoai_vllm.yaml
@@ -14,11 +14,11 @@ spec:
       - credentialsSecretRef:
           name: llmcreds
         models:
-          - name: gpt-3.5-turbo
+          - name: gpt-4.1-mini
         name: rhoai_vllm
         type: rhoai_vllm
   ols:
-    defaultModel: gpt-3.5-turbo
+    defaultModel: gpt-4.1-mini
     defaultProvider: rhoai_vllm
     deployment:
       replicas: 1

--- a/tests/scripts/test-e2e-cluster-periodics.sh
+++ b/tests/scripts/test-e2e-cluster-periodics.sh
@@ -81,14 +81,12 @@ function run_suites() {
     (( rc = rc || $? ))
 
     # smoke tests for RHOAI VLLM-compatible provider
-    # Temporarily disabled: vLLM endpoints unreachable, OLS never becomes ready (503 on /readiness)
-    # run_suite "rhoai_vllm" "smoketest" "rhoai_vllm" "$OPENAI_PROVIDER_KEY_PATH" "gpt-3.5-turbo" "$OLS_IMAGE" "default"
-    # (( rc = rc || $? ))
+    run_suite "rhoai_vllm" "smoketest" "rhoai_vllm" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "default"
+    (( rc = rc || $? ))
 
     # smoke tests for RHELAI VLLM-compatible provider
-    # Temporarily disabled: vLLM endpoints unreachable, OLS never becomes ready (503 on /readiness)
-    # run_suite "rhelai_vllm" "smoketest" "rhelai_vllm" "$OPENAI_PROVIDER_KEY_PATH" "gpt-3.5-turbo" "$OLS_IMAGE" "default"
-    # (( rc = rc || $? ))
+    run_suite "rhelai_vllm" "smoketest" "rhelai_vllm" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "default"
+    (( rc = rc || $? ))
 
     run_suite "certificates" "certificates" "openai" "$OPENAI_PROVIDER_KEY_PATH" "gpt-5.4-mini" "$OLS_IMAGE" "default"
     (( rc = rc || $? ))
@@ -126,7 +124,7 @@ function run_suites() {
     # Tests for disconnected environments
     # smoke tests for RHOAI VLLM-compatible provider
     # Temporarily disabled: vLLM endpoints unreachable, OLS never becomes ready (503 on /readiness)
-    # run_suite "rhoai_vllm" "smoketest" "rhoai_vllm" "$OPENAI_PROVIDER_KEY_PATH" "gpt-3.5-turbo" "$OLS_IMAGE" "default"
+    # run_suite "rhoai_vllm" "smoketest" "rhoai_vllm" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "default"
     # (( rc = rc || $? ))
   
   cleanup_ols_operator

--- a/tests/scripts/test-e2e-cluster.sh
+++ b/tests/scripts/test-e2e-cluster.sh
@@ -65,14 +65,12 @@ function run_suites() {
   (( rc = rc || $? ))
 
   # smoke tests for RHOAI VLLM-compatible provider
-  # Temporarily disabled: vLLM endpoints unreachable, OLS never becomes ready (503 on /readiness)
-  # run_suite "rhoai_vllm" "smoketest" "rhoai_vllm" "$OPENAI_PROVIDER_KEY_PATH" "gpt-3.5-turbo" "$OLS_IMAGE" "default"
-  # (( rc = rc || $? ))
+  run_suite "rhoai_vllm" "smoketest" "rhoai_vllm" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "default"
+  (( rc = rc || $? ))
 
   # smoke tests for RHELAI VLLM-compatible provider
-  # Temporarily disabled: vLLM endpoints unreachable, OLS never becomes ready (503 on /readiness)
-  # run_suite "rhelai_vllm" "smoketest" "rhelai_vllm" "$OPENAI_PROVIDER_KEY_PATH" "gpt-3.5-turbo" "$OLS_IMAGE" "default"
-  # (( rc = rc || $? ))
+  run_suite "rhelai_vllm" "smoketest" "rhelai_vllm" "$OPENAI_PROVIDER_KEY_PATH" "gpt-4.1-mini" "$OLS_IMAGE" "default"
+  (( rc = rc || $? ))
 
   # Bedrock suites — PROVIDER_KEY_PATH carries a discriminator ("iam" or
   # "iam_role") instead of a credential file path; see


### PR DESCRIPTION
## Description

gpt-3.5-turbo was deprecated in openai thus the tests started failing. 
Moving to 4.1-mini for rhoai and rhelai tests.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated RHEL AI and RHOAI vLLM configurations to use the `gpt-4.1-mini` model.
  * Updated the default model settings accordingly.

* **Tests**
  * Enabled RHEL AI and RHOAI vLLM smoke-test suites.
  * Updated end-to-end test scenarios to validate the new model configuration, including relevant disconnected test settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->