### PR TITLE
OLS-3221 Reconnect Postgres cache after DB restart

### DIFF
--- a/docs/config.puml
+++ b/docs/config.puml
@@ -119,6 +119,7 @@ class "OpenAIConfig" as ols.app.models.config.OpenAIConfig {
 }
 class "PostgresConfig" as ols.app.models.config.PostgresConfig {
   ca_cert_path : Optional[FilePath]
+  connect_timeout : Annotated
   dbname : str
   gss_encmode : str
   host : str
@@ -127,6 +128,7 @@ class "PostgresConfig" as ols.app.models.config.PostgresConfig {
   password_path : Optional[FilePath]
   port : Annotated
   ssl_mode : str
+  statement_timeout : Annotated
   user : str
   validate_yaml() -> Self
 }

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -807,6 +807,11 @@ class PostgresConfig(BaseModel):
     gss_encmode: str = constants.POSTGRES_CACHE_GSSENCMODE
     ca_cert_path: Optional[FilePath] = None
     max_entries: PositiveInt = constants.POSTGRES_CACHE_MAX_ENTRIES
+    connect_timeout: PositiveInt = constants.POSTGRES_CACHE_CONNECT_TIMEOUT
+    statement_timeout: PositiveInt = constants.POSTGRES_CACHE_STATEMENT_TIMEOUT
+    keepalives_idle: PositiveInt = constants.POSTGRES_CACHE_KEEPALIVES_IDLE
+    keepalives_interval: PositiveInt = constants.POSTGRES_CACHE_KEEPALIVES_INTERVAL
+    keepalives_count: PositiveInt = constants.POSTGRES_CACHE_KEEPALIVES_COUNT
     tls_security_profile: Optional["TLSSecurityProfile"] = None
 
     def __init__(self, **data: Any) -> None:

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -138,6 +138,17 @@ POSTGRES_CACHE_DBNAME = "cache"
 POSTGRES_CACHE_USER = "postgres"
 POSTGRES_CACHE_MAX_ENTRIES = 1000
 
+# bound how long a (re)connect attempt may block, in seconds
+POSTGRES_CACHE_CONNECT_TIMEOUT = 5
+
+# server-side cap on how long a single statement may run, in milliseconds
+POSTGRES_CACHE_STATEMENT_TIMEOUT = 5000
+
+# TCP keepalive settings to detect dead connections at the network level
+POSTGRES_CACHE_KEEPALIVES_IDLE = 10
+POSTGRES_CACHE_KEEPALIVES_INTERVAL = 5
+POSTGRES_CACHE_KEEPALIVES_COUNT = 3
+
 # look at https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLMODE
 # for all possible options
 POSTGRES_CACHE_SSL_MODE = "require"

--- a/ols/src/cache/postgres_cache.py
+++ b/ols/src/cache/postgres_cache.py
@@ -388,32 +388,29 @@ class PostgresCache(Cache, PostgresBase):
     def ready(self) -> bool:
         """Check if the cache is ready.
 
-        Postgres cache checks if the connection is alive. When a dead
-        connection is detected and the database is available again, the
-        connection is automatically re-established.
+        The connection is verified with a real ``SELECT 1`` round-trip so that
+        a server-side PostgreSQL restart is reliably detected. When the
+        connection is found to be dead and the database is available again, the
+        connection is automatically re-established, restoring readiness without
+        administrator intervention.
 
         Returns:
             True if the cache is ready, False otherwise.
         """
         with self._tx_lock:
-            if not self.connection or self.connection.closed == 1:
-                try:
-                    logger.info("Detected dead connection, attempting reconnect")
-                    self.connect()
+            if self.connected():
+                return True
+
+        try:
+            logger.info("Detected dead connection, attempting reconnect")
+            with self._tx_lock:
+                if self.connected():
                     return True
-                except Exception as e:
-                    logger.warning("Reconnect attempt failed: %s", e)
-                    return False
-            try:
-                return self.connection.poll() == psycopg2.extensions.POLL_OK
-            except (psycopg2.OperationalError, psycopg2.InterfaceError):
-                try:
-                    logger.info("Connection error during poll, attempting reconnect")
-                    self.connect()
-                    return True
-                except Exception as e:
-                    logger.warning("Reconnect attempt failed: %s", e)
-                    return False
+                self.connect()
+            return True
+        except (psycopg2.Error, OSError) as e:
+            logger.warning("Reconnect attempt failed: %s", e)
+            return False
 
     @staticmethod
     def _select(

--- a/ols/utils/postgres.py
+++ b/ols/utils/postgres.py
@@ -67,6 +67,11 @@ class PostgresBase(ABC):
             "sslmode": config.ssl_mode,
             "sslrootcert": config.ca_cert_path,
             "gssencmode": config.gss_encmode,
+            "connect_timeout": config.connect_timeout,
+            "keepalives": 1,
+            "keepalives_idle": config.keepalives_idle,
+            "keepalives_interval": config.keepalives_interval,
+            "keepalives_count": config.keepalives_count,
             **libpq_tls_params(config.tls_security_profile),
         }
         self.connection = psycopg2.connect(**connect_kwargs)
@@ -84,6 +89,9 @@ class PostgresBase(ABC):
             logger.exception("Error initializing Postgres schema:\n%s", e)
             raise
         self.connection.autocommit = True
+        cursor = self.connection.cursor()
+        cursor.execute("SET statement_timeout = %s", (str(config.statement_timeout),))
+        cursor.close()
 
     def connected(self) -> bool:
         """Check if the connection to Postgres is alive."""

--- a/tests/unit/cache/test_postgres_cache.py
+++ b/tests/unit/cache/test_postgres_cache.py
@@ -798,33 +798,85 @@ def test_cleanup_method_when_clean_performed():
 
 
 def test_ready():
-    """Test the Cache.ready operation."""
-    # do not use real PostgreSQL instance
+    """Test the Cache.ready operation on a live connection."""
     with patch("psycopg2.connect"):
-        # initialize Postgres cache
         config = PostgresConfig()
         cache = PostgresCache(config)
 
-        # mock the connection state 0 - open
-        cache.connection.closed = 0
-        # patch the poll function to return POLL_OK
-        cache.connection.poll = MagicMock(return_value=psycopg2.extensions.POLL_OK)
-        # cache is ready
         assert cache.ready()
 
 
-def test_ready_reconnects_on_closed_connection():
-    """Test that ready() reconnects when connection is closed."""
+def test_ready_reconnects_on_dead_connection():
+    """ready() detects a dead connection via SELECT 1 and reconnects.
+
+    Regression test for OLS-3221: a server-side PostgreSQL restart must be
+    detected via a real query round-trip so the pod recovers automatically.
+    """
     with patch("psycopg2.connect") as mock_connect:
         config = PostgresConfig()
         cache = PostgresCache(config)
 
-        # simulate closed connection
-        cache.connection.closed = 1
-
-        # ready() should attempt reconnect and succeed
-        assert cache.ready()
+        # simulate a dead connection detected by the SELECT 1 health probe
+        with patch.object(cache, "connected", return_value=False):
+            assert cache.ready()
         # connect() is called during __init__ and again during reconnect
+        assert mock_connect.call_count == 2
+
+
+def test_ready_reconnects_when_select1_raises_operational_error():
+    """ready() reconnects when the SELECT 1 probe raises OperationalError.
+
+    Integration-style test: instead of mocking connected(), simulate the
+    actual failure path where cursor.execute raises on a stale connection,
+    then recovers after reconnect.
+    """
+    with patch("psycopg2.connect") as mock_connect:
+        config = PostgresConfig()
+        cache = PostgresCache(config)
+
+        select1_calls = {"n": 0}
+
+        def execute_side_effect(*args, **kwargs):
+            if args == ("SELECT 1",):
+                select1_calls["n"] += 1
+                if select1_calls["n"] <= 2:
+                    raise psycopg2.OperationalError(
+                        "server closed the connection unexpectedly"
+                    )
+            return MagicMock()
+
+        cursor_ctx = MagicMock()
+        cursor_ctx.__enter__ = MagicMock(return_value=cursor_ctx)
+        cursor_ctx.__exit__ = MagicMock(return_value=False)
+        cursor_ctx.execute.side_effect = execute_side_effect
+        mock_connect.return_value.cursor.return_value = cursor_ctx
+
+        assert cache.ready()
+        assert mock_connect.call_count == 2
+
+
+def test_ready_reconnects_when_select1_raises_interface_error():
+    """ready() reconnects when the SELECT 1 probe raises InterfaceError."""
+    with patch("psycopg2.connect") as mock_connect:
+        config = PostgresConfig()
+        cache = PostgresCache(config)
+
+        select1_calls = {"n": 0}
+
+        def execute_side_effect(*args, **kwargs):
+            if args == ("SELECT 1",):
+                select1_calls["n"] += 1
+                if select1_calls["n"] <= 2:
+                    raise psycopg2.InterfaceError("connection already closed")
+            return MagicMock()
+
+        cursor_ctx = MagicMock()
+        cursor_ctx.__enter__ = MagicMock(return_value=cursor_ctx)
+        cursor_ctx.__exit__ = MagicMock(return_value=False)
+        cursor_ctx.execute.side_effect = execute_side_effect
+        mock_connect.return_value.cursor.return_value = cursor_ctx
+
+        assert cache.ready()
         assert mock_connect.call_count == 2
 
 
@@ -848,41 +900,9 @@ def test_ready_returns_false_when_reconnect_fails():
         config = PostgresConfig()
         cache = PostgresCache(config)
 
-        # simulate closed connection
-        cache.connection.closed = 1
         # make reconnect fail
         mock_connect.side_effect = psycopg2.OperationalError("connection refused")
 
-        assert not cache.ready()
-
-
-def test_ready_reconnects_on_poll_error():
-    """Test that ready() reconnects when poll raises OperationalError."""
-    with patch("psycopg2.connect") as mock_connect:
-        config = PostgresConfig()
-        cache = PostgresCache(config)
-
-        cache.connection.closed = 0
-        cache.connection.poll = MagicMock(
-            side_effect=psycopg2.OperationalError("Connection closed")
-        )
-
-        # ready() should attempt reconnect and succeed
-        assert cache.ready()
-        assert mock_connect.call_count == 2
-
-
-def test_ready_returns_false_when_poll_reconnect_fails():
-    """Test that ready() returns False when reconnect after poll error fails."""
-    with patch("psycopg2.connect") as mock_connect:
-        config = PostgresConfig()
-        cache = PostgresCache(config)
-
-        cache.connection.closed = 0
-        cache.connection.poll = MagicMock(
-            side_effect=psycopg2.InterfaceError("Connection closed")
-        )
-        # make reconnect fail
-        mock_connect.side_effect = psycopg2.OperationalError("connection refused")
-
-        assert not cache.ready()
+        # simulate a dead connection detected by the SELECT 1 health probe
+        with patch.object(cache, "connected", return_value=False):
+            assert not cache.ready()

--- a/tests/unit/utils/test_postgres.py
+++ b/tests/unit/utils/test_postgres.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, call, patch
 import psycopg2
 import pytest
 
-from ols.app.models.config import TLSSecurityProfile
+from ols.app.models.config import PostgresConfig, TLSSecurityProfile
 from ols.utils.postgres import PostgresBase, connection
 
 
@@ -93,7 +93,8 @@ class TestPostgresBaseConnect:
                 call("CREATE INDEX IF NOT EXISTS i1 ON t1 (id)"),
             ]
         )
