### PR TITLE
OLS-4019: drop unsupported params for LiteLLM

### DIFF
--- a/eval/system.yaml
+++ b/eval/system.yaml
@@ -121,6 +121,7 @@ environment:
   DEEPEVAL_DISABLE_PROGRESS_BAR: "YES"     # Disable DeepEval progress bars
 
   LITELLM_LOG: ERROR                       # Suppress LiteLLM verbose logging
+  LITELLM_DROP_PARAMS: "True"              # Drop params unsupported by the judge model
 
 # Logging Configuration
 logging:

--- a/eval/system_azure_openai_lseval.yaml
+++ b/eval/system_azure_openai_lseval.yaml
@@ -78,6 +78,7 @@ environment:
   DEEPEVAL_TELEMETRY_OPT_OUT: "YES"
   DEEPEVAL_DISABLE_PROGRESS_BAR: "YES"
   LITELLM_LOG: ERROR
+  LITELLM_DROP_PARAMS: "True"
 
 # Logging Configuration
 logging:

--- a/eval/system_bedrock_deepseek_lseval.yaml
+++ b/eval/system_bedrock_deepseek_lseval.yaml
@@ -78,6 +78,7 @@ environment:
   DEEPEVAL_TELEMETRY_OPT_OUT: "YES"
   DEEPEVAL_DISABLE_PROGRESS_BAR: "YES"
   LITELLM_LOG: ERROR
+  LITELLM_DROP_PARAMS: "True"
 
 # Logging Configuration
 logging:

--- a/eval/system_cluster_updates.yaml
+++ b/eval/system_cluster_updates.yaml
@@ -282,6 +282,7 @@ environment:
   DEEPEVAL_DISABLE_PROGRESS_BAR: "YES"     # Disable DeepEval progress bars
 
   LITELLM_LOG: ERROR                       # Suppress LiteLLM verbose logging
+  LITELLM_DROP_PARAMS: "True"              # Drop params unsupported by the judge model
 
 # Logging Configuration
 logging:

--- a/eval/system_openai_lseval.yaml
+++ b/eval/system_openai_lseval.yaml
@@ -80,6 +80,7 @@ environment:
   DEEPEVAL_TELEMETRY_OPT_OUT: "YES"
   DEEPEVAL_DISABLE_PROGRESS_BAR: "YES"
   LITELLM_LOG: ERROR
+  LITELLM_DROP_PARAMS: "True"
 
 # Logging Configuration
 logging:

--- a/eval/system_rhelai_vllm_lseval.yaml
+++ b/eval/system_rhelai_vllm_lseval.yaml
@@ -81,6 +81,7 @@ environment:
   DEEPEVAL_TELEMETRY_OPT_OUT: "YES"
   DEEPEVAL_DISABLE_PROGRESS_BAR: "YES"
   LITELLM_LOG: ERROR
+  LITELLM_DROP_PARAMS: "True"
 
 # Logging Configuration
 logging:

--- a/eval/system_rhoai_vllm_lseval.yaml
+++ b/eval/system_rhoai_vllm_lseval.yaml
@@ -81,6 +81,7 @@ environment:
   DEEPEVAL_TELEMETRY_OPT_OUT: "YES"
   DEEPEVAL_DISABLE_PROGRESS_BAR: "YES"
   LITELLM_LOG: ERROR
+  LITELLM_DROP_PARAMS: "True"
 
 # Logging Configuration
 logging:

--- a/eval/system_vertex_claude_lseval.yaml
+++ b/eval/system_vertex_claude_lseval.yaml
@@ -78,6 +78,7 @@ environment:
   DEEPEVAL_TELEMETRY_OPT_OUT: "YES"
   DEEPEVAL_DISABLE_PROGRESS_BAR: "YES"
   LITELLM_LOG: ERROR
+  LITELLM_DROP_PARAMS: "True"
 
 # Logging Configuration
 logging:

--- a/eval/system_vertex_gemini_lseval.yaml
+++ b/eval/system_vertex_gemini_lseval.yaml
@@ -78,6 +78,7 @@ environment:
   DEEPEVAL_TELEMETRY_OPT_OUT: "YES"
   DEEPEVAL_DISABLE_PROGRESS_BAR: "YES"
   LITELLM_LOG: ERROR
+  LITELLM_DROP_PARAMS: "True"
 
 # Logging Configuration
 logging:

--- a/eval/system_watsonx_lseval.yaml
+++ b/eval/system_watsonx_lseval.yaml
@@ -78,6 +78,7 @@ environment:
   DEEPEVAL_TELEMETRY_OPT_OUT: "YES"
   DEEPEVAL_DISABLE_PROGRESS_BAR: "YES"
   LITELLM_LOG: ERROR
+  LITELLM_DROP_PARAMS: "True"
 
 # Logging Configuration
 logging:


### PR DESCRIPTION
xref: [OLS-4019](https://redhat.atlassian.net/browse/OLS-4019)

The periodic for this repo failed this morning (see card/slack link in card):

The evaluation pipeline uses LiteLLM to call openai/gpt-5-mini. LiteLLM is sending logprobs and top_logprobs parameters that gpt-5-mini does not support. This error occurred repeatedly across multiple conversations during the evaluation scoring phase, but only 1 evaluation was counted as an ERROR (the others apparently recovered or were scored through a different code path).

```
litellm.UnsupportedParamsError: openai does not support parameters:
['logprobs', 'top_logprobs'], for model=gpt-5-mini
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation compatibility by automatically ignoring unsupported parameters when communicating with judge models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->