### PR TITLE
OLS-2190: pass username and version for on-prem watsonx

### DIFF
--- a/.ai/spec/how/llm-providers.md
+++ b/.ai/spec/how/llm-providers.md
@@ -164,6 +164,8 @@ WatsonX uses IBM's `GenTextParamsMetaNames` constants for parameter keys instead
 
 WatsonX also passes `params=self.params` to `ChatWatsonx` (as a nested dict), unlike OpenAI-compatible providers that spread params as `**self.params`.
 
+IBM Cloud SaaS (`*.ml.cloud.ibm.com`, including the default `https://us-south.ml.cloud.ibm.com`) constructs `ChatWatsonx` with `apikey` only. A Cloud Pak for Data URL additionally passes `username`, `version`, and `instance_id` (default `openshift`) read from the credentials directory. Missing username or version raises a ValueError before `ChatWatsonx` is constructed (OLS-2190 / OLS-2849).
+
 ### Bedrock model-prefix routing
 
 `bedrock.py` serves multiple model families behind the Bedrock Mantle gateway. `load()` inspects `self.model` to select the LangChain class and construct the correct Mantle endpoint URL:

--- a/.ai/spec/what/llm-providers.md
+++ b/.ai/spec/what/llm-providers.md
@@ -90,7 +90,9 @@ The following sections describe only what differs from the standard contract abo
 
 28. Parameters are passed to the LLM constructor in a `params` dict (not as top-level keyword arguments). Uses `ChatWatsonx` from LangChain IBM. Does not use httpx clients or custom certificate stores.
 
-29. Default URL: `https://us-south.ml.cloud.ibm.com`.
+29. Default URL: `https://us-south.ml.cloud.ibm.com`. IBM Cloud SaaS hosts (`*.ml.cloud.ibm.com`) authenticate with `apitoken` / `apikey` only.
+
+29a. When the WatsonX URL is on-prem Cloud Pak for Data (any host other than `*.ml.cloud.ibm.com`), the credentials directory must also contain `username` and `version` files. Those values are passed to `ChatWatsonx` as `username` and `version`. `instance_id` is optional and defaults to `openshift`. If username or version is missing, the provider must raise a clear ValueError at load time (OLS-2190, OLS-2849). IBM Cloud watsonx must not require these fields.
 
 ### RHOAI vLLM (`rhoai_vllm`)
 
@@ -170,7 +172,7 @@ The following sections describe only what differs from the standard contract abo
 - `llm_providers[].tlsSecurityProfile` -- TLS security profile with `type`, `minTLSVersion`, and `ciphers`.
 - `llm_providers[].openai_config` -- Provider-specific: `url`, `credentials_path`.
 - `llm_providers[].azure_openai_config` -- Provider-specific: `url`, `deployment_name`, `credentials_path` (directory containing `apitoken`, `client_id`, `tenant_id`, `client_secret` files).
-- `llm_providers[].watsonx_config` -- Provider-specific: `url`, `credentials_path`, `project_id`.
+- `llm_providers[].watsonx_config` -- Provider-specific: `url`, `credentials_path`, `project_id`. For Cloud Pak for Data URLs, the credentials directory also holds `username` and `version` (optional `instance_id`).
 - `llm_providers[].rhoai_vllm_config` -- Provider-specific: `url`, `credentials_path`.
 - `llm_providers[].rhelai_vllm_config` -- Provider-specific: `url`, `credentials_path`.
 - `llm_providers[].google_vertex_config` -- Provider-specific: `project`, `location`.

--- a/README.md
+++ b/README.md
@@ -254,13 +254,27 @@ Depends on configuration, but usually it is not needed to generate or use API ke
 
 ### WatsonX
 
