### PR TITLE
OLS-3221 Reconnect Postgres cache after DB restart

### DIFF
--- a/docs/config.puml
+++ b/docs/config.puml
@@ -119,6 +119,7 @@ class "OpenAIConfig" as ols.app.models.config.OpenAIConfig {
 }
 class "PostgresConfig" as ols.app.models.config.PostgresConfig {
   ca_cert_path : Optional[FilePath]
+  connect_timeout : Annotated
   dbname : str
   gss_encmode : str
   host : str
@@ -127,6 +128,7 @@ class "PostgresConfig" as ols.app.models.config.PostgresConfig {
   password_path : Optional[FilePath]
   port : Annotated
   ssl_mode : str
+  statement_timeout : Annotated
   user : str
   validate_yaml() -> Self
 }

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -807,6 +807,8 @@ class PostgresConfig(BaseModel):
     gss_encmode: str = constants.POSTGRES_CACHE_GSSENCMODE
     ca_cert_path: Optional[FilePath] = None
     max_entries: PositiveInt = constants.POSTGRES_CACHE_MAX_ENTRIES
+    connect_timeout: PositiveInt = constants.POSTGRES_CACHE_CONNECT_TIMEOUT
+    statement_timeout: PositiveInt = constants.POSTGRES_CACHE_STATEMENT_TIMEOUT
     tls_security_profile: Optional["TLSSecurityProfile"] = None
 
     def __init__(self, **data: Any) -> None:

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -138,6 +138,14 @@ POSTGRES_CACHE_DBNAME = "cache"
 POSTGRES_CACHE_USER = "postgres"
 POSTGRES_CACHE_MAX_ENTRIES = 1000
 
+# bound how long a (re)connect attempt may block, in seconds, so a readiness
+# check against an unavailable database cannot hang the probe indefinitely
+POSTGRES_CACHE_CONNECT_TIMEOUT = 5
+
+# server-side cap on how long a single statement may run, in milliseconds, so a
+# query against a wedged connection cannot block forever
+POSTGRES_CACHE_STATEMENT_TIMEOUT = 5000
+
 # look at https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLMODE
 # for all possible options
 POSTGRES_CACHE_SSL_MODE = "require"

--- a/ols/src/cache/postgres_cache.py
+++ b/ols/src/cache/postgres_cache.py
@@ -388,32 +388,25 @@ class PostgresCache(Cache, PostgresBase):
     def ready(self) -> bool:
         """Check if the cache is ready.
 
-        Postgres cache checks if the connection is alive. When a dead
-        connection is detected and the database is available again, the
-        connection is automatically re-established.
+        The connection is verified with a real ``SELECT 1`` round-trip so that
+        a server-side PostgreSQL restart is reliably detected. When the
+        connection is found to be dead and the database is available again, the
+        connection is automatically re-established, restoring readiness without
+        administrator intervention.
 
         Returns:
             True if the cache is ready, False otherwise.
         """
         with self._tx_lock:
-            if not self.connection or self.connection.closed == 1:
-                try:
-                    logger.info("Detected dead connection, attempting reconnect")
-                    self.connect()
-                    return True
-                except Exception as e:
-                    logger.warning("Reconnect attempt failed: %s", e)
-                    return False
+            if self.connected():
+                return True
             try:
-                return self.connection.poll() == psycopg2.extensions.POLL_OK
-            except (psycopg2.OperationalError, psycopg2.InterfaceError):
-                try:
-                    logger.info("Connection error during poll, attempting reconnect")
-                    self.connect()
-                    return True
-                except Exception as e:
-                    logger.warning("Reconnect attempt failed: %s", e)
-                    return False
+                logger.info("Detected dead connection, attempting reconnect")
+                self.connect()
+                return True
+            except Exception as e:
+                logger.warning("Reconnect attempt failed: %s", e)
+                return False
 
     @staticmethod
     def _select(

--- a/ols/utils/postgres.py
+++ b/ols/utils/postgres.py
@@ -67,11 +67,15 @@ class PostgresBase(ABC):
             "sslmode": config.ssl_mode,
             "sslrootcert": config.ca_cert_path,
             "gssencmode": config.gss_encmode,
+            "connect_timeout": config.connect_timeout,
             **libpq_tls_params(config.tls_security_profile),
         }
         self.connection = psycopg2.connect(**connect_kwargs)
         try:
             cursor = self.connection.cursor()
+            cursor.execute(
+                "SET statement_timeout = %s", (str(config.statement_timeout),)
+            )
             cursor.execute("SET LOCAL lock_timeout = '60s'")
             logger.info("Acquiring advisory lock for schema initialization")
             cursor.execute(self.INIT_ADVISORY_LOCK)

--- a/tests/unit/cache/test_postgres_cache.py
+++ b/tests/unit/cache/test_postgres_cache.py
@@ -798,32 +798,31 @@ def test_cleanup_method_when_clean_performed():
 
 
 def test_ready():
-    """Test the Cache.ready operation."""
+    """Test the Cache.ready operation on a live connection."""
     # do not use real PostgreSQL instance
     with patch("psycopg2.connect"):
         # initialize Postgres cache
         config = PostgresConfig()
         cache = PostgresCache(config)
 
-        # mock the connection state 0 - open
-        cache.connection.closed = 0
-        # patch the poll function to return POLL_OK
-        cache.connection.poll = MagicMock(return_value=psycopg2.extensions.POLL_OK)
-        # cache is ready
+        # a live connection: the SELECT 1 health probe in connected() succeeds
         assert cache.ready()
 
 
-def test_ready_reconnects_on_closed_connection():
-    """Test that ready() reconnects when connection is closed."""
+def test_ready_reconnects_on_dead_connection():
+    """ready() detects a dead connection via SELECT 1 and reconnects.
+
+    Regression test for OLS-3221: a server-side PostgreSQL restart must be
+    detected via a real query round-trip so the pod recovers automatically.
+    """
     with patch("psycopg2.connect") as mock_connect:
         config = PostgresConfig()
         cache = PostgresCache(config)
 
-        # simulate closed connection
-        cache.connection.closed = 1
-
-        # ready() should attempt reconnect and succeed
-        assert cache.ready()
+        # simulate a dead connection detected by the SELECT 1 health probe
+        with patch.object(cache, "connected", return_value=False):
+            # ready() should detect the dead connection and reconnect successfully
+            assert cache.ready()
         # connect() is called during __init__ and again during reconnect
         assert mock_connect.call_count == 2
 
@@ -848,41 +847,9 @@ def test_ready_returns_false_when_reconnect_fails():
         config = PostgresConfig()
         cache = PostgresCache(config)
 
-        # simulate closed connection
-        cache.connection.closed = 1
         # make reconnect fail
         mock_connect.side_effect = psycopg2.OperationalError("connection refused")
 
-        assert not cache.ready()
-
-
-def test_ready_reconnects_on_poll_error():
-    """Test that ready() reconnects when poll raises OperationalError."""
-    with patch("psycopg2.connect") as mock_connect:
-        config = PostgresConfig()
-        cache = PostgresCache(config)
-
-        cache.connection.closed = 0
-        cache.connection.poll = MagicMock(
-            side_effect=psycopg2.OperationalError("Connection closed")
-        )
-
-        # ready() should attempt reconnect and succeed
-        assert cache.ready()
-        assert mock_connect.call_count == 2
-
-
-def test_ready_returns_false_when_poll_reconnect_fails():
-    """Test that ready() returns False when reconnect after poll error fails."""
-    with patch("psycopg2.connect") as mock_connect:
-        config = PostgresConfig()
-        cache = PostgresCache(config)
-
-        cache.connection.closed = 0
-        cache.connection.poll = MagicMock(
-            side_effect=psycopg2.InterfaceError("Connection closed")
-        )
-        # make reconnect fail
-        mock_connect.side_effect = psycopg2.OperationalError("connection refused")
-
-        assert not cache.ready()
+        # simulate a dead connection detected by the SELECT 1 health probe
+        with patch.object(cache, "connected", return_value=False):
+            assert not cache.ready()

--- a/tests/unit/utils/test_postgres.py
+++ b/tests/unit/utils/test_postgres.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, call, patch
 import psycopg2
 import pytest
 
-from ols.app.models.config import TLSSecurityProfile
+from ols.app.models.config import PostgresConfig, TLSSecurityProfile
 from ols.utils.postgres import PostgresBase, connection
 
 
@@ -125,6 +125,27 @@ class TestPostgresBaseConnect:
                 FakeComponent(config=MagicMock())
 
         assert mock_connect.return_value.autocommit is False
+
+    def test_connect_passes_connect_timeout(self):
+        """connect_timeout from config bounds how long a connect may block."""
+        config = PostgresConfig()
+        with patch("psycopg2.connect") as mock_connect:
+            FakeComponent(config=config)
+
+        assert (
+            mock_connect.call_args.kwargs["connect_timeout"] == config.connect_timeout
+        )
+
+    def test_connect_sets_statement_timeout(self):
+        """statement_timeout from config is applied on the new connection."""
+        config = PostgresConfig()
+        with patch("psycopg2.connect") as mock_connect:
+            cursor = mock_connect.return_value.cursor.return_value
+            FakeComponent(config=config)
+
+        cursor.execute.assert_any_call(
+            "SET statement_timeout = %s", (str(config.statement_timeout),)
+        )
 
 
 class TestPostgresBaseConnected:


### PR DESCRIPTION
## Description

Fixes [OLS-3221](https://redhat.atlassian.net/browse/OLS-3221): app-server pods stay permanently unready after a PostgreSQL restart (node drain, eviction, OOM, rolling upgrade) and require a manual `oc rollout restart`.

### Root cause
`PostgresCache.ready()` detected a dead connection via `connection.closed` / `connection.poll()`. Neither reliably notices a **server-side** PostgreSQL restart — `closed` can stay `0` and `poll()` can return `POLL_OK` on a stale socket — so the pod kept a dead connection and never reconnected. Liveness always returned `alive=true` (never checks the DB), so the kubelet never restarted the pod either. Result: pod Running-but-NotReady forever.

### Fix (minimal, root-cause)
- `ready()` now verifies the connection with a real `SELECT 1` round-trip via the existing `connected()` helper, and reconnects when it fails. A server-side restart is reliably detected and the pod returns to Ready automatically — no restart, no manual intervention.
- Added `connect_timeout` (5s) and `statement_timeout` (5000ms), both configurable via `PostgresConfig`, so a probe against an unavailable database cannot hang the connection indefinitely.

### Why not couple liveness to the DB
Putting a shared dependency in the liveness probe is a known Kubernetes anti-pattern: a single DB outage would fail liveness on **every** app-server pod simultaneously and trigger a fleet-wide restart storm that does nothing to fix the DB. Recovery belongs in readiness + reconnect. This is an intentionally smaller alternative to #2964.

## Type of change
- [x] Bug fix

## Testing
- `make test-unit` — 1186 passed.
- Updated `ready()` unit tests to cover: live connection, dead-connection-then-reconnect ([OLS-3221](https://redhat.atlassian.net/browse/OLS-3221) regression), reconnect-fails, and `None` connection.
- Added tests asserting `connect_timeout` and `statement_timeout` are applied.
- Manual verification suggested: deploy with Postgres cache, delete the Postgres pod, restore it, and confirm app-server pods return to Ready without `oc rollout restart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable PostgreSQL connection and statement timeouts, with sensible defaults.
  - PostgreSQL sessions now apply the configured statement timeout automatically.

- **Bug Fixes**
  - Improved cache readiness checks by actively verifying connection health.
  - Automatically reconnects when an existing database connection is no longer usable.

- **Documentation**
  - Updated the PostgreSQL configuration reference to include the new timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->