### PR TITLE
OLS-3261 Retry e2e app readiness timeouts

### DIFF
--- a/tests/e2e/utils/cluster.py
+++ b/tests/e2e/utils/cluster.py
@@ -475,7 +475,7 @@ def wait_for_running_pod(
         "Waiting for containers in the server pod to become ready",
     )
     if not r:
-        raise Exception("Timed out waiting for containers to become ready")
+        raise RuntimeError("Timed out waiting for containers to become ready")
 
     if not wait_http_ready:
         return

--- a/tests/unit/e2e/test_cluster.py
+++ b/tests/unit/e2e/test_cluster.py
@@ -1,0 +1,20 @@
+"""Unit tests for e2e cluster utilities."""
+
+import pytest
+
+from tests.e2e.utils import cluster
+
+
+def test_wait_for_running_pod_raises_runtime_error_when_containers_stay_unready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Make app-pod readiness timeouts eligible for the setup retry."""
+    attempts = iter((True, True, False))
+    monkeypatch.setattr(
+        cluster,
+        "retry_until_timeout_or_success",
+        lambda *_args, **_kwargs: next(attempts),
+    )
+
+    with pytest.raises(RuntimeError, match="Timed out waiting for containers"):
+        cluster.wait_for_running_pod()


### PR DESCRIPTION
## Summary
- classify an app-server container readiness timeout as `RuntimeError`
- allow the existing one-time `adapt_ols_config` retry to recover from a transient provider-reconfiguration rollout timeout
- cover the timeout type with a unit test

## Testing
- `uv run pytest tests/unit/e2e/test_cluster.py -q`
- `uv run ruff check tests/e2e/utils/cluster.py tests/unit/e2e/test_cluster.py`
- `uv run black --check tests/e2e/utils/cluster.py tests/unit/e2e/test_cluster.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting when server containers fail to become ready by raising a more specific runtime error.

- **Tests**
  - Added coverage verifying that a timeout while waiting for running containers produces the expected error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->