### PR TITLE
OLS-3450 Update service specs for credential hot-reload

### DIFF
--- a/.ai/spec/how/config.md
+++ b/.ai/spec/how/config.md
@@ -138,6 +138,12 @@ config.reload_from_yaml_file(path)
 
 This supports both Kubernetes secret volume mounts (directory of files) and explicit file paths. The `directory_name_expected` flag (used by Azure) enforces directory-only mode. The `raise_on_error` flag controls whether missing secrets are fatal or silently ignored.
 
+### Credential hot-reload (OLS-3450)
+
+`checks.read_secret_from_path(path, default_filename)` is a lightweight re-read helper designed for per-request use. Unlike `read_secret()` (which takes a dict lookup), it takes a concrete path string and returns `None` on `OSError` (logging a warning). It is called by `ProviderConfig.get_credentials()` and `get_aws_credentials()` when `_credential_hot_reload` is `True`.
+
+The flag propagates through the config hierarchy: `Config.__init__` reads `credential_hot_reload` from the `ols_config` section and passes it to `LLMProviders(data, credential_hot_reload=...)`, which passes it to each `ProviderConfig(data, credential_hot_reload=...)`. `ProviderConfig` stores it as `_credential_hot_reload` (Pydantic `PrivateAttr`) alongside `_credentials_path`.
+
 ### TLS profile to cipher suite mapping
 
 `TLSSecurityProfile` validates against `ols/utils/tls.py`:

--- a/.ai/spec/how/llm-providers.md
+++ b/.ai/spec/how/llm-providers.md
@@ -176,7 +176,7 @@ WatsonX also passes `params=self.params` to `ChatWatsonx` (as a nested dict), un
 
 `BedrockParameters` is a single union set covering kwargs from both `ChatBedrockConverse` and `ChatOpenAI`. `BedrockParametersMapping` maps `max_tokens_for_response` to `max_completion_tokens` (the OpenAI name). For the Anthropic branch, `load()` pops `max_completion_tokens` from params since `ChatBedrockConverse` uses `max_tokens` natively.
 
-Auth supports two pathways: Bearer token (Bedrock API key via `credentials_path` file) and IAM credentials (`aws_access_key_id`, `aws_secret_access_key`, optional `role_arn` read from the `credentials_path` directory). `_has_aws_credentials()` selects the path. For IAM, Anthropic models pass a pre-configured boto3 client; OpenAI/DeepSeek models use `httpx-aws-auth` SigV4 signing injected into `http_client`/`http_async_client`.
+Auth supports two pathways: Bearer token (Bedrock API key via `get_credentials()`) and IAM credentials (`get_aws_credentials()` returns access key, secret key, optional role ARN). For IAM, Anthropic models pass a pre-configured boto3 client; OpenAI/DeepSeek models use `httpx-aws-auth` SigV4 signing injected into `http_client`/`http_async_client`. When credential hot-reload is enabled (OLS-3450), both pathways re-read credentials from disk on each `load()` call.
 
 ### Reasoning model handling
 

--- a/.ai/spec/what/config.md
+++ b/.ai/spec/what/config.md
@@ -28,6 +28,7 @@ The configuration system loads, validates, and manages the single YAML file that
 
 12. All credentials (API tokens, passwords, client secrets) must be read from files referenced by path in the configuration. Plaintext credential values must never appear directly in the YAML.
 13. Credential reading uses `checks.read_secret()`, which supports both file paths (reads the file content) and directory paths (reads a default-named file within the directory, e.g., `apitoken` for API tokens).
+13a. When `ols_config.credential_hot_reload` is `true` (OLS-3450), LLM provider credentials are re-read from disk on each request via `ProviderConfig.get_credentials()` and `checks.read_secret_from_path()`. This allows Kubernetes secret rotation to take effect without a pod restart. The `credential_hot_reload` flag is propagated from `Config` → `LLMProviders` → each `ProviderConfig` during construction. On read failure, the last good credential value is retained.
 14. The TLS key password, if needed, must also be read from a file path (`tls_key_password_path`), not stored as plaintext.
 
 ### Default Values
@@ -73,6 +74,7 @@ The YAML file has four top-level sections:
 | `ols_config.history_compression_enabled` | bool | true | Toggle conversation history compression | -- |
 | `ols_config.max_iterations` | int | mode-dependent | Tool-calling loop iteration cap (ask=5, troubleshooting=15) | -- |
 | `ols_config.tool_round_cap_fraction` | float | 0.6 | Max fraction of remaining tool token budget usable per round (0.3--0.8) | -- |
+| `ols_config.credential_hot_reload` | bool | false | When true, LLM credentials are re-read from disk on each request (OLS-3450) |
 | `ols_config.max_workers` | int | 1 | Number of concurrent workers | -- |
 | `ols_config.expire_llm_is_ready_persistent_state` | int | -1 | Expiration for LLM readiness cache (-1 = never) | -- |
 | `ols_config.tlsSecurityProfile` | object | none | TLS security profile for service endpoints | see what/security.md |
