### PR TITLE
OLS-0000 Sync .ai/spec with current code

### DIFF
--- a/.ai/spec/README.md
+++ b/.ai/spec/README.md
@@ -18,7 +18,7 @@ These specs define the requirements, behaviors, and architecture for the OLS lig
 | [query-processing.md](what/query-processing.md) | 8-stage pipeline from user query to LLM response: redaction, RAG, history, skills, tools, storage |
 | [agent-modes.md](what/agent-modes.md) | ASK vs TROUBLESHOOTING: iteration limits, system prompts, behavioral differences |
 | [conversation-history.md](what/conversation-history.md) | Storage backends, CRUD operations, compression, user isolation, concurrency |
-| [llm-providers.md](what/llm-providers.md) | Provider contract, 8 providers with deviations, parameter system, reasoning models |
+| [llm-providers.md](what/llm-providers.md) | Provider contract, 9 provider types with deviations, parameter system, reasoning models |
 | [rag.md](what/rag.md) | Document retrieval via FAISS, multi-index, BYOK, hybrid RAG (tool/skill filtering only) |
 | [auth.md](what/auth.md) | Three auth modules (k8s, noop, noop-with-token), permission scopes, user identity |
 | [tools.md](what/tools.md) | MCP tool integration: gathering, execution, token budget, filtering, approval workflow |

--- a/.ai/spec/health-report.md
+++ b/.ai/spec/health-report.md
@@ -1,46 +1,91 @@
-> **Superseded.** All issues from this report (2026-05-29) have been resolved. See `verification/spec-verify-2026-07-23.md` for the current verification report.
-
 # Spec health report
 
-Last evaluated: 2026-05-29
-Trigger: structural evaluation (user-invoked)
+Last evaluated: 2026-08-31
+Trigger: staleness + accuracy check (spec-first alignment pass)
 Layout: software (.ai/spec/)
 
 ## Stale
 
-1. **how/query-pipeline.md — tool-calling architecture refactored.** The spec describes `iterate_with_tools()`, `_invoke_llm()`, `_collect_round_llm_chunks()`, and `_process_tool_calls_for_round()` as methods of `DocsSummarizer`. They have been refactored into a separate `LLMExecutionAgent` class in `ols/src/query_helpers/llm_execution_agent.py`. `DocsSummarizer.generate_response()` now delegates to `self._llm_agent.execute()`.
+1. **how/project-structure.md — module map missing shipped files.** The `ols/` code tree
+   now contains several files with no module-map entry:
+   - `src/llms/providers/bedrock.py` (registered as `bedrock` — the AWS Bedrock provider,
+     shipped via OLS-1895) and `src/llms/providers/utils.py` (shared provider helpers, e.g.
+     Vertex OAuth scopes).
+   - `src/tools/offloaded_content.py` (offloads large tool outputs to disk with search+read
+     retrieval; `cleanup_offload_storage()` is called at startup in `app/main.py`).
+   - `utils/audit_logger.py` and `utils/otel.py` (OTel-based audit logging — implements
+     `what/audit-logging.md`).
+   - `src/rag/stop_words.py` and `src/rag_index/solr_support.py` (RAG helpers).
 
-2. **what/system-overview.md — Google Vertex providers shipped.** Rule 11 marks OLS-2521 (Google Gemini) and OLS-2776 (Anthropic) as `[PLANNED]`, but Google Vertex with both Gemini and Claude/Anthropic models is already merged and registered as `google_vertex` and `google_vertex_anthropic` provider types.
+2. **how/project-structure.md — metrics list incomplete.** The `app/metrics/metrics.py` row
+   lists only seven `ols_*` metrics. Code also defines `ols_llm_reasoning_token_total` and the
+   OTel GenAI histograms `gen_ai_client_token_usage`, `gen_ai_client_operation_duration_seconds`,
+   and `gen_ai_execute_tool_duration_seconds` (all already documented in `what/observability.md`).
 