-   Make sure the `project_id` is set up correctly.
+   IBM Cloud watsonx (default URL `https://us-south.ml.cloud.ibm.com`) only needs an API key. Put that key in `credentials_path` as a file named `apitoken`, or point `credentials_path` at the file itself.
+
+   Cloud Pak for Data (on-prem `https://cpd-....apps....`) also needs `username` and `version` in the same credentials directory. `instance_id` is optional and defaults to `openshift`.
 
   ```yaml
   - name: my_watsonx
     type: watsonx
     url: "https://us-south.ml.cloud.ibm.com"
     credentials_path: watsonx_api_key.txt
+    project_id: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+    models:
+      - name: <model name>
+  ```
+
+  On-prem example. The credentials directory contains `apitoken`, `username`, and `version`:
+
+  ```yaml
+  - name: my_watsonx_cpd
+    type: watsonx
+    url: "https://cpd-instance.apps.example.com"
+    credentials_path: /path/to/watsonx-secret
     project_id: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
     models:
       - name: <model name>

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -395,6 +395,9 @@ class ProviderConfig(BaseModel):
     google_vertex_config: Optional[GoogleVertexConfig] = None
     fake_provider_config: Optional[FakeConfig] = None
     tls_security_profile: Optional[TLSSecurityProfile] = None
+    watsonx_username: Optional[str] = None
+    watsonx_version: Optional[str] = None
+    watsonx_instance_id: Optional[str] = None
 
     def __init__(
         self,
@@ -421,6 +424,9 @@ class ProviderConfig(BaseModel):
 
         if self.type == constants.PROVIDER_BEDROCK:
             self._read_bedrock_iam_credentials(data)
+
+        if self.type == constants.PROVIDER_WATSONX:
+            self._read_watsonx_cpd_credentials(data)
 
         # OLS-622: Provider-specific configuration parameters in configuration file
         self.project_id = data.get("project_id", None)
@@ -543,6 +549,14 @@ class ProviderConfig(BaseModel):
                     self.check_provider_config(watsonx_config)
                     self.read_api_key(watsonx_config)
                     self.watsonx_config = WatsonxConfig(**watsonx_config)
+                    if self.watsonx_config.credentials_path is not None:
+                        self._read_watsonx_cpd_credentials(
+                            {
+                                constants.CREDENTIALS_PATH_SELECTOR: str(
+                                    self.watsonx_config.credentials_path
+                                )
+                            }
+                        )
                 case constants.PROVIDER_GOOGLE_VERTEX_ANTHROPIC:
                     google_vertex_anthropic_config = data.get(
                         "google_vertex_anthropic_config"
@@ -576,6 +590,47 @@ class ProviderConfig(BaseModel):
             constants.API_TOKEN_FILENAME,
             raise_on_error=False,
         )
+
+    def _watsonx_credentials_dir(self, data: Optional[dict]) -> Optional[str]:
+        """Directory that holds watsonx secret files (apitoken, username, version)."""
+        if data is None:
+            return None
+        path = data.get(constants.CREDENTIALS_PATH_SELECTOR)
+        if path is None:
+            return None
+        path = str(path)
+        if os.path.isdir(path):
+            return path
+        parent = os.path.dirname(path)
+        return parent or None
+
+    def _read_watsonx_cpd_credentials(self, data: Optional[dict]) -> None:
+        """Load optional Cloud Pak for Data fields from the credentials directory.
+
+        IBM Cloud watsonx only needs apitoken. On-prem CP4D also needs
+        username and version (OLS-2190 / OLS-2849). Files are optional at
+        config load; ChatWatsonx construction fails later if a CP4D URL is
+        used without them.
+        """
+        directory = self._watsonx_credentials_dir(data)
+        if directory is None:
+            return
+        dir_data = {constants.CREDENTIALS_PATH_SELECTOR: directory}
+
+        def _optional(filename: str) -> Optional[str]:
+            if not os.path.isfile(os.path.join(directory, filename)):
+                return None
+            return checks.read_secret(
+                dir_data,
+                constants.CREDENTIALS_PATH_SELECTOR,
+                filename,
+                directory_name_expected=True,
+                raise_on_error=False,
+            )
+
+        self.watsonx_username = _optional(constants.WATSONX_USERNAME_FILENAME)
+        self.watsonx_version = _optional(constants.WATSONX_VERSION_FILENAME)
+        self.watsonx_instance_id = _optional(constants.WATSONX_INSTANCE_ID_FILENAME)
 
     def _read_bedrock_iam_credentials(self, data: dict) -> None:
         """Read AWS IAM credentials from credentials_path directory for Bedrock."""

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -201,6 +201,14 @@ ATTACHMENT_CONTENT_TYPES = frozenset(
 # Default name of file containing API token
 API_TOKEN_FILENAME = "apitoken"  # noqa: S105  # nosec: B105
 
+# Optional Cloud Pak for Data fields, read from the credentials directory
+# when the Watsonx URL is not IBM Cloud SaaS (OLS-2190, OLS-2849).
+WATSONX_USERNAME_FILENAME = "username"
+WATSONX_VERSION_FILENAME = "version"
+WATSONX_INSTANCE_ID_FILENAME = "instance_id"
+# Default CPD instance_id for watsonx.ai software on OpenShift.
+WATSONX_DEFAULT_CPD_INSTANCE_ID = "openshift"
+
 # Default name of file containing client ID to Azure OpenAI
 AZURE_CLIENT_ID_FILENAME = "client_id"
 

--- a/ols/src/llms/providers/watsonx.py
+++ b/ols/src/llms/providers/watsonx.py
@@ -2,6 +2,7 @@
 
 import logging
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 from ibm_watsonx_ai.metanames import (
     GenTextParamsMetaNames as GenParams,
@@ -14,6 +15,18 @@ from ols.src.llms.providers.provider import LLMProvider
 from ols.src.llms.providers.registry import register_llm_provider_as
 
 logger = logging.getLogger(__name__)
+
+IBM_CLOUD_WATSONX_HOST_SUFFIX = "ml.cloud.ibm.com"
+
+
+def is_ibm_cloud_watsonx_url(url: str) -> bool:
+    """Return True when the URL is IBM Cloud watsonx SaaS (apitoken only)."""
+    if not url:
+        return True
+    host = (urlparse(str(url)).hostname or "").lower()
+    return host == IBM_CLOUD_WATSONX_HOST_SUFFIX or host.endswith(
+        "." + IBM_CLOUD_WATSONX_HOST_SUFFIX
+    )
 
 
 @register_llm_provider_as(constants.PROVIDER_WATSONX)
@@ -59,16 +72,40 @@ class Watsonx(LLMProvider):
         if self.project_id is None:
             raise ValueError("Project ID must be specified")
 
+        constructor_kwargs: dict[str, Any] = {
+            "model_id": self.model,
+            "url": self.url,
+            "apikey": self.credentials,
+            "project_id": self.project_id,
+            "params": self.params,
+        }
+
+        if not is_ibm_cloud_watsonx_url(self.url):
+            username = self.provider_config.watsonx_username
+            version = self.provider_config.watsonx_version
+            missing = [
+                name
+                for name, value in (("username", username), ("version", version))
+                if not value
+            ]
+            if missing:
+                needed = " and ".join(missing)
+                raise ValueError(
+                    "On-prem Cloud Pak for Data watsonx needs "
+                    f"{needed} in the credentials secret (keys next to apitoken). "
+                    "IBM Cloud watsonx still only needs apitoken."
+                )
+            constructor_kwargs["username"] = username
+            constructor_kwargs["version"] = version
+            constructor_kwargs["instance_id"] = (
+                self.provider_config.watsonx_instance_id
+                or constants.WATSONX_DEFAULT_CPD_INSTANCE_ID
+            )
+
         logger.info(
             "Loading WatsonX LLM: model=%s, url=%s, project_id=%s",
             self.model,
             self.url,
             self.project_id,
         )
-        return ChatWatsonx(
-            model_id=self.model,
-            url=self.url,
-            apikey=self.credentials,
-            project_id=self.project_id,
-            params=self.params,
-        )
+        return ChatWatsonx(**constructor_kwargs)

--- a/tests/unit/llms/providers/test_watsonx.py
+++ b/tests/unit/llms/providers/test_watsonx.py
@@ -1,13 +1,13 @@
 """Unit tests for Watsonx provider."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from ibm_watsonx_ai.metanames import GenTextParamsMetaNames as GenParams
 
 from ols.app.models.config import ProviderConfig
 from ols.constants import GenericLLMParameters
-from ols.src.llms.providers.watsonx import Watsonx
+from ols.src.llms.providers.watsonx import Watsonx, is_ibm_cloud_watsonx_url
 from tests.mock_classes.mock_watsonxllm import ChatWatsonx
 
 
@@ -84,7 +84,7 @@ def provider_config_with_specific_params():
             "credentials_path": "tests/config/secret/apitoken",
             "project_id": "01234567-89ab-cdef-0123-456789abcdef",
             "watsonx_config": {
-                "url": "http://watsonx.example.com",
+                "url": "https://eu-de.ml.cloud.ibm.com",
                 "credentials_path": "tests/config/secret2/apitoken",
                 "project_id": "ffffffff-89ab-cdef-0123-456789abcdef",
             },
@@ -102,9 +102,7 @@ def provider_config_with_specific_params():
 def test_basic_interface(provider_config):
     """Test basic interface."""
     with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
-        watsonx = Watsonx(
-            model="uber-model", params={}, provider_config=provider_config
-        )
+        watsonx = Watsonx(model="uber-model", params={}, provider_config=provider_config)
         llm = watsonx.load()
         assert isinstance(llm, ChatWatsonx)
         assert watsonx.default_params
@@ -123,9 +121,7 @@ def test_params_handling(provider_config):
     }
 
     with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
-        watsonx = Watsonx(
-            model="uber-model", params=params, provider_config=provider_config
-        )
+        watsonx = Watsonx(model="uber-model", params=params, provider_config=provider_config)
         llm = watsonx.load()
         assert isinstance(llm, ChatWatsonx)
         assert watsonx.default_params
@@ -180,7 +176,7 @@ def test_params_handling_specific_params(provider_config_with_specific_params):
 
         # parameters taken from provier-specific configuration
         # which takes precedence over regular configuration
-        assert watsonx.url == "http://watsonx.example.com/"
+        assert watsonx.url == "https://eu-de.ml.cloud.ibm.com/"
         assert watsonx.credentials == "secret_key_2"
         assert watsonx.project_id == "ffffffff-89ab-cdef-0123-456789abcdef"
 
@@ -198,9 +194,7 @@ def test_params_handling_none_values(provider_config):
     }
 
     with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
-        watsonx = Watsonx(
-            model="uber-model", params=params, provider_config=provider_config
-        )
+        watsonx = Watsonx(model="uber-model", params=params, provider_config=provider_config)
         llm = watsonx.load()
         assert isinstance(llm, ChatWatsonx)
         assert watsonx.default_params
@@ -225,9 +219,7 @@ def test_params_replace_default_values_with_none(provider_config):
     """Test if default values are replaced by None values."""
     with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
         # provider initialization with empty set of params
-        watsonx = Watsonx(
-            model="uber-model", params={}, provider_config=provider_config
-        )
+        watsonx = Watsonx(model="uber-model", params={}, provider_config=provider_config)
         watsonx.load()
 
         # check default value
@@ -237,9 +229,7 @@ def test_params_replace_default_values_with_none(provider_config):
         # provider initialization where default parameter is overriden
         params = {"decoding_method": None}
 
-        watsonx = Watsonx(
-            model="uber-model", params=params, provider_config=provider_config
-        )
+        watsonx = Watsonx(model="uber-model", params=params, provider_config=provider_config)
         watsonx.load()
 
         # check default value overrided by None
@@ -300,3 +290,94 @@ def test_missing_project_id_check(provider_config):
     watsonx.provider_config.project_id = None
     with pytest.raises(ValueError, match="Project ID must be specified"):
         watsonx.load()
+
+
+def _cpd_secret_dir(tmp_path, *, username=True, version=True, instance_id=False):
+    secret_dir = tmp_path / "watsonx_cpd"
+    secret_dir.mkdir()
+    (secret_dir / "apitoken").write_text("cpd_api_key")
+    if username:
+        (secret_dir / "username").write_text("cpd_user")
+    if version:
+        (secret_dir / "version").write_text("5.1")
+    if instance_id:
+        (secret_dir / "instance_id").write_text("openshift")
+    return secret_dir
+
+
+def _cpd_provider_config(secret_dir):
+    return ProviderConfig(
+        {
+            "name": "some_provider",
+            "type": "watsonx",
+            "url": "https://cpd-instance.apps.example.com",
+            "credentials_path": str(secret_dir),
+            "project_id": "01234567-89ab-cdef-0123-456789abcdef",
+            "models": [
+                {
+                    "name": "test_model_name",
+                    "url": "http://test_model_url/",
+                    "credentials_path": str(secret_dir / "apitoken"),
+                }
+            ],
+        }
+    )
+
+
+def test_ibm_cloud_does_not_pass_cpd_fields(provider_config):
+    """IBM Cloud watsonx still constructs ChatWatsonx with apikey only."""
+    mock_cls = MagicMock()
+    with patch("ols.src.llms.providers.watsonx.ChatWatsonx", mock_cls):
+        Watsonx(model="uber-model", params={}, provider_config=provider_config).load()
+    kwargs = mock_cls.call_args.kwargs
+    assert kwargs["apikey"] == "secret_key"
+    assert "username" not in kwargs
+    assert "version" not in kwargs
+    assert "instance_id" not in kwargs
+
+
+def test_cpd_passes_username_version_and_instance_id(tmp_path):
+    """CP4D URL must pass username, version, and instance_id into ChatWatsonx."""
+    provider_config = _cpd_provider_config(_cpd_secret_dir(tmp_path, instance_id=True))
+    mock_cls = MagicMock()
+    with patch("ols.src.llms.providers.watsonx.ChatWatsonx", mock_cls):
+        Watsonx(model="uber-model", params={}, provider_config=provider_config).load()
+    kwargs = mock_cls.call_args.kwargs
+    assert kwargs["apikey"] == "cpd_api_key"
+    assert kwargs["username"] == "cpd_user"
+    assert kwargs["version"] == "5.1"
+    assert kwargs["instance_id"] == "openshift"
+
+
+def test_cpd_defaults_instance_id_when_missing(tmp_path):
+    """CP4D without instance_id still works; default is openshift."""
+    provider_config = _cpd_provider_config(_cpd_secret_dir(tmp_path))
+    mock_cls = MagicMock()
+    with patch("ols.src.llms.providers.watsonx.ChatWatsonx", mock_cls):
+        Watsonx(model="uber-model", params={}, provider_config=provider_config).load()
+    assert mock_cls.call_args.kwargs["instance_id"] == "openshift"
+
+
+def test_cpd_missing_username(tmp_path):
+    """CP4D URL without username must fail clearly, not with WATSONX_USERNAME."""
+    provider_config = _cpd_provider_config(_cpd_secret_dir(tmp_path, username=False))
+    watsonx = Watsonx(model="uber-model", params={}, provider_config=provider_config)
+    with pytest.raises(ValueError, match="username"):
+        watsonx.load()
+
+
+def test_cpd_missing_version(tmp_path):
+    """CP4D URL without version must fail clearly (OLS-2849)."""
+    provider_config = _cpd_provider_config(_cpd_secret_dir(tmp_path, version=False))
+    watsonx = Watsonx(model="uber-model", params={}, provider_config=provider_config)
+    with pytest.raises(ValueError, match="version"):
+        watsonx.load()
+
+
+def test_is_ibm_cloud_watsonx_url():
+    """IBM Cloud SaaS hosts keep the apitoken-only path."""
+    assert is_ibm_cloud_watsonx_url("https://us-south.ml.cloud.ibm.com")
+    assert is_ibm_cloud_watsonx_url("https://eu-de.ml.cloud.ibm.com/ml")
+    assert is_ibm_cloud_watsonx_url("")
+    assert not is_ibm_cloud_watsonx_url("https://cpd-instance.apps.example.com")
+    assert not is_ibm_cloud_watsonx_url("https://watsonx.example.com")


### PR DESCRIPTION
[OLS-2190](https://redhat.atlassian.net/browse/OLS-2190). Also OLS-2849, because that is just the next error after username.

IBM Cloud watsonx is fine. Leave it alone. Secret with `apitoken` only, URL on `*.ml.cloud.ibm.com`. That path does not change.

On-prem Cloud Pak for Data is not IBM Cloud. The provider still built `ChatWatsonx` with apikey only, so you get `Did not find username` / `WATSONX_USERNAME`. Stick username in as an env var and you hit missing `version` (`5.0`–`5.3`). Scale the operator to 0 and edit the Deployment and it gets overwritten. That is not a fix.

What this does:

- IBM Cloud (or empty URL, we default to us-south): still apikey only.
- Any other URL: read `username` and `version` from the same credentials directory we already mount. Pass them into `ChatWatsonx`. `instance_id` is optional and defaults to `openshift`.
- If those files are missing, raise a real error. Not the Pydantic one.

The secret already lands as a directory under `/etc/apikeys/<secret>/`. Extra keys just show up as files. No new volume mounts.

Operator PR: https://github.com/openshift/lightspeed-operator/pull/2013