### PR TITLE
OLS-3599: Relax OKP tool mandate when BYOK content is configured

### DIFF
--- a/.ai/spec/what/rag.md
+++ b/.ai/spec/what/rag.md
@@ -16,7 +16,7 @@ The RAG subsystem augments LLM responses with relevant documentation so that ans
 
 6. The tool returns JSON passages with `text`, `score`, `title`, and `docs_url`. The LLM uses these to compose a grounded answer with citations.
 
-7. When the OKP tool is active, supplementary prompt guidance (`SOLR_DOCS_TOOL_SUPPLEMENT`) is appended to agent instructions (ASK mode) directing the LLM to ground answers on retrieved passages and cite sources.
+7. When the OKP tool is active, supplementary prompt guidance is appended to agent instructions (ASK mode) directing the LLM to ground answers on retrieved passages and cite sources. Two variants exist: `SOLR_DOCS_TOOL_SUPPLEMENT` (mandatory OKP invocation — used when no BYOK is configured) and `SOLR_DOCS_TOOL_SUPPLEMENT_WITH_BYOK` (used when BYOK reference content is configured). The BYOK variant labels the provided context as domain-specific knowledge, instructs the LLM to use it directly when it answers the question, and restricts OKP to supplementary general OpenShift details. It explicitly prohibits contradicting or overriding relevant domain knowledge with OKP results.
 
 8. Solr failures degrade gracefully — the tool returns empty results or a structured error, and the request continues without OKP passages. The service never fails a user request due to Solr errors.
 

--- a/ols/src/prompts/prompt_generator.py
+++ b/ols/src/prompts/prompt_generator.py
@@ -33,6 +33,7 @@ class GeneratePrompt:
         cluster_version: str = "unknown",
         skill_content: Optional[str] = None,
         solr_docs_tool_guidance: bool = False,
+        byok_active: bool = False,
     ) -> None:
         """Initialize prompt generator."""
         self._query = query
@@ -44,6 +45,7 @@ class GeneratePrompt:
         self._cluster_version = cluster_version
         self._skill_content = skill_content
         self._solr_docs_tool_guidance = solr_docs_tool_guidance
+        self._byok_active = byok_active
 
     def _get_agent_instructions(self, model: str) -> str:
         """Return agent instructions based on mode and model family."""
@@ -71,11 +73,12 @@ class GeneratePrompt:
         if self._tool_call:
             agent_instructions = self._get_agent_instructions(model)
             if self._solr_docs_tool_guidance and self._mode == QueryMode.ASK:
-                agent_instructions = (
-                    agent_instructions
-                    + "\n"
-                    + prompts.SOLR_DOCS_TOOL_SUPPLEMENT.strip()
+                supplement = (
+                    prompts.SOLR_DOCS_TOOL_SUPPLEMENT_WITH_BYOK
+                    if self._byok_active
+                    else prompts.SOLR_DOCS_TOOL_SUPPLEMENT
                 )
+                agent_instructions = agent_instructions + "\n" + supplement.strip()
             sys_intruction = sys_intruction + "\n" + agent_instructions
 
         if len(self._rag_context) > 0:

--- a/ols/src/prompts/prompts.py
+++ b/ols/src/prompts/prompts.py
@@ -97,6 +97,18 @@ Grounded answers (passages from ``search_openshift_documentation``):
 * If the answer is not based on such passages, stay concise per the general style rules above.
 """
 
+SOLR_DOCS_TOOL_SUPPLEMENT_WITH_BYOK = """
+Solr docs tool:
+* ``search_openshift_documentation`` searches published Red Hat product documentation (not live cluster resources).
+* The provided context contains domain-specific knowledge. If it answers the question, use it directly. Only call ``search_openshift_documentation`` to fill in general OpenShift details that the domain knowledge does not cover. Never contradict or override relevant domain knowledge.
+* When you use a passage from the tool, cite its ``title`` and ``docs_url`` from the tool JSON. Never invent documentation URLs.
+
+If the tool is used, grounded answers (passages from ``search_openshift_documentation``):
+* Bullets or numbered steps are allowed so passage detail is not dropped for brevity.
+* Keep concrete details from passages (manifests, ``oc`` commands, console paths).
+* If the answer is not based on such passages, stay concise per the general style rules above.
+"""
+
 TROUBLESHOOTING_SYSTEM_INSTRUCTION = """# ROLE
 You are "OpenShift Lightspeed", an AI assistant specializing in OpenShift troubleshooting and diagnostics.
 

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -98,6 +98,8 @@ class DocsSummarizer(QueryHelper):
             self._solr_hybrid is not None and self._solr_client is not None
         )
         self._solr_docs_tool_prompt_guidance = solr_docs_tool_active
+        ref = config.config.ols_config.reference_content
+        self._byok_active = ref is not None and bool(ref.indexes)
         self._tool_calling_enabled = bool(self.mcp_servers) or solr_docs_tool_active
         if self.mcp_servers:
             logger.info("MCP servers provided: %s", list(self.mcp_servers.keys()))