-3. **what/llm-providers.md — same staleness.** Planned Changes section lists OLS-2521 as future work, but Gemini via Vertex is shipped.
+3. **how/project-structure.md — middleware stack stale.** The Middleware section describes only
+   two `@app.middleware` functions and names `rest_api_counter` as the outermost layer. Code adds
+   a third, class-based ASGI middleware `_RequestBodyLimitMiddleware` registered via
+   `app.add_middleware()` as the outermost layer (rejects bodies over
+   `constants.MAX_REQUEST_BODY_SIZE` = 2 MiB with HTTP 413).
+
+4. **how/project-structure.md — stale tool-calling Implementation Note.** The note "Tool calling
+   uses a multi-round streaming loop" attributes `iterate_with_tools()` to `DocsSummarizer`. That
+   loop moved to `LLMExecutionAgent` (`_iterate_with_tools()`, `_invoke_llm()`,
+   `_process_tool_calls_for_round()`, `_collect_round_llm_chunks()`); `DocsSummarizer` delegates
+   via `self._llm_agent.execute()`. (Module map and Data Flow were already updated; this note lagged.)
+
+5. **OLS-3221 markers claim shipped, but the work is largely unshipped.** `what/api.md`,
+   `what/conversation-history.md`, and `how/cache.md` mark PostgreSQL-resilience behavior with
+   `[NEW: OLS-3221]` / `[CHANGED: OLS-3221]` (implying merged), while each file's own Planned
+   Changes section still lists OLS-3221 as `[PLANNED]` — an internal contradiction. Code check:
+   - Shipped: the `@connection` transparent-reconnect decorator and `connected()` liveness check
+     in `utils/postgres.py`; per-instance `_tx_lock` in `postgres_cache.py`.
+   - NOT shipped: background health-check loop, dual-feed health status, statement/lock timeouts,
+     health-status-backed readiness/liveness probes (liveness still returns `alive=True`
+     unconditionally; readiness calls `conversation_cache.ready()` directly), and the config
+     fields `cache_health_check_interval`, `statement_timeout`, `lock_timeout`,
+     `liveness_db_failure_threshold` (absent from `app/models/config.py`).
+   The unshipped markers were changed to `[PLANNED: OLS-3221]` to match code and the convention
+   in README (unimplemented behavior uses `[PLANNED]`).
+
+6. **README.md — provider count.** The what/ index called `llm-providers.md` "8 providers"; there
+   are now nine provider types (OpenAI, Azure OpenAI, WatsonX, RHOAI vLLM, RHEL AI vLLM, Google
+   Vertex Gemini, Google Vertex Anthropic, AWS Bedrock, Fake).
 
 ## Missing
 
-1. **how/auth.md** — Auth implementation spans 5 files and 549 LOC (K8s TokenReview, SubjectAccessReview, cluster ID retrieval, multiple auth strategies). Complex enough to warrant its own how/ file.
+1. **what/api.md — request-body size limit not specced as a behavioral rule.** The Middleware
+   section (rules 26–31) does not mention the 2 MiB request-body limit that returns HTTP 413.
+   This is shipped, client-visible behavior. Left for human decision to avoid inventing a
+   behavioral rule; the implementation detail was added to `how/project-structure.md`.
 
-2. **how/quota.md** — Quota system spans 6 files and 420 LOC (multi-limiter coordination, PostgreSQL state, scheduler daemon thread, token usage history). No how/ file documents the implementation patterns.
-
-3. **how/project-structure.md — missing LLMExecutionAgent.** The module map does not include `ols/src/query_helpers/llm_execution_agent.py`, which now contains the core tool-calling loop.
+2. **Offloaded tool-output storage has no behavioral spec.** `src/tools/offloaded_content.py`
+   (offload large tool outputs to disk, search+read retrieval, `ols_config.offload_storage_path`)
+   is not described in `what/tools.md` or `how/tools.md`. Only the module-map pointer was added.
+   Human should decide whether it warrants behavioral coverage.
 
 ## Structural concerns
 
-1. **what/api.md is 778 lines** — largest spec file by a wide margin. Covers all 16 endpoints in one file. Could be split by endpoint category (query, conversations, feedback/mcp, infrastructure) if it continues growing.
+1. **what/audit-logging.md self-referential "parent spec".** Lines 3 and 145 cite the parent spec
+   as `ols/.ai/spec/what/audit-logging.md`, which resolves to this same file (and the `ols/` prefix
+   does not exist in this repo). Likely intended to point at a workspace-level or cross-repo parent
+   spec. Not edited — the intended target is unknown; flagged for human clarification.
 
-2. **what/observability.md minor boundary violation** — references `constants.py` by file name. What/ files should be implementation-agnostic; this should be generalized to "defined as a module constant."
+2. **what/api.md is large (~789 lines).** Unchanged concern from prior reports; splitting by
+   endpoint category is optional and only worthwhile if it keeps growing.
 
 ## Findability issues
 
-None. The cross-reference table added in the alignment pass maps all what/ to how/ files. The spec index in README.md is comprehensive.
+None new. The README index and what/↔how/ cross-reference table remain comprehensive.
 