-        cursor.close.assert_called_once()
+        cursor.close.assert_called()
+        assert cursor.close.call_count == 2
         mock_connect.return_value.commit.assert_called_once()
 
     def test_connect_sets_autocommit_after_init(self):
@@ -125,6 +126,39 @@ class TestPostgresBaseConnect:
                 FakeComponent(config=MagicMock())
 
         assert mock_connect.return_value.autocommit is False
+
+    def test_connect_passes_connect_timeout(self) -> None:
+        """Verify connect_timeout reaches psycopg2.connect."""
+        config = PostgresConfig()
+        with patch("psycopg2.connect") as mock_connect:
+            FakeComponent(config=config)
+
+        assert (
+            mock_connect.call_args.kwargs["connect_timeout"] == config.connect_timeout
+        )
+
+    def test_connect_sets_statement_timeout(self) -> None:
+        """Verify statement_timeout is applied after schema initialization."""
+        config = PostgresConfig()
+        with patch("psycopg2.connect") as mock_connect:
+            cursor = mock_connect.return_value.cursor.return_value
+            FakeComponent(config=config)
+
+        cursor.execute.assert_any_call(
+            "SET statement_timeout = %s", (str(config.statement_timeout),)
+        )
+
+    def test_connect_passes_keepalive_params(self) -> None:
+        """Verify TCP keepalive parameters reach psycopg2.connect."""
+        config = PostgresConfig()
+        with patch("psycopg2.connect") as mock_connect:
+            FakeComponent(config=config)
+
+        kwargs = mock_connect.call_args.kwargs
+        assert kwargs["keepalives"] == 1
+        assert kwargs["keepalives_idle"] == config.keepalives_idle
+        assert kwargs["keepalives_interval"] == config.keepalives_interval
+        assert kwargs["keepalives_count"] == config.keepalives_count
 
 
 class TestPostgresBaseConnected:


