### PR TITLE
fix: update taskRunSpecs pipelineTaskName from clair-scan to roxctl-scan

### DIFF
--- a/.tekton/lightspeed-service-pull-request.yaml
+++ b/.tekton/lightspeed-service-pull-request.yaml
@@ -596,7 +596,7 @@ spec:
         memory: 12Gi
       requests:
         memory: 12Gi
-    pipelineTaskName: clair-scan
+    pipelineTaskName: roxctl-scan
   - computeResources:
       limits:
         memory: 12Gi

--- a/.tekton/lightspeed-service-push.yaml
+++ b/.tekton/lightspeed-service-push.yaml
@@ -596,7 +596,7 @@ spec:
         memory: 12Gi
       requests:
         memory: 12Gi
-    pipelineTaskName: clair-scan
+    pipelineTaskName: roxctl-scan
   - computeResources:
       limits:
         memory: 12Gi


### PR DESCRIPTION
## Summary

- The automated Konflux clair-scan → roxctl-scan migration (commit 1a1e9061) renamed the task in `spec.pipelineSpec.tasks` but missed updating the corresponding `taskRunSpecs` entries.
- This causes Tekton to reject PipelineRuns with a validation error: task name `clair-scan` not found in the pipeline definition.
- Fixes `pipelineTaskName: clair-scan` → `pipelineTaskName: roxctl-scan` in both `lightspeed-service-pull-request.yaml` and `lightspeed-service-push.yaml`.

## Test plan

- [ ] Verify a pull-request PipelineRun starts successfully without the `clair-scan` validation error
- [ ] Verify the push PipelineRun starts successfully
- [ ] Confirm roxctl-scan task runs with the correct memory limits (12Gi)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated pipeline configurations to use the current security scanning task.
  - Ensured the existing 12 GiB memory allocation is applied to the replacement scanning task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->