-## No issues
+## No issues (verified current)
 
-- All 7 provider files in code register 8 provider types that match the spec (openai, azure_openai, watsonx, rhoai_vllm, rhelai_vllm, google_vertex, google_vertex_anthropic, fake_provider)
-- All 16 API endpoints in code match what/api.md
-- Skills system (`ols/src/skills/`) matches what/skills.md
-- RAG system (`ols/src/rag/`, `ols/src/rag_index/`) matches what/rag.md
-- Cache implementation matches how/cache.md
-- Config implementation matches how/config.md
-- LLM provider registry and loader match how/llm-providers.md
-- Tool execution and approval match how/tools.md
-- What/how separation is well-maintained across all files
-- No unacceptable duplication between what/ and how/ layers
+- Provider registry: nine `@register_llm_provider_as` types match `what/llm-providers.md`
+  (bedrock included) and `constants.SUPPORTED_PROVIDER_TYPES`.
+- Reasoning-token support (`[PLANNED: OLS-3442]`) is correctly still planned: no `reasoning_config`
+  in provider code, no `ChatVLLMReasoning`; OpenAI still uses `reasoning_effort` model-name detection.
+- `what/observability.md` metric names, labels, and GenAI histograms match `app/metrics/metrics.py`.
+- `what/audit-logging.md` span/attribute model matches `utils/audit_logger.py` + `utils/otel.py`.
+- All 16 API endpoints and routers match `what/api.md` and `how/project-structure.md`.
+- Cache, config, quota, auth how/ specs match their implementations (aside from the OLS-3221
+  markers noted above).

--- a/.ai/spec/how/cache.md
+++ b/.ai/spec/how/cache.md
@@ -219,26 +219,23 @@ objects. Deserialization reads the `bytea` column as `memoryview`, converts to
   `pg_advisory_xact_lock` provides row-level write serialization across
   processes/pods.
 - **Connection decorator**: The `@connection` decorator on `PostgresBase`
-  checks connection liveness and reconnects before each public method call.
-  It distinguishes connection errors (broken TCP, closed connection) from
-  operational errors (SQL failures on a live connection). On connection errors,
-  it attempts to re-establish via `connect()` before retrying the operation.
-  On operational errors, it wraps in `CacheError` and propagates immediately.
-  When a connection error is detected, it also immediately marks the shared
-  health status as unhealthy (dual-feed model, see `what/conversation-history.md`
-  Rule 23). [CHANGED: OLS-3221]
-- **Operation timeouts**: All PostgreSQL operations use `statement_timeout`
-  to prevent indefinite blocking on degraded databases. The `_tx_lock` mutex
-  uses bounded acquisition timeout to prevent application-level deadlocks
-  when a thread is stuck waiting on a hung PostgreSQL advisory lock.
-  [NEW: OLS-3221]
-- **Background health-check loop**: A background thread runs on a dedicated
-  connection (independent of the cache operation connection and `_tx_lock`)
-  to periodically verify PostgreSQL connectivity and attempt reconnection.
-  It is the sole component that restores health status to healthy after
-  confirming the database is reachable. The readiness and liveness probes
+  checks connection liveness and reconnects transparently before each public
+  method call: on a broken/closed connection it re-establishes via `connect()`
+  and retries the operation. [PLANNED: OLS-3221] Distinguish connection errors
+  (broken TCP, closed connection) from operational errors (SQL failures on a
+  live connection) — wrapping the latter in `CacheError` and propagating
+  immediately — and, on a connection error, immediately mark the shared health
+  status as unhealthy (dual-feed model, see `what/conversation-history.md` Rule 24).
+- **Operation timeouts** [PLANNED: OLS-3221]: All PostgreSQL operations use
+  `statement_timeout` to prevent indefinite blocking on degraded databases. The
+  `_tx_lock` mutex uses a bounded acquisition timeout to prevent application-level
+  deadlocks when a thread is stuck waiting on a hung PostgreSQL advisory lock.
+- **Background health-check loop** [PLANNED: OLS-3221]: A background thread runs
+  on a dedicated connection (independent of the cache operation connection and
+  `_tx_lock`) to periodically verify PostgreSQL connectivity and attempt
+  reconnection. It is the sole component that restores health status to healthy
+  after confirming the database is reachable. The readiness and liveness probes
   read this loop's status without performing their own DB queries.
-  [NEW: OLS-3221]
 
 ### Capacity Eviction (Postgres)
 

