### PR TITLE
Limit request body

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1373,6 +1373,7 @@
                     },
                     "user_question": {
                         "type": "string",
+                        "maxLength": 32000,
                         "title": "User Question"
                     },
                     "llm_response": {
@@ -1393,7 +1394,8 @@
                     "user_feedback": {
                         "anyOf": [
                             {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 32000
                             },
                             {
                                 "type": "null"

--- a/ols/app/main.py
+++ b/ols/app/main.py
@@ -24,7 +24,6 @@ app = FastAPI(
     },
 )
 
-
 logger = logging.getLogger(__name__)
 
 # Endpoints that don't require security headers (health checks, metrics, etc.)
@@ -57,6 +56,17 @@ else:
 # update provider and model as soon as possible so the metrics will be visible
 # even for first scraping
 metrics.setup_model_metrics(config)
+
+
+@app.middleware("")
+async def request_body_limit(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+) -> Response:
+    """Reject requests whose Content-Length exceeds MAX_REQUEST_BODY_SIZE."""
+    content_length = request.headers.get("content-length")
+    if content_length is not None and int(content_length) > constants.MAX_REQUEST_BODY_SIZE:
+        return Response(content="Request body too large", status_code=413)
+    return await call_next(request)
 
 
 @app.middleware("")

--- a/ols/app/main.py
+++ b/ols/app/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI, Request, Response
 from starlette.datastructures import Headers
 from starlette.responses import StreamingResponse
 from starlette.routing import BaseRoute, Mount, Route, WebSocketRoute
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from ols import config, constants, version
 from ols.app import metrics, routers
@@ -58,15 +59,50 @@ else:
 metrics.setup_model_metrics(config)
 
 
-@app.middleware("")
-async def request_body_limit(
-    request: Request, call_next: Callable[[Request], Awaitable[Response]]
-) -> Response:
-    """Reject requests whose Content-Length exceeds MAX_REQUEST_BODY_SIZE."""
-    content_length = request.headers.get("content-length")
-    if content_length is not None and int(content_length) > constants.MAX_REQUEST_BODY_SIZE:
-        return Response(content="Request body too large", status_code=413)
-    return await call_next(request)
+class _BodyTooLargeError(Exception):
+    """Sentinel raised when cumulative request bytes exceed the cap."""
+
+
+class _RequestBodyLimitMiddleware:
+    """ASGI middleware that rejects requests exceeding MAX_REQUEST_BODY_SIZE.
+
+    Wraps the ASGI ``receive`` callable to track cumulative bytes from
+    ``http.request`` chunks, catching both missing and understated
+    Content-Length values.  Installed via ``add_middleware`` so it runs
+    before all ``@app.middleware`` functions (including the debug logger
+    that would otherwise buffer an oversized body).
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        """Store the wrapped ASGI application."""
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Enforce the body-size limit for HTTP requests."""
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        limit = constants.MAX_REQUEST_BODY_SIZE
+        received = 0
+
+        async def limiting_receive() -> dict:
+            nonlocal received
+            message = await receive()
+            if message["type"] == "http.request":
+                received += len(message.get("body", b""))
+                if received > limit:
+                    raise _BodyTooLargeError
+            return message
+
+        try:
+            await self.app(scope, limiting_receive, send)
+        except _BodyTooLargeError:
+            response = Response(content="Request body too large", status_code=413)
+            await response(scope, receive, send)
+
+
+app.add_middleware(_RequestBodyLimitMiddleware)
 
 
 @app.middleware("")

--- a/ols/app/main.py
+++ b/ols/app/main.py
@@ -68,9 +68,14 @@ class _RequestBodyLimitMiddleware:
 
     Wraps the ASGI ``receive`` callable to track cumulative bytes from
     ``http.request`` chunks, catching both missing and understated
-    Content-Length values.  Installed via ``add_middleware`` so it runs
-    before all ``@app.middleware`` functions (including the debug logger
-    that would otherwise buffer an oversized body).
+    Content-Length values.
+
+    Starlette applies middleware outermost-first in reverse registration
+    order (each ``add_middleware``/``@app.middleware`` call inserts at the
+    front of the stack), so this middleware must be registered *after* all
+    ``@app.middleware`` functions to become the outermost layer. Only then
+    does it wrap ``receive`` before the debug logger's ``log_requests_responses``
+    reads (and would otherwise buffer and log) an oversized body.
     """
 
     def __init__(self, app: ASGIApp) -> None:
@@ -100,9 +105,6 @@ class _RequestBodyLimitMiddleware:
         except _BodyTooLargeError:
             response = Response(content="Request body too large", status_code=413)
             await response(scope, receive, send)
-
-
-app.add_middleware(_RequestBodyLimitMiddleware)
 
 
 @app.middleware("")
@@ -233,6 +235,11 @@ async def log_requests_responses(
         response = StreamingResponse(stream_response_body(iter([response_body])))
 
     return response
+
+
+# Registered last so Starlette places it outermost: it wraps ``receive`` before
+# the middlewares above (notably the debug logger) can buffer an oversized body.
+app.add_middleware(_RequestBodyLimitMiddleware)
 
 
 routers.include_routers(app)

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -401,10 +401,10 @@ class FeedbackRequest(BaseModel):
     """
 
     conversation_id: str
-    user_question: str
+    user_question: str = Field(max_length=32_000)
     llm_response: str
     sentiment: Optional[int] = None
-    user_feedback: Optional[str] = None
+    user_feedback: Optional[str] = Field(default=None, max_length=32_000)
 
     # provides examples for /docs endpoint
     model_config = {

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -260,6 +260,9 @@ CLUSTER_QUOTA_LIMITER = "cluster_limiter"
 # MCP transport default timeout
 MCP_HTTP_TRANSPORT_DEFAULT_TIMEOUT = 5  # in seconds
 
+# Maximum HTTP request body size (2 MB) — DoS protection per OLS-2795 / SD Elements T536
+MAX_REQUEST_BODY_SIZE = 2 * 1024 * 1024
+
 # Offloading defaults
 DEFAULT_OFFLOAD_STORAGE_PATH = "/tmp/ols-offloaded"  # noqa: S108
 OFFLOAD_MAX_SEARCH_MATCHES = 50

--- a/tests/integration/test_request_body_limit.py
+++ b/tests/integration/test_request_body_limit.py
@@ -1,0 +1,61 @@
+"""Integration tests for the request body size limit middleware."""
+
+# we add new attributes into pytest instance, which is not recognized
+# properly by linters
+# pyright: reportAttributeAccessIssue=false
+
+import logging
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ols import config
+from ols.constants import MAX_REQUEST_BODY_SIZE
+
+
+@pytest.fixture(scope="function")
+def _setup():
+    """Set up the test client with debug-level logging enabled."""
+    config.reload_from_yaml_file("tests/config/config_for_integration_tests.yaml")
+
+    # app.main needs to be imported after the configuration is read
+    from ols.app.main import app  # pylint: disable=C0415
+
+    config.dev_config.disable_auth = True
+    pytest.client = TestClient(app)
+
+
+def test_oversized_body_rejected_before_debug_logging(_setup, caplog):
+    """Oversized bodies get a 413 and are never buffered by the debug logger.
+
+    The limiter must be the outermost middleware so it wraps ``receive``
+    before ``log_requests_responses`` reads the body. If it were inner, the
+    debug logger would buffer and log the whole oversized payload first.
+    """
+    caplog.set_level(logging.DEBUG, logger="ols.app.main")
+
+    marker = "OVERSIZE_BODY_MARKER"
+    body = marker.encode() + b"A" * (MAX_REQUEST_BODY_SIZE + 1)
+
+    response = pytest.client.post("/v1/query", content=body)
+
+    assert response.status_code == 413
+    # The oversized body must never reach the debug log: the limiter rejects
+    # it before log_requests_responses can buffer and decode it.
+    assert marker not in caplog.text
+
+
+def test_within_limit_body_is_logged(_setup, caplog):
+    """Control: a small body passes the limiter and is logged at debug level.
+
+    Proves the debug logger does buffer and log request bodies, so the
+    oversized-body assertion above is meaningful rather than vacuous.
+    """
+    caplog.set_level(logging.DEBUG, logger="ols.app.main")
+
+    marker = "SMALL_BODY_MARKER"
+
+    response = pytest.client.post("/v1/query", content=marker.encode())
+
+    assert response.status_code != 413
+    assert marker in caplog.text

--- a/tests/unit/app/models/test_models.py
+++ b/tests/unit/app/models/test_models.py
@@ -393,11 +393,17 @@ class TestFeedback:
         """Test user_question field rejects input exceeding 32000 characters."""
         cid = suid.get_suid()
         FeedbackRequest(
-            conversation_id=cid, user_question="x" * 32_000, llm_response="r", sentiment=1
+            conversation_id=cid,
+            user_question="x" * 32_000,
+            llm_response="r",
+            sentiment=1,
         )
         with pytest.raises(ValidationError, match="String should have at most 32000"):
             FeedbackRequest(
-                conversation_id=cid, user_question="x" * 32_001, llm_response="r", sentiment=1
+                conversation_id=cid,
+                user_question="x" * 32_001,
+                llm_response="r",
+                sentiment=1,
             )
 
     @staticmethod

--- a/tests/unit/app/models/test_models.py
+++ b/tests/unit/app/models/test_models.py
@@ -389,6 +389,36 @@ class TestFeedback:
             )
 
     @staticmethod
+    def test_feedback_user_question_max_length():
+        """Test user_question field rejects input exceeding 32000 characters."""
+        cid = suid.get_suid()
+        FeedbackRequest(
+            conversation_id=cid, user_question="x" * 32_000, llm_response="r", sentiment=1
+        )
+        with pytest.raises(ValidationError, match="String should have at most 32000"):
+            FeedbackRequest(
+                conversation_id=cid, user_question="x" * 32_001, llm_response="r", sentiment=1
+            )
+
+    @staticmethod
+    def test_feedback_user_feedback_max_length():
+        """Test user_feedback field rejects input exceeding 32000 characters."""
+        cid = suid.get_suid()
+        FeedbackRequest(
+            conversation_id=cid,
+            user_question="q",
+            llm_response="r",
+            user_feedback="x" * 32_000,
+        )
+        with pytest.raises(ValidationError, match="String should have at most 32000"):
+            FeedbackRequest(
+                conversation_id=cid,
+                user_question="q",
+                llm_response="r",
+                user_feedback="x" * 32_001,
+            )
+
+    @staticmethod
     def test_feedback_response():
         """Test the FeedbackResponse model."""
         feedback_response = "feedback received"


### PR DESCRIPTION
## Description
Restrict the size of incoming messages in services

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue https://redhat.atlassian.net/browse/OLS-2795
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests exceeding 2 MiB are now rejected with HTTP 413, including requests with missing or inaccurate size headers.
  * Feedback submissions now limit question and feedback text to 32,000 characters.
* **Validation**
  * Added checks confirming maximum-length feedback fields are accepted and longer values are rejected.
* **Documentation**
  * Updated the API schema to reflect the 32,000-character limits for feedback fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->