@@ -177,6 +179,7 @@ class DocsSummarizer(QueryHelper):
             self._mode,
             self._cluster_version,
             solr_docs_tool_guidance=self._solr_docs_tool_prompt_guidance,
+            byok_active=self._byok_active,
         ).generate_prompt(self.model)
         prompt_tokens = self._tracker.count_tokens(
             temp_prompt.format(**temp_prompt_input)
@@ -286,6 +289,7 @@ class DocsSummarizer(QueryHelper):
             self._cluster_version,
             skill_content=skill_content,
             solr_docs_tool_guidance=self._solr_docs_tool_prompt_guidance,
+            byok_active=self._byok_active,
         ).generate_prompt(self.model)
 
         log_tool_loop_iteration(

--- a/tests/unit/prompts/test_prompt_generator.py
+++ b/tests/unit/prompts/test_prompt_generator.py
@@ -437,3 +437,42 @@ def test_solr_docs_tool_guidance_false_omits_supplement():
         solr_docs_tool_guidance=False,
     ).generate_prompt("gpt-4o-mini")
     assert "Grounded answers (passages from" not in prompt.messages[0].prompt.template
+
+
+def test_solr_docs_tool_guidance_with_byok_uses_relaxed_supplement():
+    """When BYOK is active, the relaxed Solr supplement is used instead of the mandatory one."""
+    prompt, _ = GeneratePrompt(
+        query,
+        [],
+        [],
+        "SYS",
+        tool_call=True,
+        mode=QueryMode.ASK,
+        solr_docs_tool_guidance=True,
+        byok_active=True,
+    ).generate_prompt("gpt-4o-mini")
+    template = prompt.messages[0].prompt.template
+    assert "Solr docs tool:" in template
+    assert "search_openshift_documentation" in template
+    assert "ALWAYS call" not in template
+    assert "Do not rely on memory alone" not in template
+    assert "domain-specific knowledge" in template
+    assert "Never contradict or override" in template
+
+
+def test_solr_docs_tool_guidance_without_byok_uses_mandatory_supplement():
+    """When BYOK is not active, the mandatory Solr supplement is used."""
+    prompt, _ = GeneratePrompt(
+        query,
+        [],
+        [],
+        "SYS",
+        tool_call=True,
+        mode=QueryMode.ASK,
+        solr_docs_tool_guidance=True,
+        byok_active=False,
+    ).generate_prompt("gpt-4o-mini")
+    template = prompt.messages[0].prompt.template
+    assert "ALWAYS call" in template
+    assert "Do not rely on memory alone" in template
+    assert "domain-specific knowledge" not in template

--- a/tests/unit/query_helpers/test_docs_summarizer.py
+++ b/tests/unit/query_helpers/test_docs_summarizer.py
@@ -196,6 +196,27 @@ def test_summarize_no_reference_content():
     assert not summary.history_truncated
 
 
+def test_byok_active_true_when_reference_content_configured():
+    """Verify _byok_active is True when BYOK indexes are configured."""
+    summarizer = DocsSummarizer(
+        llm_loader=mock_llm_loader(mock_langchain_interface("resp")())
+    )
+    assert summarizer._byok_active
+
+
+def test_byok_active_false_when_no_reference_content():
+    """Verify _byok_active is False when no BYOK indexes are configured."""
+    original = config.config.ols_config.reference_content
+    try:
+        config.config.ols_config.reference_content = None
+        summarizer = DocsSummarizer(
+            llm_loader=mock_llm_loader(mock_langchain_interface("resp")())
+        )
+        assert not summarizer._byok_active
+    finally:
+        config.config.ols_config.reference_content = original
+
+
 def test_summarize_retrieval_logging(caplog):
     """Basic test to ensure retrieval details are visible in logs."""
     logging_config = LoggingConfig(app_log_level="debug")


### PR DESCRIPTION
## Description

## Summary

When BYOK (Bring Your Own Knowledge) indexes are configured alongside OKP (Solr),
the system prompt forced the LLM to "ALWAYS call search_openshift_documentation"
before answering. This caused OKP results to overshadow BYOK context that already
answered the question, making BYOK effectively useless.

- Add `SOLR_DOCS_TOOL_SUPPLEMENT_WITH_BYOK` prompt variant that tells the LLM to
  use provided context first and only call the OKP tool if context is insufficient
- Wire `byok_active` flag through `DocsSummarizer` → `GeneratePrompt` based on
  whether `reference_content.indexes` is configured
- Non-BYOK deployments are unaffected (original mandatory supplement is unchanged)


## Type of change

- [ ] Refactor
- [ ] New feature
- [ x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
https://redhat.atlassian.net/browse/OLS-3599
- Closes #
https://redhat.atlassian.net/browse/OLS-3599

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved document-based answers when reference content is available.
  * Relevant documents already in context can now be used directly, with searches performed only when additional information is needed.
  * Existing citation and concise-response guidance is preserved.

* **Bug Fixes**
  * Document search guidance now adapts automatically based on whether reference content is configured.

* **Tests**
  * Added coverage for reference-content detection and adaptive search guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->