--- a/.ai/spec/how/project-structure.md
+++ b/.ai/spec/how/project-structure.md
@@ -8,7 +8,7 @@ OpenShift LightSpeed (OLS) is a FastAPI service organized into four layers: `app
 
 | Path | Purpose |
 |---|---|
-| `app/main.py` | Creates the `FastAPI` instance, registers middleware (metrics counter, security headers, request/response logging), calls `routers.include_routers(app)`, optionally mounts Gradio dev UI, and stores config status. The module-level `app` object is the ASGI entry point referenced by Uvicorn as `ols.app.main:app`. |
+| `app/main.py` | Creates the `FastAPI` instance, registers middleware (metrics counter, security headers, request/response logging, and the outermost `_RequestBodyLimitMiddleware`), calls `routers.include_routers(app)`, optionally mounts Gradio dev UI, clears offloaded tool-output storage via `cleanup_offload_storage()`, and stores config status. The module-level `app` object is the ASGI entry point referenced by Uvicorn as `ols.app.main:app`. |
 | `app/routers.py` | Single function `include_routers(app)` that attaches all endpoint routers. v1-prefixed: `ols`, `streaming_ols`, `mcp_client_headers`, `mcp_apps`, `tool_approvals`, `feedback`, `conversations`. Root-level: `health`, `metrics`, `authorized`. |
 | `app/endpoints/ols.py` | `POST /v1/query` -- synchronous query endpoint. Orchestrates the full request lifecycle: auth, redaction, attachment processing, provider/model validation, quota check, `DocsSummarizer` invocation, conversation history storage, transcript storage, and quota consumption. |
 | `app/endpoints/streaming_ols.py` | `POST /v1/streaming_query` -- streaming variant of the query endpoint. Uses the same `DocsSummarizer` but yields `StreamedChunk` objects via SSE. |
@@ -19,7 +19,7 @@ OpenShift LightSpeed (OLS) is a FastAPI service organized into four layers: `app
 | `app/endpoints/mcp_client_headers.py` | MCP client header management endpoint. |
 | `app/endpoints/tool_approvals.py` | Human-in-the-loop tool approval endpoint. |
 | `app/endpoints/authorized.py` | Authorization check endpoint. |
-| `app/metrics/metrics.py` | Prometheus metric definitions: `ols_rest_api_calls_total`, `ols_response_duration_seconds`, `ols_llm_calls_total`, `ols_llm_calls_failures_total`, `ols_llm_token_sent_total`, `ols_llm_token_received_total`, `ols_provider_model_configuration`. Exposes `GET /metrics` with auth. |
+| `app/metrics/metrics.py` | Prometheus metric definitions: `ols_rest_api_calls_total`, `ols_response_duration_seconds`, `ols_llm_calls_total`, `ols_llm_calls_failures_total`, `ols_llm_token_sent_total`, `ols_llm_token_received_total`, `ols_llm_reasoning_token_total`, `ols_provider_model_configuration`, plus the OTel GenAI histograms `gen_ai_client_token_usage`, `gen_ai_client_operation_duration_seconds`, and `gen_ai_execute_tool_duration_seconds` (see `what/observability.md`). Exposes `GET /metrics` with auth. |
 | `app/metrics/token_counter.py` | `GenericTokenCounter` (LangChain callback) and `TokenMetricUpdater` (context manager) for tracking per-request token usage and updating Prometheus counters. |
 | `app/models/config.py` | All Pydantic configuration models: `Config`, `OLSConfig`, `LLMProviders`, `ProviderConfig`, `ModelConfig`, `DevConfig`, `ConversationCacheConfig`, `QuotaHandlersConfig`, `MCPServers`, `MCPServerConfig`, `ToolsApprovalConfig`, etc. |
 | `app/models/models.py` | Request/response Pydantic models: `LLMRequest`, `LLMResponse`, `CacheEntry`, `SummarizerResponse`, `StreamedChunk`, `RagChunk`, `Attachment`, `TokenCounter`, health response models, etc. |