@@ -158,4 +160,5 @@ Each provider entry under `llm_providers` supports:
 
 ## Planned Changes
 
+- [OLS-3450] Credential hot-reload: `ols_config.credential_hot_reload` field. Propagated to `ProviderConfig` to enable per-request credential re-reads via `get_credentials()`. See design spec `docs/superpowers/specs/2026-09-01-credential-hot-reload-design.md`.
 - [PLANNED: OLS-2874] Enable Skills Configuration in OLSConfig CRD -- expose `ols_config.skills` through the operator's custom resource definition, allowing skills to be configured declaratively via the OLSConfig CR.

--- a/.ai/spec/what/llm-providers.md
+++ b/.ai/spec/what/llm-providers.md
@@ -29,7 +29,7 @@ Every provider must satisfy all of the following:
 
 9. Provider-specific configuration (e.g., `openai_config`, `azure_openai_config`) takes precedence over top-level provider fields (`url`, `credentials`) whenever both are present.
 
-10. Credentials must be read from files on disk (via `credentials_path`), not from environment variables or inline config values. The file path points to a directory or file containing the secret.
+10. Credentials must be read from files on disk (via `credentials_path`), not from environment variables or inline config values. The file path points to a directory or file containing the secret. When credential hot-reload is enabled (`credential_hot_reload: true`, OLS-3450), all providers call `ProviderConfig.get_credentials()` (or `get_aws_credentials()` for Bedrock IAM) which re-reads the credential file on every invocation via `read_secret_from_path()`. On read failure, the last successfully read value is retained. When hot-reload is disabled (default), `get_credentials()` returns the startup-cached value.
 
 ### Reasoning Model Support
 
@@ -206,6 +206,7 @@ The following sections describe only what differs from the standard contract abo
 
 ## Planned Changes
 
+- [OLS-3450] Credential hot-reload: all providers call `get_credentials()` / `get_aws_credentials()` instead of accessing `self.credentials` directly. When `credential_hot_reload` is enabled, credentials are re-read from disk on each call via `read_secret_from_path()`. See design spec `docs/superpowers/specs/2026-09-01-credential-hot-reload-design.md`.
 - ~~[PLANNED: OLS-1680] STS/IAM role authentication for the AWS Bedrock provider~~ — Implemented in OLS-1895. IAM credentials (access key + secret key) and STS assume-role supported. E2E coverage tracked by [OLS-3327](https://redhat.atlassian.net/browse/OLS-3327).
 - [PLANNED: OLS-3442] Reasoning token support: per-model `reasoning_config` for all providers, vLLM `ChatVLLMReasoning` subclass, remove model-name detection from OpenAI/Azure providers. Replaces `reasoning_effort`, `reasoning_summary`, and `verbosity` fields.
 - [PLANNED: OLS-2776] Support Anthropic as a direct LLM provider (not via Google Vertex), communicating with the Anthropic API natively. Anthropic models are currently available through the Google Vertex Anthropic provider.

--- a/.ai/spec/what/security.md
+++ b/.ai/spec/what/security.md
@@ -43,7 +43,7 @@ The service must protect customer data, enforce transport-layer encryption, reda
 
 ### Credential handling
 
-23. API keys, passwords, and other secrets must never appear as plaintext values in the configuration file. All credentials must be specified as file paths; the service reads the secret value from the referenced file at startup.
+23. API keys, passwords, and other secrets must never appear as plaintext values in the configuration file. All credentials must be specified as file paths; the service reads the secret value from the referenced file at startup. When credential hot-reload is enabled (`ols_config.credential_hot_reload: true`, OLS-3450), LLM provider credentials are re-read from disk on each request via `ProviderConfig.get_credentials()` so that secret rotation takes effect without a pod restart. On read failure, the last good value is retained.
 24. Credential files may be individual files or directories containing named secret files (e.g., `apitoken`, `client_id`, `tenant_id`, `client_secret`).
 25. Sensitive HTTP request headers (`authorization`, `proxy-authorization`, `cookie`) and response headers (`www-authenticate`, `proxy-authenticate`, `set-cookie`) must be redacted in debug-level request/response logs.
 


### PR DESCRIPTION
Spec-only change for [OLS-3450](https://redhat.atlassian.net/browse/OLS-3450). Updated security.md, llm-providers.md, config.md for per-request credential re-read via get_credentials().

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the new optional credential hot-reload setting.
  * Explained how enabling hot reload applies updated provider credentials without restarting the service.
  * Documented fallback behavior when refreshed credentials cannot be read.
  * Updated Bedrock authentication guidance for bearer-token and IAM credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->