### PR DESCRIPTION
Fixes [OLS-3221](https://redhat.atlassian.net/browse/OLS-3221): app-server pods stay permanently unready after a PostgreSQL restart (node drain, eviction, OOM, rolling upgrade) and require a manual `oc rollout restart`.

Supersedes #3066 with fixes from adversarial review.

### Root cause
`PostgresCache.ready()` relied on `connection.closed` / `connection.poll()` which do not reliably detect a server-side PostgreSQL restart — `closed` can stay `0` and `poll()` can return `POLL_OK` on a stale socket.

### Fix
- **`ready()`** now verifies the connection with a real `SELECT 1` round-trip via `connected()`, and reconnects when it fails
- **`statement_timeout`** applied after schema initialization so DDL is not artificially capped at 5 seconds
- **Lock contention fix:** `_tx_lock` released between failure detection and reconnect to avoid blocking concurrent cache operations during probe timeout
- **Narrowed exception handler** to `(psycopg2.Error, OSError)` — only DB and network errors are caught
- **TCP keepalives** added (`keepalives_idle=10s`, `interval=5s`, `count=3`) to detect dead connections at the network level
- **`connect_timeout`** (5s) and **`statement_timeout`** (5000ms) configurable via `PostgresConfig`

### Testing
- `make test-unit` — 1190 passed
- Integration-style tests verifying `OperationalError`/`InterfaceError` from `SELECT 1` triggers reconnect
- Tests for `connect_timeout`, `statement_timeout`, and keepalive params
- Manual verification suggested: deploy with Postgres cache, delete the Postgres pod, restore it, and confirm app-server pods return to Ready without `oc rollout restart`

### Type of change
- [x] Bug fix