@@ -46,8 +46,10 @@ OpenShift LightSpeed (OLS) is a FastAPI service organized into four layers: `app
 | `src/llms/providers/watsonx.py` | IBM WatsonX provider implementation. |
 | `src/llms/providers/rhoai_vllm.py` | Red Hat OpenShift AI vLLM provider. |
 | `src/llms/providers/rhelai_vllm.py` | RHEL AI vLLM provider. |
-| `src/llms/providers/google_vertex.py` | Google Vertex AI (Gemini and Anthropic Claude on Vertex). |
+| `src/llms/providers/google_vertex.py` | Google Vertex AI. Registers both `google_vertex` (Gemini via `ChatGoogleGenerativeAI`) and `google_vertex_anthropic` (Claude via `ChatAnthropicVertex`). |
+| `src/llms/providers/bedrock.py` | AWS Bedrock provider (Mantle gateway). Routes to `ChatBedrockConverse` (anthropic.*) or `ChatOpenAI` (openai.* / others) by model prefix; supports bearer-token and IAM/STS auth. |
 | `src/llms/providers/fake_provider.py` | Fake provider for testing and load testing. |
+| `src/llms/providers/utils.py` | Shared provider helpers (e.g. `VERTEX_AI_OAUTH_SCOPES` and credential parsing utilities). |
 | `src/prompts/prompts.py` | System prompt templates (`QUERY_SYSTEM_INSTRUCTION`, `TROUBLESHOOTING_SYSTEM_INSTRUCTION`). |
 | `src/prompts/prompt_generator.py` | `GeneratePrompt` class that assembles `ChatPromptTemplate` from query, RAG context, history, system prompt, tool-calling flag, mode, cluster version, and optional skill content. |
 | `src/query_helpers/query_helper.py` | `QueryHelper` base class for all query processing. Resolves provider/model defaults, selects system prompt by mode (`ask` or `troubleshooting`), and stores the LLM loader callable. |
@@ -63,9 +65,12 @@ OpenShift LightSpeed (OLS) is a FastAPI service organized into four layers: `app
 | `src/quota/quota_exceed_error.py` | `QuotaExceedError` exception. |
 | `src/quota/token_usage_history.py` | `TokenUsageHistory` -- records per-user token consumption to PostgreSQL for analytics. |
 | `src/rag/hybrid_rag.py` | Hybrid RAG retrieval logic. |
+| `src/rag/stop_words.py` | `ENGLISH_STOP_WORDS` -- inlined English stop-word set for hybrid RAG tokenization and Solr query normalization (avoids an NLTK dependency). |
 | `src/rag_index/index_loader.py` | `IndexLoader` -- loads LlamaIndex vector indexes from configured reference content paths. Provides `get_retriever()` and `embed_model` for reuse. Excluded from MyPy type checking. |
+| `src/rag_index/solr_support.py` | Solr hybrid-search client (`POST /hybrid-search`, lexical-primary edismax with KNN rerank). Dedupes hits by parent and truncates to a configured max. |
 | `src/skills/skills_rag.py` | `SkillsRAG` -- hybrid BM25 + vector retrieval for skill selection. `load_skills_from_directory()` parses skill files with YAML frontmatter. |
 | `src/tools/tools.py` | `execute_tool_calls_stream()` -- runs resolved MCP tool calls with token budget enforcement and approval flow. `enforce_tool_token_budget()` truncates tool outputs that exceed remaining budget. |
+| `src/tools/offloaded_content.py` | Offloads oversized tool outputs to disk (search + read retrieval) instead of inlining them into the prompt. `cleanup_offload_storage()` clears the offload directory at startup (called from `app/main.py`). Storage path from `ols_config.offload_storage_path`. |
 | `src/tools/approval.py` | `PendingApprovalStoreBase` and `create_pending_approval_store()` -- human-in-the-loop tool approval infrastructure. |
 | `src/tools/tools_rag/hybrid_tools_rag.py` | `ToolsRAG` -- hybrid BM25 + vector retrieval (using qdrant-client and rank-bm25) for filtering MCP tools by query relevance before sending to the LLM. |
 | `src/ui/gradio_ui.py` | `GradioUI` -- optional development UI that mounts a Gradio interface onto the FastAPI app. |
@@ -86,8 +91,10 @@ OpenShift LightSpeed (OLS) is a FastAPI service organized into four layers: `app
 | `utils/environments.py` | `configure_gradio_ui_envs()` and `configure_hugging_face_envs()` -- sets environment variables before other imports. |
 | `utils/checks.py` | `InvalidConfigurationError` and validation helpers. |
 | `utils/errors_parsing.py` | `parse_generic_llm_error()` and `handle_known_errors()` -- translates LLM provider exceptions into HTTP status codes and user-facing messages. |
-| `utils/postgres.py` | PostgreSQL connection utilities. |
+| `utils/postgres.py` | PostgreSQL connection utilities. `PostgresBase`, the `@connection` auto-reconnect decorator, and the `connected()` liveness check shared by Postgres-backed components. |
 | `utils/pyroscope.py` | Optional Pyroscope profiling integration. |
+| `utils/otel.py` | OpenTelemetry tracing setup for audit spans (TracerProvider, OTLP + stdout/console exporters). Implements the transport described in `what/audit-logging.md`. |
+| `utils/audit_logger.py` | Structured audit logger emitting OTel span events (`gen_ai.choice`, `tool.result`) for compliance. Implements `what/audit-logging.md`. |
 
 ### `ols/runners/` -- Process entry points
 
@@ -238,9 +245,10 @@ All endpoints use `APIRouter` instances with tag grouping. The `include_routers(
 
 ### Middleware stack (`app/main.py`)
 
-Two middleware functions registered via `@app.middleware("")`:
-- `log_requests_responses` -- debug-level request/response body and header logging (inner, runs first).
-- `rest_api_counter` -- Prometheus histogram for response duration, counter for API calls, and security header injection on non-health endpoints (outer, runs second).
+Two middleware functions registered via `@app.middleware("")`, plus one class-based ASGI middleware added via `app.add_middleware()`:
+- `log_requests_responses` -- debug-level request/response body and header logging (innermost, runs first).
+- `rest_api_counter` -- Prometheus histogram for response duration, counter for API calls, and security header injection on non-health endpoints.
+- `_RequestBodyLimitMiddleware` -- rejects requests whose body exceeds `constants.MAX_REQUEST_BODY_SIZE` (2 MiB) with HTTP 413. Because Starlette applies middleware outermost-first in reverse registration order, this is registered *after* the two `@app.middleware` functions so it becomes the outermost layer and can reject an oversized body before the debug logger buffers it.
 
 ## Integration Points
 
@@ -310,7 +318,7 @@ In `app/endpoints/ols.py` and `app/metrics/metrics.py`, `auth_dependency = get_a
 
 ### Tool calling uses a multi-round streaming loop
 
-`DocsSummarizer.iterate_with_tools()` implements the agentic tool-calling loop. It streams LLM chunks, detects tool call requests, executes them via MCP, appends results to the message history, and re-invokes the LLM -- up to `max_rounds` iterations. The final round binds tools with `tool_choice="none"` to force a text-only response. Tool outputs are truncated by `enforce_tool_token_budget()` when they exceed the remaining token budget.
+`LLMExecutionAgent` implements the agentic tool-calling loop (`_iterate_with_tools()`, `_invoke_llm()`, `_collect_round_llm_chunks()`, `_process_tool_calls_for_round()`); `DocsSummarizer.generate_response()` delegates to `self._llm_agent.execute()`. It streams LLM chunks, detects tool call requests, executes them via MCP, appends results to the message history, and re-invokes the LLM -- up to `max_rounds` iterations. The final round binds tools with `tool_choice="none"` to force a text-only response. Tool outputs are truncated by `enforce_tool_token_budget()` when they exceed the remaining token budget.
 
 ### Entry point and build system
 

--- a/.ai/spec/what/api.md
+++ b/.ai/spec/what/api.md
@@ -43,8 +43,8 @@ The REST API is the only external interface to the OpenShift LightSpeed service.
 ### Infrastructure Endpoints
 
 22. `POST /authorized` validates the caller's credentials and authorization. The authentication check itself is the purpose of this endpoint. No `/v1` prefix.
-23. `GET /readiness` checks three subsystems: RAG index loaded (if configured), default LLM reachable, and conversation cache health status. All three must pass. When the PostgreSQL cache backend is configured, cache health is read from the background health-check loop's last-known status (see `what/conversation-history.md`, Rules 22–23) rather than performing a direct database query. This ensures the readiness probe is non-blocking and immune to deadlocks in the cache operation path. The LLM readiness result is cached for a configurable duration. Returns 503 with cause if any subsystem fails. [CHANGED: OLS-3221]
-24. `GET /liveness` checks that the process is running and, when the PostgreSQL cache backend is configured, reads the database health status from the background health-check loop. If the loop has recorded N consecutive unhealthy readings (configurable via `liveness_db_failure_threshold`, default 3), the probe returns HTTP 503 with `{"alive": false, "reason": "database unreachable"}`. If no PostgreSQL backend is configured (in-memory cache), the probe always returns `{"alive": true}`. This ensures the liveness probe is non-blocking and only triggers a pod restart after sustained failure that the background loop could not self-heal. [CHANGED: OLS-3221]
+23. `GET /readiness` checks three subsystems: RAG index loaded (if configured), default LLM reachable, and conversation cache ready (`Cache.ready()`; for PostgreSQL this polls the connection directly). All three must pass. The LLM readiness result is cached for a configurable duration. Returns 503 with cause if any subsystem fails. [PLANNED: OLS-3221] Cache health will instead be read from a background health-check loop's last-known status (see `what/conversation-history.md`, Rules 23–24) rather than a direct database query, making the probe non-blocking and immune to deadlocks in the cache operation path.
+24. `GET /liveness` returns `{"alive": true}` whenever the process is running. [PLANNED: OLS-3221] When the PostgreSQL cache backend is configured, the probe will read the database health status from the background health-check loop and, after N consecutive unhealthy readings (configurable via `liveness_db_failure_threshold`, default 3), return HTTP 503 with `{"alive": false, "reason": "database unreachable"}`. With the in-memory cache it always returns `{"alive": true}`. This keeps the probe non-blocking and only triggers a pod restart after sustained failure the background loop could not self-heal.
 25. `GET /metrics` returns Prometheus metrics in exposition format. Requires `ols-metrics-access` scope. No version prefix.
 
 ---
@@ -495,7 +495,7 @@ None required.
 
 Kubernetes readiness probe. No authentication required. No version prefix.
 
-Checks three subsystems: RAG index loaded (if configured), default LLM reachable and responsive, and conversation cache health status. When the PostgreSQL cache backend is configured, cache health is read from the background health-check loop's last-known status rather than performing a direct database query. This ensures the readiness probe is non-blocking and immune to deadlocks in the cache operation path. All three subsystems must pass. The LLM readiness result is cached; once confirmed ready, subsequent calls may return the cached result for a configurable duration (`expire_llm_is_ready_persistent_state`). [CHANGED: OLS-3221]
+Checks three subsystems: RAG index loaded (if configured), default LLM reachable and responsive, and conversation cache ready (`Cache.ready()`; PostgreSQL polls the connection directly). All three subsystems must pass. The LLM readiness result is cached; once confirmed ready, subsequent calls may return the cached result for a configurable duration (`expire_llm_is_ready_persistent_state`). [PLANNED: OLS-3221] Cache health will be read from a background health-check loop's last-known status rather than a direct database query, making the probe non-blocking and immune to deadlocks in the cache operation path.
 
 #### Response 200 (ReadinessResponse)
 
@@ -512,15 +512,15 @@ Structured error with cause indicating which subsystem is not ready: `"Index is 
 
 ### GET /liveness
 
-Kubernetes liveness probe. No authentication required. No version prefix. When the PostgreSQL cache backend is configured, reads the database health status from the background health-check loop's last-known status. Returns HTTP 503 after sustained database unavailability (configurable consecutive failure threshold). When no PostgreSQL backend is configured (in-memory cache), always succeeds if the process is running. [CHANGED: OLS-3221]
+Kubernetes liveness probe. No authentication required. No version prefix. Returns `{"alive": true}` whenever the process is running. [PLANNED: OLS-3221] When the PostgreSQL cache backend is configured, the probe will read the database health status from the background health-check loop's last-known status and return HTTP 503 after sustained database unavailability (configurable consecutive failure threshold); with the in-memory cache it always succeeds while the process is running.
 
 #### Response 200 (LivenessResponse)
 
 | Field | Type    | Description |
 |-------|---------|-------------|
-| alive | boolean | `true` when process is running and DB health threshold is not exceeded |
+| alive | boolean | `true` while the process is running (and, once OLS-3221 ships, the DB health threshold is not exceeded) |
 
-#### Response 503 (LivenessResponse)
+#### Response 503 (LivenessResponse) [PLANNED: OLS-3221]
 
 | Field  | Type    | Description |
 |--------|---------|-------------|
@@ -755,8 +755,8 @@ The service applies the following cross-cutting behaviors to all requests:
 - `ols_config.user_data_collection.transcripts_storage` -- filesystem path for transcript JSON files.
 - `ols_config.logging_config.suppress_metrics_in_log` -- suppress debug logging for `/metrics` requests.
 - `ols_config.expire_llm_is_ready_persistent_state` -- duration (seconds) to cache the LLM readiness check result. Negative or unset means cache indefinitely once ready.
-- `ols_config.liveness_db_failure_threshold` -- number of consecutive unhealthy readings from the background health-check loop before the liveness probe fails (default: 3). [NEW: OLS-3221]
-- `ols_config.cache_health_check_interval` -- interval in seconds for the background PostgreSQL health-check loop (default: 30). [NEW: OLS-3221]
+- `ols_config.liveness_db_failure_threshold` -- [PLANNED: OLS-3221] number of consecutive unhealthy readings from the background health-check loop before the liveness probe fails (default: 3).
+- `ols_config.cache_health_check_interval` -- [PLANNED: OLS-3221] interval in seconds for the background PostgreSQL health-check loop (default: 30).
 - `ols_config.reference_content` -- when set, the readiness probe checks that the RAG index is loaded.
 - `dev_config.disable_tls` -- disables TLS; affects whether HSTS header is added.
 - `dev_config.enable_dev_ui` -- mounts an embedded Gradio UI at the application root.

--- a/.ai/spec/what/conversation-history.md
+++ b/.ai/spec/what/conversation-history.md
@@ -42,7 +42,9 @@ The conversation history subsystem preserves prior exchanges within a conversati
 
 19. The in-memory cache must be a singleton: all threads within a process share one cache instance.
 
-### PostgreSQL Resilience [NEW: OLS-3221]
+### PostgreSQL Resilience [PLANNED: OLS-3221]
+
+_Already shipped: the `@connection` auto-reconnect decorator and `connected()` liveness check in `utils/postgres.py`, and the per-instance `_tx_lock` in `postgres_cache.py`. The remaining behavior below — connection/operational error distinction feeding health status, statement/lock timeouts, the background health-check loop, dual-feed health status, and health-status-backed readiness/liveness probes — is planned._
 
 20. Cache operations must distinguish between *connection errors* (broken TCP, connection refused, closed connection) and *operational errors* (SQL failures on a live connection such as constraint violations, disk full, or query syntax errors). Connection errors trigger the reconnection path via the `@connection` decorator. Operational errors are wrapped in `CacheError` and propagated immediately — reconnection would not resolve them.
 
@@ -69,9 +71,9 @@ The conversation history subsystem preserves prior exchanges within a conversati
 | `ols_config.conversation_cache.postgres.ca_cert_path` | Path to CA certificate for PostgreSQL TLS |
 | `ols_config.conversation_cache.postgres.max_entries` | Maximum total message entries for PostgreSQL cache |
 | `ols_config.history_compression_enabled` | Whether to use LLM-based history compression (default: true) |
-| `ols_config.cache_health_check_interval` | Interval in seconds for the background PostgreSQL health-check loop (default: 30) [NEW: OLS-3221] |
-| `ols_config.conversation_cache.postgres.statement_timeout` | Statement-level timeout in milliseconds for PostgreSQL operations (default: 5000) [NEW: OLS-3221] |
-| `ols_config.conversation_cache.postgres.lock_timeout` | Timeout in seconds for Python-level `_tx_lock` acquisition (default: 10) [NEW: OLS-3221] |
+| `ols_config.cache_health_check_interval` | [PLANNED: OLS-3221] Interval in seconds for the background PostgreSQL health-check loop (default: 30) |
+| `ols_config.conversation_cache.postgres.statement_timeout` | [PLANNED: OLS-3221] Statement-level timeout in milliseconds for PostgreSQL operations (default: 5000) |
+| `ols_config.conversation_cache.postgres.lock_timeout` | [PLANNED: OLS-3221] Timeout in seconds for Python-level `_tx_lock` acquisition (default: 10) |
 
 ## Constraints
 


### PR DESCRIPTION
Automated spec-drift sync from the spec-first **health** + **init (alignment)** skills. Compares `.ai/spec` against current code and corrects stale references, retires `[PLANNED]` markers for shipped work, and fixes module-map drift. Adds/updates `health-report.md`.

**Highlights:** add shipped modules (incl. Bedrock provider); middleware stack; tool-loop moved to LLMExecutionAgent; reconcile [OLS-3221](https://redhat.atlassian.net/browse/OLS-3221) status

Spec-only change (`.ai/spec/**` only), pre-push reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated provider specifications to cover 9 provider types.
  - Refreshed health, project structure, API, cache, and conversation-history documentation.
  - Clarified PostgreSQL connection liveness checks, reconnection behavior, and safeguards against unsafe retries.
  - Distinguished currently available behavior from planned resilience and health-check improvements.
  - Documented observability metrics, storage cleanup, middleware, and tool-calling components.
  - Recorded resolved health-report findings and updated related rule references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->